### PR TITLE
Add extra MessageBox tests

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -12,6 +12,8 @@ from zulipterminal.ui_tools.views import (
 )
 from zulipterminal.ui_tools.boxes import MessageBox
 
+from urwid import AttrWrap, Columns, Padding
+
 VIEWS = "zulipterminal.ui_tools.views"
 
 
@@ -763,3 +765,38 @@ class TestMessageBox:
             },
         }
         msg_box = MessageBox(message, self.model, last_message)
+
+    @pytest.mark.parametrize('message', [
+        {
+            'type': 'stream',
+            'display_recipient': 'Verona',
+            'stream_id': 5,
+            'subject': 'Test topic',
+            'flags': [],
+            'content': '<div>what are you planning to do this week</div>',
+            'reactions': [],
+            'sender_full_name': 'Alice',
+            'timestamp': 1532103879,
+        }
+    ])
+    @pytest.mark.parametrize('to_vary_in_last_message', [
+            {'display_recipient': 'Verona offtopic'},
+            {'subject': 'Test topic (previous)'},
+            {'type': 'private'},
+    ], ids=['different_stream_before', 'different_topic_before', 'PM_before'])
+    def test_main_view_generates_stream_header(self, mocker, message,
+                                               to_vary_in_last_message):
+        mocker.patch(VIEWS + ".urwid.Text")
+        self.model.stream_dict = {
+            5: {
+                'color': '#bfd56f',
+            },
+        }
+        last_message = dict(message, **to_vary_in_last_message)
+        msg_box = MessageBox(message, self.model, last_message)
+        view_components = msg_box.main_view()
+        assert len(view_components) == 3
+        assert isinstance(view_components[0], AttrWrap)
+        assert view_components[0].get_attr() == 'bar'
+        assert isinstance(view_components[1], Columns)
+        assert isinstance(view_components[2], Padding)

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -885,3 +885,50 @@ class TestMessageBox:
         assert ([w.text for w in view_components[0].widget_list] ==
                 expected_header_dated)
         assert isinstance(view_components[1], Padding)
+
+    @pytest.mark.parametrize('message', [
+        {
+            'type': 'stream',
+            'display_recipient': 'Verona',
+            'stream_id': 5,
+            'subject': 'Test topic',
+            'flags': [],
+            'content': '<div>what are you planning to do this week</div>',
+            'reactions': [],
+            'sender_full_name': 'alice',
+            'timestamp': 1532103879,
+        },
+        {
+            'type': 'private',
+            'sender_email': 'iago@zulip.com',
+            'sender_id': 5,
+            'display_recipient': [{
+                'email': 'AARON@zulip.com',
+                'id': 1,
+                'full_name': 'aaron'
+            }, {
+                'email': 'iago@zulip.com',
+                'id': 5,
+                'full_name': 'Iago'
+            }],
+            'flags': [],
+            'content': '<div>what are you planning to do this week</div>',
+            'reactions': [],
+            'sender_full_name': 'Alice',
+            'timestamp': 1532103879,
+        }
+    ])
+    @pytest.mark.parametrize('to_vary_in_each_message', [
+        {'sender_full_name': 'bob'},
+        {'timestamp': 1532103779},
+        {'timestamp': 0},
+        {}
+    ], ids=['common_author', 'common_timestamp', 'common_early_timestamp',
+            'common_unchanged_message'])
+    def test_main_view_compact_output(self, mocker, message,
+                                      to_vary_in_each_message):
+        varied_message = dict(message, **to_vary_in_each_message)
+        msg_box = MessageBox(varied_message, self.model, varied_message)
+        view_components = msg_box.main_view()
+        assert len(view_components) == 1
+        assert isinstance(view_components[0], Padding)

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -800,3 +800,54 @@ class TestMessageBox:
         assert view_components[0].get_attr() == 'bar'
         assert isinstance(view_components[1], Columns)
         assert isinstance(view_components[2], Padding)
+
+    @pytest.mark.parametrize('message', [
+        {
+            'type': 'private',
+            'sender_email': 'iago@zulip.com',
+            'sender_id': 5,
+            'display_recipient': [{
+                'email': 'AARON@zulip.com',
+                'id': 1,
+                'full_name': 'aaron'
+            }, {
+                'email': 'iago@zulip.com',
+                'id': 5,
+                'full_name': 'Iago'
+            }],
+            'flags': [],
+            'content': '<div>what are you planning to do this week</div>',
+            'reactions': [],
+            'sender_full_name': 'Alice',
+            'timestamp': 1532103879,
+        },
+    ])
+    @pytest.mark.parametrize('to_vary_in_last_message', [
+            {
+                'display_recipient': [{
+                    'email': 'AARON@zulip.com',
+                    'id': 1,
+                    'full_name': 'aaron'
+                }, {
+                    'email': 'iago@zulip.com',
+                    'id': 5,
+                    'full_name': 'Iago'
+                }, {
+                    'email': 'SE@zulip.com',
+                    'id': 6,
+                    'full_name': 'Someone Else'
+                }],
+            },
+            {'type': 'stream'},
+    ], ids=['larger_pm_group', 'stream_before'])
+    def test_main_view_generates_PM_header(self, mocker, message,
+                                           to_vary_in_last_message):
+        mocker.patch(VIEWS + ".urwid.Text")
+        last_message = dict(message, **to_vary_in_last_message)
+        msg_box = MessageBox(message, self.model, last_message)
+        view_components = msg_box.main_view()
+        assert len(view_components) == 3
+        assert isinstance(view_components[0], AttrWrap)
+        assert view_components[0].get_attr() == 'bar'
+        assert isinstance(view_components[1], Columns)
+        assert isinstance(view_components[2], Padding)

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -144,8 +144,9 @@ class MessageBox(urwid.Pile):
         self.title = self.message['subject']
         # If the topic of last message is same
         # as current message
-        if self.title == self.last_message['subject'] and\
-                self.last_message['type'] == 'stream':
+        if (self.last_message['type'] == 'stream' and
+                self.title == self.last_message['subject'] and
+                self.caption == self.last_message['display_recipient']):
             return None
         bar_color = self.model.stream_dict[self.stream_id]['color']
         bar_color = 's' + bar_color[:2] + bar_color[3] + bar_color[5]


### PR DESCRIPTION
These increase overall coverage by 0.5% and are a precursor to other commits which refactor the MessageBox code. One small code fix is also included, uncovered by adding the tests.