### PR TITLE
Link to CHANGELOG from README & add further entries for 0.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Zulip-terminal Changelog
 
-## Next release
+## 0.3.0
 
 ### Interactivity improvements
+- Much improved (& configurable on/off) autohide behavior for streams/users panels
 - Toggle thumbs-up reactions to messages (<kbd>+</kbd>)
 - Toggle star status of messages (<kbd>*</kbd> or <kbd>ctrl</kbd>+<kbd>s</kbd>)
 - Narrow to starred messges (<kbd>f</kbd>, or via new button)
@@ -20,6 +21,7 @@
 - Show marker to left of messages
 - Mark private streams with P instead of #
 - Show unread count of muted streams as M
+- Add `gruvbox` theme
 - Internal help (<kbd>?</kbd>) more compact & reordered
 - Random shortcut keys are shown at the bottom of the screen
 
@@ -27,10 +29,13 @@
 - Allow narrowing to cross-realm bots
 - Support private messages with multiple users properly
 - Avoid showing duplicate recipient bars when scrolling
+- Correctly set pointer data (for next unread)
+- Improve theme handling on command-line
 
 ### Infrastructure changes
 - Documentation improvements
 - Explicitly support latest versions of python 3.4 to 3.7
+- Preliminary support for OSX/Darwin (tested by default)
 - Higher test coverage
 - Various internal refactoring
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ An interactive terminal interface for [Zulip](https://zulipchat.com).
 [![Coverage status](https://img.shields.io/codecov/c/github/zulip/zulip-terminal/master.svg)](https://codecov.io/gh/zulip/zulip-terminal)
 [![Checked with mypy](http://www.mypy-lang.org/static/mypy_badge.svg)](http://mypy-lang.org/)
 
+## Changes
+
+Please see the [CHANGELOG](CHANGELOG.md) for released & recent changes.
+
 ## Setup:
 
 1. Install the package:


### PR DESCRIPTION
This seems correct, but please check if this makes sense for those who have contributed :)

We should only merge this just before releasing, as it updates CHANGELOG to switch 'since last update' to '0.3.0'.