### PR TITLE
bugfix: Avoid traceback when searching streams.

### DIFF
--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -473,7 +473,11 @@ class LeftColumnView(urwid.Pile):
 
         if len(streams_btn_list):
             unpinned_divider = urwid.Divider("-")
-            unpinned_divider.stream_id = -1  # FIXME
+
+            # FIXME Necessary since the divider is treated as a StreamButton
+            unpinned_divider.stream_id = -1
+            unpinned_divider.caption = ''
+
             streams_btn_list += [unpinned_divider]
 
         streams_btn_list += [


### PR DESCRIPTION
Reported by @rht: pressing q twice gives AttributeError.

This arose from the implementation of pinned streams, where a Divider
masquerades as a StreamButton, and other application parts expect it to
have certain properties. It already had a stream_id; this commit adds a
caption attribute.

Will merge once tests have run; the existing tests did not pick up this issue, which itself is another issue.