### PR TITLE
deps: Support python 3.4-3.7 in travis & setup.py.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial
+      sudo: true
 install:
   - pip install pipenv==11.10
   - pipenv install --dev Pipfile

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,10 @@ setup(
         'License :: OSI Approved :: Apache Software License',
 
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
     keywords='',
     packages=find_packages(exclude=['test', 'test.*']),


### PR DESCRIPTION
Follow-up from chat in the last 24h confirming we should aim to support 3.4/3.5, as in existing travis CI setup.

Given that 3.7 is now out, I thought we could also add that, and so have updated the travis config for that and the `setup.py` file to indicate support for 3.4-3.7.

Current tests run fine for each version, as they stand.