### PR TITLE
Add initial support for reactions via '+' key for thumbs_up.

### DIFF
--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -162,6 +162,38 @@ class TestModel:
         model.index = index
         assert current_ids == model.get_message_ids_in_current_narrow()
 
+    @pytest.mark.parametrize("msg_id, existing_reactions, expected_method", [
+        (5, [], 'POST'),
+        (5, [dict(user='me', emoji_code='1f44d')], 'DELETE'),
+        (5, [dict(user='not me', emoji_code='1f44d')], 'POST'),
+        (5, [dict(user='me', emoji_code='1f614')], 'POST'),
+        (5, [dict(user='not me', emoji_code='1f614')], 'POST'),
+    ])
+    def test_react_to_message_with_thumbs_up(self, model,
+                                             msg_id,
+                                             existing_reactions,
+                                             expected_method):
+        full_existing_reactions = [dict(er, user=dict(user_id=model.user_id
+                                                      if er['user'] == 'me'
+                                                      else model.user_id+1))
+                                   for er in existing_reactions]
+        message = dict(
+            id=msg_id,
+            reactions=full_existing_reactions)
+        reaction_spec = dict(
+            emoji_name='thumbs_up',
+            reaction_type='unicode_emoji',
+            emoji_code='1f44d')
+        model.react_to_message(message, 'thumbs_up')
+        model.client.call_endpoint.assert_called_once_with(
+            url='messages/{}/reactions'.format(msg_id),
+            method=expected_method,
+            request=reaction_spec)
+
+    def test_react_to_message_for_not_thumbs_up(self, model):
+        with pytest.raises(AssertionError):
+            model.react_to_message(dict(), 'x')
+
     def test_success_get_messages(self, mocker, messages_successful_response,
                                   index_all_messages, initial_data):
         self.client.register.return_value = initial_data

--- a/zulipterminal/config.py
+++ b/zulipterminal/config.py
@@ -99,7 +99,11 @@ KEY_BINDINGS = {
     'TAB': {
         'keys': {'tab'},
         'help_text': 'Toggle focus box in compose box'
-    }
+    },
+    'THUMBS_UP': {
+        'keys': {'+'},
+        'help_text': 'Add/remove thumbs-up reaction on a message',
+    },
 }
 
 

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -111,6 +111,30 @@ class Model:
             current_ids = self.index['search']
         return current_ids.copy()
 
+    @async
+    def react_to_message(self,
+                         message: Dict[str, Any],
+                         reaction_to_toggle: str) -> None:
+        # FIXME Only support thumbs_up for now
+        assert reaction_to_toggle == 'thumbs_up'
+
+        endpoint = 'messages/{}/reactions'.format(message['id'])
+        reaction_to_toggle_spec = dict(
+            emoji_name='thumbs_up',
+            reaction_type='unicode_emoji',
+            emoji_code='1f44d')
+        existing_reactions = [reaction['emoji_code']
+                              for reaction in message['reactions']
+                              if ('user_id' in reaction['user'] and
+                                  reaction['user']['user_id'] == self.user_id)]
+        if reaction_to_toggle_spec['emoji_code'] in existing_reactions:
+            method = 'DELETE'
+        else:
+            method = 'POST'
+        response = self.client.call_endpoint(url=endpoint,
+                                             method=method,
+                                             request=reaction_to_toggle_spec)
+
     def get_messages(self, first_anchor: bool) -> Any:
         request = {
             'anchor': self.anchor,

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -125,6 +125,11 @@ class MessageView(urwid.ListBox):
             else:
                 return super(MessageView, self).keypress(size, 'page down')
 
+        elif is_command_key('THUMBS_UP', key):
+            self.model.react_to_message(self.focus.original_widget.message,
+                                        reaction_to_toggle='thumbs_up')
+            return key
+
         key = super(MessageView, self).keypress(size, key)
         return key
 


### PR DESCRIPTION
This first stab at 'thumbs_up' works, but as with other cases of new messages being added to the message-view, doesn't quite update the view properly each time in ZT.