### PR TITLE
Add 'M' to indicate muted streams in place of absent count

### DIFF
--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -62,6 +62,9 @@ def set_count(id_list: List[int], controller: Any, new_count: int) -> None:
         if msg_type == 'stream':
             stream_id = messages[id]['stream_id']
             for stream in streams:
+                if stream.stream_id in controller.model.muted_streams:
+                    stream.update_count(-1)
+                    break
                 if stream.stream_id == stream_id:
                     stream.update_count(stream.count + new_count)
                     break

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -92,9 +92,14 @@ class StreamButton(urwid.Button):
 
     def widget(self, count: int) -> Any:
         stream_prefix = ' ' + ('P' if self.is_private else '#') + ' '
+        if count < 0:
+            count_text = ' M'  # Muted
+        elif count == 0:
+            count_text = ''
+        else:
+            count_text = ' ' + str(count)
         return urwid.AttrMap(urwid.SelectableIcon(
-            [(self.color, stream_prefix), self.caption,
-             ('idle', '' if count <= 0 else ' ' + str(count))],
+            [(self.color, stream_prefix), self.caption, ('idle', count_text)],
             len(self.caption) + 2),
             None,
             'selected')


### PR DESCRIPTION
This at least shows that muted streams are muted, whereas previously this was not obvious.

In the webapp the counts are currently still shown, but faded out; whether we duplicate that is not clear, but this at least shows that the streams are muted.