### PR TITLE
presence: Update user presence every minute.

### DIFF
--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -15,6 +15,7 @@ class TestModel:
                                        return_value=None)
         self.client = mocker.patch('zulipterminal.core.'
                                    'Controller.client')
+        mocker.patch('zulipterminal.model.Model.update_presence')
 
     @pytest.fixture
     def model(self, mocker, initial_data, user_profile):

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -43,6 +43,8 @@ class Model:
         self.streams = self.get_subscribed_streams()
         self.muted_topics = self.initial_data['muted_topics']
         self.unread_counts = classify_unread_counts(self)
+        self.new_user_input = True
+        self.update_presence()
 
     @async
     def _update_user_id(self) -> None:
@@ -110,6 +112,20 @@ class Model:
         elif narrow[0][0] == 'search':
             current_ids = self.index['search']
         return current_ids.copy()
+
+    @async
+    def update_presence(self) -> None:
+        # TODO: update response in user list.
+        response = self.client.call_endpoint(
+            url='users/me/presence',
+            request={
+                'status': 'active',
+                'new_user_input': self.new_user_input,
+            }
+        )
+        self.new_user_input = False
+        time.sleep(60)
+        self.update_presence()
 
     @async
     def react_to_message(self,

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -144,6 +144,7 @@ class View(urwid.WidgetWrap):
         self.body.focus_col = 1
 
     def keypress(self, size: Tuple[int, int], key: str) -> str:
+        self.model.new_user_input = True
         if self.controller.editor_mode:
             return self.controller.editor.keypress((size[1],), key)
         # Redirect commands to message_view.


### PR DESCRIPTION
Set new_user_input to `False` after every request.
Set new_user_input to `True` on any keypress catched by urwid.