### PR TITLE
Add private recipient grouping

### DIFF
--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -83,6 +83,7 @@ class TestController:
         assert {widget.original_widget.message['id']} == id_list
 
     def test_narrow_to_user(self, mocker, controller, user_button, index_user):
+        controller.model.client = self.client
         controller.model.narrow = []
         controller.model.index = index_user
         controller.model.msg_view = mocker.patch('urwid.SimpleFocusListWalker')
@@ -104,6 +105,7 @@ class TestController:
         assert {widget.original_widget.message['id']} == id_list
 
     def test_show_all_messages(self, mocker, controller, index_all_messages):
+        controller.model.client = self.client
         controller.model.narrow = [['stream', 'PTEST']]
         controller.model.index = index_all_messages
         controller.model.msg_view = mocker.patch('urwid.SimpleFocusListWalker')
@@ -126,6 +128,7 @@ class TestController:
         assert msg_ids == id_list
 
     def test_show_all_pm(self, mocker, controller, index_user):
+        controller.model.client = self.client
         controller.model.narrow = []
         controller.model.index = index_user
         controller.model.msg_view = mocker.patch('urwid.SimpleFocusListWalker')

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -162,9 +162,10 @@ class MessageBox(urwid.Pile):
         self.recipients = ', '.join(list(
             recipient['full_name']
             for recipient in self.message['display_recipient']
+            if recipient['email'] != self.model.client.email
         ))
         title = ('header', [
-            ('custom', 'Private Message'),
+            ('custom', 'Private Messages with'),
             ('selected', ": "),
             ('custom', self.recipients)
         ])

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -147,7 +147,14 @@ class MessageBox(urwid.Pile):
     def private_view(self) -> Any:
         self.email = self.message['sender_email']
         self.user_id = self.message['sender_id']
-        if self.user_id == self.last_message['sender_id'] and\
+
+        recipient_ids = [{recipient['id']
+                          for recipient in message['display_recipient']
+                          if 'id' in recipient}
+                         for message in (self.message, self.last_message)
+                         if 'display_recipient' in message]
+        if len(recipient_ids) == 2 and\
+                recipient_ids[0] == recipient_ids[1] and\
                 self.last_message['type'] == 'private':
             return urwid.Text(
                 ('time', ctime(self.message['timestamp'])[:-8]),


### PR DESCRIPTION
This does for private messages, what already exists for streams/topics, ie. combining conversation 'titles', as well as removing the user's name from the conversation to make it clearer.