### PR TITLE
UI: Add marker to left of message.

### DIFF
--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -343,9 +343,16 @@ class MessageBox(urwid.Pile):
         # Content
         soup = BeautifulSoup(self.message['content'], 'lxml')
         content = (None, self.soup2markup(soup))
-        content = urwid.Padding(urwid.Text(content),
-                                align='left', width=('relative', 90), left=25,
-                                min_width=50)
+        active_char = '▒'  # Options are '█', '▓', '▒', '░'
+        content = urwid.Padding(
+            urwid.LineBox(
+                urwid.Columns([
+                    (1, urwid.Text('')),
+                    urwid.Text(content),
+                ]), tline='', bline='', rline='', lline=active_char
+            ),
+            align='left', left=15, width=('relative', 100),
+            min_width=50, right=8)
 
         # Reactions
         reactions = self.reactions_view(self.message['reactions'])


### PR DESCRIPTION
The marker:
* is always present
* is colored according to read/unread/active status
* emphasizes how messages are separate when content_headers are shared
* indicates message status, when text cannot be colored
  (eg. just bold/italic text, or just a user-mention).

I was going to implement this as a column of text, but getting the height correct seemed complex - particularly when a LineBox can be used, as suggested in #98. I experimented with fuller LineBox's, but decided upon the left-side since it's like the webapp, takes up less space, and looks good :)

This could be considered to resolve #98, but I'm not sure if the intent there was to make a distinction on shape alone, in case of a no-colored approach. Otherwise, this fixes #98, and perhaps a separate issue should track potential color-absent use, if that becomes desirable.