### PR TITLE
Bugfix: Only update view if scrolling up & more messages exist

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -56,6 +56,7 @@ class TestMessageView:
         assert msg_view.focus_msg == focus_msg
 
     @pytest.mark.parametrize('messages_fetched', [
+        {},
         {201: "M1"},
         OrderedDict([(201, "M1"), (202, "M2")]),
     ])
@@ -85,14 +86,19 @@ class TestMessageView:
         assert msg_view.old_loading is False
         assert msg_view.index == {}
         assert msg_view.log == list(messages_fetched.values())  # code vs orig
-        (create_msg_box_list.
-         assert_called_once_with(msg_view.model, new_msg_ids))
-        self.model.controller.update_screen.assert_called_once_with()
+        if messages_fetched:
+            (create_msg_box_list.
+             assert_called_once_with(msg_view.model, new_msg_ids))
+            self.model.controller.update_screen.assert_called_once_with()
+        else:
+            create_msg_box_list.assert_not_called()
+            self.model.controller.update_screen.assert_not_called()
         self.model.get_messages.assert_called_once_with(num_before=30,
                                                         num_after=0,
                                                         anchor=0)
 
     @pytest.mark.parametrize('messages_fetched', [
+        {},
         {201: "M1"},
         OrderedDict([(201, "M1"), (202, "M2")]),
     ])
@@ -134,10 +140,14 @@ class TestMessageView:
         assert msg_view.old_loading is False
         assert msg_view.index == {}
         assert msg_view.log == new_msg_widgets + initial_log
-        create_msg_box_list.assert_called_once_with(msg_view.model,
-                                                    {top_id_in_narrow} |
-                                                    new_msg_ids)
-        self.model.controller.update_screen.assert_called_once_with()
+        if messages_fetched:
+            create_msg_box_list.assert_called_once_with(msg_view.model,
+                                                        {top_id_in_narrow} |
+                                                        new_msg_ids)
+            self.model.controller.update_screen.assert_called_once_with()
+        else:
+            create_msg_box_list.assert_not_called()
+            self.model.controller.update_screen.assert_not_called()
         self.model.get_messages.assert_called_once_with(num_before=30,
                                                         num_after=0,
                                                         anchor=0)

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -52,21 +52,29 @@ class MessageView(urwid.ListBox):
         if self.log:
             top_message_id = self.log[0].original_widget.message['id']
             ids_to_keep.remove(top_message_id)  # update this id
-            self.log.remove(self.log[0])  # avoid duplication when updating
+            no_update_baseline = {top_message_id}
+        else:
+            no_update_baseline = set()
 
         self.index = self.model.get_messages(num_before=30, num_after=0,
                                              anchor=anchor)
         ids_to_process = (self.model.get_message_ids_in_current_narrow() -
                           ids_to_keep)
 
-        message_list = create_msg_box_list(self.model, ids_to_process)
-        message_list.reverse()
-        for msg_w in message_list:
-            self.log.insert(0, msg_w)
+        # Only update if more messages are provided
+        if ids_to_process != no_update_baseline:
+            if self.log:
+                self.log.remove(self.log[0])  # avoid duplication when updating
 
-        self.set_focus(self.focus_msg)  # Return focus to original message
+            message_list = create_msg_box_list(self.model, ids_to_process)
+            message_list.reverse()
+            for msg_w in message_list:
+                self.log.insert(0, msg_w)
 
-        self.model.controller.update_screen()
+            self.set_focus(self.focus_msg)  # Return focus to original message
+
+            self.model.controller.update_screen()
+
         self.old_loading = False
 
     @asynch


### PR DESCRIPTION
This fixes a bug found by @rht where scrolling up beyond the top of a topic caused a traceback:
```
Traceback (most recent call last):                                                                                                                │
  File "/run/current-system/sw/lib/python3.7/threading.py", line 917, in _bootstrap_inner                                                         │
    self.run()           │                                                                                                                        │
  File "/run/current-system/sw/lib/python3.7/threading.py", line 865, in run                                                                      │
    self._target(*self._args, **self._kwargs)                                                                                                     │
  File "/home/rht/github/repos/zulip-terminal/zulipterminal/ui_tools/views.py", line 67, in load_old_messages                                     │
    self.set_focus(self.focus_msg)  # Return focus to original message                                                                            │
  File "/home/rht/code/venv/lib/python3.7/site-packages/urwid/listbox.py", line 581, in set_focus                                                 │
    self._body.set_focus(position)                                                                                                                │
  File "/home/rht/code/venv/lib/python3.7/site-packages/urwid/listbox.py", line 238, in set_focus                                                 │
    self.focus = position│                                                                                                                        │
  File "/home/rht/code/venv/lib/python3.7/site-packages/urwid/monitored_list.py", line 165, in _set_focus                                         │
    raise IndexError('focus index is out of range: %s' % (index,))                                                                                │
IndexError: focus index is out of range: 26
```

The code in question was updated recently to elide extra recipient headers when scrolling up; the bug may have originated there (#179), or beforehand, though there has not been a release between.

The commit fixing this bug updates the tests to run, with the second commit extending the tests to cover the case of no extra messages present.