### PR TITLE
Small window improvements

### DIFF
--- a/tests/ui/test_ui.py
+++ b/tests/ui/test_ui.py
@@ -105,9 +105,9 @@ class TestView:
         center.assert_called_once_with()
         right.assert_called_once_with()
         col.assert_called_once_with([
-            ('weight', 3, left()),
+            (25, left()),
             ('weight', 10, center()),
-            ('weight', 3, right()),
+            (25, right()),
         ], focus_column=1)
         assert view.body == col()
         line_box.assert_called_once_with(view.body, title=u"Zulip")

--- a/tests/ui/test_ui.py
+++ b/tests/ui/test_ui.py
@@ -99,18 +99,31 @@ class TestView:
         center = mocker.patch('zulipterminal.ui.View.message_view')
         right = mocker.patch('zulipterminal.ui.View.right_column_view')
         col = mocker.patch("zulipterminal.ui.urwid.Columns")
-        line_box = mocker.patch('zulipterminal.ui.urwid.LineBox')
+        frame = mocker.patch('zulipterminal.ui.urwid.Frame')
+        title_divider = mocker.patch('zulipterminal.ui.urwid.Divider')
+        text = mocker.patch('zulipterminal.ui.urwid.Text')
+
         view = View(self.controller)
+
         left.assert_called_once_with()
         center.assert_called_once_with()
         right.assert_called_once_with()
-        col.assert_called_once_with([
-            (25, left()),
-            ('weight', 10, center()),
-            (25, right()),
-        ], focus_column=1)
+        expected_column_calls = [
+            mocker.call([
+                (25, left()),
+                ('weight', 10, center()),
+                (25, right()),
+                ], focus_column=1),
+            mocker.call([
+                title_divider(),
+                (7, text()),
+                title_divider(),
+                ])
+        ]
+        col.assert_has_calls(expected_column_calls)
+
         assert view.body == col()
-        line_box.assert_called_once_with(view.body, title=u"Zulip")
+        frame.assert_called_once_with(view.body, col(), focus_part='body')
 
     def test_keypress(self, view, mocker):
         view.users_view = mocker.Mock()

--- a/tests/ui/test_ui.py
+++ b/tests/ui/test_ui.py
@@ -103,6 +103,15 @@ class TestView:
         title_divider = mocker.patch('zulipterminal.ui.urwid.Divider')
         text = mocker.patch('zulipterminal.ui.urwid.Text')
 
+        full_name = "Bob James"
+        email = "Bob@bob.com"
+        server = "https://chat.zulip.zulip"
+
+        mocker.patch('zulipterminal.core.Controller.client.get_profile',
+                     return_value=dict(full_name=full_name, email=email))
+        self.controller.client.base_url = server
+        title_length = (len(email) + len(full_name) + len(server) + 9)
+
         view = View(self.controller)
 
         left.assert_called_once_with()
@@ -116,7 +125,7 @@ class TestView:
                 ], focus_column=1),
             mocker.call([
                 title_divider(),
-                (7, text()),
+                (title_length, text()),
                 title_divider(),
                 ])
         ]

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -118,9 +118,9 @@ class View(urwid.WidgetWrap):
         center_column = self.message_view()
         right_column = self.right_column_view()
         body = [
-            ('weight', 3, left_column),
+            (25, left_column),
             ('weight', 10, center_column),
-            ('weight', 3, right_column),
+            (25, right_column),
         ]
         self.body = urwid.Columns(body, focus_column=1)
         w = urwid.LineBox(self.body, title=u"Zulip")

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -1,5 +1,6 @@
 import platform
 import re
+from urllib.parse import urlparse
 from typing import Any, Tuple
 
 import urwid
@@ -125,11 +126,19 @@ class View(urwid.WidgetWrap):
         self.body = urwid.Columns(body, focus_column=1)
 
         div_char = '═'
+        profile = self.controller.client.get_profile()
+
+        base_url = '{uri.scheme}://{uri.netloc}/'.format(
+                uri=urlparse(self.controller.client.base_url))
+
+        title_text = " {full_name} ({email}) - {server} ".format(
+                server=base_url, **profile)
         title_bar = urwid.Columns([
             urwid.Divider(div_char=div_char),
-            (7, urwid.Text([u" Zulip "])),
+            (len(title_text), urwid.Text([title_text])),
             urwid.Divider(div_char=div_char),
         ])
+
         w = urwid.Frame(self.body, title_bar, focus_part='body')
         return w
 

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -123,7 +123,14 @@ class View(urwid.WidgetWrap):
             (25, right_column),
         ]
         self.body = urwid.Columns(body, focus_column=1)
-        w = urwid.LineBox(self.body, title=u"Zulip")
+
+        div_char = '═'
+        title_bar = urwid.Columns([
+            urwid.Divider(div_char=div_char),
+            (7, urwid.Text([u" Zulip "])),
+            urwid.Divider(div_char=div_char),
+        ])
+        w = urwid.Frame(self.body, title_bar, focus_part='body')
         return w
 
     def keypress(self, size: Tuple[int, int], key: str) -> str:

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -9,7 +9,7 @@ class MenuButton(urwid.Button):
         self.email = email
         super(MenuButton, self).__init__("")
         self._w = urwid.AttrMap(urwid.SelectableIcon(
-            [u'    ', self.caption], 0), None, 'selected')
+            [self.caption], 0), None, 'selected')
 
 
 class HomeButton(urwid.Button):
@@ -28,8 +28,8 @@ class HomeButton(urwid.Button):
         if count <= 0:
             count = ''  # type: ignore
         return urwid.AttrMap(urwid.SelectableIcon(
-            [u'  🏡 ', self.caption, ('idle', ' ' + str(count))],
-            len(self.caption) + 5),
+            [u' 🏡 ', self.caption, ('idle', ' ' + str(count))],
+            len(self.caption) + 4),
             None,
             'selected')
 
@@ -50,8 +50,8 @@ class PMButton(urwid.Button):
         if count <= 0:
             count = ''  # type: ignore
         return urwid.AttrMap(urwid.SelectableIcon(
-            [u'  💬 ', self.caption, ('idle', ' ' + str(count))],
-            len(self.caption) + 5),
+            [u' 💬 ', self.caption, ('idle', ' ' + str(count))],
+            len(self.caption) + 4),
             None,
             'selected')
 
@@ -80,8 +80,8 @@ class StreamButton(urwid.Button):
         if count <= 0:
             count = ''  # type: ignore
         return urwid.AttrMap(urwid.SelectableIcon(
-            [(self.color, u'  # '), self.caption, ('idle', ' ' + str(count))],
-            len(self.caption) + 4),
+            [(self.color, u'# '), self.caption, ('idle', ' ' + str(count))],
+            len(self.caption) + 2),
             None,
             'selected')
 
@@ -109,8 +109,8 @@ class UserButton(urwid.Button):
         if count <= 0:
             count = ''  # type: ignore
         return urwid.AttrMap(urwid.SelectableIcon(
-            [u'  \N{BULLET}  ', self.caption, ('idle', ' ' + str(count))],
-            len(self.caption) + 5),
+            [u'\N{BULLET} ', self.caption, ('idle', ' ' + str(count))],
+            len(self.caption) + 2),
             self.color,
             'selected')
 

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -25,10 +25,9 @@ class HomeButton(urwid.Button):
         self._w = self.widget(count)
 
     def widget(self, count: int) -> Any:
-        if count <= 0:
-            count = ''  # type: ignore
         return urwid.AttrMap(urwid.SelectableIcon(
-            [u' 🏡 ', self.caption, ('idle', ' ' + str(count))],
+            [u' 🏡 ', self.caption,
+             ('idle', '' if count <= 0 else ' ' + str(count))],
             len(self.caption) + 4),
             None,
             'selected')
@@ -47,10 +46,9 @@ class PMButton(urwid.Button):
         self._w = self.widget(count)
 
     def widget(self, count: int) -> Any:
-        if count <= 0:
-            count = ''  # type: ignore
         return urwid.AttrMap(urwid.SelectableIcon(
-            [u' 💬 ', self.caption, ('idle', ' ' + str(count))],
+            [u' 💬 ', self.caption,
+             ('idle', '' if count <= 0 else ' ' + str(count))],
             len(self.caption) + 4),
             None,
             'selected')
@@ -77,10 +75,9 @@ class StreamButton(urwid.Button):
         self._w = self.widget(count)
 
     def widget(self, count: int) -> Any:
-        if count <= 0:
-            count = ''  # type: ignore
         return urwid.AttrMap(urwid.SelectableIcon(
-            [(self.color, u'# '), self.caption, ('idle', ' ' + str(count))],
+            [(self.color, u'# '), self.caption,
+             ('idle', '' if count <= 0 else ' ' + str(count))],
             len(self.caption) + 2),
             None,
             'selected')
@@ -106,10 +103,9 @@ class UserButton(urwid.Button):
         self._w = self.widget(count)
 
     def widget(self, count: int) -> Any:
-        if count <= 0:
-            count = ''  # type: ignore
         return urwid.AttrMap(urwid.SelectableIcon(
-            [u'\N{BULLET} ', self.caption, ('idle', ' ' + str(count))],
+            [u'\N{BULLET} ', self.caption,
+             ('idle', '' if count <= 0 else ' ' + str(count))],
             len(self.caption) + 2),
             self.color,
             'selected')


### PR DESCRIPTION
These commits make incremental changes to ensure that when the window is "small", that various small features are visible; these are not optimal, but appear to be an improvement over the current state.

These include:
* Removing text insets in the streams and user windows, and the MenuButtons
* Simplifying the post-user text to avoid extra spaces
* Fixing the left and right columns to a semi-arbitrary fixed-25 width (which shows most chat.zulip.org streams, and most names, without wrapping)
* Using a `Frame` rather than a `LineBox` for the 'main window' (saves a few characters)

I also included an update to the last commit to show the 'connection', ie. name/email/server, rather than 'Zulip'. I'm not sure if some of this belongs in the View, or if the text should be prefaced with 'Zulip-terminal' or similar, but this also seemed an improvement :)

I'm wondering if 'All Messages' should be moved down (or the line between it and private removed), but I'm not sure - thoughts?

The following are at ~80x25, for larger widths then the slightly narrower messages-window width arising from these changes is less significant, and I'm not sure we're really targeting 80x25? Though perhaps we should discuss what we want to support, minimally.

Current state, at ~80x25:
![80x25_old](https://user-images.githubusercontent.com/9568999/42424723-06580744-82c6-11e8-8827-d5767ee0820c.png)

After commits, at ~80x25:
![80x25_new](https://user-images.githubusercontent.com/9568999/42424728-1ae7f818-82c6-11e8-8e73-99def1d2f769.png)