### PR TITLE
[WIP] views: Do not render inactive users.

### DIFF
--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -418,6 +418,8 @@ class RightColumnView(urwid.Frame):
         for user in self.view.users:
             unread_count = self.view.model.unread_counts.get(user['user_id'],
                                                              0)
+            if unread_count <= 0:
+                continue
             self.users_btn_list.append(
                 UserButton(
                     user,


### PR DESCRIPTION
Will add the config to enable/disable this later. I haven't figured a nonintrusive way to wire the config to view, since the config dict is used only at run.py. (would preferably want not rendering inactive to be the default tho)