### PR TITLE
Bugfix: Prevent leaking exceptions when Ctrl+C is pressed during authorisation

### DIFF
--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -112,19 +112,19 @@ def main() -> None:
     """
 
     args = parse_args()
-    if args.config_file:
-        zuliprc_path = args.config_file
-    else:
-        zuliprc_path = '~/zuliprc'
-
-    zterm = parse_zuliprc(zuliprc_path)
 
     if args.profile:
         import cProfile
         prof = cProfile.Profile()
         prof.enable()
 
+    if args.config_file:
+        zuliprc_path = args.config_file
+    else:
+        zuliprc_path = '~/zuliprc'
+
     try:
+        zterm = parse_zuliprc(zuliprc_path)
         Controller(zuliprc_path, zterm['theme']).main()
     except Exception as e:
         if args.debug:


### PR DESCRIPTION
If the `zuliprc` file is missing and the user is prompted for their credentials, pressing `Ctrl+C` (especially after a couple of failed attempts to authorise) will result in a traceback of uncaught exceptions. This is fixed by moving the call to `parse_zuliprc` into a try block.