### PR TITLE
run/core: Validate & indicate source of themes early in run, not core.

### DIFF
--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -143,7 +143,7 @@ def main() -> None:
 
         print("Loading with '{}' theme specified {}..."
               .format(*theme_to_use))
-        Controller(zuliprc_path, theme_to_use[0]).main()
+        Controller(zuliprc_path, THEMES[theme_to_use[0]]).main()
     except Exception as e:
         if args.debug:
             # A unexpected exception occurred, open the debugger in debug mode

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -1,5 +1,5 @@
 from platform import platform
-from typing import Any, List
+from typing import Any, List, Tuple
 import os
 import sys
 import time
@@ -21,7 +21,9 @@ class Controller:
     the application.
     """
 
-    def __init__(self, config_file: str, theme: str) -> None:
+    def __init__(self, config_file: str, theme: List[Tuple[str, ...]]) -> None:
+        self.theme = theme
+
         self.show_loading()
         self.client = zulip.Client(config_file=config_file,
                                    client='ZulipTerminal/{} {}'.
@@ -33,8 +35,6 @@ class Controller:
         self.view = View(self)
         # Start polling for events after view is rendered.
         self.model.poll_for_events()
-        self.theme = theme
-        assert self.theme in self.view.palette  # assumed valid theme
         self.editor_mode = False  # type: bool
         self.editor = None  # type: Any
 
@@ -271,7 +271,7 @@ class Controller:
         screen = Screen()
         screen.set_terminal_properties(colors=256)
         self.loop = urwid.MainLoop(self.view,
-                                   self.view.palette[self.theme],
+                                   self.theme,
                                    screen=screen)
         self.update_pipe = self.loop.watch_pipe(self.draw_screen)
 

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -34,6 +34,7 @@ class Controller:
         # Start polling for events after view is rendered.
         self.model.poll_for_events()
         self.theme = theme
+        assert self.theme in self.view.palette  # assumed valid theme
         self.editor_mode = False  # type: bool
         self.editor = None  # type: Any
 
@@ -267,18 +268,12 @@ class Controller:
         self.last_event_id = response['last_event_id']
 
     def main(self) -> None:
-        try:
-            screen = Screen()
-            screen.set_terminal_properties(colors=256)
-            self.loop = urwid.MainLoop(self.view,
-                                       self.view.palette[self.theme],
-                                       screen=screen)
-            self.update_pipe = self.loop.watch_pipe(self.draw_screen)
-        except KeyError:
-            print('Following are the themes available:')
-            for theme in self.view.palette.keys():
-                print(theme,)
-            return
+        screen = Screen()
+        screen.set_terminal_properties(colors=256)
+        self.loop = urwid.MainLoop(self.view,
+                                   self.view.palette[self.theme],
+                                   screen=screen)
+        self.update_pipe = self.loop.watch_pipe(self.draw_screen)
 
         try:
             # TODO: Enable resuming? (in which case, remove ^Z below)

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -21,10 +21,10 @@ class View(urwid.WidgetWrap):
     """
     A class responsible for providing the application's interface.
     """
-    palette = THEMES
 
     def __init__(self, controller: Any) -> None:
         self.controller = controller
+        self.palette = controller.theme
         self.model = controller.model
         self.client = controller.client
         self.users = self.model.users

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -68,10 +68,9 @@ class StreamButton(urwid.Button):
         self.stream_id = properties[1]
         color = properties[2]
         self.color = color[:2] + color[3] + color[5]
-        view.palette['default'].append((self.color, '', '', '', self.color,
-                                       'black'))
-        view.palette['default'].append(('s' + self.color, '', '', '',
-                                       'black', self.color))
+        view.palette.append((self.color, '', '', '', self.color, 'black'))
+        view.palette.append(('s' + self.color, '', '', '', 'black',
+                             self.color))
         self.is_private = properties[3]
         self.count = count
         super(StreamButton, self).__init__("")
@@ -84,7 +83,7 @@ class StreamButton(urwid.Button):
         self._w = self.widget(count)
 
     def widget(self, count: int) -> Any:
-        stream_prefix = ' ' + ('P' if self.is_private else '#') + ' '
+        stream_prefix = 'P' if self.is_private else '#'
         if count < 0:
             count_text = ' M'  # Muted
         elif count == 0:
@@ -92,7 +91,8 @@ class StreamButton(urwid.Button):
         else:
             count_text = ' ' + str(count)
         return urwid.AttrMap(urwid.SelectableIcon(
-            [(self.color, stream_prefix), self.caption, ('idle', count_text)],
+            [' ', (self.color, stream_prefix), ' ', self.caption,
+             ('idle', count_text)],
             len(self.caption) + 2),
             None,
             'selected')


### PR DESCRIPTION
This PR validates theme selection before reaching the `Controller`, and includes much more error handling.

This was also motivated by theme specification on the command-line not being recognized - this PR shows where themes are being specified, both in the case of failure and success :)

I'm aware the code is all in the try block - this can be refactored out for cleanliness, but this feature seemed useful to have ASAP!