### PR TITLE
Bugfix: Avoid extra headers on toggling react or star

### DIFF
--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -359,8 +359,11 @@ class Model:
     def update_rendered_view(self, msg_id: int) -> None:
         # Update new content in the rendered view
         for msg_w in self.msg_list.log:
-            if msg_w.original_widget.message['id'] == msg_id:
-                msg_w_list = create_msg_box_list(self, [msg_id])
+            msg_box = msg_w.original_widget
+            if msg_box.message['id'] == msg_id:
+                msg_w_list = create_msg_box_list(
+                                self, [msg_id],
+                                last_message=msg_box.last_message)
                 if not msg_w_list:
                     return
                 else:

--- a/zulipterminal/ui_tools/utils.py
+++ b/zulipterminal/ui_tools/utils.py
@@ -6,7 +6,8 @@ from zulipterminal.ui_tools.boxes import MessageBox
 
 
 def create_msg_box_list(model: Any, messages: Union[None, Iterable[Any]]=None,
-                        focus_msg_id: Union[None, int]=None) -> List[Any]:
+                        focus_msg_id: Union[None, int]=None,
+                        last_message: Union[None, Any]=None) -> List[Any]:
     """
     MessageBox for every message displayed is created here.
     """
@@ -17,7 +18,7 @@ def create_msg_box_list(model: Any, messages: Union[None, Iterable[Any]]=None,
     message_list.sort(key=lambda msg: msg['timestamp'])
     w_list = []
     focus_msg = None
-    last_message = None
+    last_msg = last_message
     muted_msgs = 0  # No of messages that are muted.
     for msg in message_list:
         # Remove messages of muted topics / streams.
@@ -36,11 +37,11 @@ def create_msg_box_list(model: Any, messages: Union[None, Iterable[Any]]=None,
         if msg['id'] == focus_msg_id:
             focus_msg = message_list.index(msg) - muted_msgs
         w_list.append(urwid.AttrMap(
-                    MessageBox(msg, model, last_message),
+                    MessageBox(msg, model, last_msg),
                     msg_flag,
                     'msg_selected'
         ))
-        last_message = msg
+        last_msg = msg
     if focus_msg is not None:
         model.set_focus_in_current_narrow(focus_msg)
     return w_list

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -139,9 +139,9 @@ class MessageView(urwid.ListBox):
         message_view.last_message = defaultdict(dict)
         is_stream = message_view.message['type'] == 'stream'
         if is_stream:
-            footer = message_view.stream_view()
+            footer = message_view.stream_header()
         else:
-            footer = message_view.private_view()
+            footer = message_view.private_header()
         self.model.controller.view.search_box.msg_narrow.set_text(
             footer.markup
         )

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -136,7 +136,6 @@ class MessageView(urwid.ListBox):
             return
         # if view is ready display current narrow
         # at the bottom of the view.
-        message_view.last_message = defaultdict(dict)
         is_stream = message_view.message['type'] == 'stream'
         if is_stream:
             footer = message_view.stream_header()


### PR DESCRIPTION
Combined with an initial refactor commit, this fixes the situation where an extra header appears on modifying the message, such as when using '+' (or '*' soon) to toggle the thumb-up (or star) status.