### PR TITLE
Refactoring: indexing

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,12 @@
 from collections import defaultdict
+from copy import deepcopy
 from typing import Any, Dict
 
 import pytest
 
 from zulipterminal.ui_tools.boxes import MessageBox
 from zulipterminal.ui_tools.buttons import StreamButton, UserButton
+from zulipterminal.helper import initial_index as helper_initial_index
 
 
 @pytest.fixture(autouse=True)
@@ -381,6 +383,11 @@ def initial_data():
         'last_event_id': -1,
         'muted_topics': [],
     }
+
+
+@pytest.fixture
+def initial_index():
+    return deepcopy(helper_initial_index)
 
 
 @pytest.fixture

--- a/tests/helper/test_helper.py
+++ b/tests/helper/test_helper.py
@@ -25,43 +25,51 @@ def test_update_flag_empty_msg_list(mocker: Any) -> None:
 
 def test_index_messages_narrow_all_messages(mocker,
                                             messages_successful_response,
-                                            index_all_messages) -> None:
+                                            index_all_messages,
+                                            initial_index) -> None:
     messages = messages_successful_response['messages']
     model = mocker.patch('zulipterminal.model.Model.__init__',
                          return_value=None)
+    model.index = initial_index
     model.narrow = []
-    assert index_messages(messages, model) == index_all_messages
+    assert index_messages(messages, model, model.index) == index_all_messages
 
 
 def test_index_messages_narrow_stream(mocker,
                                       messages_successful_response,
-                                      index_stream) -> None:
+                                      index_stream,
+                                      initial_index) -> None:
     messages = messages_successful_response['messages']
     model = mocker.patch('zulipterminal.model.Model.__init__',
                          return_value=None)
+    model.index = initial_index
     model.narrow = [['stream', 'PTEST']]
     model.stream_id = 205
-    assert index_messages(messages, model) == index_stream
+    assert index_messages(messages, model, model.index) == index_stream
 
 
 def test_index_messages_narrow_topic(mocker,
                                      messages_successful_response,
-                                     index_topic) -> None:
+                                     index_topic,
+                                     initial_index) -> None:
     messages = messages_successful_response['messages']
     model = mocker.patch('zulipterminal.model.Model.__init__',
                          return_value=None)
+    model.index = initial_index
     model.narrow = [['stream', '7'],
                     ['topic', 'Test']]
     model.stream_id = 205
-    assert index_messages(messages, model) == index_topic
+    assert index_messages(messages, model, model.index) == index_topic
 
 
 def test_index_messages_narrow_user(mocker,
                                     messages_successful_response,
-                                    index_user):
+                                    index_user,
+                                    initial_index) -> None:
     messages = messages_successful_response['messages']
     model = mocker.patch('zulipterminal.model.Model.__init__',
                          return_value=None)
+    model.index = initial_index
     model.narrow = [['pm_with', 'boo@zulip.com']]
     model.user_id = 5140
     model.user_dict = {
@@ -69,15 +77,17 @@ def test_index_messages_narrow_user(mocker,
             'user_id': 5179,
         }
     }
-    assert index_messages(messages, model) == index_user
+    assert index_messages(messages, model, model.index) == index_user
 
 
 def test_index_messages_narrow_user_multiple(mocker,
                                              messages_successful_response,
-                                             index_user_multiple):
+                                             index_user_multiple,
+                                             initial_index) -> None:
     messages = messages_successful_response['messages']
     model = mocker.patch('zulipterminal.model.Model.__init__',
                          return_value=None)
+    model.index = initial_index
     model.narrow = [['pm_with', 'boo@zulip.com, bar@zulip.com']]
     model.user_id = 5140
     model.user_dict = {
@@ -88,7 +98,7 @@ def test_index_messages_narrow_user_multiple(mocker,
             'user_id': 5180
         }
     }
-    assert index_messages(messages, model) == index_user_multiple
+    assert index_messages(messages, model, model.index) == index_user_multiple
 
 
 @pytest.mark.parametrize('msgs_with_stars', [
@@ -99,7 +109,8 @@ def test_index_messages_narrow_user_multiple(mocker,
 def test_index_starred(mocker,
                        messages_successful_response,
                        empty_index,
-                       msgs_with_stars):
+                       msgs_with_stars,
+                       initial_index):
     messages = messages_successful_response['messages']
     for msg in messages:
         if msg['id'] in msgs_with_stars and 'starred' not in msg['flags']:
@@ -107,6 +118,7 @@ def test_index_starred(mocker,
 
     model = mocker.patch('zulipterminal.model.Model.__init__',
                          return_value=None)
+    model.index = initial_index
     model.narrow = [['is', 'starred']]
 
     expected_index = dict(empty_index, all_private={537287, 537288},
@@ -115,4 +127,4 @@ def test_index_starred(mocker,
         if msg_id in msgs_with_stars and 'starred' not in msg['flags']:
             msg['flags'].append('starred')
 
-    assert index_messages(messages, model) == expected_index
+    assert index_messages(messages, model, model.index) == expected_index

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -154,6 +154,14 @@ class TestModel:
                  }
              }
          }, {0, 1}),
+        ([['stream', 'FOO'],  # Covers one empty-set case
+         ['topic', 'BOOBOO']], {
+             'stream': {
+                 1: {
+                     'BOO': {0, 1}
+                 }
+             }
+         }, set()),
         ([['is', 'private']], {
             'all_private': {0, 1}
         }, {0, 1}),
@@ -162,6 +170,11 @@ class TestModel:
                 frozenset({1, 2}): {0, 1}
             }
         }, {0, 1}),
+        ([['pm_with', 'FOO@zulip.com']], {  # Covers recipient empty-set case
+            'private': {
+                frozenset({1, 3}): {0, 1}  # NOTE {1,3} not {1,2}
+            }
+        }, set()),
         ([['search', 'FOO']], {
             'search': {0, 1}
         }, {0, 1}),

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -113,6 +113,8 @@ class TestModel:
         ([['search', 'something interesting']],
          dict(search='something interesting')),
         ([['is', 'starred']], dict(starred=True)),
+        ([['is', 'private']], dict(pms=True)),
+        ([['pm_with', 'FOO@zulip.com']], dict(pm_with='FOO@zulip.com')),
     ])
     def test_set_narrow_already_set(self, model, narrow, good_args):
         model.narrow = narrow
@@ -125,6 +127,8 @@ class TestModel:
         ([], [['stream', 'some stream'], ['topic', 'some topic']],
          dict(stream='some stream', topic='some topic')),
         ([], [['is', 'starred']], dict(starred=True)),
+        ([], [['is', 'private']], dict(pms=True)),
+        ([], [['pm_with', 'FOO@zulip.com']], dict(pm_with='FOO@zulip.com')),
     ])
     def test_set_narrow_not_already_set(self, model, initial_narrow, narrow,
                                         good_args):

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -5,6 +5,7 @@ from typing import Any
 import pytest
 
 from zulipterminal.model import Model
+from zulipterminal.helper import initial_index
 
 
 class TestModel:
@@ -45,7 +46,7 @@ class TestModel:
         assert model.stream_id == -1
         assert model.stream_dict == {}
         assert model.recipients == frozenset()
-        assert model.index is None
+        assert model.index == initial_index
         model.get_messages.assert_called_once_with(num_before=30,
                                                    num_after=10,
                                                    anchor=None)
@@ -306,7 +307,7 @@ class TestModel:
         }
         model.client.do_api_query.assert_called_once_with(
             request, '/json/messages', method="GET")
-        assert model.index is None
+        assert model.index == initial_index
 
     @pytest.mark.parametrize('flags_before, expected_operator', [
         ([], 'add'),

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -77,14 +77,12 @@ class TestMessageView:
 
         create_msg_box_list = mocker.patch(VIEWS + ".create_msg_box_list",
                                            return_value=new_msg_widgets)
-        msg_view.index = {}
         # Specific to this version of the test
         msg_view.log = []
 
         msg_view.load_old_messages(0)
 
         assert msg_view.old_loading is False
-        assert msg_view.index == {}
         assert msg_view.log == list(messages_fetched.values())  # code vs orig
         if messages_fetched:
             (create_msg_box_list.
@@ -132,13 +130,11 @@ class TestMessageView:
                                            return_value=(new_msg_widgets +
                                                          [top_widget]))
         initial_log = [top_widget] + len(other_ids_in_narrow)*["existing"]
-        msg_view.index = {}
         msg_view.log = initial_log[:]
 
         msg_view.load_old_messages(0)
 
         assert msg_view.old_loading is False
-        assert msg_view.index == {}
         assert msg_view.log == new_msg_widgets + initial_log
         if messages_fetched:
             create_msg_box_list.assert_called_once_with(msg_view.model,
@@ -163,13 +159,11 @@ class TestMessageView:
                             return_value=ids_in_narrow)
         create_msg_box_list = mocker.patch(VIEWS + ".create_msg_box_list",
                                            return_value=["M1", "M2"])
-        msg_view.index = {}
         msg_view.log = []
 
         msg_view.load_new_messages(0)
 
         assert msg_view.new_loading is False
-        assert msg_view.index == {}
         assert msg_view.log == ['M1', 'M2']
         create_msg_box_list.assert_called_once_with(msg_view.model, set(),
                                                     last_message=None)
@@ -189,13 +183,11 @@ class TestMessageView:
                             return_value=ids_in_narrow)
         create_msg_box_list = mocker.patch(VIEWS + ".create_msg_box_list",
                                            return_value=["M1", "M2"])
-        msg_view.index = {}
         msg_view.log = [mocker.Mock()]
 
         msg_view.load_new_messages(0)
 
         assert msg_view.new_loading is False
-        assert msg_view.index == {}
         assert msg_view.log[-2:] == ['M1', 'M2']
         expected_last_msg = msg_view.log[0].original_widget.message
         (create_msg_box_list.

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -74,10 +74,10 @@ class TestMessageView:
                             "get_message_ids_in_current_narrow",
                             side_effect=[ids_in_narrow,
                                          ids_in_narrow | new_msg_ids])
-        self.model.get_messages.return_value = {}
 
         create_msg_box_list = mocker.patch(VIEWS + ".create_msg_box_list",
                                            return_value=new_msg_widgets)
+        msg_view.index = {}
         # Specific to this version of the test
         msg_view.log = []
 
@@ -128,11 +128,11 @@ class TestMessageView:
                             "get_message_ids_in_current_narrow",
                             side_effect=[ids_in_narrow,
                                          ids_in_narrow | new_msg_ids])
-        self.model.get_messages.return_value = {}
         create_msg_box_list = mocker.patch(VIEWS + ".create_msg_box_list",
                                            return_value=(new_msg_widgets +
                                                          [top_widget]))
         initial_log = [top_widget] + len(other_ids_in_narrow)*["existing"]
+        msg_view.index = {}
         msg_view.log = initial_log[:]
 
         msg_view.load_old_messages(0)
@@ -153,17 +153,17 @@ class TestMessageView:
                                                         anchor=0)
 
     # FIXME: Improve this test by covering more parameters
-    @pytest.mark.parametrize('ids_in_narrow, get_messages_return', [
-        ({0}, {}),
+    @pytest.mark.parametrize('ids_in_narrow', [
+        ({0}),
     ])
     def test_load_new_messages_empty_log(self, mocker, msg_view,
-                                         ids_in_narrow, get_messages_return):
+                                         ids_in_narrow):
         mocker.patch.object(msg_view.model,
                             "get_message_ids_in_current_narrow",
                             return_value=ids_in_narrow)
-        self.model.get_messages.return_value = get_messages_return
         create_msg_box_list = mocker.patch(VIEWS + ".create_msg_box_list",
                                            return_value=["M1", "M2"])
+        msg_view.index = {}
         msg_view.log = []
 
         msg_view.load_new_messages(0)
@@ -179,17 +179,17 @@ class TestMessageView:
                                                         anchor=0)
 
     # FIXME: Improve this test by covering more parameters
-    @pytest.mark.parametrize('ids_in_narrow, get_messages_return', [
-        ({0}, {}),
+    @pytest.mark.parametrize('ids_in_narrow', [
+        ({0}),
     ])
     def test_load_new_messages_mocked_log(self, mocker, msg_view,
-                                          ids_in_narrow, get_messages_return):
+                                          ids_in_narrow):
         mocker.patch.object(msg_view.model,
                             "get_message_ids_in_current_narrow",
                             return_value=ids_in_narrow)
-        self.model.get_messages.return_value = get_messages_return
         create_msg_box_list = mocker.patch(VIEWS + ".create_msg_box_list",
                                            return_value=["M1", "M2"])
+        msg_view.index = {}
         msg_view.log = [mocker.Mock()]
 
         msg_view.load_new_messages(0)

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -99,10 +99,12 @@ class Controller:
 
     def search_messages(self, text: str) -> None:
         # Search for a text in messages
-        self.update = False
         self.model.set_narrow(search=text)
+
+        self.update = False
         self.model.get_messages(num_after=0, num_before=30, anchor=10000000000)
-        msg_id_list = self.model.index['search']
+        msg_id_list = self.model.get_message_ids_in_current_narrow()
+
         w_list = create_msg_box_list(self.model, msg_id_list)
         self.model.msg_view.clear()
         self.model.msg_view.extend(w_list)
@@ -116,10 +118,10 @@ class Controller:
             return
 
         self.update = False
-        # store the steam id in the model
+        # store the steam id in the model (required for get_message_ids...)
         self.model.stream_id = button.stream_id
-        # get the message ids of the current narrow
-        msg_id_list = self.model.index['all_stream'][button.stream_id]
+        msg_id_list = self.model.get_message_ids_in_current_narrow()
+
         # if no messages are found get more messages
         if len(msg_id_list) == 0:
             get_msg_opts = dict(num_before=30, num_after=10,
@@ -127,7 +129,8 @@ class Controller:
             if hasattr(button, 'message'):
                 get_msg_opts['anchor'] = button.message['id']
             self.model.get_messages(**get_msg_opts)
-        msg_id_list = self.model.index['all_stream'][button.stream_id]
+        msg_id_list = self.model.get_message_ids_in_current_narrow()
+
         if hasattr(button, 'message'):
             w_list = create_msg_box_list(
                 self.model, msg_id_list, button.message['id'])
@@ -143,17 +146,18 @@ class Controller:
             return
 
         self.update = False
+        # store the steam id in the model (required for get_message_ids...)
         self.model.stream_id = button.stream_id
-        msg_id_list = self.model.index['stream'][button.stream_id].get(
-                                                    button.title, [])
+        msg_id_list = self.model.get_message_ids_in_current_narrow()
+
         if len(msg_id_list) == 0:
             get_msg_opts = dict(num_before=30, num_after=10,
                                 anchor=None)  # type: GetMessagesArgs
             if hasattr(button, 'message'):
                 get_msg_opts['anchor'] = button.message['id']
             self.model.get_messages(**get_msg_opts)
-            msg_id_list = self.model.index['stream'][button.stream_id].get(
-                                                    button.title, [])
+            msg_id_list = self.model.get_message_ids_in_current_narrow()
+
         if hasattr(button, 'message'):
             w_list = create_msg_box_list(
                 self.model, msg_id_list, button.message['id'])
@@ -180,8 +184,9 @@ class Controller:
 
         self.update = False
         recipients = frozenset(user_ids)
+        # store the recipients in the model (required for get_message_ids...)
         self.model.recipients = recipients
-        msg_id_list = self.model.index['private'].get(recipients, [])
+        msg_id_list = self.model.get_message_ids_in_current_narrow()
 
         if len(msg_id_list) == 0:
             get_msg_opts = dict(num_before=30, num_after=10,
@@ -189,7 +194,7 @@ class Controller:
             if hasattr(button, 'message'):
                 get_msg_opts['anchor'] = button.message['id']
             self.model.get_messages(**get_msg_opts)
-            msg_id_list = self.model.index['private'].get(recipients, [])
+            msg_id_list = self.model.get_message_ids_in_current_narrow()
 
         if hasattr(button, 'message'):
             w_list = create_msg_box_list(
@@ -205,12 +210,13 @@ class Controller:
             return
 
         self.update = False
-        msg_list = self.model.index['all_messages']
+        msg_id_list = self.model.get_message_ids_in_current_narrow()
+
         if hasattr(button, 'message'):
             w_list = create_msg_box_list(
-                self.model, msg_list, button.message['id'])
+                self.model, msg_id_list, button.message['id'])
         else:
-            w_list = create_msg_box_list(self.model, msg_list)
+            w_list = create_msg_box_list(self.model, msg_id_list)
 
         self._finalize_show(w_list)
 
@@ -220,11 +226,13 @@ class Controller:
             return
 
         self.update = False
-        msg_list = self.model.index['all_private']
-        if len(msg_list) == 0:
+        msg_id_list = self.model.get_message_ids_in_current_narrow()
+
+        if len(msg_id_list) == 0:
             self.model.get_messages(num_before=30, num_after=10, anchor=None)
-            msg_list = self.model.index['all_private']
-        w_list = create_msg_box_list(self.model, msg_list)
+            msg_id_list = self.model.get_message_ids_in_current_narrow()
+
+        w_list = create_msg_box_list(self.model, msg_id_list)
 
         self._finalize_show(w_list)
 
@@ -234,11 +242,13 @@ class Controller:
             return
 
         self.update = False
-        msg_list = self.model.index['all_starred']
-        if len(msg_list) == 0:
+        msg_id_list = self.model.get_message_ids_in_current_narrow()
+
+        if len(msg_id_list) == 0:
             self.model.get_messages(num_before=30, num_after=10, anchor=None)
-            msg_list = self.model.index['all_starred']
-        w_list = create_msg_box_list(self.model, msg_list)
+            msg_id_list = self.model.get_message_ids_in_current_narrow()
+
+        w_list = create_msg_box_list(self.model, msg_id_list)
 
         self._finalize_show(w_list)
 

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -215,7 +215,7 @@ class Controller:
         self._finalize_show(w_list)
 
     def show_all_pm(self, button: Any) -> None:
-        already_narrowed = self.model.set_narrow(pm_with='')
+        already_narrowed = self.model.set_narrow(pms=True)
         if already_narrowed:
             return
 

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -25,6 +25,18 @@ Index = TypedDict('Index', {
     'messages': Dict[int, Message],  # message_id: Message
 })
 
+initial_index = Index(
+    pointer=defaultdict(set),
+    stream=defaultdict(dict),
+    private=defaultdict(set),
+    all_messages=set(),
+    all_private=set(),
+    all_stream=defaultdict(set),
+    messages=defaultdict(dict),
+    search=set(),
+    all_starred=set(),
+)
+
 
 def asynch(func: Any) -> Any:
     """

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -130,7 +130,7 @@ def update_flag(id_list: List[int], controller: Any) -> None:
 
 def index_messages(messages: List[Any],
                    model: Any,
-                   index: Optional[Index]=None) -> Index:
+                   index: Index) -> Index:
     """
     STRUCTURE OF INDEX
     {
@@ -241,18 +241,6 @@ def index_messages(messages: List[Any],
         },
     }
     """
-    if index is None:
-        index = {
-            'pointer': defaultdict(set),
-            'stream': defaultdict(dict),
-            'private': defaultdict(set),
-            'all_messages': set(),
-            'all_private': set(),
-            'all_stream': defaultdict(set),
-            'messages': defaultdict(dict),
-            'search': set(),
-            'all_starred': set(),
-        }
     narrow = model.narrow
     for msg in messages:
 

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -10,7 +10,8 @@ from zulipterminal.helper import (
     asynch,
     classify_unread_counts,
     index_messages,
-    set_count
+    set_count,
+    initial_index,
 )
 from zulipterminal.ui_tools.utils import create_msg_box_list
 
@@ -36,7 +37,7 @@ class Model:
         self.update = False
         self.stream_id = -1
         self.recipients = frozenset()  # type: FrozenSet[Any]
-        self.index = None  # type: Any
+        self.index = initial_index
         self.user_id = -1  # type: int
         self.initial_data = {}  # type: Dict[str, Any]
         self._update_user_id()

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -116,12 +116,12 @@ class Model:
                 current_ids = self.index['all_stream'][stream_id]
             elif len(narrow) == 2:
                 topic = narrow[1][1]
-                current_ids = self.index['stream'][stream_id][topic]
+                current_ids = self.index['stream'][stream_id].get(topic, set())
         elif narrow[0][1] == 'private':
             current_ids = self.index['all_private']
         elif narrow[0][0] == 'pm_with':
             recipients = self.recipients
-            current_ids = self.index['private'][recipients]
+            current_ids = self.index['private'].get(recipients, set())
         elif narrow[0][0] == 'search':
             current_ids = self.index['search']
         elif narrow[0][1] == 'starred':

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -76,25 +76,27 @@ class Model:
         self.index['pointer'][str(self.narrow)] = focus_message
 
     def set_narrow(self, *,
-                   stream: Optional[str]=None, topic: Optional[str]=None,
+                   stream: Optional[str]=None,
+                   topic: Optional[str]=None,
                    search: Optional[str]=None,
+                   pms: bool=False,
                    pm_with: Optional[str]=None,
                    starred: bool=False) -> bool:
-        if search and not(stream or topic or pm_with or starred):
-            new_narrow = [['search', search]]
-        elif stream and topic and not(search or pm_with or starred):
-            new_narrow = [["stream", stream],
-                          ["topic", topic]]
-        elif stream and not(topic or search or pm_with or starred):
-            new_narrow = [['stream', stream]]
-        elif pm_with == '' and not(stream or topic or search or starred):
-            new_narrow = [['is', 'private']]
-        elif pm_with and not(stream or topic or search or starred):
-            new_narrow = [['pm_with', pm_with]]
-        elif starred and not(stream or topic or search or pm_with):
-            new_narrow = [['is', 'starred']]
-        elif not stream and not topic and not search and not pm_with:
-            new_narrow = []
+        selected_params = {k for k, v in locals().items() if k != 'self' and v}
+        valid_narrows = {
+            frozenset(): [],
+            frozenset(['search']): [['search', search]],
+            frozenset(['stream']): [['stream', stream]],
+            frozenset(['stream', 'topic']): [['stream', stream],
+                                             ['topic', topic]],
+            frozenset(['pms']): [['is', 'private']],
+            frozenset(['pm_with']): [['pm_with', pm_with]],
+            frozenset(['starred']): [['is', 'starred']],
+        }  # type: Dict[FrozenSet[str], List[Any]]
+        for narrow_param, narrow in valid_narrows.items():
+            if narrow_param == selected_params:
+                new_narrow = narrow
+                break
         else:
             raise RuntimeError("Model.set_narrow parameters used incorrectly.")
 

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -177,7 +177,7 @@ class Model:
 
     def get_messages(self, *,
                      num_after: int, num_before: int,
-                     anchor: Optional[int]) -> Any:
+                     anchor: Optional[int]) -> None:
         # anchor value may be specific message (int) or next unread (None)
         first_anchor = anchor is None
         anchor_value = anchor if anchor is not None else 0
@@ -200,7 +200,6 @@ class Model:
             query_range = num_after + num_before + 1
             if len(response['messages']) < (query_range):
                 self.update = True
-            return self.index
 
     def _update_initial_data(self) -> None:
         try:

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -516,7 +516,6 @@ class SearchBox(urwid.Pile):
 
         elif is_command_key('ENTER', key):
             self.controller.editor_mode = False
-            self.controller.model.index['search'] = set()
             self.controller.search_messages(self.text_box.edit_text)
             self.controller.view.middle_column.set_focus('body')
             return key

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -57,8 +57,7 @@ class MessageView(urwid.ListBox):
         else:
             no_update_baseline = set()
 
-        self.index = self.model.get_messages(num_before=30, num_after=0,
-                                             anchor=anchor)
+        self.model.get_messages(num_before=30, num_after=0, anchor=anchor)
         ids_to_process = (self.model.get_message_ids_in_current_narrow() -
                           ids_to_keep)
 
@@ -82,8 +81,7 @@ class MessageView(urwid.ListBox):
     def load_new_messages(self, anchor: int) -> None:
         self.new_loading = True
         current_ids = self.model.get_message_ids_in_current_narrow()
-        self.index = self.model.get_messages(num_before=0, num_after=30,
-                                             anchor=anchor)
+        self.model.get_messages(num_before=0, num_after=30, anchor=anchor)
         new_ids = self.model.get_message_ids_in_current_narrow() - current_ids
         if self.log:
             last_message = self.log[-1].original_widget.message

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -22,7 +22,6 @@ from zulipterminal.ui_tools.boxes import UserSearchBox, StreamSearchBox
 class MessageView(urwid.ListBox):
     def __init__(self, model: Any) -> None:
         self.model = model
-        self.index = model.index
         # Initialize for reference
         self.focus_msg = 0
         self.log = urwid.SimpleFocusListWalker(self.main_view())


### PR DESCRIPTION
This started as a follow-up to #211 - hence the `initial_index` commit, which avoids a need for `Optional[Index]` and lots of asserts - as well as being based on some older index-encapsulation work I had in another branch.

Subsequent commits are to:
- simplify `get_messages` (and avoid an error case) by returning `None`
- remove an unnecessary internal `index` being tracked in a view
- require the index parameter in `index_parameters` to be an `Index` (since it's initialized already)
- simplify (hopefully!) `set_narrow` via use of `locals()`, and a `dict` for the names/narrows
- simplify core (`Controller`) narrowing methods by using the `model.get_message_ids_in_current_narrow` method
- remove an unnecessary reset of the search index in `boxes.py`.

This works towards simplifying index access, behavior and encapsulation.

This does not explicitly add new features, but improves typing, some edge cases, and uses existing functions rather than digging into data structures directly, which should all make the code easier to read. For example, the narrowing functions are much clearer now IMO, and could possibly be simplified further based on some work I did in another branch locally.