### PR TITLE
hotkeys: Add `c` to compose a new stream message.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ An interactive terminal interface for [Zulip](https://zulipchat.com).
 | Command | Key Combination |
 | ------- | --------------- |
 | Reply to a message | `r` |
+| New stream message | `c` |
 | Move back from Compose box to the message | `esc` |
 
 Note: You can use `arrows`, `home`, `end`, `Page up` and `Page down` keys to move around in Zulip-Terminal.

--- a/ui_tools.py
+++ b/ui_tools.py
@@ -50,6 +50,12 @@ class MiddleColumnView(urwid.Frame):
         if key == 'esc':
             self.footer.keypress(size, 'esc')
             self.set_focus('body')
+        if key == 'c':
+            if not self.focus_position == 'footer':
+                self.body.keypress(size, 'c')
+                self.set_focus('footer')
+                self.footer.focus_position = 0
+                return key
         return super(MiddleColumnView, self).keypress(size, key)
 
 class MessageBox(urwid.Pile):
@@ -109,6 +115,11 @@ class MessageBox(urwid.Pile):
                 self.model.controller.view.write_box.private_box_view(email=self.message['sender_email'])
             if self.message['type'] == 'stream':
                 self.model.controller.view.write_box.stream_box_view(caption=self.message['stream'], title=self.message['title'])
+        if key == 'c':
+            if self.message['type'] == 'private':
+                self.model.controller.view.write_box.private_box_view(email=self.message['sender_email'])
+            if self.message['type'] == 'stream':
+                self.model.controller.view.write_box.stream_box_view(caption=self.message['stream'])
         return key
 
 


### PR DESCRIPTION
`c` hotkey will be useful when the user wants to compose a message in the same stream but in a different topic.
![c-hotkey](https://user-images.githubusercontent.com/22166422/37002191-e2fc1080-20ee-11e8-98a7-4b23121a3971.gif)
