### PR TITLE
Centralize client access within model

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -193,6 +193,8 @@ def initial_data(logged_on_user):
     Response from /register API request.
     """
     return {
+        'full_name': logged_on_user['full_name'],
+        'email': logged_on_user['email'],
         'unsubscribed': [{
             'audible_notifications': False,
             'description': 'announce',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -195,6 +195,7 @@ def initial_data(logged_on_user):
     return {
         'full_name': logged_on_user['full_name'],
         'email': logged_on_user['email'],
+        'user_id': logged_on_user['user_id'],
         'unsubscribed': [{
             'audible_notifications': False,
             'description': 'announce',
@@ -581,7 +582,7 @@ def index_all_starred(empty_index, request):
 
 @pytest.fixture(scope="module")
 def user_profile(logged_on_user):
-    return {
+    return {  # FIXME These should all be self-consistent with others?
         'max_message_id': 589270,
         'short_name': logged_on_user['short_name'],
         'full_name': logged_on_user['full_name'],

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -83,12 +83,12 @@ class TestController:
         assert {widget.original_widget.message['id']} == id_list
 
     def test_narrow_to_user(self, mocker, controller, user_button, index_user):
-        controller.model.client = self.client
         controller.model.narrow = []
         controller.model.index = index_user
         controller.model.msg_view = mocker.patch('urwid.SimpleFocusListWalker')
         controller.model.msg_list = mocker.patch('urwid.ListBox')
         controller.model.user_id = 5140
+        controller.model.user_email = "some@email"
         controller.model.user_dict = {
             user_button.email: {
                 'user_id': user_button.user_id
@@ -105,11 +105,11 @@ class TestController:
         assert {widget.original_widget.message['id']} == id_list
 
     def test_show_all_messages(self, mocker, controller, index_all_messages):
-        controller.model.client = self.client
         controller.model.narrow = [['stream', 'PTEST']]
         controller.model.index = index_all_messages
         controller.model.msg_view = mocker.patch('urwid.SimpleFocusListWalker')
         controller.model.msg_list = mocker.patch('urwid.ListBox')
+        controller.model.user_email = "some@email"
         controller.model.stream_dict = {
             205: {
                 'color': '#ffffff',
@@ -128,12 +128,14 @@ class TestController:
         assert msg_ids == id_list
 
     def test_show_all_pm(self, mocker, controller, index_user):
-        controller.model.client = self.client
         controller.model.narrow = []
         controller.model.index = index_user
         controller.model.msg_view = mocker.patch('urwid.SimpleFocusListWalker')
         controller.model.msg_list = mocker.patch('urwid.ListBox')
+        controller.model.user_email = "some@email"
+
         controller.show_all_pm('')
+
         assert controller.model.narrow == [['is', 'private']]
         controller.model.msg_view.clear.assert_called_once_with()
         num_pm = len(index_user['all_private'])
@@ -144,11 +146,11 @@ class TestController:
         assert msg_ids == id_list
 
     def test_show_all_starred(self, mocker, controller, index_all_starred):
-        controller.model.client = self.client
         controller.model.narrow = []
         controller.model.index = index_all_starred
         controller.model.muted_streams = set()  # FIXME Expand upon this
         controller.model.muted_topics = []  # FIXME Expand upon this
+        controller.model.user_email = "some@email"
         controller.model.stream_dict = {
             205: {
                 'color': '#ffffff',

--- a/tests/helper/test_helper.py
+++ b/tests/helper/test_helper.py
@@ -1,26 +1,9 @@
 import pytest
 
 from zulipterminal.helper import (
-    update_flag,
     index_messages,
 )
 from typing import Any
-
-
-def test_update_flag(mocker: Any) -> None:
-    mock_controller = mocker.patch('zulipterminal.core.Controller')
-    mock_api_query = mocker.patch('zulipterminal.core.Controller'
-                                  '.client.do_api_query')
-    update_flag([1, 2], mock_controller)
-    mock_api_query.assert_called_once_with(
-        {'flag': 'read', 'messages': [1, 2], 'op': 'add'},
-        '/json/messages/flags',
-        method='POST'
-    )
-
-
-def test_update_flag_empty_msg_list(mocker: Any) -> None:
-    assert update_flag([], mocker.patch('zulip.Client')) is None
 
 
 def test_index_messages_narrow_all_messages(mocker,

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -250,6 +250,40 @@ class TestModel:
         with pytest.raises(AssertionError):
             model.react_to_message(dict(), 'x')
 
+    @pytest.mark.parametrize('response, return_value', [
+        ({'result': 'success'}, True),
+        ({'result': 'some_failure'}, False),
+    ])
+    def test_send_private_message(self, mocker, model,
+                                  response, return_value,
+                                  content="hi!",
+                                  recipients="notification-bot@zulip.com"):
+        self.client.send_message = mocker.Mock(return_value=response)
+
+        result = model.send_private_message(recipients, content)
+
+        req = dict(type='private', to=recipients, content=content)
+        self.client.send_message.assert_called_once_with(req)
+
+        assert result == return_value
+
+    @pytest.mark.parametrize('response, return_value', [
+        ({'result': 'success'}, True),
+        ({'result': 'some_failure'}, False),
+    ])
+    def test_send_stream_message(self, mocker, model,
+                                 response, return_value,
+                                 content="hi!",
+                                 stream="foo", topic="bar"):
+        self.client.send_message = mocker.Mock(return_value=response)
+
+        result = model.send_stream_message(stream, topic, content)
+
+        req = dict(type='stream', to=stream, subject=topic, content=content)
+        self.client.send_message.assert_called_once_with(req)
+
+        assert result == return_value
+
     # NOTE: This tests only getting next-unread, not a fixed anchor
     def test_success_get_messages(self, mocker, messages_successful_response,
                                   index_all_messages, initial_data,

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -52,6 +52,8 @@ class TestModel:
         assert model.initial_data == initial_data
         model.client.get_profile.assert_called_once_with()
         assert model.user_id == user_profile['user_id']
+        assert model.user_full_name == user_profile['full_name']
+        assert model.user_email == user_profile['email']
         model.get_all_users.assert_called_once_with()
         assert model.users == []
         (model._stream_info_from_subscriptions.

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -11,11 +11,13 @@ from zulipterminal.helper import initial_index
 class TestModel:
     @pytest.fixture(autouse=True)
     def mock_external_classes(self, mocker: Any) -> None:
+        self.urlparse = mocker.patch('urllib.parse.urlparse')
         self.controller = mocker.patch('zulipterminal.core.'
                                        'Controller',
                                        return_value=None)
         self.client = mocker.patch('zulipterminal.core.'
                                    'Controller.client')
+        self.client.base_url = 'chat.zulip.zulip'
         mocker.patch('zulipterminal.model.Model.update_presence')
 
     @pytest.fixture
@@ -54,6 +56,7 @@ class TestModel:
         assert model.user_id == user_profile['user_id']
         assert model.user_full_name == user_profile['full_name']
         assert model.user_email == user_profile['email']
+        # FIXME Add test here for model.server_url
         model.get_all_users.assert_called_once_with()
         assert model.users == []
         (model._stream_info_from_subscriptions.

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -52,7 +52,6 @@ class TestModel:
                                                    num_after=10,
                                                    anchor=None)
         assert model.initial_data == initial_data
-        model.client.get_profile.assert_called_once_with()
         assert model.user_id == user_profile['user_id']
         assert model.user_full_name == user_profile['full_name']
         assert model.user_email == user_profile['email']
@@ -67,7 +66,6 @@ class TestModel:
         assert model.unread_counts == []
 
     def test_register_initial_desired_events(self, mocker, initial_data):
-        mocker.patch('zulipterminal.model.Model._update_user_id')
         mocker.patch('zulipterminal.model.Model.get_messages')
         mocker.patch('zulipterminal.model.Model.get_all_users')
         self.client.register.return_value = initial_data
@@ -294,7 +292,6 @@ class TestModel:
                                   index_all_messages, initial_data,
                                   num_before=30, num_after=10):
         self.client.register.return_value = initial_data
-        mocker.patch('zulipterminal.model.Model._update_user_id')
         mocker.patch('zulipterminal.model.Model.get_all_users',
                      return_value=[])
         mocker.patch('zulipterminal.model.Model.'
@@ -335,7 +332,6 @@ class TestModel:
 
         # Initialize Model
         self.client.register.return_value = initial_data
-        mocker.patch('zulipterminal.model.Model._update_user_id')
         mocker.patch('zulipterminal.model.Model.get_all_users',
                      return_value=[])
         mocker.patch('zulipterminal.model.Model.'
@@ -369,7 +365,6 @@ class TestModel:
                                initial_data, num_before=30, num_after=10):
         # Initialize Model
         self.client.register.return_value = initial_data
-        mocker.patch('zulipterminal.model.Model._update_user_id')
         mocker.patch('zulipterminal.model.Model.get_all_users',
                      return_value=[])
         mocker.patch('zulipterminal.model.Model.'
@@ -433,7 +428,6 @@ class TestModel:
     def test__update_initial_data_raises_exception(self, mocker, initial_data):
         # Initialize Model
         mocker.patch('zulipterminal.model.Model.get_messages')
-        mocker.patch('zulipterminal.model.Model._update_user_id')
         mocker.patch('zulipterminal.model.Model.get_all_users',
                      return_value=[])
         mocker.patch('zulipterminal.model.Model.'
@@ -456,8 +450,6 @@ class TestModel:
 
     def test_get_all_users(self, mocker, initial_data, user_list, user_dict,
                            user_id):
-        mocker.patch('zulipterminal.model.Model._update_user_id',
-                     return_value=user_id)
         mocker.patch('zulipterminal.model.Model.get_messages')
         self.client.register.return_value = initial_data
         mocker.patch('zulipterminal.model.Model.'

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -373,6 +373,21 @@ class TestModel:
             request=request
         )
 
+    def test_update_flag(self, model, mocker: Any) -> None:
+        mock_api_query = mocker.patch('zulipterminal.core.Controller'
+                                      '.client.do_api_query')
+
+        model.update_flag([1, 2])
+
+        mock_api_query.assert_called_once_with(
+            {'flag': 'read', 'messages': [1, 2], 'op': 'add'},
+            '/json/messages/flags',
+            method='POST'
+        )
+
+    def test_update_flag_empty_msg_list(self, model) -> None:
+        assert model.update_flag([]) is None
+
     def test__update_initial_data(self, model, initial_data):
         assert model.initial_data == initial_data
 

--- a/tests/ui/test_ui.py
+++ b/tests/ui/test_ui.py
@@ -7,7 +7,6 @@ class TestView:
     def mock_external_classes(self, mocker):
         self.controller = mocker.patch('zulipterminal.core.Controller',
                                        return_value=None)
-        self.client = mocker.patch('zulipterminal.core.Controller.client')
         self.model = mocker.patch('zulipterminal.core.Controller.model')
         self.write_box = mocker.patch('zulipterminal.ui.WriteBox')
         self.search_box = mocker.patch('zulipterminal.ui.SearchBox')
@@ -22,7 +21,6 @@ class TestView:
         view = View(self.controller)
         assert view.controller == self.controller
         assert view.model == self.model
-        assert view.client == self.client
         assert view.pinned_streams == self.model.pinned_streams
         assert view.unpinned_streams == self.model.unpinned_streams
         self.write_box.assert_called_once_with(view)
@@ -82,18 +80,21 @@ class TestView:
 
         full_name = "Bob James"
         email = "Bob@bob.com"
-        server = "https://chat.zulip.zulip"
+        server = "https://chat.zulip.zulip/"
 
-        mocker.patch('zulipterminal.core.Controller.client.get_profile',
-                     return_value=dict(full_name=full_name, email=email))
-        self.controller.client.base_url = server
-        title_length = (len(email) + len(full_name) + len(server) + 9)
+        self.controller.model = self.model
+        self.model.user_full_name = full_name
+        self.model.user_email = email
+        self.model.server_url = server
+
+        title_length = (len(email) + len(full_name) + len(server) + 8)
 
         view = View(self.controller)
 
         left.assert_called_once_with()
         center.assert_called_once_with()
         right.assert_called_once_with()
+
         expected_column_calls = [
             mocker.call([
                 (View.LEFT_WIDTH, left()),

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -911,7 +911,7 @@ class TestMessageBox:
                 'color': '#bfd56f',
             },
         }
-        self.model.client.base_url = "SOME_BASE_URL"
+        self.model.server_url = "SOME_BASE_URL"
         # NOTE Absence of previous (last) message should not affect markup
         msg_box = MessageBox(message, self.model, None)
 

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -293,7 +293,6 @@ class TestMessageView:
         msg_w.set_attr_map.return_value = None
         msg_view.body.get_focus.return_value = (msg_w, 0)
         msg_view.body.get_prev.return_value = (None, 1)
-        update_flag = mocker.patch(VIEWS + ".update_flag")
         msg_view.model.narrow = []
         msg_view.model.index = {
             'messages': {
@@ -310,14 +309,15 @@ class TestMessageView:
         msg_view.read_message()
         assert msg_view.update_search_box_narrow.called
         assert msg_view.model.index['messages'][1]['flags'] == ['read']
-        update_flag.assert_called_once_with([1], self.model.controller)
+        self.model.update_flag.assert_called_once_with([1])
 
     def test_read_message_no_msgw(self, mocker, msg_view):
         # MSG_W is NONE CASE
         msg_view.body.get_focus.return_value = (None, 0)
-        update_flag = mocker.patch(VIEWS + ".update_flag")
+
         msg_view.read_message()
-        update_flag.assert_not_called()
+
+        self.model.update_flag.assert_not_called()
 
 
 class TestStreamsView:

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -114,20 +114,6 @@ def set_count(id_list: List[int], controller: Any, new_count: int) -> None:
     controller.update_screen()
 
 
-@asynch
-def update_flag(id_list: List[int], controller: Any) -> None:
-    if not id_list:
-        return
-    request = {
-        'messages': id_list,
-        'flag': 'read',
-        'op': 'add',
-    }
-    client = controller.client
-    client.do_api_query(request, '/json/messages/flags', method="POST")
-    set_count(id_list, controller, -1)
-
-
 def index_messages(messages: List[Any],
                    model: Any,
                    index: Index) -> Index:

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -80,7 +80,11 @@ class Model:
         self.stream_id = -1
         self.recipients = frozenset()  # type: FrozenSet[Any]
         self.index = initial_index
+
         self.user_id = -1  # type: int
+        self.user_email = ""
+        self.user_full_name = ""
+
         self.initial_data = {}  # type: Dict[str, Any]
 
         # Register to the queue before initializing further so that we don't
@@ -333,6 +337,8 @@ class Model:
                    for name, future in futures.items()}
         if all(results.values()):
             self.user_id = results['user_id']
+            self.user_email = self.initial_data['email']
+            self.user_full_name = self.initial_data['full_name']
         else:
             failures = [name for name, result in results.items() if not result]
             raise ServerConnectionFailure(", ".join(failures))

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -227,6 +227,19 @@ class Model:
                                              method='POST',
                                              request=request)
 
+    @asynch
+    def update_flag(self, id_list: List[int]) -> None:
+        if not id_list:
+            return
+        request = {
+            'messages': id_list,
+            'flag': 'read',
+            'op': 'add',
+        }
+        self.client.do_api_query(request, '/json/messages/flags',
+                                 method="POST")
+        set_count(id_list, self.controller, -1)  # FIXME Update?
+
     def get_messages(self, *,
                      num_after: int, num_before: int,
                      anchor: Optional[int]) -> bool:

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1,4 +1,5 @@
 import json
+from urllib.parse import urlparse
 from threading import Thread
 from concurrent.futures import ThreadPoolExecutor, wait, Future
 import time
@@ -84,6 +85,8 @@ class Model:
         self.user_id = -1  # type: int
         self.user_email = ""
         self.user_full_name = ""
+        self.server_url = '{uri.scheme}://{uri.netloc}/'.format(
+                          uri=urlparse(self.client.base_url))
 
         self.initial_data = {}  # type: Dict[str, Any]
 

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -240,6 +240,27 @@ class Model:
                                  method="POST")
         set_count(id_list, self.controller, -1)  # FIXME Update?
 
+    def send_private_message(self, recipients: str,
+                             content: str) -> bool:
+        request = {
+            'type': 'private',
+            'to': recipients,
+            'content': content,
+        }
+        response = self.client.send_message(request)
+        return response['result'] == 'success'
+
+    def send_stream_message(self, stream: str, topic: str,
+                            content: str) -> bool:
+        request = {
+            'type': 'stream',
+            'to': stream,
+            'subject': topic,
+            'content': content,
+        }
+        response = self.client.send_message(request)
+        return response['result'] == 'success'
+
     def get_messages(self, *,
                      num_after: int, num_before: int,
                      anchor: Optional[int]) -> bool:

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -1,6 +1,5 @@
 import platform
 import re
-from urllib.parse import urlparse
 from typing import Any, Tuple, List, Dict, Optional
 import random
 
@@ -29,7 +28,6 @@ class View(urwid.WidgetWrap):
         self.controller = controller
         self.palette = controller.theme
         self.model = controller.model
-        self.client = controller.client
         self.users = self.model.users
         self.pinned_streams = self.model.pinned_streams
         self.unpinned_streams = self.model.unpinned_streams
@@ -95,13 +93,12 @@ class View(urwid.WidgetWrap):
         self.body = urwid.Columns(body, focus_column=0)
 
         div_char = '═'
-        profile = self.controller.client.get_profile()
-
-        base_url = '{uri.scheme}://{uri.netloc}/'.format(
-                uri=urlparse(self.controller.client.base_url))
 
         title_text = " {full_name} ({email}) - {server} ".format(
-                server=base_url, **profile)
+                     full_name=self.model.user_full_name,
+                     email=self.model.user_email,
+                     server=self.model.server_url)
+
         title_bar = urwid.Columns([
             urwid.Divider(div_char=div_char),
             (len(title_text), urwid.Text([title_text])),

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -183,7 +183,7 @@ class MessageBox(urwid.Pile):
         self.recipients = ', '.join(list(
             recipient['full_name']
             for recipient in self.message['display_recipient']
-            if recipient['email'] != self.model.client.email
+            if recipient['email'] != self.model.user_email
         ))
         title_markup = ('header', [
             ('custom', 'Private Messages with'),
@@ -289,7 +289,7 @@ class MessageBox(urwid.Pile):
                     if link.startswith('/user_uploads/'):
                         # Append org url to before user_uploads to convert it
                         # into a link.
-                        link = self.model.client.base_url + link
+                        link = self.model.server_url + link
                     markup.append(
                         ('link', '[' + text + ']' + '(' + link + ')'))
             elif element.name == 'blockquote':
@@ -421,7 +421,7 @@ class MessageBox(urwid.Pile):
         emails = []
         for recipient in self.message['display_recipient']:
             email = recipient['email']
-            if email == self.model.client.email:
+            if email == self.model.user_email:
                 continue
             emails.append(recipient['email'])
         return ', '.join(emails)

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -15,7 +15,7 @@ from zulipterminal.config.keys import is_command_key
 class WriteBox(urwid.Pile):
     def __init__(self, view: Any) -> None:
         super(WriteBox, self).__init__(self.main_view(True))
-        self.client = view.client
+        self.model = view.model
         self.view = view
 
     def main_view(self, new: bool) -> Any:
@@ -82,20 +82,17 @@ class WriteBox(urwid.Pile):
     def keypress(self, size: Tuple[int, int], key: str) -> str:
         if is_command_key('SEND_MESSAGE', key):
             if not self.to_write_box:
-                request = {
-                    'type': 'stream',
-                    'to': self.stream_write_box.edit_text,
-                    'subject': self.title_write_box.edit_text,
-                    'content': self.msg_write_box.edit_text,
-                }
+                success = self.model.send_stream_message(
+                    stream=self.stream_write_box.edit_text,
+                    topic=self.title_write_box.edit_text,
+                    content=self.msg_write_box.edit_text
+                )
             else:
-                request = {
-                    'type': 'private',
-                    'to': self.to_write_box.edit_text,
-                    'content': self.msg_write_box.edit_text,
-                }
-            response = self.client.send_message(request)
-            if response['result'] == 'success':
+                success = self.model.send_private_message(
+                    recipients=self.to_write_box.edit_text,
+                    content=self.msg_write_box.edit_text
+                )
+            if success:
                 self.msg_write_box.edit_text = ''
         elif is_command_key('GO_BACK', key):
             self.view.controller.editor_mode = False

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -5,7 +5,7 @@ import threading
 import urwid
 
 from zulipterminal.config.keys import KEY_BINDINGS, is_command_key
-from zulipterminal.helper import asynch, update_flag, match_user
+from zulipterminal.helper import asynch, match_user
 from zulipterminal.ui_tools.buttons import (
     TopicButton,
     UnreadPMButton,
@@ -196,7 +196,7 @@ class MessageView(urwid.ListBox):
             msg_w, curr_pos = self.body.get_prev(curr_pos)
             if msg_w is None:
                 break
-        update_flag(read_msg_ids, self.model.controller)
+        self.model.update_flag(read_msg_ids)
 
 
 class StreamsView(urwid.Frame):


### PR DESCRIPTION
These commits centralize the use of the zulip client into the `Model`, rather than being scattered through the code. I'm not fully convinced that the `Model` is the 'right' place for them, but the rest are there right now and it feels logical to have them all together, and know where to look for them!

In summary, this PR:
* moves the `update_flag` function into being a `Model` method
* extracts code from `WriteBox` into two further `Model` methods
* adds various attributes to the `Model` from the initial data, and the `server_url` from the client
* uses `user_id` from the `initial_data`, rather than obtaining it separately

After previously adding the ThreadPoolExecutor for doing the initial data fetch in parallel, the last change actually shrinks this back down to one worker thread. For now I feel it's reasonable to leave this infrastructure in place.