### PR TITLE
model: Use `client.get_members` method to get user data.

### DIFF
--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -70,11 +70,11 @@ class ZulipModel(object):
                 fetch_event_types=[
                     'presence',
                     'subscription',
-                    'realm_user',
                     'message',
                     'update_message_flags',
                     ],
             )
+            result['realm_users'] = self.client.get_members()['members']
             return result
         except Exception:
             print("Invalid API key")


### PR DESCRIPTION
Including `realm_user` in `fetch_event_types` loads a lot of
useless data and increases startup time.