### PR TITLE
Improve/reorder help for shortcut keys & remove QUIT_HELP

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ autohide=autohide
 ## Hot Keys
 | Command                                               | Key Combination                               |
 | ----------------------------------------------------- | --------------------------------------------- |
+| Display help menu                                     | <kbd>?</kbd>                                  |
 | Go Back                                               | <kbd>esc</kbd>                                |
 | Previous message                                      | <kbd>Up</kbd> / <kbd>k</kbd>                  |
 | Next message                                          | <kbd>Down</kbd> / <kbd>j</kbd>                |
@@ -81,26 +82,25 @@ autohide=autohide
 | Scroll up                                             | <kbd>PgUp</kbd> / <kbd>K</kbd>                |
 | Scroll down                                           | <kbd>PgDn</kbd> / <kbd>J</kbd>                |
 | Go to the last message                                | <kbd>G</kbd> / <kbd>end</kbd>                 |
-| Reply to a message                                    | <kbd>r</kbd>                                  |
-| Reply to an author                                    | <kbd>R</kbd>                                  |
-| Reply mentioning sender of the message                | <kbd>@</kbd>                                  |
-| Reply quoting the message text                        | <kbd>></kbd>                                  |
-| New stream message                                    | <kbd>c</kbd>                                  |
-| New private message                                   | <kbd>x</kbd>                                  |
+| Reply to the current message                          | <kbd>r</kbd>                                  |
+| Reply mentioning the sender of the current message    | <kbd>@</kbd>                                  |
+| Reply quoting the current message text                | <kbd>></kbd>                                  |
+| Reply privately to the sender of the current message  | <kbd>R</kbd>                                  |
+| New message to a stream                               | <kbd>c</kbd>                                  |
+| New message to a person or group of people            | <kbd>x</kbd>                                  |
 | Toggle focus box in compose box                       | <kbd>tab</kbd>                                |
 | Send a message                                        | <kbd>Alt Enter</kbd> / <kbd>Ctrl d</kbd>                         |
-| Narrow to a stream                                    | <kbd>S</kbd>                                  |
-| Narrow to a topic                                     | <kbd>s</kbd>                                  |
-| Narrow to private messages                            | <kbd>P</kbd>                                  |
-| Narrow to starred messages                            | <kbd>f</kbd>                                  |
+| Narrow to the stream of the current message           | <kbd>s</kbd>                                  |
+| Narrow to the topic of the current message            | <kbd>S</kbd>                                  |
+| Narrow to all private messages                        | <kbd>P</kbd>                                  |
+| Narrow to all starred messages                        | <kbd>f</kbd>                                  |
 | Next Unread Topic                                     | <kbd>n</kbd>                                  |
-| Next Unread PM                                        | <kbd>p</kbd>                                  |
+| Next Unread private message                           | <kbd>p</kbd>                                  |
 | Search People                                         | <kbd>w</kbd>                                  |
 | Search Messages                                       | <kbd>/</kbd>                                  |
 | Search Streams                                        | <kbd>q</kbd>                                  |
-| Add/remove thumbs-up reaction on a message            | <kbd>+</kbd>                                  |
-| Add/remove star status of a message                   | <kbd>*</kbd>                                  |
-| Display help menu                                     | <kbd>?</kbd>                                  |
+| Add/remove thumbs-up reaction to the current message  | <kbd>+</kbd>                                  |
+| Add/remove star status of the current message         | <kbd>*</kbd>                                  |
 | Jump to the Beginning of line                         | <kbd>Ctrl</kbd> + <kbd>A</kbd>                |
 | Jump backward one character                           | <kbd>Ctrl</kbd> + <kbd>B</kbd> / <kbd>←</kbd> |
 | Jump backward one word                                | <kbd>Meta</kbd> + <kbd>B</kbd>                |

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -13,6 +13,7 @@ from zulipterminal.ui_tools.views import (
 )
 from zulipterminal.ui_tools.boxes import MessageBox
 from zulipterminal.ui_tools.buttons import TopButton, StreamButton, UserButton
+from zulipterminal.config.keys import keys_for_command
 
 from urwid import AttrWrap, Columns, Padding, Text
 
@@ -822,8 +823,8 @@ class TestHelpMenu:
         self.help_view.keypress(size, key)
         assert not self.controller.exit_help.called
 
-    def test_keypress_q(self):
-        key = "q"
+    @pytest.mark.parametrize('key', keys_for_command("GO_BACK"))
+    def test_keypress_goback(self, key):
         size = (200, 20)
         self.help_view.keypress(size, key)
         assert self.controller.exit_help.called

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -1,6 +1,14 @@
 from typing import Set
 
 KEY_BINDINGS = {
+    'HELP': {
+        'keys': {'?'},
+        'help_text': 'Display help menu',
+    },
+    'QUIT_HELP': {
+        'keys': {'q', 'esc'},
+        'help_text': 'Quit help menu',
+    },
     'GO_BACK': {
         'keys': {'esc'},
         'help_text': 'Go Back',
@@ -35,27 +43,27 @@ KEY_BINDINGS = {
     },
     'REPLY_MESSAGE': {
         'keys': {'r', 'enter'},
-        'help_text': 'Reply to a message',
-    },
-    'REPLY_AUTHOR': {
-        'keys': {'R'},
-        'help_text': 'Reply to an author',
+        'help_text': 'Reply to the current message',
     },
     'MENTION_REPLY': {
         'keys': {'@'},
-        'help_text': 'Reply mentioning the sender of the message'
+        'help_text': 'Reply mentioning the sender of the current message'
     },
     'QUOTE_REPLY': {
         'keys': {'>'},
-        'help_text': 'Reply quoting message text',
+        'help_text': 'Reply quoting the current message text',
+    },
+    'REPLY_AUTHOR': {
+        'keys': {'R'},
+        'help_text': 'Reply privately to the sender of the current message',
     },
     'STREAM_MESSAGE': {
         'keys': {'c'},
-        'help_text': 'New stream message',
+        'help_text': 'New message to a stream',
     },
     'PRIVATE_MESSAGE': {
         'keys': {'x'},
-        'help_text': 'New private message',
+        'help_text': 'New message to a person or group of people',
     },
     'TAB': {
         'keys': {'tab'},
@@ -67,11 +75,11 @@ KEY_BINDINGS = {
     },
     'STREAM_NARROW': {
         'keys': {'s'},
-        'help_text': 'Narrow to a stream',
+        'help_text': 'Narrow to the stream of the current message',
     },
     'TOPIC_NARROW': {
         'keys': {'S'},
-        'help_text': 'Narrow to a topic',
+        'help_text': 'Narrow to the topic of the current message',
     },
     'ALL_PM': {
         'keys': {'P'},
@@ -101,25 +109,17 @@ KEY_BINDINGS = {
         'keys': {'q'},
         'help_text': 'Search Streams',
     },
-    'HELP': {
-        'keys': {'?'},
-        'help_text': 'Display help menu',
-    },
     'ENTER': {
         'keys': {'enter'},
         'help_text': 'Perform current action',
     },
-    'QUIT_HELP': {
-        'keys': {'q', 'esc'},
-        'help_text': 'Quit help menu',
-    },
     'THUMBS_UP': {
         'keys': {'+'},
-        'help_text': 'Add/remove thumbs-up reaction on a message',
+        'help_text': 'Add/remove thumbs-up reaction to the current message',
     },
     'TOGGLE_STAR_STATUS': {
         'keys': {'ctrl s', '*'},
-        'help_text': 'Add/remove star status of a message',
+        'help_text': 'Add/remove star status of the current message',
     },
 }
 

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -5,10 +5,6 @@ KEY_BINDINGS = {
         'keys': {'?'},
         'help_text': 'Display help menu',
     },
-    'QUIT_HELP': {
-        'keys': {'q', 'esc'},
-        'help_text': 'Quit help menu',
-    },
     'GO_BACK': {
         'keys': {'esc'},
         'help_text': 'Go Back',

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -85,7 +85,7 @@ class Controller:
     def show_help(self) -> None:
         self.loop.widget = urwid.Overlay(
             urwid.LineBox(HelpView(self),
-                          title="Help Menu ('q' quits, up/down scrolls)"),
+                          title="Help Menu ('esc' quits, up/down scrolls)"),
             self.view,
             align='center',
             width=('relative', 100),

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -566,6 +566,6 @@ class HelpView(urwid.ListBox):
         super(HelpView, self).__init__(self.log)
 
     def keypress(self, size: Tuple[int, int], key: str) -> str:
-        if is_command_key('QUIT_HELP', key):
+        if is_command_key('GO_BACK', key):
             self.controller.exit_help()
         return super(HelpView, self).keypress(size, key)


### PR DESCRIPTION
@rishig How does this look like, reordering/naming, based on what you said before?

We can discuss further on #z-t, but I was reading it recently and these where some more obvious improvements (at least to my eye):
* reordered/clearer/consistent help text
* remove help-specific 'exiting'