### PR TITLE
Mark private streams

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -214,6 +214,22 @@ def initial_data():
             'email_address': '',
             'color': '#c2c2c2',
             'in_home_view': True
+        }, {
+            # This is a private stream;
+            # only description/stream_id/invite_only/name/color vary from above
+            'audible_notifications': False,
+            'description': 'Some private stream',
+            'stream_id': 99,
+            'is_old_stream': True,
+            'desktop_notifications': False,
+            'pin_to_top': False,
+            'stream_weekly_traffic': 53,
+            'invite_only': True,
+            'name': 'Secret stream',
+            'push_notifications': False,
+            'email_address': '',
+            'color': '#c3c3c3',
+            'in_home_view': True
         }],
         'msg': '',
         'max_message_id': 552761,
@@ -683,5 +699,6 @@ def streams():
     """
     return [
         ['Django', 86, '#94c849', False],
-        ['GSoC', 14, '#c2c2c2', False]
+        ['GSoC', 14, '#c2c2c2', False],
+        ['Secret stream', 99, '#c3c3c3', True],
     ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,7 +31,7 @@ def stream_button(mocker):
     Mocked stream button.
     """
     button = StreamButton(
-        properties=['PTEST', 205, '#bfd56f'],
+        properties=['PTEST', 205, '#bfd56f', False],
         controller=mocker.patch('zulipterminal.core.Controller'),
         view=mocker.patch('zulipterminal.ui.View')
     )
@@ -682,6 +682,6 @@ def streams():
     `initial_data` fixture.
     """
     return [
-        ['Django', 86, '#94c849'],
-        ['GSoC', 14, '#c2c2c2']
+        ['Django', 86, '#94c849', False],
+        ['GSoC', 14, '#c2c2c2', False]
     ]

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -634,6 +634,7 @@ class TestLeftColumnView:
             'all_pms': 0,
             86: 1,
             14: 1,
+            99: 1,
         }
         self.view.controller = mocker.Mock()
         self.super_mock = mocker.patch(VIEWS + ".urwid.Pile.__init__")
@@ -657,11 +658,12 @@ class TestLeftColumnView:
         stream_view = mocker.patch(VIEWS + '.StreamsView')
         line_box = mocker.patch(VIEWS + '.urwid.LineBox')
         left_col_view = LeftColumnView(self.view)
-        stream_button.assert_called_with(
-            streams[1],
-            controller=self.view.controller,
-            view=self.view,
-            count=1)
+        stream_button.assert_has_calls(
+            [mocker.call(stream,
+                         controller=self.view.controller,
+                         view=self.view,
+                         count=1)
+             for stream in streams])
 
 
 class TestHelpMenu:

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -250,6 +250,7 @@ class Model:
             stream['name'],
             stream['stream_id'],
             stream['color'],
+            stream['invite_only'],
         ] for stream in subscriptions
         ]
         return sorted(stream_names, key=lambda s: s[0].lower())

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -79,6 +79,7 @@ class StreamButton(urwid.Button):
                                        'black'))
         view.palette['default'].append(('s' + self.color, '', '', '',
                                        'black', self.color))
+        self.is_private = properties[3]
         self.count = count
         super(StreamButton, self).__init__("")
         self._w = self.widget(count)
@@ -90,8 +91,9 @@ class StreamButton(urwid.Button):
         self._w = self.widget(count)
 
     def widget(self, count: int) -> Any:
+        stream_prefix = ' ' + ('P' if self.is_private else '#') + ' '
         return urwid.AttrMap(urwid.SelectableIcon(
-            [(self.color, u' # '), self.caption,
+            [(self.color, stream_prefix), self.caption,
              ('idle', '' if count <= 0 else ' ' + str(count))],
             len(self.caption) + 2),
             None,


### PR DESCRIPTION
This PR shows private streams with a 'P' (rather than '#'), much like a lock is shown in the zulip web-app.

Current tests pass with the first commit; the second commit extends them to include a private-stream test-case and so improves the test coverage.