### PR TITLE
Reorder shortcut keys (& fix a few typos)

### DIFF
--- a/zulipterminal/config.py
+++ b/zulipterminal/config.py
@@ -1,4 +1,8 @@
 KEY_BINDINGS = {
+    'GO_BACK': {
+        'keys': {'esc'},
+        'help_text': 'Go Back',
+    },
     'PREVIOUS_MESSAGE': {
         'keys': {'k', 'up'},
         'help_text': 'Previous message',
@@ -35,13 +39,29 @@ KEY_BINDINGS = {
         'keys': {'R'},
         'help_text': 'Reply to an author',
     },
+    'MENTION_REPLY': {
+        'keys': {'@'},
+        'help_text': 'Reply mentioning the sender of the message'
+    },
+    'QUOTE_REPLY': {
+        'keys': {'>'},
+        'help_text': 'Reply quoting message text',
+    },
     'STREAM_MESSAGE': {
         'keys': {'c'},
         'help_text': 'New stream message',
     },
-    'GO_BACK': {
-        'keys': {'esc'},
-        'help_text': 'Go Back',
+    'PRIVATE_MESSAGE': {
+        'keys': {'x'},
+        'help_text': 'New private message',
+    },
+    'TAB': {
+        'keys': {'tab'},
+        'help_text': 'Toggle focus box in compose box'
+    },
+    'SEND_MESSAGE': {
+        'keys': {'meta enter'},
+        'help_text': 'Send a message',
     },
     'STREAM_NARROW': {
         'keys': {'S'},
@@ -58,10 +78,6 @@ KEY_BINDINGS = {
     'NEXT_UNREAD_PM': {
         'keys': {'p'},
         'help_text': 'Next unread private message',
-    },
-    'SEND_MESSAGE': {
-        'keys': {'meta enter'},
-        'help_text': 'Send a message',
     },
     'SEARCH_PEOPLE': {
         'keys': {'w'},
@@ -91,25 +107,9 @@ KEY_BINDINGS = {
         'keys': {'q', 'esc'},
         'help_text': 'Quit help menu',
     },
-    'PRIVATE_MESSAGE': {
-        'keys': {'x'},
-        'help_text': 'New private message',
-    },
-    'TAB': {
-        'keys': {'tab'},
-        'help_text': 'Toggle focus box in compose box'
-    },
     'THUMBS_UP': {
         'keys': {'+'},
         'help_text': 'Add/remove thumbs-up reaction on a message',
-    },
-    'MENTION_REPLY': {
-        'keys': {'@'},
-        'help_text': 'Reply mentioning the sender of the message'
-    },
-    'QUOTE_REPLY': {
-        'keys': {'>'},
-        'help_text': 'Reply quoting message text',
     },
 }
 

--- a/zulipterminal/config.py
+++ b/zulipterminal/config.py
@@ -2,7 +2,6 @@ KEY_BINDINGS = {
     'PREVIOUS_MESSAGE': {
         'keys': {'k', 'up'},
         'help_text': 'Previous message',
-
     },
     'NEXT_MESSAGE': {
         'keys': {'j', 'down'},
@@ -34,7 +33,7 @@ KEY_BINDINGS = {
     },
     'REPLY_AUTHOR': {
         'keys': {'R'},
-        'help_text': 'Reply to a author',
+        'help_text': 'Reply to an author',
     },
     'STREAM_MESSAGE': {
         'keys': {'c'},
@@ -86,7 +85,7 @@ KEY_BINDINGS = {
     },
     'ALL_PM': {
         'keys': {'P'},
-        'help_text': 'Show all private messgaes',
+        'help_text': 'Show all private messages',
     },
     'QUIT_HELP': {
         'keys': {'q', 'esc'},

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -255,7 +255,7 @@ def index_messages(messages: List[Any], model: Any, index: Any=None)\
 
 
 def classify_unread_counts(model: Any) -> Dict[str, Any]:
-    # TODO: supprot group pms
+    # TODO: support group pms
     unread_msg_counts = model.initial_data['unread_msgs']
     unread_counts = dict()  # type: Dict[Any, Any]
     unread_counts['all_msg'] = 0

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -244,7 +244,7 @@ class MessageBox(urwid.Pile):
                     markup.append(
                         ('link', '[' + text + ']' + '(' + link + ')'))
             elif element.name == 'blockquote':
-                # BLOCKQOTE TEXT
+                # BLOCKQUOTE TEXT
                 markup.append((
                     'blockquote', self.soup2markup(element)
                 ))


### PR DESCRIPTION
* Reordered the shortcut key listing in the help (via `config.py`) to group similar commands;
* Collected together some typos I remembered from browsing the code.

The first one is small but important - if I scan the help and find 'new [something] message' I would expect to find 'new [otherthing] message' nearby, as well as how to reply, or edit messages, and the same for other aspects.