### PR TITLE
WIP: run/core: Minimal fix for being initially unable to find server.

### DIFF
--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -6,7 +6,7 @@ import tempfile
 from typing import Dict, Any
 from os import path, remove
 
-from zulipterminal.core import Controller
+from zulipterminal.core import Controller, ZulipServerConnectionFailure
 from zulipterminal.config.themes import THEMES
 
 
@@ -167,6 +167,9 @@ def main() -> None:
         Controller(zuliprc_path,
                    THEMES[theme_to_use[0]],
                    autohide_setting).main()
+    except ZulipServerConnectionFailure as e:
+        print("\n\033[91mZulip Error: {}.".format(e))
+        sys.exit(1)
     except Exception as e:
         if args.debug:
             # A unexpected exception occurred, open the debugger in debug mode


### PR DESCRIPTION
This minimally fixes #216 via the changes listed below.
This does not avoid an issue if other threaded methods fail due to a
lack of connection, particularly if they throw an exception, since
exceptions don't work well between threads.

This is not ideal, since we lose a thread option here, but it does
detect the lack of server connection early.

* core: Add ZulipServerConnectionFailure exception to core (later to model?)
* core: Remove @asynch from Controller.register_initial_desired_events
* run: If Controller() fails due to connection, catch this exception & exit