### PR TITLE
Add preliminary CLI tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,6 @@ ignore_missing_imports = True
 [coverage:run]
 branch = True
 omit =
-    zulipterminal/cli/*
 #     a/b.py,
 #     fizz/buzz/bar.py
 

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -1,0 +1,28 @@
+import pytest
+from zulipterminal.cli.run import main
+
+
+@pytest.mark.parametrize('options', ['-h', '--help'])
+def test_main_help(capsys, options):
+    with pytest.raises(SystemExit):
+        main([options])
+
+    captured = capsys.readouterr()
+
+    lines = captured.out.strip().split("\n")
+
+    assert lines[0].startswith('usage: ')
+
+    required_arguments = {
+        '--theme THEME, -t THEME',
+        '-h, --help',
+        '-d, --debug',
+        '--profile',
+        '--config-file CONFIG_FILE, -c CONFIG_FILE'
+    }
+    optional_argument_lines = {line[2:] for line in lines
+                               if len(line) > 2 and line[2] == '-'}
+    for line in optional_argument_lines:
+        assert any(line.startswith(arg) for arg in required_arguments)
+
+    assert captured.err == ""

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -3,7 +3,7 @@ import configparser
 import traceback
 import sys
 import tempfile
-from typing import Dict, Any
+from typing import Dict, Any, List, Optional
 from os import path, remove
 
 from zulipterminal.core import Controller
@@ -11,7 +11,7 @@ from zulipterminal.model import ServerConnectionFailure
 from zulipterminal.config.themes import THEMES
 
 
-def parse_args() -> argparse.Namespace:
+def parse_args(argv: List[str]) -> argparse.Namespace:
     description = '''
         Starts Zulip-Terminal.
         '''
@@ -35,8 +35,7 @@ def parse_args() -> argparse.Namespace:
                         action="store_true",
                         default=False, help='Profile runtime.')
 
-    args = parser.parse_args()
-    return args
+    return parser.parse_args(argv)
 
 
 def get_api_key(realm_url: str) -> Any:
@@ -115,12 +114,13 @@ def parse_zuliprc(zuliprc_str: str) -> Dict[str, Any]:
     return settings
 
 
-def main() -> None:
+def main(options: Optional[List[str]]=None) -> None:
     """
     Launch Zulip Terminal.
     """
 
-    args = parse_args()
+    argv = options if options is not None else sys.argv[1:]
+    args = parse_args(argv)
 
     if args.profile:
         import cProfile


### PR DESCRIPTION
The CLI (run.py) code is currently completely untested. I initially started with some 'black box' testing by running it on the command-line using Popen, but that severely limits the ability to mock. Instead, I've slightly adjusted the function signature of `main` and `parse_args` to explicitly pass in either specific options (for testing) or `sys.argv`, enabling things to broadly still just work with `setup.py`.

The latter two commits then add tests for -h/--help and connection failure respectively.

The main intent here is to enable further (and indicate examples through existing) tests to be added based on these.

This does reduce the code coverage, since it adds `cli/*` back into the coverage being checked, though not by much.