### PR TITLE
[WIP] mypy: Add /tools to test mypy annotations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,8 @@ pytest --pep8
 ```
 ### **Need Help?**
 Come meet us at [Zulip](https://chat.zulip.org/#narrow/stream/206-zulip-terminal).
+
+* To check the type annotations, run:
+```
+./tools/run-mypy
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pytest-pep8==1.0.6
 pytest-mock==1.7.1
 pudb==2017.1.4
 snakeviz==0.4.2
+mypy==0.560

--- a/tools/lister.py
+++ b/tools/lister.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+import os
+import sys
+import subprocess
+import re
+from collections import defaultdict
+import argparse
+from six.moves import filter
+
+from typing import Union, List, Dict
+
+def get_ftype(fpath: str, use_shebang: bool) -> str:
+    ext = os.path.splitext(fpath)[1]
+    if ext:
+        return ext[1:]
+    elif use_shebang:
+        # opening a file may throw an OSError
+        with open(fpath) as f:
+            first_line = f.readline()
+            if re.search(r'^#!.*\bpython3', first_line):
+                return 'py'
+            elif re.search(r'^#!', first_line):
+                print('Error: Unknown shebang in file "%s":\n%s' % (fpath, first_line), file=sys.stderr)
+                return ''
+            else:
+                return ''
+    else:
+        return ''
+
+def list_files(targets=[], ftypes=[], use_shebang=True, modified_only=False,
+               exclude=[], group_by_ftype=False, extless_only=False):
+    """
+    List files tracked by git.
+    Returns a list of files which are either in targets or in directories in targets.
+    If targets is [], list of all tracked files in current directory is returned.
+    Other arguments:
+    ftypes - List of file types on which to filter the search.
+        If ftypes is [], all files are included.
+    use_shebang - Determine file type of extensionless files from their shebang.
+    modified_only - Only include files which have been modified.
+    exclude - List of files or directories to be excluded, relative to repository root.
+    group_by_ftype - If True, returns a dict of lists keyed by file type.
+        If False, returns a flat list of files.
+    extless_only - Only include extensionless files in output.
+    """
+    ftypes = [x.strip('.') for x in ftypes]
+    ftypes_set = set(ftypes)
+
+    # Really this is all bytes -- it's a file path -- but we get paths in
+    # sys.argv as str, so that battle is already lost.  Settle for hoping
+    # everything is UTF-8.
+    repository_root = subprocess.check_output(['git', 'rev-parse', '--show-toplevel']).strip().decode('utf-8')
+    exclude_abspaths = [os.path.abspath(os.path.join(repository_root, fpath)) for fpath in exclude]
+
+    cmdline = ['git', 'ls-files'] + targets
+    if modified_only:
+        cmdline.append('-m')
+
+    files_gen = (x.strip() for x in subprocess.check_output(cmdline, universal_newlines=True).split('\n'))
+    # throw away empty lines and non-files (like symlinks)
+    files = list(filter(os.path.isfile, files_gen))
+
+    result_dict = defaultdict(list)  # type: Dict[str, List[str]]
+    result_list = []  # type: List[str]
+
+    for fpath in files:
+        # this will take a long time if exclude is very large
+        ext = os.path.splitext(fpath)[1]
+        if extless_only and ext:
+            continue
+        absfpath = os.path.abspath(fpath)
+        if any(absfpath == expath or absfpath.startswith(os.path.abspath(expath) + os.sep)
+               for expath in exclude_abspaths):
+            continue
+
+        if ftypes or group_by_ftype:
+            try:
+                filetype = get_ftype(fpath, use_shebang)
+            except (OSError, UnicodeDecodeError) as e:
+                etype = e.__class__.__name__
+                print('Error: %s while determining type of file "%s":' % (etype, fpath), file=sys.stderr)
+                print(e, file=sys.stderr)
+                filetype = ''
+            if ftypes and filetype not in ftypes_set:
+                continue
+
+        if group_by_ftype:
+            result_dict[filetype].append(fpath)
+        else:
+            result_list.append(fpath)
+
+    if group_by_ftype:
+        return result_dict
+    else:
+        return result_list
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="List files tracked by git and optionally filter by type")
+    parser.add_argument('targets', nargs='*', default=[],
+                        help='''files and directories to include in the result.
+                        If this is not specified, the current directory is used''')
+    parser.add_argument('-m', '--modified', action='store_true', default=False, help='list only modified files')
+    parser.add_argument('-f', '--ftypes', nargs='+', default=[],
+                        help="list of file types to filter on. All files are included if this option is absent")
+    parser.add_argument('--ext-only', dest='extonly', action='store_true', default=False,
+                        help='only use extension to determine file type')
+    parser.add_argument('--exclude', nargs='+', default=[],
+                        help='list of files and directories to exclude from results, relative to repo root')
+    parser.add_argument('--extless-only', dest='extless_only', action='store_true', default=False,
+                        help='only include extensionless files in output')
+    args = parser.parse_args()
+    listing = list_files(targets=args.targets, ftypes=args.ftypes, use_shebang=not args.extonly,
+                         modified_only=args.modified, exclude=args.exclude, extless_only=args.extless_only)
+    for l in listing:
+        print(l)

--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -14,55 +14,68 @@ os.chdir(os.path.dirname(TOOLS_DIR))
 sys.path.append(os.path.dirname(TOOLS_DIR))
 
 parser = argparse.ArgumentParser(description="Run mypy on files tracked by git.")
-parser.add_argument('targets',nargs="*", default=[],help="""files and directories to include in the result.
+parser.add_argument('targets', nargs='*', default=[],
+                    help="""files and directories to include in the result.
                     If this is not specified, the current directory is used""")
-parser.add_argument('-m','--modified', action = 'store_true', help = 'All modified files.',default = False)
-parser.add_argument('-a','--all', action = 'store_true')
-parser.add_argument('--quick', action='store_true', default=False,
-                    help="Use the quick flag with mypy" )
-parser.add_argument('--ignore-missing-imports', dest='ignore_missing_imports', action='store_true', default=False,
-                    help="Use the --ignore-missing-imports flag with mypy")
+parser.add_argument('-m', '--modified', action='store_true', default=False, help='list only modified files')
+parser.add_argument('-a', '--all', dest='all', action='store_true', default=False,
+                    help="""run mypy on all python files, ignoring the exclude list.
+                    This is useful if you have to find out which files fail mypy check.""")
+parser.add_argument('--no-disallow-untyped-defs', dest='disallow_untyped_defs', action='store_false', default=True,
+                    help="""Don't throw errors when functions are not annotated""")
+parser.add_argument('--scripts-only', dest='scripts_only', action='store_true', default=False,
+                    help="""Only type check extensionless python scripts""")
+parser.add_argument('--no-strict-optional', dest='strict_optional', action='store_false', default=True,
+                    help="""Don't use the --strict-optional flag with mypy""")
+parser.add_argument('--warn-unused-ignores', dest='warn_unused_ignores', action='store_true', default=False,
+                    help="""Use the --warn-unused-ignores flag with mypy""")
 parser.add_argument('--no-ignore-missing-imports', dest='ignore_missing_imports', action='store_false', default=True,
                     help="""Don't use the --ignore-missing-imports flag with mypy""")
-
+parser.add_argument('--quick', action='store_true', default=False,
+                    help="""Use the --quick flag with mypy""")
 
 args = parser.parse_args()
-exclude = []
-
-if args.all:
-    exclude = []
 
 files_dict = cast(Dict[str,List[str]],
              lister.list_files(targets = args.targets,ftypes=['py'],
                                use_shebang=True, modified_only=args.modified,
-                               exclude = exclude +['stubs'], group_by_ftype=True,
+                               group_by_ftype=True,
                                ))
 
-python_files = [fpath for fpath in files_dict['py']]
 
-if not python_files:
-    print("There are no files to run mypy on.")
-    sys.exit(0)
+pyi_files = set(files_dict['pyi'])
+python_files = [fpath for fpath in files_dict['py']
+                if not fpath.endswith('.py') or fpath + 'i' not in pyi_files]
 
-rep_python_files = {}
-rep_python_files['zulipterminal'] = []
+repo_python_files = {}
+repo_python_files['zulipterminal'] = []
 for file_path in python_files:
-    rep = PurePath(file_path).parts[0]
-    if rep in rep_python_files:
-        rep_python_files[rep].append(file_path)
+    repo = PurePath(file_path).parts[0]
+    if repo in repo_python_files:
+        repo_python_files[repo].append(file_path)
 
 mypy_command = "mypy"
 
-extra_args = []
-
-
+extra_args = ["--check-untyped-defs",
+              "--follow-imports=silent",
+              "--scripts-are-modules",
+              "--disallow-any-generics",
+              "-i"]
+if args.disallow_untyped_defs:
+    extra_args.append("--disallow-untyped-defs")
+if args.warn_unused_ignores:
+    extra_args.append("--warn-unused-ignores")
+if args.strict_optional:
+    extra_args.append("--strict-optional")
+if args.ignore_missing_imports:
+    extra_args.append("--ignore-missing-imports")
 if args.quick:
     extra_args.append("--quick")
 
 # run mypy
 status = 0
-for rep, python_files in rep_python_files.items():
-    print("Running mypy for `{}`".format(rep))
+for repo, python_files in repo_python_files.items():
+    print("Running mypy for `{}`.".format(repo), flush=True)
     if python_files:
         result = subprocess.call([mypy_command] + extra_args + python_files)
         if result != 0:

--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import argparse
+import subprocess
+import lister
+from typing import cast, Dict, List
+from pathlib import PurePath
+
+TOOLS_DIR = os.path.dirname(os.path.abspath(__file__))
+os.chdir(os.path.dirname(TOOLS_DIR))
+
+sys.path.append(os.path.dirname(TOOLS_DIR))
+
+parser = argparse.ArgumentParser(description="Run mypy on files tracked by git.")
+parser.add_argument('targets',nargs="*", default=[],help="""files and directories to include in the result.
+                    If this is not specified, the current directory is used""")
+parser.add_argument('-m','--modified', action = 'store_true', help = 'All modified files.',default = False)
+parser.add_argument('-a','--all', action = 'store_true')
+parser.add_argument('--quick', action='store_true', default=False,
+                    help="Use the quick flag with mypy" )
+parser.add_argument('--ignore-missing-imports', dest='ignore_missing_imports', action='store_true', default=False,
+                    help="Use the --ignore-missing-imports flag with mypy")
+parser.add_argument('--no-ignore-missing-imports', dest='ignore_missing_imports', action='store_false', default=True,
+                    help="""Don't use the --ignore-missing-imports flag with mypy""")
+
+
+args = parser.parse_args()
+exclude = []
+
+if args.all:
+    exclude = []
+
+files_dict = cast(Dict[str,List[str]],
+             lister.list_files(targets = args.targets,ftypes=['py'],
+                               use_shebang=True, modified_only=args.modified,
+                               exclude = exclude +['stubs'], group_by_ftype=True,
+                               ))
+
+python_files = [fpath for fpath in files_dict['py']]
+
+if not python_files:
+    print("There are no files to run mypy on.")
+    sys.exit(0)
+
+rep_python_files = {}
+rep_python_files['zulipterminal'] = []
+for file_path in python_files:
+    rep = PurePath(file_path).parts[0]
+    if rep in rep_python_files:
+        rep_python_files[rep].append(file_path)
+
+mypy_command = "mypy"
+
+extra_args = []
+
+
+if args.quick:
+    extra_args.append("--quick")
+
+# run mypy
+status = 0
+for rep, python_files in rep_python_files.items():
+    print("Running mypy for `{}`".format(rep))
+    if python_files:
+        result = subprocess.call([mypy_command] + extra_args + python_files)
+        if result != 0:
+            status = result
+    else:
+        print("There are no files to run mypy on.")
+sys.exit(status)


### PR DESCRIPTION
It tests the mypy annotations in the code inside ```zulipterminal``` directory,  that is, whenever the code is modified or not, we can check if it is mypy annotated or not by running ```./tools/run-mypy```.

Currently, it has three optional arguments:

- ```--modified```: To check all modified files.
- ```--all```: To check all the files.
- ```--quick```: To use the quick flag with mypy.

@amanagr, can you please review it?