### PR TITLE
bugfix: Elide divs/spans with no class in soup2markup.

### DIFF
--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -212,7 +212,9 @@ class MessageBox(urwid.Pile):
             return ''
 
     def soup2markup(self, soup: Any) -> List[Any]:
-        markup = []
+        # Ensure a string is provided, in case the soup finds none
+        # This could occur if eg. an image is removed or not shown
+        markup = ['']
         for element in soup:
             if isinstance(element, NavigableString):
                 # NORMAL STRINGS

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -217,13 +217,13 @@ class MessageBox(urwid.Pile):
             if isinstance(element, NavigableString):
                 # NORMAL STRINGS
                 markup.append(element)
-            elif element.name == 'div' and\
+            elif element.name == 'div' and element.attrs and\
                     'message_embed' in element.attrs.get('class'):
                 # Do not display embedded content
                 # since Embedded content can be very dynamic
                 # TODO: Support Embedded content
                 continue
-            elif element.name == 'span' and\
+            elif element.name == 'span' and element.attrs and\
                     'user-mention' in element.attrs.get('class', []):
                 # USER MENTIONS
                 markup.append(('span', element.text))
@@ -252,7 +252,7 @@ class MessageBox(urwid.Pile):
                 markup.append((
                     'code', element.text
                 ))
-            elif element.name == 'div' and\
+            elif element.name == 'div' and element.attrs and\
                     'codehilite' in element.attrs.get('class', []):
                 markup.append((
                     'code', element.text


### PR DESCRIPTION
This caused a crash; this commit checks for `element.attrs` in the
conditionals before getting the class.

See https://chat.zulip.org/#narrow/stream/9-issues/subject/Un-classed.20DIV.20in.20rendered.20content.3F/near/655208