### PR TITLE
Improved model (client-server) error handling

### DIFF
--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -7,6 +7,7 @@ from typing import Dict, Any
 from os import path, remove
 
 from zulipterminal.core import Controller
+from zulipterminal.model import ServerConnectionFailure
 from zulipterminal.config.themes import THEMES
 
 
@@ -167,6 +168,9 @@ def main() -> None:
         Controller(zuliprc_path,
                    THEMES[theme_to_use[0]],
                    autohide_setting).main()
+    except ServerConnectionFailure as e:
+        print("\n\033[91mError connecting to Zulip server: {}.".format(e))
+        sys.exit(1)
     except Exception as e:
         if args.debug:
             # A unexpected exception occurred, open the debugger in debug mode

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -23,6 +23,10 @@ GetMessagesArgs = TypedDict('GetMessagesArgs', {
     })
 
 
+class ServerConnectionFailure(Exception):
+    pass
+
+
 class Model:
     """
     A class responsible for storing the data to be displayed.
@@ -239,7 +243,8 @@ class Model:
         if all(results.values()):
             self.user_id = results['user_id']
         else:
-            pass  # FIXME Implement error-handling here
+            failures = [name for name, result in results.items() if not result]
+            raise ServerConnectionFailure(", ".join(failures))
 
     def get_all_users(self) -> List[Dict[str, Any]]:
         # Dict which stores the active/idle status of users (by email)


### PR DESCRIPTION
This should fix #216 via the last commit, as well as output errors if the `get_messages` or `user_id` calls fail. You can test the former just by running with no connection, and for the latter by adding a `time.sleep` call before the `_update_initial_data` call in `Model.__init__` and then eg. quickly turning off your wifi.

I spent a while investigating 'simpler' alternatives to the `ThreadPoolExecutor`, keeping `Thread`s around, but this seems pretty straightforward; the main motivation is that the `Future`s are a simple way to return an error status, rather than setting eg. values in passed-in list variables, or using a `Queue`. It was more obviously useful when there was another thread for `_update_realm_users`, but that's clearly not relevant now (as I suspected at some point recently).

Next, I plan to bring the two register calls together, but wanted to get this out for review given that I've had to rebase once already ;)