### PR TITLE
model: Improve encapsulation of narrow

### DIFF
--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -89,6 +89,16 @@ class TestModel:
         model.set_focus_in_current_narrow(msg_id)
         assert model.index['pointer'][str(narrow)] == msg_id
 
+    @pytest.mark.parametrize('bad_args', [
+        dict(topic='some topic'),
+        dict(stream='foo', search='text'),
+        dict(topic='blah', search='text'),
+        dict(pm_with='someone', topic='foo')
+    ])
+    def test_set_narrow_bad_input(self, model, bad_args):
+        with pytest.raises(RuntimeError):
+            model.set_narrow(**bad_args)
+
     def test_success_get_messages(self, mocker, messages_successful_response,
                                   index_all_messages, initial_data):
         # Initialize Model

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -73,6 +73,22 @@ class TestModel:
         model.narrow = narrow
         assert model.get_focus_in_current_narrow() == msg_id
 
+    @pytest.mark.parametrize('msg_id', [1, 5])
+    @pytest.mark.parametrize('narrow', [
+        [],
+        [['stream', 'hello world']],
+        [['stream', 'hello world'], ['topic', "what's it all about?"]],
+        [['pm_with', 'FOO@zulip.com']],
+        [['pm_with', 'Foo@zulip.com, Bar@zulip.com']],
+        [['is', 'private']],
+    ])
+    def test_set_focus_in_current_narrow(self, mocker, model, narrow, msg_id):
+        from collections import defaultdict
+        model.index = dict(pointer=defaultdict(set))
+        model.narrow = narrow
+        model.set_focus_in_current_narrow(msg_id)
+        assert model.index['pointer'][str(narrow)] == msg_id
+
     def test_success_get_messages(self, mocker, messages_successful_response,
                                   index_all_messages, initial_data):
         # Initialize Model

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -58,6 +58,21 @@ class TestModel:
         self.classify_unread_counts.assert_called_once_with(model)
         assert model.unread_counts == []
 
+    @pytest.mark.parametrize('msg_id', [1, 5, set()])
+    @pytest.mark.parametrize('narrow', [
+        [],
+        [['stream', 'hello world']],
+        [['stream', 'hello world'], ['topic', "what's it all about?"]],
+        [['pm_with', 'FOO@zulip.com']],
+        [['pm_with', 'Foo@zulip.com, Bar@zulip.com']],
+        [['is', 'private']],
+    ])
+    def test_get_focus_in_current_narrow_individually(self,
+                                                      model, msg_id, narrow):
+        model.index = {'pointer': {str(narrow): msg_id}}
+        model.narrow = narrow
+        assert model.get_focus_in_current_narrow() == msg_id
+
     def test_success_get_messages(self, mocker, messages_successful_response,
                                   index_all_messages, initial_data):
         # Initialize Model

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -99,6 +99,19 @@ class TestModel:
         with pytest.raises(RuntimeError):
             model.set_narrow(**bad_args)
 
+    @pytest.mark.parametrize('narrow, good_args', [
+        ([], dict()),
+        ([['stream', 'some stream']], dict(stream='some stream')),
+        ([['stream', 'some stream'], ['topic', 'some topic']],
+         dict(stream='some stream', topic='some topic')),
+        ([['search', 'something interesting']],
+         dict(search='something interesting')),
+    ])
+    def test_set_narrow_already_set(self, model, narrow, good_args):
+        model.narrow = narrow
+        assert model.set_narrow(**good_args)
+        assert model.narrow == narrow
+
     def test_success_get_messages(self, mocker, messages_successful_response,
                                   index_all_messages, initial_data):
         # Initialize Model

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -112,6 +112,19 @@ class TestModel:
         assert model.set_narrow(**good_args)
         assert model.narrow == narrow
 
+    @pytest.mark.parametrize('initial_narrow, narrow, good_args', [
+        ([['stream', 'foo']], [], dict()),
+        ([], [['stream', 'some stream']], dict(stream='some stream')),
+        ([], [['stream', 'some stream'], ['topic', 'some topic']],
+         dict(stream='some stream', topic='some topic')),
+    ])
+    def test_set_narrow_not_already_set(self, model, initial_narrow, narrow,
+                                        good_args):
+        model.narrow = initial_narrow
+        assert not model.set_narrow(**good_args)
+        assert model.narrow != initial_narrow
+        assert model.narrow == narrow
+
     def test_success_get_messages(self, mocker, messages_successful_response,
                                   index_all_messages, initial_data):
         # Initialize Model

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -125,6 +125,43 @@ class TestModel:
         assert model.narrow != initial_narrow
         assert model.narrow == narrow
 
+    @pytest.mark.parametrize("narrow, index, current_ids", [
+        ([], {
+            "all_messages": {0, 1}
+        }, {0, 1}),
+        ([['stream', 'FOO']], {
+            "all_stream": {
+                1: {0, 1}
+            }
+        }, {0, 1}),
+        ([['stream', 'FOO'],
+         ['topic', 'BOO']], {
+             'stream': {
+                 1: {
+                     'BOO': {0, 1}
+                 }
+             }
+         }, {0, 1}),
+        ([['is', 'private']], {
+            'all_private': {0, 1}
+        }, {0, 1}),
+        ([['pm_with', 'FOO@zulip.com']], {
+            'private': {
+                frozenset({1, 2}): {0, 1}
+            }
+        }, {0, 1}),
+        ([['search', 'FOO']], {
+            'search': {0, 1}
+        }, {0, 1})
+    ])
+    def test_get_message_ids_in_current_narrow(self, mocker, model,
+                                               narrow, index, current_ids):
+        model.recipients = frozenset({1, 2})
+        model.stream_id = 1
+        model.narrow = narrow
+        model.index = index
+        assert current_ids == model.get_message_ids_in_current_narrow()
+
     def test_success_get_messages(self, mocker, messages_successful_response,
                                   index_all_messages, initial_data):
         # Initialize Model

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -34,27 +34,17 @@ class TestMessageView:
         assert msg_view.old_loading is False
         assert msg_view.new_loading is False
 
-    @pytest.mark.parametrize("index, focus_msg", [
-        ({
-            'pointer': {
-                "[]": set(),
-            }
-        }, 1),
-        ({
-            'pointer': {
-                "[]": 0,
-            }
-        }, 0)
+    @pytest.mark.parametrize("narrow_focus_pos, focus_msg", [
+        (set(), 1), (0, 0)
     ])
-    def test_main_view(self, mocker, index, focus_msg):
+    def test_main_view(self, mocker, narrow_focus_pos, focus_msg):
         mocker.patch(VIEWS + ".MessageView.read_message")
         self.urwid.SimpleFocusListWalker.return_value = mocker.Mock()
         mocker.patch(VIEWS + ".MessageView.set_focus")
         msg_list = ["MSG1", "MSG2"]
         mocker.patch(VIEWS + ".create_msg_box_list",
                      return_value=msg_list)
-        self.model.index = index
-        self.model.narrow = '[]'
+        self.model.get_focus_in_current_narrow.return_value = narrow_focus_pos
         msg_view = MessageView(self.model)
         assert msg_view.focus_msg == focus_msg
 

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -172,6 +172,7 @@ class Controller:
 
         if focus_position == set():
             focus_position = len(w_list) - 1
+        assert not isinstance(focus_position, set)
         self.model.msg_view.clear()
         self.model.msg_view.extend(w_list)
         if focus_position >= 0 and focus_position < len(w_list):

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -168,7 +168,8 @@ class Controller:
         self._finalize_show(w_list)
 
     def _finalize_show(self, w_list: List[Any]) -> None:
-        focus_position = self.model.index['pointer'][str(self.model.narrow)]
+        focus_position = self.model.get_focus_in_current_narrow()
+
         if focus_position == set():
             focus_position = len(w_list) - 1
         self.model.msg_view.clear()

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1,6 +1,6 @@
 import json
 import time
-from typing import Any, Dict, List, FrozenSet
+from typing import Any, Dict, List, FrozenSet, Set, Union
 
 import urwid
 
@@ -41,6 +41,13 @@ class Model:
         self.streams = self.get_subscribed_streams()
         self.muted_topics = self.initial_data['muted_topics']
         self.unread_counts = classify_unread_counts(self)
+
+    def get_focus_in_current_narrow(self) -> Union[int, Set[None]]:
+        """
+        Returns the focus in the current narrow.
+        For no existing focus this returns {}, otherwise the message ID.
+        """
+        return self.index['pointer'][str(self.narrow)]
 
     def get_messages(self, first_anchor: bool) -> Any:
         request = {

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -78,6 +78,26 @@ class Model:
         else:
             return True
 
+    def get_message_ids_in_current_narrow(self) -> Any:
+        narrow = self.narrow
+        if narrow == []:
+            current_ids = self.index['all_messages'].copy()
+        elif narrow[0][0] == 'stream':
+            stream_id = self.stream_id
+            if len(narrow) == 1:
+                current_ids = self.index['all_stream'][stream_id].copy()
+            elif len(narrow) == 2:
+                topic = narrow[1][1]
+                current_ids = self.index['stream'][stream_id][topic].copy()
+        elif narrow[0][1] == 'private':
+            current_ids = self.index['all_private'].copy()
+        elif narrow[0][0] == 'pm_with':
+            recipients = self.recipients
+            current_ids = self.index['private'][recipients].copy()
+        elif narrow[0][0] == 'search':
+            current_ids = self.index['search'].copy()
+        return current_ids
+
     def get_messages(self, first_anchor: bool) -> Any:
         request = {
             'anchor': self.anchor,

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -49,6 +49,9 @@ class Model:
         """
         return self.index['pointer'][str(self.narrow)]
 
+    def set_focus_in_current_narrow(self, focus_message: int) -> None:
+        self.index['pointer'][str(self.narrow)] = focus_message
+
     def get_messages(self, first_anchor: bool) -> Any:
         request = {
             'anchor': self.anchor,

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -78,25 +78,25 @@ class Model:
         else:
             return True
 
-    def get_message_ids_in_current_narrow(self) -> Any:
+    def get_message_ids_in_current_narrow(self) -> Set[int]:
         narrow = self.narrow
         if narrow == []:
-            current_ids = self.index['all_messages'].copy()
+            current_ids = self.index['all_messages']
         elif narrow[0][0] == 'stream':
             stream_id = self.stream_id
             if len(narrow) == 1:
-                current_ids = self.index['all_stream'][stream_id].copy()
+                current_ids = self.index['all_stream'][stream_id]
             elif len(narrow) == 2:
                 topic = narrow[1][1]
-                current_ids = self.index['stream'][stream_id][topic].copy()
+                current_ids = self.index['stream'][stream_id][topic]
         elif narrow[0][1] == 'private':
-            current_ids = self.index['all_private'].copy()
+            current_ids = self.index['all_private']
         elif narrow[0][0] == 'pm_with':
             recipients = self.recipients
-            current_ids = self.index['private'][recipients].copy()
+            current_ids = self.index['private'][recipients]
         elif narrow[0][0] == 'search':
-            current_ids = self.index['search'].copy()
-        return current_ids
+            current_ids = self.index['search']
+        return current_ids.copy()
 
     def get_messages(self, first_anchor: bool) -> Any:
         request = {

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1,6 +1,6 @@
 import json
 import time
-from typing import Any, Dict, List, FrozenSet, Set, Union
+from typing import Any, Dict, List, FrozenSet, Set, Union, Optional
 
 import urwid
 
@@ -51,6 +51,32 @@ class Model:
 
     def set_focus_in_current_narrow(self, focus_message: int) -> None:
         self.index['pointer'][str(self.narrow)] = focus_message
+
+    def set_narrow(self, *,
+                   stream: Optional[str]=None, topic: Optional[str]=None,
+                   search: Optional[str]=None,
+                   pm_with: Optional[str]=None) -> bool:
+        if search and not(stream or topic or pm_with):
+            new_narrow = [['search', search]]
+        elif stream and topic and not(search or pm_with):
+            new_narrow = [["stream", stream],
+                          ["topic", topic]]
+        elif stream and not(topic or search or pm_with):
+            new_narrow = [['stream', stream]]
+        elif pm_with == '' and not(stream or topic or search):
+            new_narrow = [['is', 'private']]
+        elif pm_with and not(stream or topic or search):
+            new_narrow = [['pm_with', pm_with]]
+        elif not stream and not topic and not search and not pm_with:
+            new_narrow = []
+        else:
+            raise RuntimeError("Model.set_narrow parameters used incorrectly.")
+
+        if new_narrow != self.narrow:
+            self.narrow = new_narrow
+            return False
+        else:
+            return True
 
     def get_messages(self, first_anchor: bool) -> Any:
         request = {

--- a/zulipterminal/ui_tools/utils.py
+++ b/zulipterminal/ui_tools/utils.py
@@ -42,7 +42,7 @@ def create_msg_box_list(model: Any, messages: Union[None, Iterable[Any]]=None,
         ))
         last_message = msg
     if focus_msg is not None:
-        model.index['pointer'][str(model.narrow)] = focus_msg
+        model.set_focus_in_current_narrow(focus_msg)
     return w_list
 
 

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -32,7 +32,7 @@ class MessageView(urwid.ListBox):
 
     def main_view(self) -> List[Any]:
         msg_btn_list = create_msg_box_list(self.model)
-        focus_msg = self.model.index['pointer'][str(self.model.narrow)]
+        focus_msg = self.model.get_focus_in_current_narrow()
         if focus_msg == set():
             focus_msg = len(msg_btn_list) - 1
         self.focus_msg = focus_msg

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -38,26 +38,6 @@ class MessageView(urwid.ListBox):
         self.focus_msg = focus_msg
         return msg_btn_list
 
-    def get_current_ids(self) -> Any:
-        narrow = self.model.narrow
-        if not narrow:
-            current_ids = self.index['all_messages'].copy()
-        elif narrow[0][0] == 'stream':
-            stream_id = self.model.stream_id
-            if len(narrow) == 1:
-                current_ids = self.index['all_stream'][stream_id].copy()
-            elif len(narrow) == 2:
-                topic = narrow[1][1]
-                current_ids = self.index['stream'][stream_id][topic].copy()
-        elif narrow[0][1] == 'private':
-            current_ids = self.index['all_private'].copy()
-        elif narrow[0][0] == 'pm_with':
-            recipients = self.model.recipients
-            current_ids = self.index['private'][recipients].copy()
-        elif narrow[0][0] == 'search':
-            current_ids = self.index['search'].copy()
-        return current_ids
-
     @async
     def load_old_messages(self, anchor: int=10000000000) -> None:
         self.old_loading = True
@@ -66,9 +46,9 @@ class MessageView(urwid.ListBox):
         # We don't want message after the current message
         self.model.num_after = 0
         self.model.num_before = 30
-        current_ids = self.get_current_ids()
+        current_ids = self.model.get_message_ids_in_current_narrow()
         self.index = self.model.get_messages(False)
-        msg_ids = self.get_current_ids() - current_ids
+        msg_ids = self.model.get_message_ids_in_current_narrow() - current_ids
         message_list = create_msg_box_list(self.model, msg_ids)
         message_list.reverse()
         for msg_w in message_list:
@@ -82,9 +62,9 @@ class MessageView(urwid.ListBox):
         self.model.anchor = anchor
         self.model.num_before = 0
         self.model.num_after = 30
-        current_ids = self.get_current_ids()
+        current_ids = self.model.get_message_ids_in_current_narrow()
         self.index = self.model.get_messages(False)
-        msg_ids = self.get_current_ids() - current_ids
+        msg_ids = self.model.get_message_ids_in_current_narrow() - current_ids
         message_list = create_msg_box_list(self.model, msg_ids)
         self.log.extend(message_list)
         self.model.controller.loop.draw_screen()

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -148,8 +148,7 @@ class MessageView(urwid.ListBox):
         if msg_w is None:
             return
         # save the current focus
-        key = str(self.model.narrow)
-        self.model.index['pointer'][key] = self.focus_position
+        self.model.set_focus_in_current_narrow(self.focus_position)
         # msg ids that have been read
         read_msg_ids = list()  # type: List[int]
         # until we find a read message above the current message


### PR DESCRIPTION
This introduces:
* `model.set_narrow`
* `model.get_focus_in_current_narrow`
* `model.set_focus_in_current_narrow`

It also migrates the `get_current_ids` method from `views.py` to `model.py`, since this is very model-specific code.

There are a few remaining accesses of `model.narrow`, but these are minor; I'd suggest a followup commit to rename `narrow` -> `_narrow` to clarify that this is intended as essentially a private variable.

Tests are also added and migrated, where applicable; other than seeking confirmation that this change seems reasonable, my concern is perhaps that I'm not using the existing test fixtures to the fullest extent, but perhaps this can be discussed further subsequently.

I've looked into further improving the encapsulation, of the index, but this is more challenging and it'd be good to get feedback on this first :)