### PR TITLE
Bugfix: Update & access index correctly for multiple PM recipients

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -129,6 +129,44 @@ def messages_successful_response() -> Dict[str, Any]:
                 'full_name': 'Foo Foo',
                 'email': 'foo@zulip.com',
             }],
+        }, {
+            'id': 537288,
+            'sender_full_name': 'Foo Foo',
+            'timestamp': 1520918737,
+            'client': 'website',
+            'recipient_id': 5780,  # FIXME Unsure
+            'is_me_message': False,
+            'sender_email': 'foo@zulip.com',
+            'flags': ['read'],
+            'sender_id': 5140,
+            'content_type': 'text/x-markdown',
+            'sender_realm_str': '',
+            'subject': '',
+            'reactions': [],
+            'type': 'private',
+            'avatar_url': '/user_avatars/2/foo.png?x=x&version=2',
+            'subject_links': [],
+            'sender_short_name': 'foo',
+            'content': 'Hey PM content here again.',
+            'display_recipient': [{
+                'id': 5179,
+                'is_mirror_dummy': False,
+                'full_name': 'Boo Boo',
+                'short_name': 'boo',
+                'email': 'boo@zulip.com',
+            }, {
+                'short_name': 'foo',
+                'id': 5140,
+                'is_mirror_dummy': False,
+                'full_name': 'Foo Foo',
+                'email': 'foo@zulip.com',
+            }, {
+                'short_name': 'bar',
+                'id': 5180,
+                'is_mirror_dummy': False,
+                'full_name': 'Bar Bar',
+                'email': 'bar@zulip.com',
+            }],
         }],
         'result': 'success',
         'msg': '',
@@ -353,7 +391,7 @@ def index_all_messages():
     return {
         'pointer': defaultdict(set, {}),
         'private': defaultdict(set, {}),
-        'all_messages':  {537286, 537287},
+        'all_messages':  {537286, 537287, 537288},
         'all_private': set(),
         'messages': defaultdict(dict, {
             537286: {
@@ -410,6 +448,45 @@ def index_all_messages():
                 'sender_id': 5140,
                 'sender_full_name': 'Foo Foo',
                 'subject_links': []
+            },
+            537288: {
+                'id': 537288,
+                'sender_full_name': 'Foo Foo',
+                'timestamp': 1520918737,
+                'client': 'website',
+                'recipient_id': 5780,  # FIXME Unsure
+                'is_me_message': False,
+                'sender_email': 'foo@zulip.com',
+                'flags': ['read'],
+                'sender_id': 5140,
+                'content_type': 'text/x-markdown',
+                'sender_realm_str': '',
+                'subject': '',
+                'reactions': [],
+                'type': 'private',
+                'avatar_url': '/user_avatars/2/foo.png?x=x&version=2',
+                'subject_links': [],
+                'sender_short_name': 'foo',
+                'content': 'Hey PM content here again.',
+                'display_recipient': [{
+                    'id': 5179,
+                    'is_mirror_dummy': False,
+                    'full_name': 'Boo Boo',
+                    'short_name': 'boo',
+                    'email': 'boo@zulip.com',
+                }, {
+                    'short_name': 'foo',
+                    'id': 5140,
+                    'is_mirror_dummy': False,
+                    'full_name': 'Foo Foo',
+                    'email': 'foo@zulip.com',
+                }, {
+                    'short_name': 'bar',
+                    'id': 5180,
+                    'is_mirror_dummy': False,
+                    'full_name': 'Bar Bar',
+                    'email': 'bar@zulip.com',
+                }],
             }
         }),
         'all_stream': defaultdict(set, {}),
@@ -427,7 +504,8 @@ def index_stream():
         'private': defaultdict(set, {}),
         'all_messages': set(),
         'all_private': {
-            537287
+            537287,
+            537288
         },
         'all_stream': defaultdict(set, {
             205: {
@@ -492,6 +570,45 @@ def index_stream():
                 'subject_links': [],
                 'id': 537287,
                 'is_me_message': False
+            },
+            537288: {
+                'id': 537288,
+                'sender_full_name': 'Foo Foo',
+                'timestamp': 1520918737,
+                'client': 'website',
+                'recipient_id': 5780,  # FIXME Unsure
+                'is_me_message': False,
+                'sender_email': 'foo@zulip.com',
+                'flags': ['read'],
+                'sender_id': 5140,
+                'content_type': 'text/x-markdown',
+                'sender_realm_str': '',
+                'subject': '',
+                'reactions': [],
+                'type': 'private',
+                'avatar_url': '/user_avatars/2/foo.png?x=x&version=2',
+                'subject_links': [],
+                'sender_short_name': 'foo',
+                'content': 'Hey PM content here again.',
+                'display_recipient': [{
+                    'id': 5179,
+                    'is_mirror_dummy': False,
+                    'full_name': 'Boo Boo',
+                    'short_name': 'boo',
+                    'email': 'boo@zulip.com',
+                }, {
+                    'short_name': 'foo',
+                    'id': 5140,
+                    'is_mirror_dummy': False,
+                    'full_name': 'Foo Foo',
+                    'email': 'foo@zulip.com',
+                }, {
+                    'short_name': 'bar',
+                    'id': 5180,
+                    'is_mirror_dummy': False,
+                    'full_name': 'Bar Bar',
+                    'email': 'bar@zulip.com',
+                }],
             }
         })
     }
@@ -567,6 +684,45 @@ def index_topic():
                 'flags': ['read'],
                 'type': 'private',
                 'sender_email': 'foo@zulip.com'
+            },
+            537288: {
+                'id': 537288,
+                'sender_full_name': 'Foo Foo',
+                'timestamp': 1520918737,
+                'client': 'website',
+                'recipient_id': 5780,  # FIXME Unsure
+                'is_me_message': False,
+                'sender_email': 'foo@zulip.com',
+                'flags': ['read'],
+                'sender_id': 5140,
+                'content_type': 'text/x-markdown',
+                'sender_realm_str': '',
+                'subject': '',
+                'reactions': [],
+                'type': 'private',
+                'avatar_url': '/user_avatars/2/foo.png?x=x&version=2',
+                'subject_links': [],
+                'sender_short_name': 'foo',
+                'content': 'Hey PM content here again.',
+                'display_recipient': [{
+                    'id': 5179,
+                    'is_mirror_dummy': False,
+                    'full_name': 'Boo Boo',
+                    'short_name': 'boo',
+                    'email': 'boo@zulip.com',
+                }, {
+                    'short_name': 'foo',
+                    'id': 5140,
+                    'is_mirror_dummy': False,
+                    'full_name': 'Foo Foo',
+                    'email': 'foo@zulip.com',
+                }, {
+                    'short_name': 'bar',
+                    'id': 5180,
+                    'is_mirror_dummy': False,
+                    'full_name': 'Bar Bar',
+                    'email': 'bar@zulip.com',
+                }],
             }
         }),
         'pointer': defaultdict(set, {}),
@@ -586,10 +742,7 @@ def index_user():
     return {
         'stream': defaultdict(dict, {}),
         'private': defaultdict(set, {
-            frozenset({
-                5179,
-                5140
-            }): {
+            frozenset({5179, 5140}): {
                 537287
             }
         }),
@@ -650,10 +803,170 @@ def index_user():
                     'is_mirror_dummy': False,
                     'email': 'foo@zulip.com'
                 }]
+            },
+            537288: {
+                'id': 537288,
+                'sender_full_name': 'Foo Foo',
+                'timestamp': 1520918737,
+                'client': 'website',
+                'recipient_id': 5780,  # FIXME Unsure
+                'is_me_message': False,
+                'sender_email': 'foo@zulip.com',
+                'flags': ['read'],
+                'sender_id': 5140,
+                'content_type': 'text/x-markdown',
+                'sender_realm_str': '',
+                'subject': '',
+                'reactions': [],
+                'type': 'private',
+                'avatar_url': '/user_avatars/2/foo.png?x=x&version=2',
+                'subject_links': [],
+                'sender_short_name': 'foo',
+                'content': 'Hey PM content here again.',
+                'display_recipient': [{
+                    'id': 5179,
+                    'is_mirror_dummy': False,
+                    'full_name': 'Boo Boo',
+                    'short_name': 'boo',
+                    'email': 'boo@zulip.com',
+                }, {
+                    'short_name': 'foo',
+                    'id': 5140,
+                    'is_mirror_dummy': False,
+                    'full_name': 'Foo Foo',
+                    'email': 'foo@zulip.com',
+                }, {
+                    'short_name': 'bar',
+                    'id': 5180,
+                    'is_mirror_dummy': False,
+                    'full_name': 'Bar Bar',
+                    'email': 'bar@zulip.com',
+                }],
             }
         }),
         'all_private': {
-            537287
+            537287,
+            537288
+        },
+        'all_stream': defaultdict(set, {}),
+        'search': set(),
+    }
+
+
+@pytest.fixture(scope="module")
+def index_user_multiple():
+    """
+    Expected index of initial_data when model.narrow = [['pm_with',
+                                            'boo@zulip.com, bar@zulip.com'],
+    """
+    return {
+        'stream': defaultdict(dict, {}),
+        'private': defaultdict(set, {
+            frozenset({5179, 5140, 5180}): {
+                537288
+            }
+        }),
+        'all_messages': set(),
+        'pointer': defaultdict(set, {}),
+        'messages': defaultdict(dict, {
+            537286: {
+                'subject': 'Test',
+                'sender_full_name': 'Foo Foo',
+                'sender_short_name': 'foo',
+                'sender_email': 'foo@zulip.com',
+                'is_me_message': False,
+                'content_type': 'text/x-markdown',
+                'type': 'stream',
+                'id': 537286,
+                'sender_id': 5140,
+                'sender_realm_str': '',
+                'stream_id': 205,
+                'content': 'Stream content here.',
+                'reactions': [],
+                'subject_links': [],
+                'client': 'website',
+                'flags': ['read'],
+                'timestamp': 1520918722,
+                'avatar_url': '/user_avatars/2/foo.png?x=x&version=2',
+                'recipient_id': 6076,
+                'display_recipient': 'PTEST'
+            },
+            537287: {
+                'subject': '',
+                'sender_full_name': 'Foo Foo',
+                'sender_short_name': 'foo',
+                'sender_email': 'foo@zulip.com',
+                'is_me_message': False,
+                'content_type': 'text/x-markdown',
+                'reactions': [],
+                'id': 537287,
+                'sender_id': 5140,
+                'sender_realm_str': '',
+                'type': 'private',
+                'content': 'Hey PM content here.',
+                'subject_links': [],
+                'client': 'website',
+                'flags': ['read'],
+                'timestamp': 1520918736,
+                'avatar_url': '/user_avatars/2/foo.png?x=x&version=2',
+                'recipient_id': 5780,
+                'display_recipient': [{
+                    'short_name': 'boo',
+                    'id': 5179,
+                    'full_name': 'Boo Boo',
+                    'is_mirror_dummy': False,
+                    'email': 'boo@zulip.com'
+                }, {
+                    'id': 5140,
+                    'short_name': 'foo',
+                    'full_name': 'Foo Foo',
+                    'is_mirror_dummy': False,
+                    'email': 'foo@zulip.com'
+                }]
+            },
+            537288: {
+                'id': 537288,
+                'sender_full_name': 'Foo Foo',
+                'timestamp': 1520918737,
+                'client': 'website',
+                'recipient_id': 5780,  # FIXME Unsure
+                'is_me_message': False,
+                'sender_email': 'foo@zulip.com',
+                'flags': ['read'],
+                'sender_id': 5140,
+                'content_type': 'text/x-markdown',
+                'sender_realm_str': '',
+                'subject': '',
+                'reactions': [],
+                'type': 'private',
+                'avatar_url': '/user_avatars/2/foo.png?x=x&version=2',
+                'subject_links': [],
+                'sender_short_name': 'foo',
+                'content': 'Hey PM content here again.',
+                'display_recipient': [{
+                    'id': 5179,
+                    'is_mirror_dummy': False,
+                    'full_name': 'Boo Boo',
+                    'short_name': 'boo',
+                    'email': 'boo@zulip.com',
+                }, {
+                    'short_name': 'foo',
+                    'id': 5140,
+                    'is_mirror_dummy': False,
+                    'full_name': 'Foo Foo',
+                    'email': 'foo@zulip.com',
+                }, {
+                    'short_name': 'bar',
+                    'id': 5180,
+                    'is_mirror_dummy': False,
+                    'full_name': 'Bar Bar',
+                    'email': 'bar@zulip.com',
+                }],
+            }
+        }),
+        'all_private': {
+            537287,
+            537288
         },
         'all_stream': defaultdict(set, {}),
         'search': set(),

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -121,11 +121,11 @@ class TestController:
         controller.show_all_messages('')
         assert controller.model.narrow == []
         controller.model.msg_view.clear.assert_called_once_with()
-        controller.model.msg_list.set_focus.assert_called_once_with(1)
+        num_am = len(index_all_messages['all_messages'])
+        controller.model.msg_list.set_focus.assert_called_once_with(num_am - 1)
         widgets = controller.model.msg_view.extend.call_args_list[0][0][0]
         id_list = index_all_messages['all_messages']
-        msg_ids = set(widget.original_widget.message['id']
-                      for widget in widgets)
+        msg_ids = {widget.original_widget.message['id'] for widget in widgets}
         assert msg_ids == id_list
 
     def test_show_all_pm(self, mocker, controller, index_user):
@@ -137,10 +137,12 @@ class TestController:
         controller.show_all_pm('')
         assert controller.model.narrow == [['is', 'private']]
         controller.model.msg_view.clear.assert_called_once_with()
-        controller.model.msg_list.set_focus.assert_called_once_with(0)
+        num_pm = len(index_user['all_private'])
+        controller.model.msg_list.set_focus.assert_called_once_with(num_pm - 1)
+        widgets = controller.model.msg_view.extend.call_args_list[0][0][0]
         id_list = index_user['all_private']
-        widget = controller.model.msg_view.extend.call_args_list[0][0][0][0]
-        assert {widget.original_widget.message['id']} == id_list
+        msg_ids = {widget.original_widget.message['id'] for widget in widgets}
+        assert msg_ids == id_list
 
     def test_register_initial_desired_events(self, mocker):
         self.config_file = 'path/to/zuliprc'

--- a/tests/helper/test_helper.py
+++ b/tests/helper/test_helper.py
@@ -68,3 +68,22 @@ def test_index_messages_narrow_user(mocker,
         }
     }
     assert index_messages(messages, model) == index_user
+
+
+def test_index_messages_narrow_user_multiple(mocker,
+                                             messages_successful_response,
+                                             index_user_multiple):
+    messages = messages_successful_response['messages']
+    model = mocker.patch('zulipterminal.model.Model.__init__',
+                         return_value=None)
+    model.narrow = [['pm_with', 'boo@zulip.com, bar@zulip.com']]
+    model.user_id = 5140
+    model.user_dict = {
+        'boo@zulip.com': {
+            'user_id': 5179,
+        },
+        'bar@zulip.com': {
+            'user_id': 5180
+        }
+    }
+    assert index_messages(messages, model) == index_user_multiple

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -236,10 +236,12 @@ def index_messages(messages: List[Any], model: Any, index: Any=None)\
                     recipient['id'] for recipient in msg['display_recipient']
                 ))
 
-                if narrow[0][0] == 'pm_with' and recipients == frozenset({
-                        model.user_id, model.user_dict[narrow[0][1]]['user_id']
-                }):
-                    index['private'][recipients].add(msg['id'])
+                if narrow[0][0] == 'pm_with':
+                    narrow_emails = ([model.user_dict[email]['user_id']
+                                      for email in narrow[0][1].split(', ')] +
+                                     [model.user_id])
+                    if recipients == frozenset(narrow_emails):
+                        index['private'][recipients].add(msg['id'])
 
             if msg['type'] == 'stream' and msg['stream_id'] == model.stream_id:
                 index['all_stream'][msg['stream_id']].add(msg['id'])


### PR DESCRIPTION
I fixed this while refactoring, but backported it since this seems to cause a crash on master.

I've added/amended tests/fixtures to include a multiple-recipient case, and if the commits are reordered (or the bugfix is removed) then the additional test indeed fails.

The bugfix commit itself is small and appears to work fine, and the `core.py` code is now more consistent with similar functions, however:
* it doesn't set `button.user_id` (it doesn't seem an issue?)
* was the different layout/branching of the old code important?