### PR TITLE
Improve Installation notes for users & developers

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,15 +15,12 @@ Please see the [CHANGELOG](CHANGELOG.md) for released & recent changes.
 
 ## Installation & Running
 
-We recommend installing `zulip-term` in a python virtual environment, something like the following:
-```
-[sudo] pip3 install virtualenv
-virtualenv /tmp/zt/
-. /tmp/zt/bin/activate
-pip3 install zulip-term
-```
+We recommend installing `zulip-term` in a new python virtual environment (venv); with the required python 3.4+, the following should work on most systems:
+1. `python3 -m venv zulip-terminal-venv` (creates a venv named `zulip-terminal-venv` in the current directory)
+2. `source zulip-terminal-venv/bin/activate` (activates the venv; this assumes a bash-like shell)
+3. `pip3 install zulip-term` (downloads and installs the latest zulip-terminal release from PyPI)
 
-Zulip Terminal installs as `zulip-term`, so just run:
+Zulip Terminal installs as `zulip-term`, so you can then run:
 ```
 $ zulip-term
 ```
@@ -35,6 +32,10 @@ Loading with:
    autohide setting 'autohide' specified with no config.
 Welcome to Zulip.
 ```
+
+### NOTE: Running in subsequent/different sessions
+
+If you open a different terminal window (or log-off/restart your computer), you'll need to run **step 2** of the installation again before running `zulip-term`, since that activates that virtual environment. You can read more about virtual environments in the [Python 3 library venv documentation](https://docs.python.org/3/library/venv.html).
 
 ### NOTE: The zuliprc file
 

--- a/README.md
+++ b/README.md
@@ -181,32 +181,18 @@ $ pip3 install -e .[dev]
 $ zulip-term
 ```
 
-### Running tests
+## Development tasks
 
-* To run all tests (including the linter):
-```
-pipenv run pytest
-```
+Once you have a development environment set up, you might find the following useful, depending upon your type of environment:
 
-* To generate coverage report for tests:
-```
-pipenv run pytest --cov-report html:cov_html --cov=./
-```
+| Task | Pip | Pipenv |
+|-|-|-|
+| Run all tests (including linter) | `pytest` | `pipenv run pytest` |
+| Build test coverage report | `pytest --cov-report html:cov_html --cov=./` | `pipenv run pytest --cov-report html:cov_html --cov=./` |
+| Check type annotations | `./tools/run-mypy` | `pipenv run ./tools/run-mypy` |
+| Run in debug mode | `zulip-term -d` | `pipenv run zulip-term -d` |
+| Run with profiling | `zulip-term --profile` | `pipenv run zulip-term --profile` |
 
-* To check the type annotations, run:
-```
-pipenv run ./tools/run-mypy
-```
-
-* To open in debug mode:
-```
-pipenv run zulip-term -d
-```
-
-* To profile runtime:
-```
-pipenv run zulip-term --profile
-```
 
 ## Contributor Guidelines
 

--- a/README.md
+++ b/README.md
@@ -124,9 +124,13 @@ autohide=autohide
 
 Note: You can use `arrows`, `home`, `end`, `Page up` and `Page down` keys to move around in Zulip-Terminal.
 
-## Development
+## Setting up a development environment
 
-For development, the setup process is a little different.
+Various options are available; we are exploring the benefits of each and would appreciate feedback on which you use or feel works best.
+
+Note that the tools used in each case are typically the same, but are called in different ways.
+
+### Pipenv
 
 1. Install pipenv
 ```
@@ -141,7 +145,7 @@ $ python3 -m pip install --user pipenv
 $ git clone git@github.com:zulip/zulip-terminal.git
 ```
 
-3. Install dev requirements
+3. Install zulip-term, with the development requirements
 ```
 $ cd zulip-terminal
 $ pipenv --three
@@ -152,6 +156,29 @@ $ pipenv run python setup.py develop
 4. Run the client
 ```
 $ pipenv run zulip-term
+```
+
+### Pip
+
+1. Manually create & activate a virtual environment; any method should work, such as that used in the above simple installation
+
+    1. `python3 -m venv zulip-terminal-venv` (creates a venv named `zulip-terminal-venv` in the current directory)
+    2. `source zulip-terminal-venv/bin/activate` (activates the venv; this assumes a bash-like shell)
+
+2. Clone the zulip/zulip-terminal repository locally
+```
+$ git clone git@github.com:zulip/zulip-terminal.git
+```
+
+3. Install zulip-term, with the development requirements
+```
+$ cd zulip-terminal
+$ pip3 install -e .[dev]
+```
+
+4. Run the client
+```
+$ zulip-term
 ```
 
 ### Running tests
@@ -181,7 +208,7 @@ pipenv run zulip-term -d
 pipenv run zulip-term --profile
 ```
 
-### Contributor Guidelines
+## Contributor Guidelines
 
 Zulip Terminal is being build by an awesome community of [Zulip](https://zulipchat.com/team).
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,12 @@ Various options are available; we are exploring the benefits of each and would a
 
 Note that the tools used in each case are typically the same, but are called in different ways.
 
+With any option, you first need to clone the zulip/zulip-terminal repository locally (the following will place the repository in the current directory):
+```
+$ git clone git@github.com:zulip/zulip-terminal.git
+```
+The following commands should be run in the repository directory, which can be achieved with `cd zulip-terminal`.
+
 ### Pipenv
 
 1. Install pipenv
@@ -140,22 +146,11 @@ $ printf '\nexport PATH="%s:$PATH"\n' '${HOME}/.local/bin' | tee -a ~/.bashrc
 $ python3 -m pip install --user pipenv
 ```
 
-2. Clone the zulip/zulip-terminal repository locally
+2. Install zulip-term, with the development requirements
 ```
-$ git clone git@github.com:zulip/zulip-terminal.git
-```
-
-3. Install zulip-term, with the development requirements
-```
-$ cd zulip-terminal
 $ pipenv --three
 $ pipenv install --dev
 $ pipenv run python setup.py develop
-```
-
-4. Run the client
-```
-$ pipenv run zulip-term
 ```
 
 ### Pip
@@ -165,20 +160,9 @@ $ pipenv run zulip-term
     1. `python3 -m venv zulip-terminal-venv` (creates a venv named `zulip-terminal-venv` in the current directory)
     2. `source zulip-terminal-venv/bin/activate` (activates the venv; this assumes a bash-like shell)
 
-2. Clone the zulip/zulip-terminal repository locally
+2. Install zulip-term, with the development requirements
 ```
-$ git clone git@github.com:zulip/zulip-terminal.git
-```
-
-3. Install zulip-term, with the development requirements
-```
-$ cd zulip-terminal
 $ pip3 install -e .[dev]
-```
-
-4. Run the client
-```
-$ zulip-term
 ```
 
 ## Development tasks
@@ -187,11 +171,12 @@ Once you have a development environment set up, you might find the following use
 
 | Task | Pip | Pipenv |
 |-|-|-|
+| Run normally | `zulip-term` | `pipenv run zulip-term` |
+| Run in debug mode | `zulip-term -d` | `pipenv run zulip-term -d` |
+| Run with profiling | `zulip-term --profile` | `pipenv run zulip-term --profile` |
 | Run all tests (including linter) | `pytest` | `pipenv run pytest` |
 | Build test coverage report | `pytest --cov-report html:cov_html --cov=./` | `pipenv run pytest --cov-report html:cov_html --cov=./` |
 | Check type annotations | `./tools/run-mypy` | `pipenv run ./tools/run-mypy` |
-| Run in debug mode | `zulip-term -d` | `pipenv run zulip-term -d` |
-| Run with profiling | `zulip-term --profile` | `pipenv run zulip-term --profile` |
 
 
 ## Contributor Guidelines

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ $ pipenv run zulip-term
 
 ### Running tests
 
-* To run all tests:
+* To run all tests (including the linter):
 ```
 pipenv run pytest
 ```
@@ -164,11 +164,6 @@ pipenv run pytest
 * To generate coverage report for tests:
 ```
 pipenv run pytest --cov-report html:cov_html --cov=./
-```
-
-* To run the linter:
-```
-pipenv run pytest --pep8
 ```
 
 * To check the type annotations, run:


### PR DESCRIPTION
I've attempted to improve/update the notes again, including broadening the details of virtual environments and   adding a native pip (as opposed to pipenv) install, to give people an alternative option.

Re that last point, I'm happy to move the pip notes to after pipenv, if that would be preferred.

I'm still interested in adding tox support so we can run multiple environments locally like on Travis, but that would be yet another alternative :) 