### PR TITLE
Ensure Gravatar=True & combine Model.event_types use as originally planned

### DIFF
--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -275,7 +275,7 @@ class TestModel:
             'num_after': num_after,
             'apply_markdown': True,
             'use_first_unread_anchor': True,
-            'client_gravatar': False,
+            'client_gravatar': True,
             'narrow': json.dumps(model.narrow),
         }
         model.client.do_api_query.assert_called_once_with(

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -203,7 +203,7 @@ class Model:
             'num_after': num_after,
             'apply_markdown': True,
             'use_first_unread_anchor': first_anchor,
-            'client_gravatar': False,
+            'client_gravatar': True,
             'narrow': json.dumps(self.narrow),
         }
         response = self.client.do_api_query(request, '/json/messages',
@@ -457,6 +457,7 @@ class Model:
         ]
         try:
             response = self.client.register(event_types=event_types,
+                                            client_gravatar=True,
                                             apply_markdown=True)
         except zulip.ZulipError as e:
             raise ServerConnectionFailure(e)

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -448,15 +448,8 @@ class Model:
                 self.controller.update_screen()
 
     def _register_desired_events(self) -> None:
-        event_types = [
-            'message',
-            'update_message',
-            'reaction',
-            'typing',
-            'update_message_flags',
-        ]
         try:
-            response = self.client.register(event_types=event_types,
+            response = self.client.register(event_types=Model.event_types,
                                             client_gravatar=True,
                                             apply_markdown=True)
         except zulip.ZulipError as e:


### PR DESCRIPTION
These are very small changes:
* one to fix #219 based on discussion there, and after the combining of the `register` calls
* another to actually use the `Model.event_types` in both potential calls to `register`, as intended 