### PR TITLE
Add tests & extra function for config.

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,3 +19,16 @@ def test_keys_for_command(command):
 def test_keys_for_command_invalid_command(command):
     with pytest.raises(config.InvalidCommand):
         config.keys_for_command(command)
+
+
+@pytest.mark.parametrize('command', AVAILABLE_COMMANDS)
+def test_is_command_key_matching_keys(command):
+    for key in config.keys_for_command(command):
+        assert config.is_command_key(command, key)
+
+
+@pytest.mark.parametrize('command', AVAILABLE_COMMANDS)
+def test_is_command_key_nonmatching_keys(command):
+    keys_to_test = USED_KEYS - config.keys_for_command(command)
+    for key in keys_to_test:
+        assert not config.is_command_key(command, key)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -32,3 +32,9 @@ def test_is_command_key_nonmatching_keys(command):
     keys_to_test = USED_KEYS - config.keys_for_command(command)
     for key in keys_to_test:
         assert not config.is_command_key(command, key)
+
+
+@pytest.mark.parametrize('command', ['BLAH'*10])
+def test_is_command_key_invalid_command(command):
+    with pytest.raises(config.InvalidCommand):
+        config.is_command_key(command, 'esc')  # specific key doesn't matter

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,3 +7,15 @@ AVAILABLE_COMMANDS = list(config.KEY_BINDINGS.keys())
 USED_KEYS = {key
              for values in config.KEY_BINDINGS.values()
              for key in values['keys']}
+
+
+@pytest.mark.parametrize('command', AVAILABLE_COMMANDS)
+def test_keys_for_command(command):
+    assert (config.KEY_BINDINGS[command]['keys'] ==
+            config.keys_for_command(command))
+
+
+@pytest.mark.parametrize('command', ['BLAH'*10])
+def test_keys_for_command_invalid_command(command):
+    with pytest.raises(config.InvalidCommand):
+        config.keys_for_command(command)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,9 @@
+import pytest
+
+from zulipterminal import config
+
+AVAILABLE_COMMANDS = list(config.KEY_BINDINGS.keys())
+
+USED_KEYS = {key
+             for values in config.KEY_BINDINGS.values()
+             for key in values['keys']}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,32 +9,37 @@ USED_KEYS = {key
              for key in values['keys']}
 
 
-@pytest.mark.parametrize('command', AVAILABLE_COMMANDS)
-def test_keys_for_command(command):
-    assert (config.KEY_BINDINGS[command]['keys'] ==
-            config.keys_for_command(command))
+@pytest.fixture(params=config.KEY_BINDINGS.keys())
+def valid_command(request):
+    return request.param
 
 
-@pytest.mark.parametrize('command', ['BLAH'*10])
-def test_keys_for_command_invalid_command(command):
+@pytest.fixture(params=['BLAH*10'])
+def invalid_command(request):
+    return request.param
+
+
+def test_keys_for_command(valid_command):
+    assert (config.KEY_BINDINGS[valid_command]['keys'] ==
+            config.keys_for_command(valid_command))
+
+
+def test_keys_for_command_invalid_command(invalid_command):
     with pytest.raises(config.InvalidCommand):
-        config.keys_for_command(command)
+        config.keys_for_command(invalid_command)
 
 
-@pytest.mark.parametrize('command', AVAILABLE_COMMANDS)
-def test_is_command_key_matching_keys(command):
-    for key in config.keys_for_command(command):
-        assert config.is_command_key(command, key)
+def test_is_command_key_matching_keys(valid_command):
+    for key in config.keys_for_command(valid_command):
+        assert config.is_command_key(valid_command, key)
 
 
-@pytest.mark.parametrize('command', AVAILABLE_COMMANDS)
-def test_is_command_key_nonmatching_keys(command):
-    keys_to_test = USED_KEYS - config.keys_for_command(command)
+def test_is_command_key_nonmatching_keys(valid_command):
+    keys_to_test = USED_KEYS - config.keys_for_command(valid_command)
     for key in keys_to_test:
-        assert not config.is_command_key(command, key)
+        assert not config.is_command_key(valid_command, key)
 
 
-@pytest.mark.parametrize('command', ['BLAH'*10])
-def test_is_command_key_invalid_command(command):
+def test_is_command_key_invalid_command(invalid_command):
     with pytest.raises(config.InvalidCommand):
-        config.is_command_key(command, 'esc')  # specific key doesn't matter
+        config.is_command_key(invalid_command, 'esc')  # key doesn't matter

--- a/zulipterminal/config.py
+++ b/zulipterminal/config.py
@@ -1,3 +1,5 @@
+from typing import Set
+
 KEY_BINDINGS = {
     'GO_BACK': {
         'keys': {'esc'},
@@ -114,6 +116,10 @@ KEY_BINDINGS = {
 }
 
 
+class InvalidCommand(Exception):
+    pass
+
+
 def is_command_key(command: str, key: str) -> bool:
     """
     Returns the mapped binding for a key if mapped
@@ -123,3 +129,13 @@ def is_command_key(command: str, key: str) -> bool:
         return True
     else:
         return False
+
+
+def keys_for_command(command: str) -> Set[str]:
+    """
+    Returns the actual keys for a given mapped command
+    """
+    try:
+        return set(KEY_BINDINGS[command]['keys'])
+    except KeyError as exception:
+        raise InvalidCommand(command)

--- a/zulipterminal/config.py
+++ b/zulipterminal/config.py
@@ -125,10 +125,13 @@ def is_command_key(command: str, key: str) -> bool:
     Returns the mapped binding for a key if mapped
     or the key otherwise.
     """
-    if key in KEY_BINDINGS[command]['keys']:
-        return True
-    else:
-        return False
+    try:
+        if key in KEY_BINDINGS[command]['keys']:
+            return True
+        else:
+            return False
+    except KeyError as exception:
+        raise InvalidCommand(command)
 
 
 def keys_for_command(command: str) -> Set[str]:

--- a/zulipterminal/config.py
+++ b/zulipterminal/config.py
@@ -126,10 +126,7 @@ def is_command_key(command: str, key: str) -> bool:
     or the key otherwise.
     """
     try:
-        if key in KEY_BINDINGS[command]['keys']:
-            return True
-        else:
-            return False
+        return key in KEY_BINDINGS[command]['keys']
     except KeyError as exception:
         raise InvalidCommand(command)
 


### PR DESCRIPTION
Originally motivated by broadening the `keypress` tests, which are currently hardcoded to specific keys rather than the `KEY_BINDINGS` in `config.py`, to iterate through listed possible keys. Then noticed this file was untested, thought of refactoring, but wanted to add (the minimal!) tests first :)

It turned out easier to write the `is_command_key` tests in terms of `keys_for_command`, hence the test infrastructure commit is currently separate reflecting my reordering.

PLEASE CHECK: The docstring for `is_command_key` currently indicates it returns "a key if mapped or the key otherwise". I've not intended to change this behavior, but it seems not to describe current master? I can incorporate this if relevant.