### PR TITLE
Error handling and other small fixes in run.py

### DIFF
--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -2,7 +2,6 @@ import argparse
 import configparser
 import traceback
 import sys
-import tempfile
 import logging
 import requests
 from typing import Dict, Any, List, Optional, Tuple

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -108,7 +108,8 @@ def parse_zuliprc(zuliprc_str: str) -> Dict[str, Any]:
     while not path.exists(zuliprc_path):
         try:
             fetch_zuliprc(zuliprc_path)
-        except OSError:
+        # Invalid user inputs (e.g. pressing arrow keys) may cause ValueError
+        except (OSError, ValueError):
             # Remove zuliprc file if created.
             if path.exists(zuliprc_path):
                 remove(zuliprc_path)

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -108,12 +108,15 @@ def parse_zuliprc(zuliprc_str: str) -> Dict[str, Any]:
     while not path.exists(zuliprc_path):
         try:
             fetch_zuliprc(zuliprc_path)
-        except Exception:
-            print(in_color('red',
-                           "\nInvalid Credentials, Please try again!\n"))
+        except OSError:
             # Remove zuliprc file if created.
             if path.exists(zuliprc_path):
                 remove(zuliprc_path)
+            print(in_color('red',
+                           "\nInvalid Credentials, Please try again!\n"))
+        except EOFError:
+            # Assume that the user pressed Ctrl+D and continue the loop
+            print("\n")
 
     zuliprc = configparser.ConfigParser()
     zuliprc.read(zuliprc_path)

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -105,7 +105,7 @@ def fetch_zuliprc(zuliprc_path: str) -> None:
 
 def parse_zuliprc(zuliprc_str: str) -> Dict[str, Any]:
     zuliprc_path = path.expanduser(zuliprc_str)
-    if not path.exists(zuliprc_path):
+    while not path.exists(zuliprc_path):
         try:
             fetch_zuliprc(zuliprc_path)
         except Exception:
@@ -114,7 +114,6 @@ def parse_zuliprc(zuliprc_str: str) -> Dict[str, Any]:
             # Remove zuliprc file if created.
             if path.exists(zuliprc_path):
                 remove(zuliprc_path)
-            parse_zuliprc(zuliprc_str)
 
     zuliprc = configparser.ConfigParser()
     zuliprc.read(zuliprc_path)

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -4,7 +4,8 @@ import traceback
 import sys
 import tempfile
 import logging
-from typing import Dict, Any, List, Optional
+import requests
+from typing import Dict, Any, List, Optional, Tuple
 from os import path, remove
 
 from urwid import set_encoding
@@ -59,9 +60,8 @@ def parse_args(argv: List[str]) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
-def get_api_key(realm_url: str) -> Any:
+def get_api_key(realm_url: str) -> Tuple[requests.Response, str]:
     from getpass import getpass
-    import requests
 
     email = input(in_color('blue', "Email: "))
     password = getpass(in_color('blue', "Password: "))
@@ -93,7 +93,7 @@ def fetch_zuliprc(zuliprc_path: str) -> None:
 
     while res.status_code != 200:
         print(in_color('red', "\nUsername or Password Incorrect!\n"))
-        res = get_api_key(realm_url)
+        res, email = get_api_key(realm_url)
 
     with open(zuliprc_path, 'w') as f:
         f.write('[api]' +

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -119,7 +119,19 @@ def parse_zuliprc(zuliprc_str: str) -> Dict[str, Any]:
             print("\n")
 
     zuliprc = configparser.ConfigParser()
-    zuliprc.read(zuliprc_path)
+
+    try:
+        res = zuliprc.read(zuliprc_path)
+        if len(res) == 0:
+            print(in_color('red',
+                           "\nZuliprc file could not be accessed at " +
+                           zuliprc_path + "\n"))
+            sys.exit(1)
+    except configparser.MissingSectionHeaderError:
+        print(in_color('red',
+                       "\nFailed to parse zuliprc file at " +
+                       zuliprc_path + "\n"))
+        sys.exit(1)
 
     # default settings
     NO_CONFIG = 'with no config'


### PR DESCRIPTION
This PR is a small refactoring of `run.py` that was proposed some time ago on zulip chat. The main idea was to eliminate unnecessary recursion from `parse_zuliprc`, but I've also changed error handling a bit.

List of changes:
– remove an unused import
– remove recursion from `parse_zuliprc`
– narrow down caught exception types where possible
– fix a bug where `fetch_zuliprc` would throw an exception because of incorrect variable assignment (line 95)
– handle errors in the actual parsing of `zuliprc` (e.g. when the path passed as an argument led to a random file or a directory)
– when a `parse_zuliprc` call is interrupted by `Ctrl+D`, don't delete the `zuliprc` file if it has been created. This was briefly discussed on chat. A situation where `zuliprc` has to be deleted, i.e. when `zuliprc` was created by zulip but an exception occurred immediately afterwards, is rather unlikely. At the same time it is never the case when `Ctrl+D` is pressed (`zuliprc` is created after all user input is read). It means that by _not_ deleting the file we might allow a situation where the user can provide their own config file at the given path without quitting the program and then press `Ctrl+D` to be magically logged in after the file is discovered.
I'm not sure this is the ideal design, though, so we can discuss it.