### PR TITLE
CI: Add testing on Windows.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,23 @@
+version: "{build}"
+os: Windows Server 2012 R2
+cache:
+  - '%LOCALAPPDATA%\pip\Cache'
+environment:
+  matrix:
+    - PYTHON: "C:\\Python35"
+      PYTHON_VERSION: 3.5
+
+build: none
+init:
+  - "ECHO %PYTHON%"
+  - ps: "ls C:\\Python*"
+
+install:
+  - "set PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+  - "pip install pipenv==11.10"
+  - "pipenv install --dev Pipfile"
+
+test_script:
+  - "pipenv run pytest"
+  - "pipenv run pytest --pep8"
+  - "pipenv run ./tools/run-mypy"


### PR DESCRIPTION
While Travis also has beta support for Windows, I have tested it to be slower than appveyor. Needs to be enabled at https://www.appveyor.com/.