### PR TITLE
[WIP (tests/locking?)] Update read and starred messages methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Use enter to reply to a message
 - Disable responding to suspend (<kbd>ctrl</kbd>+<kbd>z</kbd>), since cannot resume (yet)
 - Disable responding to <kbd>ctrl</kbd>+<kbd>s</kbd> for flow control, enabling use with starring
+- Improved synchronizing of read and starred message status with server (and so webapp)
 
 ### Visual improvements
 - Reorder streams into pinned and unpinned groups

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -619,14 +619,14 @@ class TestModel:
         model.update_reaction(response)
         assert len(model.index['messages'][1]['reactions']) == 1
 
-    def test_update_star_status_no_index(self, mocker, model):
-        model.index = dict(messages={1: {}})  # Not indexed
-        event = dict(messages=[1])
+    def test_update_star_status_not_indexed(self, mocker, model):
+        model.index = dict(messages={2: {}})  # Not indexed
+        event = dict(messages=[1], all=False)
         mocker.patch('zulipterminal.model.Model.update_rendered_view')
 
         model.update_star_status(event)
 
-        assert model.index == dict(messages={1: {}})
+        assert model.index == dict(messages={2: {}})
         model.update_rendered_view.assert_not_called()
 
     def test_update_star_status_invalid_operation(self, mocker, model):
@@ -635,7 +635,8 @@ class TestModel:
             'messages': [1],
             'type': 'update_message_flags',
             'flag': 'starred',
-            'operation': 'OTHER'  # not 'add' or 'remove'
+            'operation': 'OTHER',  # not 'add' or 'remove'
+            'all': False,
         }
         mocker.patch('zulipterminal.model.Model.update_rendered_view')
         with pytest.raises(RuntimeError):
@@ -660,7 +661,8 @@ class TestModel:
             'messages': [1],
             'type': 'update_message_flags',
             'flag': 'starred',
-            'operation': event_op
+            'operation': event_op,
+            'all': False,
         }
         mocker.patch('zulipterminal.model.Model.update_rendered_view')
 

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -413,10 +413,11 @@ class Model:
                   -1*len(messages_to_mark_read))
 
     def update_star_status(self, event: Dict[str, Any]) -> None:
-        assert len(event['messages']) == 1  # FIXME: Can be multiple?
-        message_id = event['messages'][0]
+        assert not event['all']  # FIXME Should handle
+        indexed_messages = set(self.index['messages'])
+        messages_to_mark_starred = set(event['messages'])
 
-        if self.index['messages'][message_id] != {}:
+        for message_id in messages_to_mark_starred & indexed_messages:
             msg = self.index['messages'][message_id]
             if event['operation'] == 'add':
                 if 'starred' not in msg['flags']:


### PR DESCRIPTION
This is intended to add read-flag updates sent from the server, so if messages are read in the webapp and ZT is running, the intention is that the unread counts and status in ZT should update at the same time. It also extends the capability of the similar starred feature to cover where multiple message updates occur at once, in line with the read-flag version.

I would appreciate any testing of this PR :)

CAVEATS:
* On reading many messages quickly (in the webapp), the numbers can become out of sync with ZT (is this due to some kind of locking issue? multiple messages sent from the server which aren't responded to?)
* Some stream totals are occasionally wrong on loading?
* I'd like to add some tests for the new method, but wanted to look for feedback first.