### PR TITLE
run: Set encoding to 'utf-8' at the start.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Important bugfixes
 - Avoid crash in rare care of empty message content
+- Set terminal locale to `utf-8` by default which removes issues with rendering double width characters.
 
 ## 0.3.1
 

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -6,6 +6,8 @@ import tempfile
 from typing import Dict, Any, List, Optional
 from os import path, remove
 
+from urwid import set_encoding
+
 from zulipterminal.core import Controller
 from zulipterminal.model import ServerConnectionFailure
 from zulipterminal.config.themes import (
@@ -138,6 +140,8 @@ def main(options: Optional[List[str]]=None) -> None:
 
     argv = options if options is not None else sys.argv[1:]
     args = parse_args(argv)
+
+    set_encoding('utf-8')
 
     if args.profile:
         import cProfile


### PR DESCRIPTION
This works on MacOs and Linux.

@neiljp I don't think we need to display warning as this works without fail with urwid. If the user still is seeing question marks, it might be due to different problems like one of those double width problems or terminal input-output stream being manipulated or being modified before reaching urwid by terminal.