### PR TITLE
Add version.py & use in core & setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ import sys
 import codecs
 from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
+from zulipterminal.version import ZT_VERSION
 
 
 class PyTest(TestCommand):
@@ -42,7 +43,7 @@ dev_helper_deps = [
 
 setup(
     name='zulip-term',
-    version='0.2.0',
+    version=ZT_VERSION,
     description='A terminal-based interface to zulip chat',
     long_description=long_description(),
     long_description_content_type='text/markdown',

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -4,6 +4,7 @@ from typing import Any
 import pytest
 
 from zulipterminal.core import Controller
+from zulipterminal.version import ZT_VERSION
 
 
 class TestController:
@@ -29,7 +30,7 @@ class TestController:
     def test_initialize_controller(self, controller, mocker) -> None:
         self.client.assert_called_once_with(
             config_file=self.config_file,
-            client='ZulipTerminal/0.1.0 ' + platform(),
+            client='ZulipTerminal/' + ZT_VERSION + ' ' + platform(),
         )
         self.model.assert_called_once_with(controller)
         self.view.assert_called_once_with(controller)

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -7,6 +7,7 @@ import time
 import urwid
 import zulip
 
+from zulipterminal.version import ZT_VERSION
 from zulipterminal.helper import asynch
 from zulipterminal.model import Model, GetMessagesArgs
 from zulipterminal.ui import View, Screen
@@ -23,7 +24,8 @@ class Controller:
     def __init__(self, config_file: str, theme: str) -> None:
         self.show_loading()
         self.client = zulip.Client(config_file=config_file,
-                                   client='ZulipTerminal/0.1.0 ' + platform())
+                                   client='ZulipTerminal/{} {}'.
+                                          format(ZT_VERSION, platform()))
         # Register to the queue before initializing Model or View
         # so that we don't lose any updates while messages are being fetched.
         self.register_initial_desired_events()

--- a/zulipterminal/version.py
+++ b/zulipterminal/version.py
@@ -1,0 +1,1 @@
+ZT_VERSION = '0.2.1+git'


### PR DESCRIPTION
While exploring the code to check the agent being reported, I noticed the version was hard-coded and doesn't match `setup.py` (or pypi).

This PR pulls this from a central file for both, and given 0.2.1 is on pypi, I set the version to `0.2.1+git`.