### PR TITLE
ui: Clear screen for any distortions after loop draws screen.

### DIFF
--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -78,6 +78,7 @@ def set_count(id_list: List[int], controller: Any, new_count: int) -> None:
     while not hasattr(controller, 'loop'):
         time.sleep(0.1)
     controller.loop.draw_screen()
+    controller.loop.screen.clear()
 
 
 @async

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -246,6 +246,7 @@ class Model:
 
             set_count([response['id']], self.controller, 1)
             self.controller.loop.draw_screen()
+            self.controller.loop.screen.clear()
 
     def update_message(self, response: Dict[str, Any]) -> None:
         """
@@ -298,6 +299,7 @@ class Model:
                 msg_pos = self.msg_list.log.index(msg_w)
                 self.msg_list.log[msg_pos] = new_msg_w
                 self.controller.loop.draw_screen()
+                self.controller.loop.screen.clear()
 
     @async
     def poll_for_events(self) -> None:

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -58,6 +58,7 @@ class MessageView(urwid.ListBox):
         for msg_w in message_list:
             self.log.insert(0, msg_w)
         self.model.controller.loop.draw_screen()
+        self.model.controller.loop.screen.clear()
         self.old_loading = False
 
     @async
@@ -72,6 +73,7 @@ class MessageView(urwid.ListBox):
         message_list = create_msg_box_list(self.model, msg_ids)
         self.log.extend(message_list)
         self.model.controller.loop.draw_screen()
+        self.model.controller.loop.screen.clear()
         self.new_loading = False
 
     def mouse_event(self, size: Any, event: str, button: int, col: int,
@@ -194,7 +196,7 @@ class StreamsView(urwid.Frame):
                 streams_display.remove(stream)
         self.log.clear()
         self.log.extend(streams_display)
-        self.view.controller.loop.draw_screen()
+        self.view.controller.loop.screen.clear()
         self.search_lock.release()
 
     def mouse_event(self, size: Any, event: str, button: int, col: int,
@@ -219,6 +221,7 @@ class StreamsView(urwid.Frame):
             self.log.extend(self.streams_btn_list)
             self.set_focus('body')
             self.view.controller.loop.draw_screen()
+            self.view.controller.loop.screen.clear()
             return key
         return super(StreamsView, self).keypress(size, key)
 
@@ -373,6 +376,7 @@ class RightColumnView(urwid.Frame):
             urwid.SimpleFocusListWalker(users_display))
         self.set_body(self.body)
         self.view.controller.loop.draw_screen()
+        self.view.controller.loop.screen.clear()
         self.search_lock.release()
 
     def users_view(self) -> Any:
@@ -405,6 +409,7 @@ class RightColumnView(urwid.Frame):
             self.set_body(self.body)
             self.set_focus('body')
             self.view.controller.loop.draw_screen()
+            self.view.controller.loop.screen.clear()
             return key
         return super(RightColumnView, self).keypress(size, key)
 


### PR DESCRIPTION
This corrects many of the distortions in the which appear
when ZT updates widgets. There are still some distortions left
with user search which need to be investigated further.