### PR TITLE
Starred update generalization

### DIFF
--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -665,7 +665,7 @@ class TestModel:
 
     def test_update_star_status_no_index(self, mocker, model):
         model.index = dict(messages={})  # Not indexed
-        event = dict(messages=[1], flag='starred')
+        event = dict(messages=[1], flag='starred', all=False)
         mocker.patch('zulipterminal.model.Model.update_rendered_view')
 
         model.update_message_flag_status(event)
@@ -679,7 +679,8 @@ class TestModel:
             'messages': [1],
             'type': 'update_message_flags',
             'flag': 'starred',
-            'operation': 'OTHER'  # not 'add' or 'remove'
+            'operation': 'OTHER',  # not 'add' or 'remove'
+            'all': False,
         }
         mocker.patch('zulipterminal.model.Model.update_rendered_view')
         with pytest.raises(RuntimeError):
@@ -714,7 +715,8 @@ class TestModel:
             'messages': event_message_ids,
             'type': 'update_message_flags',
             'flag': 'starred',
-            'operation': event_op
+            'operation': event_op,
+            'all': False,
         }
         mocker.patch('zulipterminal.model.Model.update_rendered_view')
 

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -668,7 +668,7 @@ class TestModel:
         event = dict(messages=[1], flag='starred')
         mocker.patch('zulipterminal.model.Model.update_rendered_view')
 
-        model.update_star_status(event)
+        model.update_message_flag_status(event)
 
         assert model.index == dict(messages={1: {}})
         model.update_rendered_view.assert_not_called()
@@ -683,7 +683,7 @@ class TestModel:
         }
         mocker.patch('zulipterminal.model.Model.update_rendered_view')
         with pytest.raises(RuntimeError):
-            model.update_star_status(event)
+            model.update_message_flag_status(event)
         model.update_rendered_view.assert_not_called()
 
     @pytest.mark.parametrize('event_op, flags_before, flags_after', [
@@ -708,7 +708,7 @@ class TestModel:
         }
         mocker.patch('zulipterminal.model.Model.update_rendered_view')
 
-        model.update_star_status(event)
+        model.update_message_flag_status(event)
 
         assert model.index['messages'][1]['flags'] == flags_after
         model.update_rendered_view.assert_called_once_with(1)

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -104,7 +104,7 @@ class Model:
             'update_message': self.update_message,
             'reaction': self.update_reaction,
             'typing': self.handle_typing_event,
-            'update_message_flags': self.update_star_status,
+            'update_message_flags': self.update_message_flag_status,
         }  # type: Dict[str, Callable[[Event], None]]
 
     def _update_user_id(self) -> Optional[int]:
@@ -530,10 +530,10 @@ class Model:
             self.index['messages'][message_id] = message
             self.update_rendered_view(message_id)
 
-    def update_star_status(self, event: Event) -> None:
-        # TODO: Should also support 'read' flag changes?
-        # In that case, should rename this function and adapt
-        if event['flag'] != 'starred':
+    def update_message_flag_status(self, event: Event) -> None:
+        # TODO: Expand from 'starred' to also support 'read' flag changes?
+        flag_to_change = event['flag']
+        if flag_to_change != 'starred':
             return
 
         assert len(event['messages']) == 1  # FIXME: Can be multiple?
@@ -542,11 +542,11 @@ class Model:
         if self.index['messages'][message_id] != {}:
             msg = self.index['messages'][message_id]
             if event['operation'] == 'add':
-                if 'starred' not in msg['flags']:
-                    msg['flags'].append('starred')
+                if flag_to_change not in msg['flags']:
+                    msg['flags'].append(flag_to_change)
             elif event['operation'] == 'remove':
-                if 'starred' in msg['flags']:
-                    msg['flags'].remove('starred')
+                if flag_to_change in msg['flags']:
+                    msg['flags'].remove(flag_to_change)
             else:
                 raise RuntimeError(event, msg['flags'])
 

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -536,10 +536,10 @@ class Model:
         if flag_to_change != 'starred':
             return
 
-        assert len(event['messages']) == 1  # FIXME: Can be multiple?
-        message_id = event['messages'][0]
+        indexed_message_ids = set(self.index['messages'])
+        message_ids_to_mark = set(event['messages'])
 
-        if self.index['messages'][message_id] != {}:
+        for message_id in message_ids_to_mark & indexed_message_ids:
             msg = self.index['messages'][message_id]
             if event['operation'] == 'add':
                 if flag_to_change not in msg['flags']:

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -45,6 +45,7 @@ Event = TypedDict('Event', {
     'messages': List[int],
     'operation': str,
     'flag': str,
+    'all': bool,
     # message:
     'message': Message,
 }, total=False)  # Each Event will only have a subset of these
@@ -531,6 +532,9 @@ class Model:
             self.update_rendered_view(message_id)
 
     def update_message_flag_status(self, event: Event) -> None:
+        if event['all']:  # FIXME Should handle eventually
+            return
+
         # TODO: Expand from 'starred' to also support 'read' flag changes?
         flag_to_change = event['flag']
         if flag_to_change != 'starred':


### PR DESCRIPTION
This partially covers the work started in the not-merged #207, in smaller blocks, making it easier to cover the read-message-flags case from this improved point.

This:
* generalizes the method (including name) to deal with all message-flag updates
* generalizes the method internals to work with a general flag-to-change text
* extends the handling to cope with multiple message ids
* ensures we fail fast if we receive an (unhandled as yet) request to flag 'all' messages