### PR TITLE
model: In case of all read msgs don't set pointer to received anchor.

### DIFF
--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -237,7 +237,8 @@ class TestModel:
             request, '/json/messages', method="GET")
         assert model.index == index_all_messages
         anchor = messages_successful_response['anchor']
-        assert model.index['pointer'][str(model.narrow)] == anchor
+        if anchor < 10000000000000000:
+            assert model.index['pointer'][str(model.narrow)] == anchor
         assert model.update is True
 
     def test_get_message_false_first_anchor(

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -194,7 +194,7 @@ class Model:
                                             method="GET")
         if response['result'] == 'success':
             self.index = index_messages(response['messages'], self, self.index)
-            if first_anchor:
+            if first_anchor and response['anchor'] != 10000000000000000:
                 self.index['pointer'][str(self.narrow)] = response['anchor']
             query_range = num_after + num_before + 1
             if len(response['messages']) < (query_range):


### PR DESCRIPTION
ZT is crashing if the user has all the messages read since the
anchor is then set to 10000000000000000 by zulip api.

This tries to set pointer to 10000000000000000 and since there aren't that many messages in zt, it crashes.