### PR TITLE
Improved autohide behavior & zuliprc configuration option

### DIFF
--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -23,9 +23,10 @@ class TestController:
     def controller(self, mocker) -> None:
         self.config_file = 'path/to/zuliprc'
         self.theme = 'default'
+        self.autohide = True  # FIXME Add tests for no-autohide
         mocker.patch('zulipterminal.core.Controller.'
                      'register_initial_desired_events')
-        return Controller(self.config_file, self.theme)
+        return Controller(self.config_file, self.theme, self.autohide)
 
     def test_initialize_controller(self, controller, mocker) -> None:
         self.client.assert_called_once_with(
@@ -176,7 +177,8 @@ class TestController:
     def test_register_initial_desired_events(self, mocker):
         self.config_file = 'path/to/zuliprc'
         self.theme = 'default'
-        controller = Controller(self.config_file, self.theme)
+        self.autohide = True  # FIXME Test with both options
+        controller = Controller(self.config_file, self.theme, self.autohide)
         event_types = [
             'message',
             'update_message',

--- a/tests/ui/test_ui.py
+++ b/tests/ui/test_ui.py
@@ -38,8 +38,8 @@ class TestView:
         middle_view = mocker.patch('zulipterminal.ui.MiddleColumnView')
         line_box = mocker.patch('zulipterminal.ui.urwid.LineBox')
         return_value = view.message_view()
-        middle_view.assert_called_once_with(view.model, view.write_box,
-                                            view.search_box)
+        middle_view.assert_called_once_with(view, view.model,
+                                            view.write_box, view.search_box)
         assert view.middle_column == middle_view()
         assert return_value == line_box()
 
@@ -156,10 +156,10 @@ class TestView:
         right.assert_called_once_with()
         expected_column_calls = [
             mocker.call([
-                (0, left()),
+                (25, left()),
                 ('weight', 10, center()),
                 (0, right()),
-                ], focus_column=1),
+                ], focus_column=0),
             mocker.call([
                 title_divider(),
                 (title_length, text()),
@@ -189,7 +189,7 @@ class TestView:
     def test_keypress_w(self, view, mocker):
         view.users_view = mocker.Mock()
         view.body = mocker.Mock()
-        view.body.contents = [mocker.Mock()]
+        view.body.contents = ['streams', 'messages', mocker.Mock()]
         view.left_column = mocker.Mock()
         view.right_column = mocker.Mock()
         view.user_search = mocker.Mock()
@@ -201,7 +201,7 @@ class TestView:
         # Test "w" keypress
         view.keypress(size, "w")
         view.users_view.keypress.assert_called_once_with(size, "w")
-        assert view.body.focus_col == 0
+        assert view.body.focus_col == 2
         view.user_search.set_edit_text.assert_called_once_with("")
         assert view.controller.editor_mode is True
         assert view.controller.editor == view.user_search
@@ -211,7 +211,7 @@ class TestView:
         view.left_col_w = mocker.Mock()
         view.stream_w.search_box = mocker.Mock()
         view.body = mocker.Mock()
-        view.body.contents = [mocker.Mock()]
+        view.body.contents = [mocker.Mock(), 'messages', 'users']
         view.left_column = mocker.Mock()
         view.right_column = mocker.Mock()
         size = (20,)

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -425,6 +425,7 @@ class TestMiddleColumnView:
     def mock_external_classes(self, mocker):
         mocker.patch(VIEWS + ".MessageView", return_value="MSG_LIST")
         self.model = mocker.Mock()
+        self.view = mocker.Mock()
         self.write_box = mocker.Mock()
         self.search_box = mocker.Mock()
         self.super = mocker.patch(VIEWS + '.urwid.Frame.__init__')
@@ -433,7 +434,8 @@ class TestMiddleColumnView:
 
     @pytest.fixture
     def mid_col_view(self):
-        return MiddleColumnView(self.model, self.write_box, self.search_box)
+        return MiddleColumnView(self.view, self.model,
+                                self.write_box, self.search_box)
 
     def test_init(self, mid_col_view):
         assert mid_col_view.model == self.model

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -97,11 +97,19 @@ def parse_zuliprc(zuliprc_str: str) -> Dict[str, Any]:
     zuliprc.read(zuliprc_path)
 
     # default settings
-    settings = {'theme': ('default', 'with no config')}
+    NO_CONFIG = 'with no config'
+    settings = {
+        'theme': ('default', NO_CONFIG),
+        'autohide': ('autohide', NO_CONFIG),
+    }
 
     if 'zterm' in zuliprc:
-        if 'theme' in zuliprc['zterm']:
-            settings['theme'] = (zuliprc['zterm']['theme'], 'in zuliprc file')
+        config = zuliprc['zterm']
+        ZULIPRC_CONFIG = 'in zuliprc file'
+        if 'theme' in config:
+            settings['theme'] = (config['theme'], ZULIPRC_CONFIG)
+        if 'autohide' in config:
+            settings['autohide'] = (config['autohide'], ZULIPRC_CONFIG)
 
     return settings
 
@@ -141,9 +149,24 @@ def main() -> None:
                   "using -t/--theme options on command line.")
             sys.exit(1)
 
-        print("Loading with '{}' theme specified {}..."
-              .format(*theme_to_use))
-        Controller(zuliprc_path, THEMES[theme_to_use[0]]).main()
+        valid_autohide_settings = {'autohide', 'no_autohide'}
+        if zterm['autohide'][0] not in valid_autohide_settings:
+            print("Invalid autohide setting '{}' was specified {}."
+                  .format(*zterm['autohide']))
+            print("The following options are available:")
+            for option in valid_autohide_settings:
+                print("  ", option)
+            print("Specify the autohide option in zuliprc file.")
+            sys.exit(1)
+        autohide_setting = (zterm['autohide'][0] == 'autohide')
+
+        print("Loading with:")
+        print("   theme '{}' specified {}.".format(*theme_to_use))
+        print("   autohide setting '{}' specified {}."
+              .format(*zterm['autohide']))
+        Controller(zuliprc_path,
+                   THEMES[theme_to_use[0]],
+                   autohide_setting).main()
     except Exception as e:
         if args.debug:
             # A unexpected exception occurred, open the debugger in debug mode

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -22,8 +22,10 @@ class Controller:
     the application.
     """
 
-    def __init__(self, config_file: str, theme: ThemeSpec) -> None:
+    def __init__(self, config_file: str, theme: ThemeSpec,
+                 autohide: bool) -> None:
         self.theme = theme
+        self.autohide = autohide
 
         self.show_loading()
         self.client = zulip.Client(config_file=config_file,

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -89,11 +89,18 @@ class View(urwid.WidgetWrap):
         self.left_column = self.left_column_view()
         self.center_column = self.message_view()
         self.right_column = self.right_column_view()
-        body = [
-            (25, self.left_column),
-            ('weight', 10, self.center_column),
-            (0, self.right_column),
-        ]
+        if self.controller.autohide:
+            body = [
+                (25, self.left_column),
+                ('weight', 10, self.center_column),
+                (0, self.right_column),
+            ]
+        else:
+            body = [
+                (25, self.left_column),
+                ('weight', 10, self.center_column),
+                (25, self.right_column),
+            ]
         self.body = urwid.Columns(body, focus_column=0)
 
         div_char = '═'
@@ -115,6 +122,8 @@ class View(urwid.WidgetWrap):
         return w
 
     def show_left_panel(self, *, visible: bool) -> None:
+        if not self.controller.autohide:
+            return
         width = 25 if visible else 0
         self.body.contents[0] = (
             self.left_column,
@@ -124,6 +133,8 @@ class View(urwid.WidgetWrap):
             self.body.focus_col = 0
 
     def show_right_panel(self, *, visible: bool) -> None:
+        if not self.controller.autohide:
+            return
         width = 25 if visible else 0
         self.body.contents[2] = (
             self.right_column,

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -39,7 +39,7 @@ class View(urwid.WidgetWrap):
         return self.left_col_w
 
     def message_view(self) -> Any:
-        self.middle_column = MiddleColumnView(self.model, self.write_box,
+        self.middle_column = MiddleColumnView(self, self.model, self.write_box,
                                               self.search_box)
         w = urwid.LineBox(self.middle_column, bline="")
         return w
@@ -90,11 +90,11 @@ class View(urwid.WidgetWrap):
         self.center_column = self.message_view()
         self.right_column = self.right_column_view()
         body = [
-            (0, self.left_column),
+            (25, self.left_column),
             ('weight', 10, self.center_column),
             (0, self.right_column),
         ]
-        self.body = urwid.Columns(body, focus_column=1)
+        self.body = urwid.Columns(body, focus_column=0)
 
         div_char = '═'
         profile = self.controller.client.get_profile()
@@ -114,20 +114,29 @@ class View(urwid.WidgetWrap):
                         footer=self.footer_view())
         return w
 
-    def toggle_left_panel(self) -> None:
+    def show_left_panel(self, *, visible: bool) -> None:
+        width = 25 if visible else 0
         self.body.contents[0] = (
             self.left_column,
-            self.body.options(width_type='given', width_amount=0),
+            self.body.options(width_type='given', width_amount=width),
         )
-        self.body.focus_col = 1
+        if visible:
+            self.body.focus_col = 0
+
+    def show_right_panel(self, *, visible: bool) -> None:
+        width = 25 if visible else 0
+        self.body.contents[2] = (
+            self.right_column,
+            self.body.options(width_type='given', width_amount=width),
+        )
+        if visible:
+            self.body.focus_col = 2
 
     def keypress(self, size: Tuple[int, int], key: str) -> str:
         self.model.new_user_input = True
         if self.controller.editor_mode:
             return self.controller.editor.keypress((size[1],), key)
         # Redirect commands to message_view.
-        elif is_command_key('GO_BACK', key):
-            self.toggle_left_panel()
         elif is_command_key('SEARCH_MESSAGES', key) or\
                 is_command_key('NEXT_UNREAD_TOPIC', key) or\
                 is_command_key('NEXT_UNREAD_PM', key) or\
@@ -136,25 +145,19 @@ class View(urwid.WidgetWrap):
             self.middle_column.keypress(size, key)
             return key
         elif is_command_key('SEARCH_PEOPLE', key):
-            self.body.contents[0] = (
-                self.right_column,
-                self.body.options(width_type='given', width_amount=25),
-            )
             # Start User Search if not in editor_mode
             self.users_view.keypress(size, 'w')
-            self.body.focus_col = 0
+            self.show_left_panel(visible=False)
+            self.show_right_panel(visible=True)
             self.user_search.set_edit_text("")
             self.controller.editor_mode = True
             self.controller.editor = self.user_search
             return key
         elif is_command_key('SEARCH_STREAMS', key):
-            self.body.contents[0] = (
-                self.left_column,
-                self.body.options(width_type='given', width_amount=25),
-            )
             # jump stream search
             self.left_col_w.keypress(size, 'q')
-            self.body.focus_col = 0
+            self.show_right_panel(visible=False)
+            self.show_left_panel(visible=True)
             self.stream_w.search_box.set_edit_text("")
             self.controller.editor_mode = True
             self.controller.editor = self.stream_w.search_box

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -38,7 +38,8 @@ class TopButton(urwid.Button):
 
     def keypress(self, size: Tuple[int, int], key: str) -> str:
         if is_command_key('ENTER', key):
-            self.controller.view.toggle_left_panel()
+            self.controller.view.show_left_panel(visible=False)
+            self.controller.view.body.focus_col = 1
         return super().keypress(size, key)
 
 
@@ -99,7 +100,8 @@ class StreamButton(urwid.Button):
 
     def keypress(self, size: Tuple[int, int], key: str) -> str:
         if is_command_key('ENTER', key):
-            self.controller.view.toggle_left_panel()
+            self.controller.view.show_left_panel(visible=False)
+            self.controller.view.body.focus_col = 1
         return super(StreamButton, self).keypress(size, key)
 
 
@@ -136,7 +138,7 @@ class UserButton(urwid.Button):
             self.view.body.focus_col = 1
             self.view.body.focus.original_widget.set_focus('footer')
             self.view.write_box.private_box_view(self)
-            self.view.toggle_left_panel()
+            return key
         return super(UserButton, self).keypress(size, key)
 
 

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -274,10 +274,12 @@ class UsersView(urwid.ListBox):
 
 
 class MiddleColumnView(urwid.Frame):
-    def __init__(self, model: Any, write_box: Any, search_box: Any) -> None:
+    def __init__(self, view: Any, model: Any,
+                 write_box: Any, search_box: Any) -> None:
         msg_list = MessageView(model)
         self.model = model
         self.controller = model.controller
+        self.view = view
         self.last_unread_topic = None
         self.last_unread_pm = None
         self.search_box = search_box
@@ -370,6 +372,10 @@ class MiddleColumnView(urwid.Frame):
             self.set_focus('footer')
             self.footer.focus_position = 0
             return key
+        elif is_command_key('GO_LEFT', key):
+            self.view.show_left_panel(visible=True)
+        elif is_command_key('GO_RIGHT', key):
+            self.view.show_right_panel(visible=True)
         return super(MiddleColumnView, self).keypress(size, key)
 
 
@@ -441,6 +447,8 @@ class RightColumnView(urwid.Frame):
             self.set_focus('body')
             self.view.controller.update_screen()
             return key
+        elif is_command_key('GO_LEFT', key):
+            self.view.show_right_panel(visible=False)
         return super(RightColumnView, self).keypress(size, key)
 
 
@@ -517,6 +525,8 @@ class LeftColumnView(urwid.Pile):
             self.focus_position = 1
             self.view.stream_w.keypress(size, key)
             return key
+        elif is_command_key('GO_RIGHT', key):
+            self.view.show_left_panel(visible=False)
         return super(LeftColumnView, self).keypress(size, key)
 
 


### PR DESCRIPTION
The new autohide (the first commit) involves the following changes:
- Users list returns to the right side
- Initial view defaults to showing streams & messages, focused on home
- GO_LEFT/GO_RIGHT keys move into Streams/Users lists respectively
- Streams and Users lists autohide when moving away from them
- Two View methods are used to show/hide Streams & Users (left/right panels)
- View parameter added to MiddleColumnView __init__ for show/hide calls

The second commit then adds similar option behavior as recently added for themes, but to enable or disable the autohide behavior.

Try this out and let me know what you think :) It feels a lot more natural to me, but then again I wrote it!