### PR TITLE
config: Switch the key for stream narrow and topic narrow.

### DIFF
--- a/zulipterminal/config.py
+++ b/zulipterminal/config.py
@@ -66,11 +66,11 @@ KEY_BINDINGS = {
         'help_text': 'Send a message',
     },
     'STREAM_NARROW': {
-        'keys': {'S'},
+        'keys': {'s'},
         'help_text': 'Narrow to a stream',
     },
     'TOPIC_NARROW': {
-        'keys': {'s'},
+        'keys': {'S'},
         'help_text': 'Narrow to a topic',
     },
     'NEXT_UNREAD_TOPIC': {


### PR DESCRIPTION
This is in order to be consistent with the webapp.
A screenshot of the webapp key map exists at
https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/Narrowing.20behavior