### PR TITLE
Disable ctrl-z and ctrl-s (enabling star key use)

### DIFF
--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -165,5 +165,6 @@ class TestController:
         controller.view.palette = {
             'default': 'theme_properties'
         }
+        mock_tsk = mocker.patch('zulipterminal.ui.Screen.tty_signal_keys')
         controller.main()
         assert mock_loop.call_count == 1

--- a/zulipterminal/config.py
+++ b/zulipterminal/config.py
@@ -114,7 +114,7 @@ KEY_BINDINGS = {
         'help_text': 'Add/remove thumbs-up reaction on a message',
     },
     'TOGGLE_STAR_STATUS': {
-        'keys': {'*'},  # FIXME 'ctrl s' should work according to urwid
+        'keys': {'ctrl s', '*'},
         'help_text': 'Add/remove star status of a message',
     },
 }

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -268,6 +268,7 @@ class Controller:
             # TODO: Enable resuming? (in which case, remove ^Z below)
             disabled_keys = {
                 'susp': 'undefined',  # Disable ^Z for suspending
+                'stop': 'undefined',  # Disable ^S, enabling shortcut key use
             }
             old_signal_list = screen.tty_signal_keys(**disabled_keys)
             self.loop.run()

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -265,11 +265,18 @@ class Controller:
             return
 
         try:
+            # TODO: Enable resuming? (in which case, remove ^Z below)
+            disabled_keys = {
+                'susp': 'undefined',  # Disable ^Z for suspending
+            }
+            old_signal_list = screen.tty_signal_keys(**disabled_keys)
             self.loop.run()
 
         except Exception:
             self.restore_stdout()
+            screen.tty_signal_keys(*old_signal_list)
             raise
 
         finally:
             self.restore_stdout()
+            screen.tty_signal_keys(*old_signal_list)


### PR DESCRIPTION
It seems reasonable to disable both of these since:
- we don't currently respond appropriately to ^Z
- flow control is probably not relevant at this point (we could disable ^Q as well as ^S?)

We could potentially enable/disable the latter two for use as shortcut keys, and amend the signal code in `core.py` at run-time, but for now it seems reasonable to just disable it.

Not excluding ^Q should be safe, since that resumes the flow after a ^S.

The second commit fixes #166, so [un]starring keys will then incorporate the webapp (but retain `*`).