### PR TITLE
run: Support running in WSL by replacing SI/SO.

### DIFF
--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -5,7 +5,7 @@ import urwid
 import zulip
 
 from zulipterminal.model import Model
-from zulipterminal.ui import View
+from zulipterminal.ui import View, Screen
 from zulipterminal.ui_tools.utils import create_msg_box_list
 
 
@@ -192,9 +192,11 @@ class Controller:
 
     def main(self) -> None:
         try:
+            screen = Screen()
+            screen.set_terminal_properties(colors=256)
             self.loop = urwid.MainLoop(self.view,
-                                       self.view.palette[self.theme])
-            self.loop.screen.set_terminal_properties(colors=256)
+                                       self.view.palette[self.theme],
+                                       screen=screen)
         except KeyError:
             print('Following are the themes available:')
             for theme in self.view.palette.keys():

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -1,3 +1,5 @@
+import platform
+import re
 from typing import Any, Tuple
 
 import urwid
@@ -138,3 +140,14 @@ class View(urwid.WidgetWrap):
 
         else:
             return super(View, self).keypress(size, get_key(key))
+
+
+class Screen(urwid.raw_display.Screen):
+
+    def write(self, data: Any) -> None:
+        if "Microsoft" in platform.platform():
+            # replace urwid's SI/SO, which produce artifacts under WSL.
+            # https://github.com/urwid/urwid/issues/264#issuecomment-358633735
+            # Above link describes the change.
+            data = re.sub("[\x0e\x0f]", "", data)
+        super().write(data)


### PR DESCRIPTION
Look at https://github.com/urwid/urwid/issues/264#issuecomment-358633735 for more details.