### PR TITLE
Polish Help menu

### DIFF
--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -80,14 +80,15 @@ class Controller:
         self.loop.draw_screen()
 
     def show_help(self) -> None:
-        self.loop.widget = urwid.LineBox(urwid.Overlay(
-            HelpView(self),
+        self.loop.widget = urwid.Overlay(
+            urwid.LineBox(HelpView(self),
+                          title="Help Menu ('q' quits, up/down scrolls)"),
             self.view,
             align='center',
             width=('relative', 100),
             valign='middle',
             height=('relative', 100)
-        ))
+        )
 
     def exit_help(self) -> None:
         self.loop.widget = self.view

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -500,18 +500,13 @@ class HelpView(urwid.ListBox):
         for _, binding in KEY_BINDINGS.items():
             commands = ", ".join(binding['keys'])
             self.log.append(
-                urwid.Columns([
-                    urwid.LineBox(
-                        urwid.Text(binding['help_text']),
-                        tlcorner=' ', tline=' ', lline=' ', trcorner=' ',
-                        blcorner=' ', rline=' ', bline='-', brcorner=' '
-                    ),
-                    urwid.LineBox(
-                        urwid.Text(commands),
-                        tlcorner=' ', tline=' ', lline=' ', trcorner=' ',
-                        blcorner=' ', rline=' ', bline='-', brcorner=' '
-                    )
-                ])
+                urwid.Columns([urwid.LineBox(
+                                   urwid.Text(text),
+                                   tlcorner=' ', brcorner=' ',
+                                   trcorner=' ', blcorner=' ',
+                                   rline=' ', lline=' ',
+                                   bline='-', tline=' ',
+                               ) for text in (binding['help_text'], commands)])
             )
         super(HelpView, self).__init__(self.log)
 

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -494,18 +494,17 @@ class LeftColumnView(urwid.Pile):
 class HelpView(urwid.ListBox):
     def __init__(self, controller: Any) -> None:
         self.controller = controller
-        self.log = urwid.SimpleFocusListWalker([urwid.Text('')])
-        for _, binding in KEY_BINDINGS.items():
-            commands = ", ".join(binding['keys'])
-            self.log.append(
-                urwid.Columns([urwid.LineBox(
+        self.log = urwid.SimpleFocusListWalker(
+            [urwid.Text('')] +
+            [urwid.Columns([urwid.LineBox(
                                    urwid.Text(text),
                                    tlcorner='', brcorner='',
                                    trcorner='', blcorner='',
                                    rline=' ', lline=' ',
                                    bline='-', tline='',
-                               ) for text in (binding['help_text'], commands)])
-            )
+                            ) for text in (binding['help_text'],
+                                           ", ".join(binding['keys']))])
+             for binding in KEY_BINDINGS.values()])
         super(HelpView, self).__init__(self.log)
 
     def keypress(self, size: Tuple[int, int], key: str) -> str:

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -502,10 +502,10 @@ class HelpView(urwid.ListBox):
             self.log.append(
                 urwid.Columns([urwid.LineBox(
                                    urwid.Text(text),
-                                   tlcorner=' ', brcorner=' ',
-                                   trcorner=' ', blcorner=' ',
+                                   tlcorner='', brcorner='',
+                                   trcorner='', blcorner='',
                                    rline=' ', lline=' ',
-                                   bline='-', tline=' ',
+                                   bline='-', tline='',
                                ) for text in (binding['help_text'], commands)])
             )
         super(HelpView, self).__init__(self.log)

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -494,9 +494,7 @@ class LeftColumnView(urwid.Pile):
 class HelpView(urwid.ListBox):
     def __init__(self, controller: Any) -> None:
         self.controller = controller
-        self.log = urwid.SimpleFocusListWalker([
-            urwid.Text("Press q to quit.", align='center')
-        ])
+        self.log = urwid.SimpleFocusListWalker([urwid.Text('')])
         for _, binding in KEY_BINDINGS.items():
             commands = ", ".join(binding['keys'])
             self.log.append(


### PR DESCRIPTION
This PR:
* switches the loop in `HelpView` into a list comprehension, and adds another to reduce duplication;
* saves visual space by removing blank lines and moving the (adjusted) title into the `LineBox` frame, reducing the need to scroll.

I've retained a blank line at the top, as it seems to separate the title/frame from the help better.

I think it would be good to connect the details on navigating the help with the help entries, but I think that is more a point for discussion.