### PR TITLE
boxes: Show topic changes by bar background & surrounding spaces.

### DIFF
--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -33,7 +33,7 @@ class View(urwid.WidgetWrap):
             ('idle',         'yellow',        'black'),
             ('title',        'white, bold',   'black'),
             ('time',         'light blue', 'black'),
-            ('bar',          'white',         'black'),
+            ('bar',          'white',         'dark gray'),
             ('emoji',        'light magenta', 'black'),
         ],
         'light': [

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -139,9 +139,8 @@ class MessageBox(urwid.Pile):
         bar_color = self.model.stream_dict[self.stream_id]['color']
         bar_color = 's' + bar_color[:2] + bar_color[3] + bar_color[5]
         stream_title_markup = ('bar', [
-            (bar_color, self.caption),
-            (None, '>'),
-            ('title', self.title)
+            (bar_color, '{} >'.format(self.caption)),
+            ('title', ' {} '.format(self.title))
         ])
         stream_title = urwid.Text(stream_title_markup)
         header = urwid.AttrWrap(stream_title, 'bar')


### PR DESCRIPTION
This spaces out the topic slightly from the stream and the dividing '>' character, adds a space after the topic, and then styles the 'bar'.

This is intended to bring back some of the topic separation/heading styling, but maintaining the stream/topic styling distinction.