### PR TITLE
Zulip-Terminal: Support Scrolling and use Stream ID to store stream messages.

### DIFF
--- a/core.py
+++ b/core.py
@@ -23,10 +23,10 @@ class ZulipController:
     def narrow_to_stream(self, button: Any) -> None:
         self.view.narrow = ujson.dumps([['stream', button.caption]])
         self.model.msg_view.clear()
-        messages = self.model.messages[button.caption]
+        messages = self.model.messages[button.stream_id]
         if len(messages) == 0:
             classified_msgs = self.model.load_old_messages(False)
-            messages = classified_msgs[button.caption]
+            messages = classified_msgs[button.stream_id]
         self.model.msg_view.extend(create_msg_box_list(messages, self.model))
         self.model.num_before = len(messages)
 

--- a/helper.py
+++ b/helper.py
@@ -22,13 +22,17 @@ def classify_message(own_email: str, new_messages: NMSGL, classified_messages: C
     """
     Classifies messages into their respective types/streams.
     """
+    # Initialize classified_messages
     if classified_messages is None:
+        # defaultdict is used to ease the process of adding new keys
         classified_messages = defaultdict(list)
-    for msg in new_messages:
 
-        msg_type = msg['display_recipient']
-        sender = msg['sender_full_name']
-        if msg['type'] == 'private':
+    for msg in new_messages:
+        if msg['type'] == 'stream':
+            msg_type = msg['stream_id']
+            sender = msg['sender_full_name']
+        else:  # Private message
+            # Just a hunch to get the email of the other person in PM
             msg_type = msg['display_recipient'][0]['email']
             pm_with_name = msg['display_recipient'][0]['full_name']
             if msg_type == own_email:

--- a/model.py
+++ b/model.py
@@ -24,11 +24,11 @@ class ZulipModel(object):
             u'Private messages',
         ]
 
-        ''' 
+        '''
         Stores all the messages, type: Dict[str, Dict[Dict[str, Any]]]
             Example:
             {
-                'aman@zulip.com' : [
+                'hamelet@example.com' : [ # Store other user's id in PM (regardless of sender)
                     # List of Messages
                     {
                         'sender' : 'Aman Agrawal',
@@ -39,6 +39,12 @@ class ZulipModel(object):
                                 'email':'hamlet@example.com',
                                 'short_name':'hamlet',
                                 'id':31572
+                            },
+                            {
+                                'full_name': 'Aman Agrawal',
+                                'email' : 'aman@zulip.com',
+                                'short_name' : 'aman',
+                                'id' : '123',
                             }
                         ],
                         'title' : '',
@@ -48,7 +54,7 @@ class ZulipModel(object):
                     },
                     ...
                 ],
-                'integrations' : [
+                '89' : [ # Stream ID
                     {
                         'sender' : 'aman',
                         'time' : '8 AM',
@@ -95,11 +101,13 @@ class ZulipModel(object):
             print("Invalid API key")
             raise urwid.ExitMainLoop()
 
-    def get_subscribed_streams(self) -> List[str]:
+    def get_subscribed_streams(self) -> List[List[str]]:
         try :
             streams = self.client.get_streams(include_subscribed=True, include_public=False)
-            stream_names = [stream['name'] for stream in streams['streams']]
-            return sorted(stream_names, key=str.lower)
+            # Store Pair of stream name and id's for storing in buttons
+            # this is useful when narrowing to a stream
+            stream_names = [[stream['name'], stream['stream_id']] for stream in streams['streams']]
+            return sorted(stream_names, key=lambda s: s[0].lower())
         except Exception:
             print("Invalid API key")
             raise urwid.ExitMainLoop()
@@ -111,3 +119,4 @@ class ZulipModel(object):
         self.messages[key] += cmsg[key]
         if view.narrow == ujson.dumps([]) or ujson.loads(view.narrow)[0][1] == key:
             self.msg_list.log.append(urwid.AttrMap(MessageBox(cmsg[key][0], self), None, 'msg_selected'))
+        self.controller.loop.draw_screen()

--- a/ui.py
+++ b/ui.py
@@ -7,6 +7,8 @@ from ui_tools import (
     MenuButton,
     MessageView,
     MiddleColumnView,
+    StreamsView,
+    UsersView,
 )
 
 class ZulipView(urwid.WidgetWrap):
@@ -42,7 +44,7 @@ class ZulipView(urwid.WidgetWrap):
 
     def streams_view(self) -> Any:
         streams_btn_list = [MenuButton(item, controller=self.controller, view=self, stream=True) for item in self.streams]
-        w = urwid.ListBox(urwid.SimpleFocusListWalker(streams_btn_list))
+        w = StreamsView(streams_btn_list)
         w = urwid.LineBox(w, title="Streams")
         return w
 
@@ -61,7 +63,7 @@ class ZulipView(urwid.WidgetWrap):
 
     def users_view(self) -> Any:
         users_btn_list = [MenuButton(item[0], item[1], controller=self.controller, view=self, user=True) for item in self.users]
-        w = urwid.ListBox(urwid.SimpleFocusListWalker(users_btn_list))
+        w = UsersView(urwid.SimpleFocusListWalker(users_btn_list))
         return w
 
     def right_column_view(self) -> Any:
@@ -74,10 +76,10 @@ class ZulipView(urwid.WidgetWrap):
         center_column = self.message_view()
         right_column = self.right_column_view()
         body = [
-            ('weight', 30, left_column),
-            ('weight', 100, center_column),
-            ('weight', 30, right_column),
+            ('weight', 3, left_column),
+            ('weight', 10, center_column),
+            ('weight', 3, right_column),
         ]
-        w = urwid.Columns(body, focus_column=1)
-        w = urwid.LineBox(w, title=u"Zulip")
+        self.body = urwid.Columns(body, focus_column=1)
+        w = urwid.LineBox(self.body, title=u"Zulip")
         return w

--- a/ui_tools.py
+++ b/ui_tools.py
@@ -6,6 +6,37 @@ import itertools
 # No of MESSAGES LOADED PER REQUEST
 LOAD_MSG = 50
 
+class StreamsView(urwid.ListBox):
+    def __init__(self, streams_btn_list: List[Any]) -> None:
+        self.log = urwid.SimpleFocusListWalker(streams_btn_list)
+        super(StreamsView, self).__init__(self.log)
+
+    def mouse_event(self, size, event, button, col, row, focus):
+        if event == 'mouse press':
+            if button == 4:
+                self.keypress(size, 'up')
+                return True
+            if button == 5:
+                self.keypress(size, 'down')
+                return True
+        return super(StreamsView, self).mouse_event(size, event, button, col, row, focus)
+
+class UsersView(urwid.ListBox):
+    def __init__(self, users_btn_list: List[Any]) -> None:
+        self.log = urwid.SimpleFocusListWalker(users_btn_list)
+        super(UsersView, self).__init__(self.log)
+
+    def mouse_event(self, size, event, button, col, row, focus):
+        if event == 'mouse press':
+            if button == 4:
+                for _ in range(5):
+                    self.keypress(size, 'up')
+                return True
+            if button == 5:
+                for _ in range(5):
+                    self.keypress(size, 'down')
+        return super(UsersView, self).mouse_event(size, event, button, col, row, focus)
+
 class MiddleColumnView(urwid.Frame):
     def __init__(self, messages: Any, model: Any, write_box: Any) -> None:
         msg_list = MessageView(messages, model)
@@ -57,6 +88,13 @@ class MessageBox(urwid.Pile):
     def selectable(self):
         return True
 
+    def mouse_event(self, size, event, button, col, row, focus):
+        if event == 'mouse press':
+            if button == 1:
+                self.keypress(size, 'enter')
+                return True
+        return super(MessageBox, self).mouse_event(size, event, button, col, row, focus)
+
     def keypress(self, size, key):
         if key == 'enter':
             if self.message['type'] == 'private':
@@ -92,6 +130,16 @@ class MessageView(urwid.ListBox):
         for msg in new_messages[self.model.num_before-LOAD_MSG:]:
             self.log.insert(0, urwid.AttrMap(MessageBox(msg, self.model), None, 'msg_selected'))
 
+    def mouse_event(self, size, event, button, col, row, focus):
+        if event == 'mouse press':
+            if button == 4:
+                self.keypress(size, 'up')
+                return True
+            if button == 5:
+                self.keypress(size, 'down')
+                return True
+        return super(MessageView, self).mouse_event(size, event, button, col, row, focus)
+
     def keypress(self, size: Tuple[int, int], key: str) -> str:
         if key == 'down':
             try:
@@ -110,21 +158,23 @@ class MessageView(urwid.ListBox):
         key = super(MessageView, self).keypress(size, key)
         return key
 
-# TODO: Create Separate Buttons for streams, users and view.menu
 class MenuButton(urwid.Button):
-    def __init__(self, caption: str, email: str='', controller: Any=None, view: Any=None, user: str=False, stream: bool=False) -> None:
-        self.caption = caption
+    def __init__(self, caption: Any, email: str='', controller: Any=None, view: Any=None, user: str=False, stream: bool=False) -> None:
+        self.caption = caption  # str
+        if stream:  # caption = [stream_name, stream_id]
+            self.caption = caption[0]
+            self.stream_id = caption[1]
         self.email = email
         super(MenuButton, self).__init__("")
         self._w = urwid.AttrMap(urwid.SelectableIcon(
-            [u'  # ', caption], 0), None, 'selected')
+            [u'  # ', self.caption], 0), None, 'selected')
         if stream:
             urwid.connect_signal(self, 'click', controller.narrow_to_stream)
             urwid.connect_signal(self, 'click', view.write_box.stream_box_view)
         if user:
             urwid.connect_signal(self, 'click', controller.narrow_to_user)
             urwid.connect_signal(self, 'click', view.write_box.private_box_view)
-        if caption == u'All messages':
+        if self.caption == u'All messages':
             urwid.connect_signal(self, 'click', controller.show_all_messages)
 
 


### PR DESCRIPTION
UsersView, StreamsView and MessageBox View support scrolling.
Message click opens write box with relevant field(s) prefilled.
Update Screen on getting new updates using `loop.draw_screen()` method.