### PR TITLE
bugfix: Avoid showing extra recipient headers on scrolling/appending

### DIFF
--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -389,6 +389,24 @@ class TestModel:
         (create_msg_box_list.
          assert_called_once_with(model, [0], last_message=None))
 
+    def test_append_message_with_valid_log(self, mocker, model):
+        model.update = True
+        index_msg = mocker.patch('zulipterminal.model.index_messages',
+                                 return_value={})
+        model.msg_list = mocker.Mock()
+        create_msg_box_list = mocker.patch('zulipterminal.model.'
+                                           'create_msg_box_list',
+                                           return_value=["msg_w"])
+        model.msg_list.log = [mocker.Mock()]
+
+        model.append_message({'id': 0})
+
+        assert len(model.msg_list.log) == 2  # Added "msg_w" element
+        # NOTE: So we expect the first element *was* the last_message parameter
+        expected_last_msg = model.msg_list.log[0].original_widget.message
+        (create_msg_box_list.
+         assert_called_once_with(model, [0], last_message=expected_last_msg))
+
     @pytest.mark.parametrize('response, narrow, recipients, log', [
         ({'type': 'stream', 'id': 1}, [], frozenset(), ['msg_w']),
         ({'type': 'private', 'id': 1},

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -373,6 +373,22 @@ class TestModel:
         model = Model(self.controller)
         assert model.streams == streams
 
+    def test_append_message_with_Falsey_log(self, mocker, model):
+        model.update = True
+        index_msg = mocker.patch('zulipterminal.model.index_messages',
+                                 return_value={})
+        model.msg_list = mocker.Mock()
+        create_msg_box_list = mocker.patch('zulipterminal.model.'
+                                           'create_msg_box_list',
+                                           return_value=["msg_w"])
+        model.msg_list.log = []
+
+        model.append_message({'id': 0})
+
+        assert len(model.msg_list.log) == 1  # Added "msg_w" element
+        (create_msg_box_list.
+         assert_called_once_with(model, [0], last_message=None))
+
     @pytest.mark.parametrize('response, narrow, recipients, log', [
         ({'type': 'stream', 'id': 1}, [], frozenset(), ['msg_w']),
         ({'type': 'private', 'id': 1},
@@ -405,7 +421,9 @@ class TestModel:
         model.recipients = recipients
         model.user_id = user_profile['user_id']
         model.user_dict = user_dict
+
         model.append_message(response)
+
         assert model.msg_list.log == log
         set_count.assert_called_once_with([response['id']], self.controller, 1)
         model.update = False

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -299,11 +299,17 @@ class Model:
         response['flags'] = []
         if hasattr(self.controller, 'view') and self.update:
             self.index = index_messages([response], self, self.index)
-            msg_w_list = create_msg_box_list(self, [response['id']])
+            if self.msg_list.log:
+                last_message = self.msg_list.log[-1].original_widget.message
+            else:
+                last_message = None
+            msg_w_list = create_msg_box_list(self, [response['id']],
+                                             last_message=last_message)
             if not msg_w_list:
                 return
             else:
                 msg_w = msg_w_list[0]
+
             if not self.narrow:
                 self.msg_list.log.append(msg_w)
 

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -65,9 +65,16 @@ class MessageView(urwid.ListBox):
         current_ids = self.model.get_message_ids_in_current_narrow()
         self.index = self.model.get_messages(num_before=0, num_after=30,
                                              anchor=anchor)
-        msg_ids = self.model.get_message_ids_in_current_narrow() - current_ids
-        message_list = create_msg_box_list(self.model, msg_ids)
+        new_ids = self.model.get_message_ids_in_current_narrow() - current_ids
+        if self.log:
+            last_message = self.log[-1].original_widget.message
+        else:
+            last_message = None
+
+        message_list = create_msg_box_list(self.model, new_ids,
+                                           last_message=last_message)
         self.log.extend(message_list)
+
         self.model.controller.update_screen()
         self.new_loading = False
 


### PR DESCRIPTION
Currently, when scrolling up or down beyond the messages currently "known", or when extra messages are sent from the server, they are simply added as an individual message in a new `MessageBox` with no context.

To include the context, this PR passes `last_message` to `create_msg_box_list` when adding to the bottom of the `MessageView`, and includes the top message in the messages to render when adding to the top (scrolling up).

Tests have been amended/added and give coverage, though could probably be improved upon further in future.