### PR TITLE
Test theme completeness

### DIFF
--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -1,5 +1,5 @@
 import pytest
-from zulipterminal.cli.run import main, in_color
+from zulipterminal.cli.run import main, in_color, THEMES
 from zulipterminal.model import ServerConnectionFailure
 
 
@@ -60,6 +60,48 @@ def test_valid_zuliprc_but_no_connection(capsys, mocker, tmpdir,
     expected_lines = [
         "Loading with:",
         "   theme 'default' specified with no config.",
+        "   autohide setting 'autohide' specified with no config.",
+        "\x1b[91m",
+        ("Error connecting to Zulip server: {}.\x1b[0m".
+            format(server_connection_error)),
+    ]
+    assert lines == expected_lines
+
+    assert captured.err == ""
+
+
+@pytest.mark.parametrize('bad_theme', ['c', 'd'])
+def test_warning_regarding_incomplete_theme(capsys, mocker, tmpdir,
+                                            monkeypatch,
+                                            bad_theme,
+                                            server_connection_error="sce"):
+    mocker.patch('zulipterminal.core.Controller.__init__',
+                 side_effect=ServerConnectionFailure(server_connection_error))
+
+    monkeypatch.setitem(THEMES, bad_theme, [])
+    mocker.patch('zulipterminal.cli.run.all_themes',
+                 return_value=('a', 'b', 'c', 'd'))
+    mocker.patch('zulipterminal.cli.run.complete_and_incomplete_themes',
+                 return_value=(['a', 'b'], ['c', 'd']))
+
+    zuliprc_path = str(tmpdir) + "/zuliprc"
+    with open(zuliprc_path, "w") as f:
+        f.write("[api]")  # minimal to avoid Exception
+
+    with pytest.raises(SystemExit) as e:
+        main(["-c", zuliprc_path, "-t", bad_theme])
+        assert str(e.value) == '1'
+
+    captured = capsys.readouterr()
+
+    lines = captured.out.strip().split("\n")
+    expected_lines = [
+        "Loading with:",
+        "   theme '{}' specified on command line.".format(bad_theme),
+        "\x1b[93m"
+        "   WARNING: Incomplete theme; results may vary!",
+        "      (you could try: {}, {})"
+        "\x1b[0m".format('a', 'b'),
         "   autohide setting 'autohide' specified with no config.",
         "\x1b[91m",
         ("Error connecting to Zulip server: {}.\x1b[0m".

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -1,6 +1,14 @@
 import pytest
-from zulipterminal.cli.run import main
+from zulipterminal.cli.run import main, in_color
 from zulipterminal.model import ServerConnectionFailure
+
+
+@pytest.mark.parametrize('color, code', [
+    ('red', '\x1b[91m'),
+    ('blue', '\x1b[94m'),
+])
+def test_in_color(color, code, text="some text"):
+    assert in_color(color, text) == code + text + "\x1b[0m"
 
 
 @pytest.mark.parametrize('options', ['-h', '--help'])

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -5,7 +5,11 @@ from zulipterminal.model import ServerConnectionFailure
 
 @pytest.mark.parametrize('color, code', [
     ('red', '\x1b[91m'),
+    ('green', '\x1b[92m'),
+    ('yellow', '\x1b[93m'),
     ('blue', '\x1b[94m'),
+    ('purple', '\x1b[95m'),
+    ('cyan', '\x1b[96m'),
 ])
 def test_in_color(color, code, text="some text"):
     assert in_color(color, text) == code + text + "\x1b[0m"

--- a/tests/config/test_themes.py
+++ b/tests/config/test_themes.py
@@ -1,6 +1,8 @@
 import pytest
 
-from zulipterminal.config.themes import THEMES, required_styles
+from zulipterminal.config.themes import (
+    THEMES, required_styles, complete_and_incomplete_themes
+)
 
 expected_complete_themes = {
     'default', 'gruvbox',
@@ -20,3 +22,10 @@ def test_builtin_theme_completeness(theme_name):
     assert len(styles_in_theme) >= len(required_styles)
     assert all(required_style in styles_in_theme
                for required_style in required_styles)
+
+
+def test_complete_and_incomplete_themes():
+    # These are sorted to ensure reproducibility
+    result = (sorted(list(expected_complete_themes)),
+              sorted(list(set(THEMES)-expected_complete_themes)))
+    assert result == complete_and_incomplete_themes()

--- a/tests/config/test_themes.py
+++ b/tests/config/test_themes.py
@@ -1,0 +1,22 @@
+import pytest
+
+from zulipterminal.config.themes import THEMES, required_styles
+
+expected_complete_themes = {
+    'default', 'gruvbox',
+}
+
+
+# Check built-in themes are complete for quality-control purposes
+@pytest.mark.parametrize('theme_name', [
+    theme if theme in expected_complete_themes
+    else pytest.param(theme, marks=pytest.mark.xfail(reason="incomplete"))
+    for theme in THEMES
+])
+def test_builtin_theme_completeness(theme_name):
+    theme = THEMES[theme_name]
+    styles_in_theme = {style[0] for style in theme}
+
+    assert len(styles_in_theme) >= len(required_styles)
+    assert all(required_style in styles_in_theme
+               for required_style in required_styles)

--- a/tests/config/test_themes.py
+++ b/tests/config/test_themes.py
@@ -1,12 +1,16 @@
 import pytest
 
 from zulipterminal.config.themes import (
-    THEMES, required_styles, complete_and_incomplete_themes
+    THEMES, required_styles, all_themes, complete_and_incomplete_themes
 )
 
 expected_complete_themes = {
     'default', 'gruvbox',
 }
+
+
+def test_all_themes():
+    assert all_themes() == list(THEMES.keys())
 
 
 # Check built-in themes are complete for quality-control purposes

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -8,7 +8,7 @@ from os import path, remove
 
 from zulipterminal.core import Controller
 from zulipterminal.model import ServerConnectionFailure
-from zulipterminal.config.themes import THEMES
+from zulipterminal.config.themes import THEMES, all_themes
 
 
 def in_color(color: str, text: str) -> str:
@@ -154,12 +154,12 @@ def main(options: Optional[List[str]]=None) -> None:
             theme_to_use = (args.theme, 'on command line')
         else:
             theme_to_use = zterm['theme']
-        valid_themes = THEMES.keys()
-        if theme_to_use[0] not in valid_themes:
+        available_themes = all_themes()
+        if theme_to_use[0] not in available_themes:
             print("Invalid theme '{}' was specified {}."
                   .format(*theme_to_use))
             print("The following themes are available:")
-            for theme in valid_themes:
+            for theme in available_themes:
                 print("  ", theme)
             print("Specify theme in zuliprc file or override "
                   "using -t/--theme options on command line.")

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -13,10 +13,15 @@ from zulipterminal.config.themes import THEMES
 
 def in_color(color: str, text: str) -> str:
     color_for_str = {
-        'red': '\033[91m',
-        'blue': '\033[94m',
+        'red': '1',
+        'green': '2',
+        'yellow': '3',
+        'blue': '4',
+        'purple': '5',
+        'cyan': '6',
     }
-    return "{}{}{}".format(color_for_str[color], text, "\033[0m")
+    # We can use 3 instead of 9 if high-contrast is eg. less compatible?
+    return "\033[9{}m{}\033[0m".format(color_for_str[color], text)
 
 
 def parse_args(argv: List[str]) -> argparse.Namespace:

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -8,7 +8,9 @@ from os import path, remove
 
 from zulipterminal.core import Controller
 from zulipterminal.model import ServerConnectionFailure
-from zulipterminal.config.themes import THEMES, all_themes
+from zulipterminal.config.themes import (
+    THEMES, all_themes, complete_and_incomplete_themes
+)
 
 
 def in_color(color: str, text: str) -> str:
@@ -178,6 +180,13 @@ def main(options: Optional[List[str]]=None) -> None:
 
         print("Loading with:")
         print("   theme '{}' specified {}.".format(*theme_to_use))
+        complete, incomplete = complete_and_incomplete_themes()
+        if theme_to_use[0] in incomplete:
+            print(in_color('yellow',
+                           "   WARNING: Incomplete theme; "
+                           "results may vary!\n"
+                           "      (you could try: {})".
+                           format(", ".join(complete))))
         print("   autohide setting '{}' specified {}."
               .format(*zterm['autohide']))
         Controller(zuliprc_path,

--- a/zulipterminal/config/themes.py
+++ b/zulipterminal/config/themes.py
@@ -138,3 +138,10 @@ THEMES = {
         ('name',         'dark red',     'light gray', 'bold'),
     ]
 }  # type: Dict[str, ThemeSpec]
+
+
+def complete_and_incomplete_themes() -> Tuple[List[str], List[str]]:
+    complete = {name for name, styles in THEMES.items()
+                if set(s[0] for s in styles).issuperset(required_styles)}
+    incomplete = list(set(THEMES) - complete)
+    return sorted(list(complete)), sorted(incomplete)

--- a/zulipterminal/config/themes.py
+++ b/zulipterminal/config/themes.py
@@ -2,6 +2,32 @@ from typing import Dict, List, Tuple, Optional
 
 ThemeSpec = List[Tuple[Optional[str], ...]]
 
+required_styles = {
+    None,
+    'selected',
+    'msg_selected',
+    'header',
+    'custom',
+    'content',
+    'name',
+    'unread',
+    'active',
+    'idle',
+    'offline',
+    'inactive',
+    'title',
+    'time',
+    'bar',
+    'emoji',
+    'span',
+    'link',
+    'blockquote',
+    'code',
+    'bold',
+    'footer',
+    'starred',
+}
+
 # Colors used in gruvbox-256
 # See https://github.com/morhetz/gruvbox/blob/master/colors/gruvbox.vim
 BLACK = 'h234'  # dark0_hard

--- a/zulipterminal/config/themes.py
+++ b/zulipterminal/config/themes.py
@@ -140,6 +140,10 @@ THEMES = {
 }  # type: Dict[str, ThemeSpec]
 
 
+def all_themes() -> List[str]:
+    return list(THEMES.keys())
+
+
 def complete_and_incomplete_themes() -> Tuple[List[str], List[str]]:
     complete = {name for name, styles in THEMES.items()
                 if set(s[0] for s in styles).issuperset(required_styles)}


### PR DESCRIPTION
This work arose out of observing users use the older/incomplete light and blue themes. Hence
* the first commit checks whether themes are complete (have all styles) for the CI; two are currently marked as incomplete, which causes them to be expected failures (and so OK, for now)
* the addition of `complete_and_incomplete_themes` (2nd commit) allows `run.py` to determine complete themes at runtime, and consequently give feedback (a WARNING) on potential quality issues which might be seen

Other than those explicit changes, this includes quite a few other changes, and tests, including
* tests for `in_color` (introduced recently)
* extension of `in_color` to other colors (including yellow, subsequently used for the added WARNING
* add a simple `all_themes` method to `themes.py`; this is minimal, but helps mocking when testing
* some test refactoring

Hopefully this is rather straightforward, and should improve the user experience :)

As and when the existing and/or new themes are being developed, we can amend the parameters so that tests are not expected to fail, of course ;)