### PR TITLE
boxes: Remove excess spacing in message display for wide screens.

### DIFF
--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -196,7 +196,7 @@ class MessageBox(urwid.Pile):
             return urwid.Padding(
                 urwid.Text(([
                     ('emoji', emoji.demojize(emojis + custom_emojis))
-                ])), align='left', width=('relative', 50), left=35,
+                ])), align='left', width=('relative', 90), left=25,
                 min_width=50)
         except Exception:
             return ''
@@ -211,7 +211,7 @@ class MessageBox(urwid.Pile):
 
         content = [emoji.demojize(self.message['content'])]
         content = urwid.Padding(urwid.Text(content),
-                                align='left', width=('relative', 50), left=35,
+                                align='left', width=('relative', 90), left=25,
                                 min_width=50)
 
         message_author = self.message['sender_full_name']


### PR DESCRIPTION
These figures are a little too embedded for my liking, but for now they make the wider-screen behavior much less cramped, while retaining more spacing than before.