### PR TITLE
Centralize client.register calls into Model & combine

### DIFF
--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -24,8 +24,6 @@ class TestController:
         self.config_file = 'path/to/zuliprc'
         self.theme = 'default'
         self.autohide = True  # FIXME Add tests for no-autohide
-        mocker.patch('zulipterminal.core.Controller.'
-                     'register_initial_desired_events')
         return Controller(self.config_file, self.theme, self.autohide)
 
     def test_initialize_controller(self, controller, mocker) -> None:
@@ -36,7 +34,6 @@ class TestController:
         self.model.assert_called_once_with(controller)
         self.view.assert_called_once_with(controller)
         self.model.poll_for_events.assert_called_once_with()
-        controller.register_initial_desired_events.assert_called_once_with()
         assert controller.theme == self.theme
 
     def test_narrow_to_stream(self, mocker, controller,
@@ -173,22 +170,6 @@ class TestController:
         widgets = controller.model.msg_view.extend.call_args_list[0][0][0]
         msg_ids = {widget.original_widget.message['id'] for widget in widgets}
         assert msg_ids == id_list
-
-    def test_register_initial_desired_events(self, mocker):
-        self.config_file = 'path/to/zuliprc'
-        self.theme = 'default'
-        self.autohide = True  # FIXME Test with both options
-        controller = Controller(self.config_file, self.theme, self.autohide)
-        event_types = [
-            'message',
-            'update_message',
-            'reaction',
-            'typing',
-            'update_message_flags',
-        ]
-        controller.client.register.assert_called_once_with(
-                                   event_types=event_types,
-                                   apply_markdown=True)
 
     def test_main(self, mocker, controller):
         ret_mock = mocker.Mock()

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -61,6 +61,34 @@ class TestModel:
         self.classify_unread_counts.assert_called_once_with(model)
         assert model.unread_counts == []
 
+    def test_register_initial_desired_events(self, mocker, initial_data):
+        mocker.patch('zulipterminal.model.Model._update_user_id')
+        mocker.patch('zulipterminal.model.Model.get_messages')
+        self.client.register.return_value = initial_data
+
+        model = Model(self.controller)
+
+        event_types = [
+            'message',
+            'update_message',
+            'reaction',
+            'typing',
+            'update_message_flags',
+        ]
+        fetch_event_types = [
+            'presence',
+            'subscription',
+            'message',
+            'update_message_flags',
+            'muted_topics',
+            'realm_user',
+        ]
+        model.client.register.assert_has_calls(
+                [mocker.call(event_types=event_types,
+                             apply_markdown=True),
+                 mocker.call(fetch_event_types=fetch_event_types,
+                             client_gravatar=True)])
+
     @pytest.mark.parametrize('msg_id', [1, 5, set()])
     @pytest.mark.parametrize('narrow', [
         [],

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -83,11 +83,11 @@ class TestModel:
             'muted_topics',
             'realm_user',
         ]
-        model.client.register.assert_has_calls(
-                [mocker.call(event_types=event_types,
-                             apply_markdown=True),
-                 mocker.call(fetch_event_types=fetch_event_types,
-                             client_gravatar=True)])
+        model.client.register.assert_called_once_with(
+                event_types=event_types,
+                fetch_event_types=fetch_event_types,
+                apply_markdown=True,
+                client_gravatar=True)
 
     @pytest.mark.parametrize('msg_id', [1, 5, set()])
     @pytest.mark.parametrize('narrow', [

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -31,9 +31,6 @@ class Controller:
         self.client = zulip.Client(config_file=config_file,
                                    client='ZulipTerminal/{} {}'.
                                           format(ZT_VERSION, platform()))
-        # Register to the queue before initializing Model or View
-        # so that we don't lose any updates while messages are being fetched.
-        self.register_initial_desired_events()
         self.model = Model(self)
         self.view = View(self)
         # Start polling for events after view is rendered.
@@ -264,23 +261,6 @@ class Controller:
         self.model.msg_view.extend(w_list)
         if focus_position >= 0 and focus_position < len(w_list):
             self.model.msg_list.set_focus(focus_position)
-
-    def register_initial_desired_events(self) -> None:
-        event_types = [
-            'message',
-            'update_message',
-            'reaction',
-            'typing',
-            'update_message_flags',
-        ]
-        try:
-            response = self.client.register(event_types=event_types,
-                                            apply_markdown=True)
-        except zulip.ZulipError as e:
-            raise ServerConnectionFailure(e)
-        self.max_message_id = response['max_message_id']
-        self.queue_id = response['queue_id']
-        self.last_event_id = response['last_event_id']
 
     def main(self) -> None:
         screen = Screen()


### PR DESCRIPTION
Currently there is a `fetch_event_types` register call in `Model`, and an `event_types` register call in `Controller` (in core). This PR brings the latter into the `Model`, and then combines them to use a single `register` call to the API. The method moved across is maintained for re-use in the case of the server queue being garbage-collected, with the `event_types` data extracted into the top of the `Model` itself.

This was discussed in this topic:
https://chat.zulip.org/#narrow/stream/206-zulip-terminal/subject/Fetching.20realm_users/near/677096 