### PR TITLE
Show starred messages & refactor MessageBox.main_view()

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -867,9 +867,9 @@ class TestMessageBox:
         }
     ])
     @pytest.mark.parametrize('expected_header, to_vary_in_last_message', [
-        (['alice', 'DAYDATETIME'], {'sender_full_name': 'bob'}),
-        (['DAYDATETIME'], {'timestamp': 1532103779}),  # 100 earlier
-        (['alice', 'DAYDATETIME'], {'timestamp': 0}),  # much earlier!
+        (['alice', ' ', 'DAYDATETIME'], {'sender_full_name': 'bob'}),
+        ([' ', ' ', 'DAYDATETIME'], {'timestamp': 1532103779}),  # 100 earlier
+        (['alice', ' ', 'DAYDATETIME'], {'timestamp': 0}),  # much earlier!
     ], ids=['author_different', 'earlier_message', 'much_earlier_message'])
     def test_main_view_content_header_without_header(self, mocker, message,
                                                      expected_header,

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -41,7 +41,8 @@ class View(urwid.WidgetWrap):
             ('blockquote',   'brown',           'black'),
             ('code',         'black',           'white'),
             ('bold',         'white, bold',     'black'),
-            ('footer',       'white',           'dark red',   'bold')
+            ('footer',       'white',           'dark red',   'bold'),
+            ('starred',      'light red, bold', 'black'),
         ],
         'light': [
             (None,           'black',        'white'),

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -299,21 +299,17 @@ class MessageBox(urwid.Pile):
             'star_status': (message_is_starred !=
                             ('starred' in self.last_message['flags'])),
         }
-        no_differences = (not different['topic'] and
-                          not different['author'] and
-                          not different['24h'] and
-                          not different['timestamp'] and
-                          not different['star_status'])
+        no_differences = not any(different.values())
 
         # Include author name/star/time under various conditions
         TextType = Dict[str, Tuple[Optional[str], str]]
         text = {key: (None, ' ')
                 for key in ('author', 'star', 'time')}  # type: TextType
-        if different['topic'] or different['author'] or different['24h']:
+        if any(different[key] for key in ('topic', 'author', '24h')):
             text['author'] = ('name', message_author)
         if message_is_starred:
             text['star'] = ('starred', "*")
-        if different['topic'] or different['author'] or different['timestamp']:
+        if any(different[key] for key in ('topic', 'author', 'timestamp')):
             text['time'] = ('time', message_time)
 
         content_header = urwid.Columns([

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -287,33 +287,33 @@ class MessageBox(urwid.Pile):
         message_time = self._time_for_message(self.message)
 
         # Statements as to how the message varies from the previous one
-        different_topic = header is not None
-        different_author = (
-            self.last_message['sender_full_name'] != message_author)
-        more_than_24h_apart = (
-            'timestamp' in self.last_message and
-            (datetime.fromtimestamp(self.message['timestamp']) -
-             datetime.fromtimestamp(self.last_message['timestamp'])).days)
-        different_timestamp = (
-            'timestamp' in self.last_message and
-            message_time != self._time_for_message(self.last_message))
-        different_star_status = (
-            message_is_starred != ('starred' in self.last_message['flags']))
-        no_differences = (not different_topic and
-                          not different_author and
-                          not more_than_24h_apart and
-                          not different_timestamp and
-                          not different_star_status)
+        different = {
+            'topic': header is not None,
+            'author': self.last_message['sender_full_name'] != message_author,
+            '24h': 'timestamp' in self.last_message and
+                   (datetime.fromtimestamp(self.message['timestamp']) -
+                    datetime.fromtimestamp(self.last_message['timestamp']))
+                   .days,
+            'timestamp': 'timestamp' in self.last_message and
+                   message_time != self._time_for_message(self.last_message),
+            'star_status': (message_is_starred !=
+                            ('starred' in self.last_message['flags'])),
+        }
+        no_differences = (not different['topic'] and
+                          not different['author'] and
+                          not different['24h'] and
+                          not different['timestamp'] and
+                          not different['star_status'])
 
         # Include author name/star/time under various conditions
         TextType = Dict[str, Tuple[Optional[str], str]]
         text = {key: (None, ' ')
                 for key in ('author', 'star', 'time')}  # type: TextType
-        if different_topic or different_author or more_than_24h_apart:
+        if different['topic'] or different['author'] or different['24h']:
             text['author'] = ('name', message_author)
         if message_is_starred:
             text['star'] = ('starred', "*")
-        if different_topic or different_author or different_timestamp:
+        if different['topic'] or different['author'] or different['timestamp']:
             text['time'] = ('time', message_time)
 
         content_header = urwid.Columns([

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -330,14 +330,13 @@ class MessageBox(urwid.Pile):
         else:
             content_header = None
 
-        view = [header, content_header, content, reactions]
-        if header is None:
-            view.remove(header)
-        if not any_differences:
-            view.remove(content_header)
-        if reactions == '':
-            view.remove(reactions)
-        return view
+        parts = {
+            header: header is not None,
+            content_header: any_differences,
+            content: True,
+            reactions: reactions != ''
+        }
+        return [part for part, condition in parts.items() if condition]
 
     def selectable(self) -> bool:
         return True

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -270,18 +270,14 @@ class MessageBox(urwid.Pile):
         return markup
 
     def main_view(self) -> List[Any]:
+
+        # Header
         if self.message['type'] == 'stream':
             header = self.stream_view()
         else:
             header = self.private_view()
 
-        reactions = self.reactions_view(self.message['reactions'])
-        soup = BeautifulSoup(self.message['content'], 'lxml')
-        content = (None, self.soup2markup(soup))
-        content = urwid.Padding(urwid.Text(content),
-                                align='left', width=('relative', 90), left=25,
-                                min_width=50)
-
+        # Content Header
         message = {
             key: {
                 'is_starred': 'starred' in msg['flags'],
@@ -295,9 +291,7 @@ class MessageBox(urwid.Pile):
             for key, msg in dict(this=self.message,
                                  last=self.last_message).items()
         }
-
-        # Statements as to how the message varies from the previous one
-        different = {
+        different = {  # How this message differs from the previous one
             'topic': header is not None,
             'author': message['last']['author'] != message['this']['author'],
             '24h': (message['last']['datetime'] is not None and
@@ -330,6 +324,17 @@ class MessageBox(urwid.Pile):
         else:
             content_header = None
 
+        # Content
+        soup = BeautifulSoup(self.message['content'], 'lxml')
+        content = (None, self.soup2markup(soup))
+        content = urwid.Padding(urwid.Text(content),
+                                align='left', width=('relative', 90), left=25,
+                                min_width=50)
+
+        # Reactions
+        reactions = self.reactions_view(self.message['reactions'])
+
+        # Build parts together and return
         parts = {
             header: header is not None,
             content_header: any_differences,

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -309,29 +309,31 @@ class MessageBox(urwid.Pile):
             'star_status': (message['this']['is_starred'] !=
                             message['last']['is_starred']),
         }
-        no_differences = not any(different.values())
+        any_differences = any(different.values())
 
-        # Include author name/star/time under various conditions
-        TextType = Dict[str, Tuple[Optional[str], str]]
-        text = {key: (None, ' ')
-                for key in ('author', 'star', 'time')}  # type: TextType
-        if any(different[key] for key in ('topic', 'author', '24h')):
-            text['author'] = ('name', message['this']['author'])
-        if message['this']['is_starred']:
-            text['star'] = ('starred', "*")
-        if any(different[key] for key in ('topic', 'author', 'timestamp')):
-            text['time'] = ('time', message['this']['time'])
+        if any_differences:  # Construct content_header, if needed
+            TextType = Dict[str, Tuple[Optional[str], str]]
+            text = {key: (None, ' ')
+                    for key in ('author', 'star', 'time')}  # type: TextType
+            if any(different[key] for key in ('topic', 'author', '24h')):
+                text['author'] = ('name', message['this']['author'])
+            if message['this']['is_starred']:
+                text['star'] = ('starred', "*")
+            if any(different[key] for key in ('topic', 'author', 'timestamp')):
+                text['time'] = ('time', message['this']['time'])
 
-        content_header = urwid.Columns([
-            ('weight', 10, urwid.Text(text['author'])),
-            (1, urwid.Text(text['star'], align='right')),
-            (16, urwid.Text(text['time'], align='right')),
-            ], dividechars=1)
+            content_header = urwid.Columns([
+                ('weight', 10, urwid.Text(text['author'])),
+                (1, urwid.Text(text['star'], align='right')),
+                (16, urwid.Text(text['time'], align='right')),
+                ], dividechars=1)
+        else:
+            content_header = None
 
         view = [header, content_header, content, reactions]
         if header is None:
             view.remove(header)
-        if no_differences:
+        if not any_differences:
             view.remove(content_header)
         if reactions == '':
             view.remove(reactions)


### PR DESCRIPTION
* Shows stars applied to messages in other clients
* Amends and adds tests related to the star-viewing code
* Refactor code to aid readability using additional dicts, `any` and comprehensions

Old tests amended, more tests added (coverage still at 65.7%).