### PR TITLE
Right panel count alignment and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Next Release
 
 ### Visual improvements
-- Right-align unread-counts in left panel (as in webapp)
+- Right-align unread-counts in left & right panels (as in webapp)
 - Move intrusive flashing cursor in left panel to far left side
 
 ## 0.3.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,7 +42,7 @@ def stream_button(mocker):
 
 
 @pytest.fixture
-def user_button(mocker):
+def user_button(mocker, width=38):
     """
     Mocked User Button.
     """
@@ -52,6 +52,7 @@ def user_button(mocker):
             'full_name': 'Boo Boo',
             'email': 'boo@zulip.com',
         },
+        width=width,
         controller=mocker.patch('zulipterminal.core.Controller'),
         view=mocker.patch('zulipterminal.ui.View')
     )

--- a/tests/ui/test_ui.py
+++ b/tests/ui/test_ui.py
@@ -112,6 +112,50 @@ class TestView:
         frame.assert_called_once_with(
             view.body, col(), focus_part='body', footer=footer_view())
 
+    @pytest.mark.parametrize('autohide', [True, False])
+    @pytest.mark.parametrize('visible, width', [
+        (True, 25),
+        (False, 0)
+    ])
+    def test_show_left_panel(self, mocker, view,
+                             visible, width, autohide):
+        view.left_panel = mocker.Mock()
+        view.body = mocker.Mock()
+        view.body.contents = [mocker.Mock(), mocker.Mock(), mocker.Mock()]
+        view.controller.autohide = autohide
+
+        view.show_left_panel(visible=visible)
+
+        if autohide:
+            (view.body.options.
+             assert_called_once_with(width_type='given', width_amount=width))
+            if visible:
+                assert view.body.focus_col == 0
+        else:
+            view.body.options.assert_not_called()
+
+    @pytest.mark.parametrize('autohide', [True, False])
+    @pytest.mark.parametrize('visible, width', [
+        (True, 25),
+        (False, 0)
+    ])
+    def test_show_right_panel(self, mocker, view,
+                              visible, width, autohide):
+        view.right_panel = mocker.Mock()
+        view.body = mocker.Mock()
+        view.body.contents = [mocker.Mock(), mocker.Mock(), mocker.Mock()]
+        view.controller.autohide = autohide
+
+        view.show_right_panel(visible=visible)
+
+        if autohide:
+            (view.body.options.
+             assert_called_once_with(width_type='given', width_amount=width))
+            if visible:
+                assert view.body.focus_col == 2
+        else:
+            view.body.options.assert_not_called()
+
     def test_keypress(self, view, mocker):
         view.users_view = mocker.Mock()
         view.body = mocker.Mock()

--- a/tests/ui/test_ui.py
+++ b/tests/ui/test_ui.py
@@ -47,7 +47,7 @@ class TestView:
         right_view = mocker.patch('zulipterminal.ui.RightColumnView')
         line_box = mocker.patch('zulipterminal.ui.urwid.LineBox')
         return_value = view.right_column_view()
-        right_view.assert_called_once_with(view)
+        right_view.assert_called_once_with(View.RIGHT_WIDTH, view)
         assert view.users_view == right_view()
         assert return_value == line_box()
 

--- a/tests/ui/test_ui.py
+++ b/tests/ui/test_ui.py
@@ -130,9 +130,9 @@ class TestView:
         view.users_view = mocker.Mock()
         view.body = mocker.Mock()
         view.body.contents = ['streams', 'messages', mocker.Mock()]
-        view.left_column = mocker.Mock()
-        view.right_column = mocker.Mock()
         view.user_search = mocker.Mock()
+        view.left_panel = mocker.Mock()
+        view.right_panel = mocker.Mock()
         size = (20,)
 
         super_view = mocker.patch("zulipterminal.ui.urwid.WidgetWrap.keypress")
@@ -152,8 +152,8 @@ class TestView:
         view.stream_w.search_box = mocker.Mock()
         view.body = mocker.Mock()
         view.body.contents = [mocker.Mock(), 'messages', 'users']
-        view.left_column = mocker.Mock()
-        view.right_column = mocker.Mock()
+        view.left_panel = mocker.Mock()
+        view.right_panel = mocker.Mock()
         size = (20,)
 
         super_view = mocker.patch("zulipterminal.ui.urwid.WidgetWrap.keypress")
@@ -161,7 +161,7 @@ class TestView:
 
         # Test "q" keypress
         view.keypress(size, "q")
-        view.left_col_w.keypress.assert_called_once_with(size, "q")
+        view.left_panel.keypress.assert_called_once_with(size, "q")
         assert view.body.focus_col == 0
         view.stream_w.search_box.set_edit_text.assert_called_once_with("")
         assert view.controller.editor_mode is True

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -642,9 +642,9 @@ class TestRightColumnView:
         self.super = mocker.patch(VIEWS + ".urwid.Frame.__init__")
 
     @pytest.fixture
-    def right_col_view(self, mocker):
+    def right_col_view(self, mocker, width=50):
         mocker.patch(VIEWS + ".RightColumnView.users_view")
-        return RightColumnView(self.view)
+        return RightColumnView(width, self.view)
 
     def test_init(self, right_col_view):
         assert right_col_view.view == self.view
@@ -699,7 +699,7 @@ class TestRightColumnView:
         (None, 0, False, 'inactive'),
     ])
     def test_users_view(self, users, users_btn_len, editor_mode, status,
-                        mocker):
+                        mocker, width=40):
         self.view.users = [{
             'user_id': 1,
             'status': status
@@ -710,7 +710,7 @@ class TestRightColumnView:
         mocker.patch(VIEWS + ".UsersView")
         list_w = mocker.patch(VIEWS + ".urwid.SimpleFocusListWalker")
 
-        right_col_view = RightColumnView(self.view)
+        right_col_view = RightColumnView(width, self.view)
 
         if status != 'inactive':
             unread_counts = right_col_view.view.model.unread_counts
@@ -719,6 +719,7 @@ class TestRightColumnView:
                 self.view.users[0],
                 controller=self.view.controller,
                 view=self.view,
+                width=width,
                 color=self.view.users[0]['status'],
                 count=1
             )

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -38,24 +38,21 @@ class View(urwid.WidgetWrap):
         super(View, self).__init__(self.main_window())
 
     def left_column_view(self) -> Any:
-        self.left_col_w = LeftColumnView(View.LEFT_WIDTH, self)
-        return self.left_col_w
+        return LeftColumnView(View.LEFT_WIDTH, self)
 
     def message_view(self) -> Any:
         self.middle_column = MiddleColumnView(self, self.model, self.write_box,
                                               self.search_box)
-        w = urwid.LineBox(self.middle_column, bline="")
-        return w
+        return urwid.LineBox(self.middle_column, bline="")
 
     def right_column_view(self) -> Any:
         self.users_view = RightColumnView(View.RIGHT_WIDTH, self)
-        w = urwid.LineBox(
+        return urwid.LineBox(
             self.users_view, title=u"Users",
             tlcorner=u'─', tline=u'─', lline=u'',
             trcorner=u'─', blcorner=u'─', rline=u'',
             bline=u'', brcorner=u''
         )
-        return w
 
     def get_random_help(self) -> List[Any]:
         # Get a hotkey randomly from KEY_BINDINGS
@@ -80,20 +77,20 @@ class View(urwid.WidgetWrap):
         return urwid.AttrWrap(urwid.Text(text_header), 'footer')
 
     def main_window(self) -> Any:
-        self.left_column = self.left_column_view()
-        self.center_column = self.message_view()
-        self.right_column = self.right_column_view()
+        self.left_panel = self.left_column_view()
+        self.center_panel = self.message_view()
+        self.right_panel = self.right_column_view()
         if self.controller.autohide:
             body = [
-                (View.LEFT_WIDTH, self.left_column),
-                ('weight', 10, self.center_column),
-                (0, self.right_column),
+                (View.LEFT_WIDTH, self.left_panel),
+                ('weight', 10, self.center_panel),
+                (0, self.right_panel),
             ]
         else:
             body = [
-                (View.LEFT_WIDTH, self.left_column),
-                ('weight', 10, self.center_column),
-                (View.RIGHT_WIDTH, self.right_column),
+                (View.LEFT_WIDTH, self.left_panel),
+                ('weight', 10, self.center_panel),
+                (View.RIGHT_WIDTH, self.right_panel),
             ]
         self.body = urwid.Columns(body, focus_column=0)
 
@@ -120,7 +117,7 @@ class View(urwid.WidgetWrap):
             return
         width = 25 if visible else 0
         self.body.contents[0] = (
-            self.left_column,
+            self.left_panel,
             self.body.options(width_type='given', width_amount=width),
         )
         if visible:
@@ -131,7 +128,7 @@ class View(urwid.WidgetWrap):
             return
         width = 25 if visible else 0
         self.body.contents[2] = (
-            self.right_column,
+            self.right_panel,
             self.body.options(width_type='given', width_amount=width),
         )
         if visible:
@@ -160,7 +157,7 @@ class View(urwid.WidgetWrap):
             return key
         elif is_command_key('SEARCH_STREAMS', key):
             # jump stream search
-            self.left_col_w.keypress(size, 'q')
+            self.left_panel.keypress(size, 'q')
             self.show_right_panel(visible=False)
             self.show_left_panel(visible=True)
             self.stream_w.search_box.set_edit_text("")

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -23,6 +23,7 @@ class View(urwid.WidgetWrap):
     """
 
     LEFT_WIDTH = 25
+    RIGHT_WIDTH = 25
 
     def __init__(self, controller: Any) -> None:
         self.controller = controller
@@ -47,7 +48,7 @@ class View(urwid.WidgetWrap):
         return w
 
     def right_column_view(self) -> Any:
-        self.users_view = RightColumnView(self)
+        self.users_view = RightColumnView(View.RIGHT_WIDTH, self)
         w = urwid.LineBox(
             self.users_view, title=u"Users",
             tlcorner=u'─', tline=u'─', lline=u'',
@@ -92,7 +93,7 @@ class View(urwid.WidgetWrap):
             body = [
                 (View.LEFT_WIDTH, self.left_column),
                 ('weight', 10, self.center_column),
-                (25, self.right_column),
+                (View.RIGHT_WIDTH, self.right_column),
             ]
         self.body = urwid.Columns(body, focus_column=0)
 

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -116,7 +116,9 @@ class StreamButton(urwid.Button):
 
 class UserButton(urwid.Button):
     def __init__(self, user: Dict[str, Any], controller: Any,
-                 view: Any, color: Optional[str]=None, count: int=0) -> None:
+                 view: Any, width: int,
+                 color: Optional[str]=None, count: int=0) -> None:
+        self.width = width
         self.caption = user['full_name']  # str
         self.email = user['email']
         self.user_id = user['user_id']
@@ -134,10 +136,11 @@ class UserButton(urwid.Button):
         self._w = self.widget(count)
 
     def widget(self, count: int) -> Any:
+        spaces = self.width - (3 + len(self.caption) + len(str(count)) + 1)
+        count_str = '' if count <= 0 else str(count)
         return urwid.AttrMap(urwid.SelectableIcon(
-            [u'\N{BULLET} ', self.caption,
-             ('idle', '' if count <= 0 else ' ' + str(count))],
-            len(self.caption) + 2),
+            [u' \N{BULLET} ', self.caption, spaces*' ', ('idle',  count_str)],
+            0),  # cursor location
             self.color,
             'selected')
 

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -381,7 +381,8 @@ class RightColumnView(urwid.Frame):
     Displays the users list on the right side of the app.
     """
 
-    def __init__(self, view: Any) -> None:
+    def __init__(self, width: int, view: Any) -> None:
+        self.width = width
         self.view = view
         self.user_search = UserSearchBox(self)
         urwid.connect_signal(self.user_search, 'change',
@@ -431,6 +432,7 @@ class RightColumnView(urwid.Frame):
                     user,
                     controller=self.view.controller,
                     view=self.view,
+                    width=self.width,
                     color=user['status'],
                     count=unread_count
                 )


### PR DESCRIPTION
Main feature: adjust styling in user-list to align unread counts and indent slightly, in line with left column.

Additionally:
* some renaming/removal of internal variables in ui.py
* tests for `show_left_panel` and `show_right_panel`