### PR TITLE
Indicate server connectivity via heartbeat

### DIFF
--- a/tests/ui/test_ui.py
+++ b/tests/ui/test_ui.py
@@ -49,6 +49,24 @@ class TestView:
         assert view.users_view == right_view()
         assert return_value == line_box()
 
+    def test_update_last_connection_time(self, view, monkeypatch,
+                                         day=23, month=1, year=2019,
+                                         hour=12, minute=29, sec=35):
+        import datetime
+
+        class dt:
+            def now():
+                return datetime.datetime(year, month, day, hour, minute, sec)
+        monkeypatch.setattr('zulipterminal.ui.datetime', dt)
+
+        view.update_last_connection_time()
+
+        (view._w.footer[1].set_text.
+         assert_called_once_with("  Last server contact: {}:{} "
+                                 "({:0>2}/{:0>2}/{})".
+                                 format(hour, minute, day, month, year)))
+        view.controller.update_screen.assert_called_once_with()
+
     def test_set_footer_text_default(self, view, mocker):
         mocker.patch('zulipterminal.ui.View.get_random_help',
                      return_value=['some help text'])

--- a/tests/ui/test_ui.py
+++ b/tests/ui/test_ui.py
@@ -55,18 +55,18 @@ class TestView:
 
         view.set_footer_text()
 
-        view._w.footer.set_text.assert_called_once_with(['some help text'])
+        view._w.footer[0].set_text.assert_called_once_with(['some help text'])
         view.controller.update_screen.assert_called_once_with()
 
     def test_set_footer_text_specific_text(self, view, text='blah'):
         view.set_footer_text([text])
 
-        view._w.footer.set_text.assert_called_once_with([text])
+        view._w.footer[0].set_text.assert_called_once_with([text])
         view.controller.update_screen.assert_called_once_with()
 
     def test_footer_view(self, mocker, view):
         footer = view.footer_view()
-        assert isinstance(footer.text, str)
+        assert isinstance(footer[0].text, str)
 
     def test_main_window(self, mocker):
         left = mocker.patch('zulipterminal.ui.View.left_column_view')

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -68,6 +68,7 @@ class Model:
         'reaction',
         'typing',
         'update_message_flags',
+        # Don't need to ask for heartbeat messages; these are automatic
     ]
 
     def __init__(self, controller: Any) -> None:
@@ -112,7 +113,11 @@ class Model:
             'reaction': self.update_reaction,
             'typing': self.handle_typing_event,
             'update_message_flags': self.update_message_flag_status,
+            'heartbeat': self.respond_to_heartbeat,
         }  # type: Dict[str, Callable[[Event], None]]
+
+    def respond_to_heartbeat(self, event: Event) -> None:
+        self.controller.view.update_last_connection_time()
 
     def get_focus_in_current_narrow(self) -> Union[int, Set[None]]:
         """

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -67,12 +67,14 @@ class View(urwid.WidgetWrap):
             text = self.get_random_help()
         else:
             text = text_list
-        self._w.footer.set_text(text)
+        self._w.footer[0].set_text(text)
         self.controller.update_screen()
 
     def footer_view(self) -> Any:
-        text_header = self.get_random_help()
-        return urwid.AttrWrap(urwid.Text(text_header), 'footer')
+        footer_columns = urwid.Columns([
+            urwid.AttrWrap(urwid.Text(self.get_random_help()), 'footer')
+        ])
+        return footer_columns
 
     def main_window(self) -> Any:
         self.left_panel = self.left_column_view()

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -2,6 +2,7 @@ import platform
 import re
 from typing import Any, Tuple, List, Dict, Optional
 import random
+from datetime import datetime, date, time
 
 import urwid
 
@@ -70,11 +71,20 @@ class View(urwid.WidgetWrap):
         self._w.footer[0].set_text(text)
         self.controller.update_screen()
 
+    def _connection_text_now(self) -> str:
+        return ("  Last server contact: " +  # Leading spaces are gap from help
+                datetime.now().strftime("%H:%M (%d/%m/%Y)"))
+
+    def update_last_connection_time(self) -> None:
+        self._w.footer[1].set_text(self._connection_text_now())
+        self.controller.update_screen()
+
     def footer_view(self) -> Any:
-        footer_columns = urwid.Columns([
-            urwid.AttrWrap(urwid.Text(self.get_random_help()), 'footer')
+        server_datetime_text = self._connection_text_now()
+        return urwid.Columns([
+            urwid.AttrWrap(urwid.Text(self.get_random_help()), 'footer'),
+            (41, urwid.AttrWrap(urwid.Text(server_datetime_text), 'footer')),
         ])
-        return footer_columns
 
     def main_window(self) -> Any:
         self.left_panel = self.left_column_view()


### PR DESCRIPTION
This PR uses the automatic heartbeat event from the server to show the connectivity status in the bottom-right of the application.

Note that although the window says "Last server contact", this only updates on heartbeat events; we can change this to be more expressive/accurate, eg. trigger on every server event, or specifically say 'heartbeat' or similar.

I'm not sure that we handle reconnecting properly, but this gives an indication of whether things should be working, visually, which is perhaps not always obvious.