### PR TITLE
ui: Add 16:default,256:gruvbox colorscheme.

### DIFF
--- a/zulipterminal/config/themes.py
+++ b/zulipterminal/config/themes.py
@@ -2,6 +2,21 @@ from typing import Dict, List, Tuple, Optional
 
 ThemeSpec = List[Tuple[Optional[str], ...]]
 
+# Colors used in gruvbox-256
+# See https://github.com/morhetz/gruvbox/blob/master/colors/gruvbox.vim
+BLACK = 'h234'  # dark0_hard
+WHITE = 'h246'  # light4_256
+WHITEBOLD = '%s, bold' % WHITE
+DARKBLUE = 'h24'  # faded_blue
+DARKRED = 'h88'  # faded_red
+LIGHTBLUE = 'h109'  # bright_blue
+YELLOW = 'h172'  # neutral_yellow
+YELLOWBOLD = '%s, bold' % YELLOW
+LIGHTGREEN = 'h142'  # bright_green
+LIGHTRED = 'h167'  # bright_red
+LIGHTREDBOLD = '%s, bold' % LIGHTRED
+GRAY = 'h244'  # gray_244
+
 THEMES = {
     'default': [
         (None,           'white',           'black'),
@@ -25,6 +40,52 @@ THEMES = {
         ('bold',         'white, bold',     'black'),
         ('footer',       'white',           'dark red',   'bold'),
         ('starred',      'light red, bold', 'black'),
+    ],
+    'gruvbox': [
+        # default colorscheme on 16 colors, gruvbox colorscheme
+        # on 256 colors
+        (None,           'white',           'black',
+         None,           WHITE,             BLACK),
+        ('selected',     'light magenta',   'dark blue',
+         None,           'light magenta',   DARKBLUE),
+        ('msg_selected', 'light green',     'black',
+         None,           LIGHTGREEN,        BLACK),
+        ('header',       'dark cyan',       'dark blue',
+         'bold',         'dark cyan',       DARKBLUE),
+        ('custom',       'white',           'dark blue',
+         'underline',    WHITE,             DARKBLUE),
+        ('content',      'white',           'black',
+         'standout',     WHITE,             BLACK),
+        ('name',         'yellow, bold',    'black',
+         None,           YELLOWBOLD,        BLACK),
+        ('unread',       'light blue',      'black',
+         None,           LIGHTBLUE,         BLACK),
+        ('active',       'white',           'black',
+         None,           WHITE,             BLACK),
+        ('idle',         'yellow',          'black',
+         None,           YELLOW,            BLACK),
+        ('title',        'white, bold',     'black',
+         None,           WHITEBOLD,         BLACK),
+        ('time',         'light blue',      'black',
+         None,           LIGHTBLUE,         BLACK),
+        ('bar',          'white',           'dark gray',
+         None,           WHITE,             GRAY),
+        ('emoji',        'light magenta',   'black',
+         None,           'light magenta',   BLACK),
+        ('span',         'light red, bold', 'black',
+         None,           LIGHTREDBOLD,      BLACK),
+        ('link',         'light blue',      'black',
+         None,           LIGHTBLUE,         BLACK),
+        ('blockquote',   'brown',           'black',
+         None,           'brown',           BLACK),
+        ('code',         'black',           'white',
+         None,           BLACK,             WHITE),
+        ('bold',         'white, bold',     'black',
+         None,           WHITEBOLD,         BLACK),
+        ('footer',       'white',           'dark red',
+         'bold',         WHITE,             DARKRED),
+        ('starred',      'light red, bold', 'black',
+         None,           LIGHTREDBOLD,      BLACK),
     ],
     'light': [
         (None,           'black',        'white'),


### PR DESCRIPTION
Proof-of-concept of using 256-color mode with gruvbox theme (https://github.com/morhetz/gruvbox/blob/master/colors/gruvbox.vim).

Before:
![2018-12-16-075049_1920x1080_scrot](https://user-images.githubusercontent.com/395821/50051325-9e13b000-0107-11e9-9bac-ac8b8f5de040.png)

After:
![2018-12-16-080025_1920x1080_scrot](https://user-images.githubusercontent.com/395821/50051381-b932ef80-0108-11e9-9576-058769430059.png)


Still hardcoded. I should make 2 preparatory commits to: enable/disable the 256-color on terminals that support 256-color, conf to easily modify the color instead of at ui.py.