### PR TITLE
Add Starred messages key (f) and button

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ theme=default
 | Narrow to a stream                                    | <kbd>S</kbd>                                  |
 | Narrow to a topic                                     | <kbd>s</kbd>                                  |
 | Narrow to private messages                            | <kbd>P</kbd>                                  |
+| Narrow to starred messages                            | <kbd>f</kbd>                                  |
 | Next Unread Topic                                     | <kbd>n</kbd>                                  |
 | Next Unread PM                                        | <kbd>p</kbd>                                  |
 | Search People                                         | <kbd>w</kbd>                                  |

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,7 +69,7 @@ def msg_box(mocker, messages_successful_response):
 # --------------- Model Fixtures ----------------------------------------------
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture
 def messages_successful_response() -> Dict[str, Any]:
     """
     A successful response from a /messages API query.
@@ -383,7 +383,7 @@ def initial_data():
     }
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def empty_index():
     return {
         'pointer': defaultdict(set, {}),
@@ -493,7 +493,7 @@ def empty_index():
     }
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def index_all_messages(empty_index):
     """
     Expected index of `initial_data` fixture when model.narrow = []
@@ -501,7 +501,7 @@ def index_all_messages(empty_index):
     return dict(empty_index, **{'all_messages': {537286, 537287, 537288}})
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def index_stream(empty_index):
     """
     Expected index of initial_data when model.narrow = [['stream', '7']]
@@ -511,7 +511,7 @@ def index_stream(empty_index):
     return dict(empty_index, **diff)
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def index_topic(empty_index):
     """
     Expected index of initial_data when model.narrow = [['stream', '7'],
@@ -521,7 +521,7 @@ def index_topic(empty_index):
     return dict(empty_index, **diff)
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def index_user(empty_index):
     """
     Expected index of initial_data when model.narrow = [['pm_with',
@@ -532,7 +532,7 @@ def index_user(empty_index):
     return dict(empty_index, **diff)
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def index_user_multiple(empty_index):
     """
     Expected index of initial_data when model.narrow = [['pm_with',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -393,6 +393,7 @@ def empty_index():
         'all_stream': defaultdict(set, {}),
         'stream': defaultdict(dict, {}),
         'search': set(),
+        'all_starred': set(),
         'messages': defaultdict(dict, {
             537286: {
                 'type': 'stream',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -544,6 +544,21 @@ def index_user_multiple(empty_index):
     return dict(empty_index, **diff)
 
 
+@pytest.fixture(params=[
+    {537286, 537287, 537288},
+    {537286}, {537287}, {537288},
+    {537286, 537287}, {537286, 537288}, {537287, 537288},
+])
+def index_all_starred(empty_index, request):
+    msgs_with_stars = request.param
+    index = dict(empty_index, all_starred=msgs_with_stars,
+                 all_private={537287, 537288})
+    for msg_id, msg in index['messages'].items():
+        if msg_id in msgs_with_stars and 'starred' not in msg['flags']:
+            msg['flags'].append('starred')
+    return index
+
+
 @pytest.fixture(scope="module")
 def user_profile():
     return {

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -145,6 +145,34 @@ class TestController:
         msg_ids = {widget.original_widget.message['id'] for widget in widgets}
         assert msg_ids == id_list
 
+    def test_show_all_starred(self, mocker, controller, index_all_starred):
+        controller.model.client = self.client
+        controller.model.narrow = []
+        controller.model.index = index_all_starred
+        controller.model.muted_streams = set()  # FIXME Expand upon this
+        controller.model.muted_topics = []  # FIXME Expand upon this
+        controller.model.stream_dict = {
+            205: {
+                'color': '#ffffff',
+            }
+        }
+        controller.model.msg_view = mocker.patch('urwid.SimpleFocusListWalker')
+        controller.model.msg_list = mocker.patch('urwid.ListBox')
+
+        controller.show_all_starred('')
+
+        assert controller.model.narrow == [['is', 'starred']]
+
+        controller.model.msg_view.clear.assert_called_once_with()
+
+        num_sm = len(index_all_starred['all_starred'])
+        controller.model.msg_list.set_focus.assert_called_once_with(num_sm - 1)
+
+        id_list = index_all_starred['all_starred']
+        widgets = controller.model.msg_view.extend.call_args_list[0][0][0]
+        msg_ids = {widget.original_widget.message['id'] for widget in widgets}
+        assert msg_ids == id_list
+
     def test_register_initial_desired_events(self, mocker):
         self.config_file = 'path/to/zuliprc'
         self.theme = 'default'

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -69,6 +69,7 @@ class TestModel:
         [['pm_with', 'FOO@zulip.com']],
         [['pm_with', 'Foo@zulip.com, Bar@zulip.com']],
         [['is', 'private']],
+        [['is', 'starred']],
     ])
     def test_get_focus_in_current_narrow_individually(self,
                                                       model, msg_id, narrow):
@@ -84,6 +85,7 @@ class TestModel:
         [['pm_with', 'FOO@zulip.com']],
         [['pm_with', 'Foo@zulip.com, Bar@zulip.com']],
         [['is', 'private']],
+        [['is', 'starred']],
     ])
     def test_set_focus_in_current_narrow(self, mocker, model, narrow, msg_id):
         from collections import defaultdict
@@ -109,6 +111,7 @@ class TestModel:
          dict(stream='some stream', topic='some topic')),
         ([['search', 'something interesting']],
          dict(search='something interesting')),
+        ([['is', 'starred']], dict(starred=True)),
     ])
     def test_set_narrow_already_set(self, model, narrow, good_args):
         model.narrow = narrow
@@ -120,6 +123,7 @@ class TestModel:
         ([], [['stream', 'some stream']], dict(stream='some stream')),
         ([], [['stream', 'some stream'], ['topic', 'some topic']],
          dict(stream='some stream', topic='some topic')),
+        ([], [['is', 'starred']], dict(starred=True)),
     ])
     def test_set_narrow_not_already_set(self, model, initial_narrow, narrow,
                                         good_args):
@@ -155,6 +159,9 @@ class TestModel:
         }, {0, 1}),
         ([['search', 'FOO']], {
             'search': {0, 1}
+        }, {0, 1}),
+        ([['is', 'starred']], {
+            'all_starred': {0, 1}
         }, {0, 1})
     ])
     def test_get_message_ids_in_current_narrow(self, mocker, model,

--- a/zulipterminal/config.py
+++ b/zulipterminal/config.py
@@ -73,6 +73,14 @@ KEY_BINDINGS = {
         'keys': {'S'},
         'help_text': 'Narrow to a topic',
     },
+    'ALL_PM': {
+        'keys': {'P'},
+        'help_text': 'Narrow to all private messages',
+    },
+    'ALL_STARRED': {
+        'keys': {'f'},
+        'help_text': 'Narrow to all starred messages',
+    },
     'NEXT_UNREAD_TOPIC': {
         'keys': {'n'},
         'help_text': 'Next unread topic',
@@ -100,10 +108,6 @@ KEY_BINDINGS = {
     'ENTER': {
         'keys': {'enter'},
         'help_text': 'Perform current action',
-    },
-    'ALL_PM': {
-        'keys': {'P'},
-        'help_text': 'Show all private messages',
     },
     'QUIT_HELP': {
         'keys': {'q', 'esc'},

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -226,6 +226,20 @@ class Controller:
 
         self._finalize_show(w_list)
 
+    def show_all_starred(self, button: Any) -> None:
+        already_narrowed = self.model.set_narrow(starred=True)
+        if already_narrowed:
+            return
+
+        self.update = False
+        msg_list = self.model.index['all_starred']
+        if len(msg_list) == 0:
+            self.model.get_messages(num_before=30, num_after=10, anchor=None)
+            msg_list = self.model.index['all_starred']
+        w_list = create_msg_box_list(self.model, msg_list)
+
+        self._finalize_show(w_list)
+
     def _finalize_show(self, w_list: List[Any]) -> None:
         focus_position = self.model.get_focus_in_current_narrow()
 

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -219,6 +219,7 @@ def index_messages(messages: List[Any], model: Any, index: Any=None)\
             'all_stream': defaultdict(set),
             'messages': defaultdict(dict),
             'search': set(),
+            'all_starred': set(),
         }
     narrow = model.narrow
     for msg in messages:
@@ -232,6 +233,10 @@ def index_messages(messages: List[Any], model: Any, index: Any=None)\
             continue
 
         if len(narrow) == 1:
+
+            if narrow[0][1] == 'starred':
+                if 'starred' in msg['flags']:
+                    index['all_starred'].add(msg['id'])
 
             if msg['type'] == 'private':
                 index['all_private'].add(msg['id'])

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -77,18 +77,21 @@ class Model:
     def set_narrow(self, *,
                    stream: Optional[str]=None, topic: Optional[str]=None,
                    search: Optional[str]=None,
-                   pm_with: Optional[str]=None) -> bool:
-        if search and not(stream or topic or pm_with):
+                   pm_with: Optional[str]=None,
+                   starred: bool=False) -> bool:
+        if search and not(stream or topic or pm_with or starred):
             new_narrow = [['search', search]]
-        elif stream and topic and not(search or pm_with):
+        elif stream and topic and not(search or pm_with or starred):
             new_narrow = [["stream", stream],
                           ["topic", topic]]
-        elif stream and not(topic or search or pm_with):
+        elif stream and not(topic or search or pm_with or starred):
             new_narrow = [['stream', stream]]
-        elif pm_with == '' and not(stream or topic or search):
+        elif pm_with == '' and not(stream or topic or search or starred):
             new_narrow = [['is', 'private']]
-        elif pm_with and not(stream or topic or search):
+        elif pm_with and not(stream or topic or search or starred):
             new_narrow = [['pm_with', pm_with]]
+        elif starred and not(stream or topic or search or pm_with):
+            new_narrow = [['is', 'starred']]
         elif not stream and not topic and not search and not pm_with:
             new_narrow = []
         else:
@@ -118,6 +121,8 @@ class Model:
             current_ids = self.index['private'][recipients]
         elif narrow[0][0] == 'search':
             current_ids = self.index['search']
+        elif narrow[0][1] == 'starred':
+            current_ids = self.index['all_starred']
         return current_ids.copy()
 
     @asynch

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -466,6 +466,8 @@ class MessageBox(urwid.Pile):
             )
         elif is_command_key('ALL_PM', key):
             self.model.controller.show_all_pm(self)
+        elif is_command_key('ALL_STARRED', key):
+            self.model.controller.show_all_starred(self)
         elif is_command_key('MENTION_REPLY', key):
             self.keypress(size, 'enter')
             mention = '@**' + self.message['sender_full_name'] + '** '

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -9,7 +9,6 @@ from urwid_readline import ReadlineEdit
 from bs4 import BeautifulSoup
 from bs4.element import NavigableString, Tag
 
-from zulipterminal.ui_tools.buttons import MenuButton
 from zulipterminal.config import is_command_key
 
 

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -68,6 +68,27 @@ class PMButton(urwid.Button):
         return super(PMButton, self).keypress(size, key)
 
 
+class StarredButton(urwid.Button):
+    def __init__(self, controller: Any) -> None:
+        self.caption = 'Starred messages'
+        super(StarredButton, self).__init__("")
+        self.count = 0  # Starred messages are already marked read
+        self._w = self.widget(0)
+        urwid.connect_signal(self, 'click', controller.show_all_starred)
+
+    def update_count(self, count: int) -> None:
+        self.count = count
+        self._w = self.widget(count)
+
+    def widget(self, count: int) -> Any:
+        return urwid.AttrMap(urwid.SelectableIcon(
+            [u' \N{BULLET} ', self.caption,
+             ('idle', '' if count <= 0 else ' ' + str(count))],
+            len(self.caption) + 4),
+            None,
+            'selected')
+
+
 class StreamButton(urwid.Button):
     def __init__(self, properties: List[Any],
                  controller: Any, view: Any, count: int=0) -> None:

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Tuple, Callable
 
 import urwid
 
@@ -14,14 +14,15 @@ class MenuButton(urwid.Button):
             [self.caption], 0), None, 'selected')
 
 
-class HomeButton(urwid.Button):
-    def __init__(self, controller: Any, count: int=0) -> None:
-        self.caption = 'All messages'
+class TopButton(urwid.Button):
+    def __init__(self, controller: Any, caption: str,
+                 show_function: Callable[..., Any], count: int=0) -> None:
+        self.caption = caption
         self.count = count
-        super(HomeButton, self).__init__("")
+        super().__init__("")
         self._w = self.widget(count)
         self.controller = controller
-        urwid.connect_signal(self, 'click', controller.show_all_messages)
+        urwid.connect_signal(self, 'click', show_function)
 
     def update_count(self, count: int) -> None:
         self.count = count
@@ -38,55 +39,26 @@ class HomeButton(urwid.Button):
     def keypress(self, size: Tuple[int, int], key: str) -> str:
         if is_command_key('ENTER', key):
             self.controller.view.toggle_left_panel()
-        return super(HomeButton, self).keypress(size, key)
+        return super().keypress(size, key)
 
 
-class PMButton(urwid.Button):
+class HomeButton(TopButton):
     def __init__(self, controller: Any, count: int=0) -> None:
-        self.caption = 'Private messages'
-        super(PMButton, self).__init__("")
-        self.count = count
-        self._w = self.widget(count)
-        self.controller = controller
-        urwid.connect_signal(self, 'click', controller.show_all_pm)
-
-    def update_count(self, count: int) -> None:
-        self.count = count
-        self._w = self.widget(count)
-
-    def widget(self, count: int) -> Any:
-        return urwid.AttrMap(urwid.SelectableIcon(
-            [u' \N{BULLET} ', self.caption,
-             ('idle', '' if count <= 0 else ' ' + str(count))],
-            len(self.caption) + 4),
-            None,
-            'selected')
-
-    def keypress(self, size: Tuple[int, int], key: str) -> str:
-        if is_command_key('ENTER', key):
-            self.controller.view.toggle_left_panel()
-        return super(PMButton, self).keypress(size, key)
+        super().__init__(controller, 'All messages',
+                         controller.show_all_messages, count=count)
 
 
-class StarredButton(urwid.Button):
+class PMButton(TopButton):
+    def __init__(self, controller: Any, count: int=0) -> None:
+        super().__init__(controller, 'Private messages',
+                         controller.show_all_pm, count=count)
+
+
+class StarredButton(TopButton):
     def __init__(self, controller: Any) -> None:
-        self.caption = 'Starred messages'
-        super(StarredButton, self).__init__("")
-        self.count = 0  # Starred messages are already marked read
-        self._w = self.widget(0)
-        urwid.connect_signal(self, 'click', controller.show_all_starred)
-
-    def update_count(self, count: int) -> None:
-        self.count = count
-        self._w = self.widget(count)
-
-    def widget(self, count: int) -> Any:
-        return urwid.AttrMap(urwid.SelectableIcon(
-            [u' \N{BULLET} ', self.caption,
-             ('idle', '' if count <= 0 else ' ' + str(count))],
-            len(self.caption) + 4),
-            None,
-            'selected')
+        super().__init__(controller, 'Starred messages',
+                         controller.show_all_starred,
+                         count=0)  # Starred messages are already marked read
 
 
 class StreamButton(urwid.Button):

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -12,6 +12,7 @@ from zulipterminal.ui_tools.buttons import (
     UserButton,
     HomeButton,
     PMButton,
+    StarredButton,
     StreamButton,
 )
 from zulipterminal.ui_tools.utils import create_msg_box_list
@@ -461,11 +462,17 @@ class LeftColumnView(urwid.Pile):
     def menu_view(self) -> Any:
         count = self.model.unread_counts.get('all_msg', 0)
         self.view.home_button = HomeButton(self.controller, count=count)
+
         count = self.model.unread_counts.get('all_pms', 0)
         self.view.pm_button = PMButton(self.controller, count=count)
+
+        # Starred messages are by definition read already
+        self.view.starred_button = StarredButton(self.controller)
+
         menu_btn_list = [
             self.view.home_button,
             self.view.pm_button,
+            self.view.starred_button,
         ]
         w = urwid.ListBox(urwid.SimpleFocusListWalker(menu_btn_list))
         return w


### PR DESCRIPTION
This completes my push to add starred message support; this was working some time ago, but is now sufficiently polished and tested to be a PR :)

I find this useful not just for marking messages as starred/unstarred (via `*` or `ctrl s` to toggle), but now also for showing those messages with just a key, and occasionally via the starred-message button.

Given the duplication in StarredButton, the last commit also is quite a simplification of similar buttons.

Also @amanagr `MenuButton` isn't used, correct? Could we remove that in a different PR?