### PR TITLE
ui: Add feature to send multiline messages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ An interactive terminal interface for [Zulip](https://zulipchat.com).
 | Move back from Compose box to the message | `esc` |
 | Narrow to a stream | `S` |
 | Narrow to a topic | `s` |
+| Send a message | `Alt Enter` |
 
 Note: You can use `arrows`, `home`, `end`, `Page up` and `Page down` keys to move around in Zulip-Terminal.
 

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -41,7 +41,7 @@ class WriteBox(urwid.Pile):
         self.to_write_box = None
         if caption == '':
             caption = button.caption
-        self.msg_write_box = urwid.Edit(u"> ")
+        self.msg_write_box = urwid.Edit(u"> ", multiline=True)
         self.stream_write_box = urwid.Edit(
             caption=u"Stream:  ",
             edit_text=caption
@@ -59,7 +59,7 @@ class WriteBox(urwid.Pile):
         self.contents = write_box
 
     def keypress(self, size: Tuple[int, int], key: str) -> str:
-        if key == 'enter':
+        if key == 'meta enter':
             if not self.to_write_box:
                 request = {
                     'type': 'stream',


### PR DESCRIPTION
Use `Alt enter to send messages.`
`Ctrl enter` is not used due to some issues in using it with
different terminals.