### PR TITLE
ui: Remove distortions in ui by running draw_screen in main thread.

### DIFF
--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -382,7 +382,7 @@ class TestModel:
         model.update_message(response)
         assert model.index['messages'][1]['content'] == response['content']
         assert model.msg_list.log[0] == mock_msg
-        self.controller.loop.draw_screen.assert_called_once_with()
+        self.controller.update_screen.assert_called_once_with()
 
         # TEST FOR FALSE CASES
         model.index['messages'][1] = {}
@@ -441,7 +441,7 @@ class TestModel:
         model.update_reaction(response)
         update_emoji = model.index['messages'][1]['reactions'][1]['emoji_code']
         assert update_emoji == response['emoji_code']
-        self.controller.loop.draw_screen.assert_called_once_with()
+        self.controller.update_screen.assert_called_once_with()
 
         # TEST FOR FALSE CASES
         model.index['messages'][1] = {}

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -64,7 +64,7 @@ class TestMessageView:
         assert msg_view.model.num_before == 30
         assert msg_view.index == {}
         create_msg_box_list.assert_called_once_with(msg_view.model, set())
-        self.model.controller.loop.draw_screen.assert_called_once_with()
+        self.model.controller.update_screen.assert_called_once_with()
 
     def test_load_new_messages(self, mocker, msg_view):
         mocker.patch.object(msg_view.model,
@@ -81,7 +81,7 @@ class TestMessageView:
         assert msg_view.index == {}
         msg_view.log.extend.assert_called_once_with(['M1', 'M2'])
         create_msg_box_list.assert_called_once_with(msg_view.model, set())
-        self.model.controller.loop.draw_screen.assert_called_once_with()
+        self.model.controller.update_screen.assert_called_once_with()
 
     @pytest.mark.parametrize("event, button, keypress", [
         ("mouse press", 4, "up"),

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -1,5 +1,6 @@
 from platform import platform
 from typing import Any, List
+import os
 
 import urwid
 import zulip
@@ -30,6 +31,13 @@ class Controller:
         self.theme = theme
         self.editor_mode = False  # type: bool
         self.editor = None  # type: Any
+
+    def update_screen(self) -> None:
+        # Write something to update pipe to trigger draw_screen
+        os.write(self.update_pipe, b'1')
+
+    def draw_screen(self, *args: Any, **kwargs: Any) -> None:
+        self.loop.draw_screen()
 
     def show_help(self) -> None:
         self.loop.widget = urwid.LineBox(urwid.Overlay(
@@ -214,6 +222,7 @@ class Controller:
             self.loop = urwid.MainLoop(self.view,
                                        self.view.palette[self.theme],
                                        screen=screen)
+            self.update_pipe = self.loop.watch_pipe(self.draw_screen)
         except KeyError:
             print('Following are the themes available:')
             for theme in self.view.palette.keys():

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -77,7 +77,7 @@ def set_count(id_list: List[int], controller: Any, new_count: int) -> None:
 
     while not hasattr(controller, 'loop'):
         time.sleep(0.1)
-    controller.loop.draw_screen()
+    controller.update_screen()
 
 
 @async

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -245,7 +245,7 @@ class Model:
                     self.msg_list.log.append(msg_w)
 
             set_count([response['id']], self.controller, 1)
-            self.controller.loop.draw_screen()
+            self.controller.update_screen()
 
     def update_message(self, response: Dict[str, Any]) -> None:
         """
@@ -297,7 +297,7 @@ class Model:
                     new_msg_w = msg_w_list[0]
                 msg_pos = self.msg_list.log.index(msg_w)
                 self.msg_list.log[msg_pos] = new_msg_w
-                self.controller.loop.draw_screen()
+                self.controller.update_screen()
 
     @async
     def poll_for_events(self) -> None:

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -59,7 +59,7 @@ class MessageView(urwid.ListBox):
         message_list.reverse()
         for msg_w in message_list:
             self.log.insert(0, msg_w)
-        self.model.controller.loop.draw_screen()
+        self.model.controller.update_screen()
         self.old_loading = False
 
     @async
@@ -73,7 +73,7 @@ class MessageView(urwid.ListBox):
         msg_ids = self.model.get_message_ids_in_current_narrow() - current_ids
         message_list = create_msg_box_list(self.model, msg_ids)
         self.log.extend(message_list)
-        self.model.controller.loop.draw_screen()
+        self.model.controller.update_screen()
         self.new_loading = False
 
     def mouse_event(self, size: Any, event: str, button: int, col: int,
@@ -196,7 +196,7 @@ class StreamsView(urwid.Frame):
                 streams_display.remove(stream)
         self.log.clear()
         self.log.extend(streams_display)
-        self.view.controller.loop.draw_screen()
+        self.view.controller.update_screen()
         self.search_lock.release()
 
     def mouse_event(self, size: Any, event: str, button: int, col: int,
@@ -220,7 +220,7 @@ class StreamsView(urwid.Frame):
             self.log.clear()
             self.log.extend(self.streams_btn_list)
             self.set_focus('body')
-            self.view.controller.loop.draw_screen()
+            self.view.controller.update_screen()
             return key
         return super(StreamsView, self).keypress(size, key)
 
@@ -374,7 +374,7 @@ class RightColumnView(urwid.Frame):
         self.body = UsersView(
             urwid.SimpleFocusListWalker(users_display))
         self.set_body(self.body)
-        self.view.controller.loop.draw_screen()
+        self.view.controller.update_screen()
         self.search_lock.release()
 
     def users_view(self) -> Any:
@@ -406,7 +406,7 @@ class RightColumnView(urwid.Frame):
                 urwid.SimpleFocusListWalker(self.users_btn_list))
             self.set_body(self.body)
             self.set_focus('body')
-            self.view.controller.loop.draw_screen()
+            self.view.controller.update_screen()
             return key
         return super(RightColumnView, self).keypress(size, key)
 


### PR DESCRIPTION
Running MainLoop.draw_screen in a  threaded process distorts the
screen. Setting up pipe method to always run draw_screen in
main thread removes all distortions.