### PR TITLE
CHANGELOG.md: Add file listing new git features & earlier versions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,41 @@
+# Zulip-terminal Changelog
+
+## Next release
+
+### Interactivity improvements
+- Toggle thumbs-up reactions to messages (<kbd>+</kbd>)
+- Toggle star status of messages (<kbd>*</kbd> or <kbd>ctrl</kbd>+<kbd>s</kbd>)
+- Narrow to starred messges (<kbd>f</kbd>, or via new button)
+- Reply mentioning sender (<kbd>@</kbd>)
+- Reply quoting mesage (<kbd>></kbd>)
+- Use enter to reply to a message
+- Disable responding to suspend (<kbd>ctrl</kbd>+<kbd>z</kbd>), since cannot resume (yet)
+- Disable responding to <kbd>ctrl</kbd>+<kbd>s</kbd> for flow control, enabling use with starring
+
+### Visual improvements
+- Reorder streams into pinned and unpinned groups
+- Style message contents (extracted using beautifulsoup)
+- Improve recipient (eg. stream/topic) bar formatting
+- Show star status of messages
+- Show marker to left of messages
+- Mark private streams with P instead of #
+- Show unread count of muted streams as M
+- Internal help (<kbd>?</kbd>) more compact & reordered
+- Random shortcut keys are shown at the bottom of the screen
+
+### Important bugfixes
+- Allow narrowing to cross-realm bots
+- Support private messages with multiple users properly
+- Avoid showing duplicate recipient bars when scrolling
+
+### Infrastructure changes
+- Documentation improvements
+- Explicitly support latest versions of python 3.4 to 3.7
+- Higher test coverage
+- Various internal refactoring
+
+## 0.2.1
+### Bugfix release
+
+## 0.2.0
+### First PyPI release


### PR DESCRIPTION
I thought it would be useful to collate the changes since the last release; this is based on the git log since 0.2.0 was tagged; I'm not sure precisely what went into 0.2.1, and what to place under those versions.