### PR TITLE
setup: Specify python requirements for pip>=9.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
     ],
+    python_requires='>=3.4, <3.8',
     keywords='',
     packages=find_packages(exclude=['test', 'test.*']),
     zip_safe=True,


### PR DESCRIPTION
For a sufficiently up to date pip, we can specify python when installing using pip; given we test against 3.4-3.7 now, I set this to `>=3.4, <3.8`.