### PR TITLE
bugfix: now-renamed register_initial_desired_events is used in model.

### DIFF
--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -22,7 +22,7 @@ class TestController:
         self.config_file = 'path/to/zuliprc'
         self.theme = 'default'
         mocker.patch('zulipterminal.core.Controller.'
-                     '_register_initial_desired_events')
+                     'register_initial_desired_events')
         return Controller(self.config_file, self.theme)
 
     def test_initialize_controller(self, controller, mocker) -> None:
@@ -33,7 +33,7 @@ class TestController:
         self.model.assert_called_once_with(controller)
         self.view.assert_called_once_with(controller)
         self.model.poll_for_events.assert_called_once_with()
-        controller._register_initial_desired_events.assert_called_once_with()
+        controller.register_initial_desired_events.assert_called_once_with()
         assert controller.theme == self.theme
 
     def test_narrow_to_stream(self, mocker, controller,

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -20,7 +20,7 @@ class Controller:
                                    client='ZulipTerminal/0.1.0 ' + platform())
         # Register to the queue before initializing Model or View
         # so that we don't lose any updates while messages are being fetched.
-        self._register_initial_desired_events()
+        self.register_initial_desired_events()
         self.model = Model(self)
         self.view = View(self)
         # Start polling for events after view is rendered.
@@ -176,7 +176,7 @@ class Controller:
         if focus_position >= 0 and focus_position < len(w_list):
             self.model.msg_list.set_focus(focus_position)
 
-    def _register_initial_desired_events(self) -> None:
+    def register_initial_desired_events(self) -> None:
         event_types = [
             'message',
             'update_message',

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -222,7 +222,7 @@ class Model:
         last_event_id = self.controller.last_event_id
         while True:
             if queue_id is None:
-                self.controller.register()
+                self.controller.register_initial_desired_events()
                 queue_id = self.controller.queue_id
                 last_event_id = self.controller.last_event_id
 


### PR DESCRIPTION
One commit in my earlier PR, I just noticed a missing external call of the function, so it should probably not have an underscore prefix, and should be called correctly from model.py.