### PR TITLE
message_view: Keep the focus widget in center of the view.

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -100,17 +100,20 @@ class TestMessageView:
         key = "down"
         msg_view.new_loading = False
         mocker.patch(VIEWS + ".MessageView.focus_position", return_value=0)
+        mocker.patch(VIEWS + ".MessageView.set_focus_valign")
         msg_view.log.next_position.return_value = 1
         msg_view.keypress(size, key)
         msg_view.log.next_position.assert_called_once_with(
             msg_view.focus_position)
         msg_view.set_focus.assert_called_with(1, 'above')
+        msg_view.set_focus_valign.assert_called_once_with('middle')
 
     def test_keypress_down_key_exception(self, mocker, msg_view):
         size = (20,)
         key = "down"
         msg_view.new_loading = False
         mocker.patch(VIEWS + ".MessageView.focus_position", return_value=0)
+        mocker.patch(VIEWS + ".MessageView.set_focus_valign")
 
         # Raise exception
         msg_view.log.next_position = Exception()
@@ -131,17 +134,20 @@ class TestMessageView:
         key = "up"
         size = (20,)
         mocker.patch(VIEWS + ".MessageView.focus_position", return_value=0)
+        mocker.patch(VIEWS + ".MessageView.set_focus_valign")
         msg_view.old_loading = False
         msg_view.log.prev_position.return_value = 1
         msg_view.keypress(size, key)
         msg_view.log.prev_position.assert_called_once_with(
             msg_view.focus_position)
         msg_view.set_focus.assert_called_with(1, 'below')
+        msg_view.set_focus_valign.assert_called_once_with('middle')
 
     def test_keypress_up_raise_exception(self, mocker, msg_view):
         key = "up"
         size = (20,)
         mocker.patch(VIEWS + ".MessageView.focus_position", return_value=0)
+        mocker.patch(VIEWS + ".MessageView.set_focus_valign")
         msg_view.old_loading = False
 
         # Raise exception

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -93,6 +93,8 @@ class MessageView(urwid.ListBox):
             try:
                 position = self.log.next_position(self.focus_position)
                 self.set_focus(position, 'above')
+                self.set_focus_valign('middle')
+
                 return key
             except Exception:
                 if self.focus:
@@ -104,6 +106,7 @@ class MessageView(urwid.ListBox):
             try:
                 position = self.log.prev_position(self.focus_position)
                 self.set_focus(position, 'below')
+                self.set_focus_valign('middle')
                 return key
             except Exception:
                 if self.focus:


### PR DESCRIPTION
This helps user to read content more easily.