### PR TITLE
ui: Remove redundant recipient bars.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,7 +52,8 @@ def msg_box(mocker, messages_successful_response):
     """
     return MessageBox(
         messages_successful_response['messages'][0],
-        mocker.patch('zulipterminal.model.Model')
+        mocker.patch('zulipterminal.model.Model'),
+        None,
     )
 
 

--- a/zulipterminal/ui_tools/utils.py
+++ b/zulipterminal/ui_tools/utils.py
@@ -14,6 +14,7 @@ def create_msg_box_list(model: Any, messages: Union[None, Iterable[Any]]=None,
     message_list.sort(key=lambda msg: msg['timestamp'])
     w_list = []
     focus_msg = None
+    last_message = None
     for msg in message_list:
         msg_flag = 'unread'  # type: Union[str, None]
         flags = msg.get('flags')
@@ -26,10 +27,11 @@ def create_msg_box_list(model: Any, messages: Union[None, Iterable[Any]]=None,
         if msg['id'] == focus_msg_id:
             focus_msg = message_list.index(msg)
         w_list.append(urwid.AttrMap(
-                    MessageBox(msg, model),
+                    MessageBox(msg, model, last_message),
                     msg_flag,
                     'msg_selected'
         ))
+        last_message = msg
     if model.index['pointer'][str(model.narrow)] == set() and\
             focus_msg is not None:
         model.index['pointer'][str(model.narrow)] = focus_msg


### PR DESCRIPTION
Use the last message to check whether to render recipient bar for
a message or not.