### PR TITLE
deps: Install typing only on < 3.5.

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ url = "https://pypi.python.org/simple"
 name = "pypi"
 
 [packages]
-typing = "==3.6.4"
+typing = {version="==3.6.4", markers="python_version < '3.5'"}
 urwid = "==2.0.1"
 zulip = "==0.4.7"
 emoji = "==0.5.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-typing==3.6.4
+typing==3.6.4; python_version < '3.5'
 urwid==2.0.1
 zulip==0.4.7
 pytest==3.4.2

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup(
     },
     tests_require=testing_deps,
     install_requires=[
-        'typing==3.6.4',
+        "typing==3.6.4; python_version < '3.5'",
         'urwid==2.0.1',
         'zulip==0.4.7',
         'emoji==0.5.0',


### PR DESCRIPTION
This has been fixed in master though I couldn't find the reason why. It would be safer to not install `typing` on newer version.