### PR TITLE
editor: Fix bugs related to `urwid_readline` library.

### DIFF
--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -127,8 +127,7 @@ class View(urwid.WidgetWrap):
 
     def keypress(self, size: Tuple[int, int], key: str) -> str:
         if self.controller.editor_mode:
-            return self.controller.editor.keypress((20,), key)
-
+            return self.controller.editor.keypress((size[1],), key)
         elif key == "w":
             # Start User Search if not in editor_mode
             self.users_view.keypress(size, 'w')

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -97,8 +97,6 @@ class WriteBox(urwid.Pile):
             self.contents[0][0].focus_col = 1
         elif key == 'left' and self.to_write_box is None:
             self.contents[0][0].focus_col = 0
-        elif key == 'enter' and self.focus == self.msg_write_box:
-            self.msg_write_box.insert_text('\n')
         key = super(WriteBox, self).keypress(size, key)
         return key
 


### PR DESCRIPTION
urwid_readline automatically inserts a new line so we don't need
to do it manually.
We should send the real size of the keypress and not the
default size.