### PR TITLE
Improve messages output (MessageBox)

### DIFF
--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 from time import ctime
+from datetime import datetime
 from typing import Any, Dict, List, Tuple, Union
 
 import emoji
@@ -200,10 +201,16 @@ class MessageBox(urwid.Pile):
         content = urwid.Text(content)
 
         time = urwid.Text((self._time_for_message()), align='right')
-        if header is not None or (
-                self.last_message['sender_full_name'] !=
-                self.message['sender_full_name']):
-            # Include (author) name if different stream/topic or author
+        # Include (author) name with message time for various reasons:
+        include_author = (
+            header is not None or
+            (self.last_message['sender_full_name'] !=
+             self.message['sender_full_name']) or
+            ('timestamp' in self.last_message and
+                (datetime.fromtimestamp(self.message['timestamp']) -
+                 datetime.fromtimestamp(self.last_message['timestamp'])).days)
+        )
+        if include_author:
             author = urwid.Text([('name', self.message['sender_full_name'])])
             author_and_time = urwid.Columns([author, time])
         else:

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -117,6 +117,9 @@ class MessageBox(urwid.Pile):
             self.last_message = defaultdict(dict)
         super(MessageBox, self).__init__(self.main_view())
 
+    def _time_for_message(self) -> str:
+        return ctime(self.message['timestamp'])[:-8]
+
     def stream_view(self) -> Any:
         self.caption = self.message['display_recipient']
         self.stream_id = self.message['stream_id']
@@ -125,9 +128,7 @@ class MessageBox(urwid.Pile):
         # as current message
         if self.title == self.last_message['subject'] and\
                 self.last_message['type'] == 'stream':
-            return urwid.Text(
-                (None, ctime(self.message['timestamp'])[:-8]),
-                align='right')
+            return urwid.Text((None, self._time_for_message()), align='right')
         bar_color = self.model.stream_dict[self.stream_id]['color']
         bar_color = 's' + bar_color[:2] + bar_color[3] + bar_color[5]
         stream_title = (bar_color, [
@@ -136,8 +137,7 @@ class MessageBox(urwid.Pile):
             (bar_color, self.title)
         ])
         stream_title = urwid.Text(stream_title)
-        time = urwid.Text((bar_color, ctime(self.message['timestamp'])[:-8]),
-                          align='right')
+        time = urwid.Text((bar_color, self._time_for_message()), align='right')
         header = urwid.Columns([
             stream_title,
             time,
@@ -157,9 +157,7 @@ class MessageBox(urwid.Pile):
         if len(recipient_ids) == 2 and\
                 recipient_ids[0] == recipient_ids[1] and\
                 self.last_message['type'] == 'private':
-            return urwid.Text(
-                ('time', ctime(self.message['timestamp'])[:-8]),
-                align='right')
+            return urwid.Text((None, self._time_for_message()), align='right')
         self.recipients = ', '.join(list(
             recipient['full_name']
             for recipient in self.message['display_recipient']
@@ -171,8 +169,7 @@ class MessageBox(urwid.Pile):
             ('custom', self.recipients)
         ])
         title = urwid.Text(title)
-        time = urwid.Text(('custom', ctime(self.message['timestamp'])[:-8]),
-                          align='right')
+        time = urwid.Text(('custom', self._time_for_message()), align='right')
         header = urwid.Columns([
             title,
             time,

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -199,9 +199,15 @@ class MessageBox(urwid.Pile):
         content = [emoji.demojize(self.message['content'])]
         content = urwid.Text(content)
 
-        author = urwid.Text([('name', self.message['sender_full_name'])])
         time = urwid.Text((self._time_for_message()), align='right')
-        author_and_time = urwid.Columns([author, time])
+        if header is not None or (
+                self.last_message['sender_full_name'] !=
+                self.message['sender_full_name']):
+            # Include (author) name if different stream/topic or author
+            author = urwid.Text([('name', self.message['sender_full_name'])])
+            author_and_time = urwid.Columns([author, time])
+        else:
+            author_and_time = time
 
         view = [header, author_and_time, content, reactions]
         if reactions == '':


### PR DESCRIPTION
This broadly improves the layout of the central window, at least to my eye, by:
* shifting the date in line with the author-name (sender)
* omitting repeated author-names, where people send messages without another author replying

This also saves vertical space, through the first change, which was one original motivation.

The first commit is less necessary now, since the time is in the `main_view` method, but I still think is a reasonable functionality to extract.

Please give this a try to see the change in layout.