### PR TITLE
deps: Require mypy_extensions>=0.4 for TypedDict.

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -11,6 +11,7 @@ emoji = "==0.5.0"
 urwid-readline = "==0.7"
 beautifulsoup4 = "==4.6.0"
 lxml = "==4.2.3"
+mypy_extensions = ">=0.4"
 
 [dev-packages]
 pytest = "==3.4.2"

--- a/setup.py
+++ b/setup.py
@@ -86,5 +86,6 @@ setup(
         'urwid_readline==0.7',
         'beautifulsoup4==4.6.0',
         'lxml==4.2.3',
+        'mypy_extensions>=0.4',
     ],
 )


### PR DESCRIPTION
I introduced the use of `TypedDict` to resolve a mypy issue, in an earlier commit; since this was in a dev environment, `mypy_extensions` was already installed and everything just worked, but this is not the case in a simple install, as mentioned at https://github.com/zulip/zulip-terminal/issues/163#issuecomment-439580517.

Ideally `TypedDict` will become a full and useful type in a later python, but for now the simplest approach appears to be to depend upon `mypy_extensions`.