### PR TITLE
Zulip-Terminal: Minor Bug Fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ An interactive terminal interface for [Zulip](https://zulipchat.com).
   2. Install the requirements:
   ```
   cd zulip-terminal
-  pip install -r requirements.txt
+  sudo apt-get install python3-pip
+  pip3 install -r requirements.txt
   ```
 
   3. Download the `zuliprc` file into zulip-terminal directory from [Zulip](https://chat.zulip.org/#settings/your-account)

--- a/core.py
+++ b/core.py
@@ -1,7 +1,7 @@
 import zulip
 import urwid
 from typing import Any
-import ujson
+import json
 import itertools
 
 from ui_tools import create_msg_box_list
@@ -21,7 +21,7 @@ class ZulipController:
         self.view = ZulipView(self)
 
     def narrow_to_stream(self, button: Any) -> None:
-        self.view.narrow = ujson.dumps([['stream', button.caption]])
+        self.view.narrow = json.dumps([['stream', button.caption]])
         self.model.msg_view.clear()
         messages = self.model.messages[button.stream_id]
         if len(messages) == 0:
@@ -31,7 +31,7 @@ class ZulipController:
         self.model.num_before = len(messages)
 
     def narrow_to_user(self, button: Any) -> None:
-        self.view.narrow = ujson.dumps([["pm_with", button.email]])
+        self.view.narrow = json.dumps([["pm_with", button.email]])
         self.model.msg_view.clear()
         messages = self.model.messages[button.email]
         if len(messages) == 0:
@@ -51,7 +51,7 @@ class ZulipController:
         self.model.num_before = len(messages)
 
     def show_all_messages(self, button: Any) -> None:
-        self.view.narrow = ujson.dumps([])
+        self.view.narrow = json.dumps([])
         self.model.msg_view.clear()
         self.model.msg_view.extend(create_msg_box_list(itertools.chain.from_iterable(self.model.messages.values()), self.model))
         self.num_before = len(list(itertools.chain.from_iterable(self.model.messages.values())))

--- a/helper.py
+++ b/helper.py
@@ -36,8 +36,11 @@ def classify_message(own_email: str, new_messages: NMSGL, classified_messages: C
             msg_type = msg['display_recipient'][0]['email']
             pm_with_name = msg['display_recipient'][0]['full_name']
             if msg_type == own_email:
-                msg_type = msg['display_recipient'][1]['email']
-                pm_with_name = msg['display_recipient'][1]['full_name']
+                try:
+                    msg_type = msg['display_recipient'][1]['email']
+                    pm_with_name = msg['display_recipient'][1]['full_name']
+                except IndexError:
+                    pass
 
             if own_email == msg['sender_email']:
                 pm_with_name = "You and " + pm_with_name

--- a/model.py
+++ b/model.py
@@ -1,7 +1,7 @@
 from typing import Any, List, Tuple, Dict
 import time
 import urwid
-import ujson
+import json
 
 from ui_tools import MessageBox
 from helper import classify_message
@@ -117,6 +117,6 @@ class ZulipModel(object):
         view = self.controller.view
         key = list(cmsg.keys())[0]
         self.messages[key] += cmsg[key]
-        if view.narrow == ujson.dumps([]) or ujson.loads(view.narrow)[0][1] == key:
+        if view.narrow == json.dumps([]) or json.loads(view.narrow)[0][1] == key:
             self.msg_list.log.append(urwid.AttrMap(MessageBox(cmsg[key][0], self), None, 'msg_selected'))
         self.controller.loop.draw_screen()


### PR DESCRIPTION
Use json instead of ujson to load/dump objects.
Explicitly use `pip3` instead of `pip` in installation instructions.
Support self messages in PM.