### PR TITLE
BUGFIX: boxes: Avoid crash in soup2markup with empty content/soup.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Move intrusive flashing cursor in left panel to far left side
 - Show user status as `active` (Green), `idle` (Yellow) or `offline` (White) using different colors.
 
+### Important bugfixes
+- Avoid crash in rare care of empty message content
+
 ## 0.3.1
 
 ### Interactivity improvements

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -857,6 +857,7 @@ class TestMessageBox:
             msg_box = MessageBox(message, self.model, None)
 
     @pytest.mark.parametrize('content, markup', [
+        ('', []),
         ('<p>hi</p>', ['', 'hi']),
         ('<span class="user-mention">@Bob Smith', [('span', '@Bob Smith')]),
         ('<span class="user-group-mention">@A Group', [('span', '@A Group')]),
@@ -890,7 +891,7 @@ class TestMessageBox:
         ('<div class="inline-preview-twitter"',
             ['[TWITTER PREVIEW NOT RENDERED]']),
     ], ids=[
-        'p', 'user-mention', 'group-mention', 'code', 'codehilite',
+        'empty', 'p', 'user-mention', 'group-mention', 'code', 'codehilite',
         'strong', 'em', 'blockquote',
         'embedded_content', 'link_sametext', 'link_differenttext',
         'link_userupload', 'listitem', 'listitems',

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -227,6 +227,8 @@ class MessageBox(urwid.Pile):
         # Ensure a string is provided, in case the soup finds none
         # This could occur if eg. an image is removed or not shown
         markup = ['']
+        if soup is None:  # This is not iterable, so return promptly
+            return markup
         unrendered_tags = {  # In pairs of 'tag_name': 'text'
             # TODO: Some of these could be implemented
             'br': '',  # No indicator of absence


### PR DESCRIPTION
In the middle of working on another branch, I noticed that going to the `test here` stream on chat.zulip.org caused a crash, due to an empty message content - which is of course rather rare. Possibly even the web client will not send empty messages by default?

In any case, this PR avoids a crash, adds a test case, and amends the CHANGELOG ready for the next release.