### PR TITLE
Refactor Buttons by extending general features into TopButton & inheriting 

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1159,48 +1159,73 @@ class TestMessageBox:
 
 
 class TestTopButton:
+    @pytest.mark.parametrize('prefix', [
+        None, '\N{BULLET}', '-', ('blue', 'o'),
+    ])
     @pytest.mark.parametrize('width, count, short_text', [
         (8, 0, 'c..'),
         (9, 0, 'ca..'),
+        (9, -1, 'c..'),
         (9, 1, 'c..'),
         (10, 0, 'cap..'),
+        (10, -1, 'ca..'),
         (10, 1, 'ca..'),
         (11, 0, 'capt..'),
+        (11, -1, 'cap..'),
         (11, 1, 'cap..'),
         (11, 10, 'ca..'),
         (12, 0, 'caption'),
+        (12, -1, 'capt..'),
         (12, 1, 'capt..'),
         (12, 10, 'cap..'),
         (12, 100, 'ca..'),
         (13, 0, 'caption'),
+        (13, -1, 'caption'),
         (13, 10, 'capt..'),
         (13, 100, 'cap..'),
         (13, 1000, 'ca..'),
         (15, 0, 'caption'),
+        (15, -1, 'caption'),
         (15, 1, 'caption'),
         (15, 10, 'caption'),
         (15, 100, 'caption'),
         (15, 1000, 'capt..'),
         (25, 0, 'caption'),
+        (25, -1, 'caption'),
         (25, 1, 'caption'),
         (25, 19, 'caption'),
         (25, 199, 'caption'),
         (25, 1999, 'caption'),
     ])
     def test_text_content(self, mocker,
+                          prefix,
                           width, count, short_text, caption='caption'):
         show_function = mocker.Mock()
 
-        top_button = TopButton(controller=mocker.Mock(),
-                               caption=caption,
-                               show_function=show_function,
-                               width=width,
-                               count=count)
+        if isinstance(prefix, tuple):
+            prefix = prefix[1]  # just checking text, not color
+
+        if prefix is None:
+            top_button = TopButton(controller=mocker.Mock(),
+                                   caption=caption,
+                                   show_function=show_function,
+                                   width=width,
+                                   count=count)
+            prefix = '\N{BULLET}'
+        else:
+            top_button = TopButton(controller=mocker.Mock(),
+                                   caption=caption,
+                                   show_function=show_function,
+                                   prefix_character=prefix,
+                                   width=width,
+                                   count=count)
 
         text = top_button._w._original_widget.get_text()
         count_str = '' if count == 0 else str(count)
-        expected_text = ' \N{BULLET} {}{}{}'.format(
-                short_text,
+        if count < 0:
+            count_str = 'M'
+        expected_text = ' {} {}{}{}'.format(
+                prefix, short_text,
                 (width - 4 - len(short_text) - len(count_str))*' ',
                 count_str)
         assert len(text[0]) == len(expected_text) == (width - 1)

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Tuple, Callable, Optional
+from typing import Any, Dict, List, Tuple, Callable, Optional, Union
 
 import urwid
 
@@ -17,8 +17,10 @@ class MenuButton(urwid.Button):
 class TopButton(urwid.Button):
     def __init__(self, controller: Any, caption: str,
                  show_function: Callable[..., Any], width: int,
+                 prefix_character: Union[str, Tuple[Any, str]]='\N{BULLET}',
                  count: int=0) -> None:
         self.caption = caption
+        self.prefix_character = prefix_character
         self.count = count
         self.width_for_text_space_count = width - 4
         super().__init__("")
@@ -31,7 +33,12 @@ class TopButton(urwid.Button):
         self._w = self.widget(count)
 
     def widget(self, count: int) -> Any:
-        count_text = '' if count <= 0 else str(count)
+        if count < 0:
+            count_text = 'M'  # Muted
+        elif count == 0:
+            count_text = ''
+        else:
+            count_text = str(count)
 
         # Shrink text, but always require at least one space
         max_caption_length = (self.width_for_text_space_count -
@@ -43,7 +50,9 @@ class TopButton(urwid.Button):
         num_spaces = max_caption_length - len(caption) + 1
 
         return urwid.AttrMap(urwid.SelectableIcon(
-            [u' \N{BULLET} ', caption, num_spaces*' ', ('idle',  count_text)],
+            [' ', self.prefix_character,
+             ' {}{}'.format(caption, num_spaces*' '),
+             ('idle',  count_text)],
             0),  # cursor location
             None,
             'selected')

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -18,11 +18,14 @@ class TopButton(urwid.Button):
     def __init__(self, controller: Any, caption: str,
                  show_function: Callable[..., Any], width: int,
                  prefix_character: Union[str, Tuple[Any, str]]='\N{BULLET}',
+                 text_color: Optional[str]=None,
                  count: int=0) -> None:
         self.caption = caption
         self.prefix_character = prefix_character
         self.count = count
         self.width_for_text_space_count = width - 4
+        self.text_color = text_color
+        self.show_function = show_function
         super().__init__("")
         self._w = self.widget(count)
         self.controller = controller
@@ -54,13 +57,15 @@ class TopButton(urwid.Button):
              ' {}{}'.format(caption, num_spaces*' '),
              ('idle',  count_text)],
             0),  # cursor location
-            None,
+            self.text_color,
             'selected')
 
     def keypress(self, size: Tuple[int, int], key: str) -> str:
         if is_command_key('ENTER', key):
             self.controller.view.show_left_panel(visible=False)
+            self.controller.view.show_right_panel(visible=False)
             self.controller.view.body.focus_col = 1
+            self.show_function(self)
         return super().keypress(size, key)
 
 

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -29,7 +29,7 @@ class TopButton(urwid.Button):
         super().__init__("")
         self._w = self.widget(count)
         self.controller = controller
-        urwid.connect_signal(self, 'click', show_function)
+        urwid.connect_signal(self, 'click', self.activate)
 
     def update_count(self, count: int) -> None:
         self.count = count
@@ -60,12 +60,15 @@ class TopButton(urwid.Button):
             self.text_color,
             'selected')
 
+    def activate(self, key: Any) -> None:
+        self.controller.view.show_left_panel(visible=False)
+        self.controller.view.show_right_panel(visible=False)
+        self.controller.view.body.focus_col = 1
+        self.show_function(self)
+
     def keypress(self, size: Tuple[int, int], key: str) -> str:
         if is_command_key('ENTER', key):
-            self.controller.view.show_left_panel(visible=False)
-            self.controller.view.show_right_panel(visible=False)
-            self.controller.view.body.focus_col = 1
-            self.show_function(self)
+            self.activate(key)
         return super().keypress(size, key)
 
 


### PR DESCRIPTION
This continues some of the previous simplification of inheriting from `TopButton`, and extends it for `StreamButton` and `UserButton`. This dramatically reduces the duplicated widget code, which was clear when adding the 'truncated text' code, at the slight code of adding some parameters for the 'prefix character' (bullet, '#', 'P', etc, which can be colored), accounting for muted counts, and overall coloring (as per UserButton). I can see this being useful to easily specify eg. different icons for home/starred etc in future if go choose to go that way, though the motivation at this point is to simplify.

**NOTE** The last commit I am a little less sure about, and would appreciate feedback on. It ensures that a click and pressing `ENTER` do the same thing; currently a click on a button does not autohide, it just narrows, leaving any side panel still visible. The difference in behavior can be strange, but if users are clicking then the left/right panels now, with autohide as standard, then they may expect the window to disappear anyhow? 