### PR TITLE
 Delete the client queue before shutdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ build/*
 zulip_term.egg-info
 zulip-terminal-tracebacks.log
 
+.vscode/*

--- a/Pipfile
+++ b/Pipfile
@@ -6,7 +6,7 @@ name = "pypi"
 [packages]
 typing = {version="==3.6.4", markers="python_version < '3.5'"}
 urwid = "==2.0.1"
-zulip = "==0.4.7"
+zulip = "==0.5.7"
 emoji = "==0.5.0"
 urwid-readline = "==0.8"
 beautifulsoup4 = "==4.6.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 typing==3.6.4; python_version < '3.5'
 urwid==2.0.1
-zulip==0.4.7
+zulip==0.5.7
 pytest==3.4.2
 pytest-cov==2.5.1
 pytest-pep8==1.0.6

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setup(
     install_requires=[
         "typing==3.6.4; python_version < '3.5'",
         'urwid==2.0.1',
-        'zulip==0.4.7',
+        'zulip==0.5.7',
         'emoji==0.5.0',
         'urwid_readline==0.8',
         'beautifulsoup4==4.6.0',


### PR DESCRIPTION
This deletes the queue(deregister) before shutdown(^C) of the ZT.
Fixes #241 