### PR TITLE
Allow 'P' and 'f' keys to work from side panels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Interactivity improvements
 - Add additional shortcut key for sending messages (<kbd>ctrl</kbd>+<kbd>d</kbd>)
+- Allow <kbd>f</kbd> and <kbd>P</kbd> shortcut keys to work from side panels (narrow starred & private messages)
 
 ### Visual improvements
 - Right-align unread-counts in left & right panels (as in webapp)

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -146,6 +146,12 @@ class View(urwid.WidgetWrap):
             self.body.focus_col = 1
             self.middle_column.keypress(size, key)
             return key
+        elif is_command_key('ALL_PM', key):
+            self.model.controller.show_all_pm(self)
+            self.body.focus_col = 1
+        elif is_command_key('ALL_STARRED', key):
+            self.model.controller.show_all_starred(self)
+            self.body.focus_col = 1
         elif is_command_key('SEARCH_PEOPLE', key):
             # Start User Search if not in editor_mode
             self.users_view.keypress(size, 'w')

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -465,10 +465,6 @@ class MessageBox(urwid.Pile):
             self.model.controller.view.write_box.private_box_view(
                 email=self.message['sender_email']
             )
-        elif is_command_key('ALL_PM', key):
-            self.model.controller.show_all_pm(self)
-        elif is_command_key('ALL_STARRED', key):
-            self.model.controller.show_all_starred(self)
         elif is_command_key('MENTION_REPLY', key):
             self.keypress(size, 'enter')
             mention = '@**' + self.message['sender_full_name'] + '** '


### PR DESCRIPTION
Currently these keys only work from the central panel, but I feel these should be narrowing keys which work from anywhere in the app.

I moved the relevant `Controller` calls from the `MessageView` and made it change focus to the messages.

CHANGELOG also amended.