### PR TITLE
Sets current narrow marker for empty narrows.

### DIFF
--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -666,6 +666,67 @@ class TestModel:
         set_count.assert_called_once_with([event['message']['id']],
                                           self.controller, 1)
 
+    @pytest.mark.parametrize('previous_message', [
+        ({'type': 'private', 'id': None,
+          'display_recipient': [{'id': 100, 'email': 'bar@zulip.com'}]}),
+        ({'type': 'stream', 'stream_id': 1, 'id': None,
+          'subject': 'FOO', 'display_recipient': 'bar'})
+    ])
+    @pytest.mark.parametrize('response, narrow', [
+        (
+            {'type': 'private', 'id': 0,
+             'display_recipient': [{'id': 200, 'email': 'boo@zulip.com'}]},
+            [['pm_with', 'bar@zulip.com']]
+        ),
+        (
+            {'type': 'stream', 'stream_id': 1, 'id': 0,
+             'subject': 'FOO', 'display_recipient': 'boo'},
+            [['stream', 'bar']]
+        ),
+        (
+            {'type': 'stream', 'stream_id': 1, 'id': 0,
+             'subject': 'FOO', 'display_recipient': 'bar'},
+            [['stream', 'bar']]
+        ),
+        (
+            {'type': 'private', 'id': 0,
+             'display_recipient': [{'id': 100, 'email': 'bar@zulip.com'}]},
+            [['pm_with', 'bar@zulip.com']]
+        ),
+        (
+            {'type': 'private', 'id': 0,
+             'display_recipient': [{'id': 100, 'email': 'bar@zulip.com'},
+                                   {'id': 200, 'email': 'boo@zulip.com'}]},
+            [['pm_with', 'bar@zulip.com']]
+        )
+    ], ids=['PM_to_user_in_different_PM_narrow',
+            'stream_to_different_stream',
+            'stream__to_same_stream',
+            'PM_to_user_in_same_PM_narrow',
+            'GroupPM_to_user_in_PM_narrow'
+            ])
+    def test_append_message_with_dummy_previous_message(
+            self, mocker, model,
+            previous_message, response, narrow,
+            user_profile):
+        model.update = True
+        index_msg = mocker.patch('zulipterminal.model.index_messages',
+                                 return_value={})
+        model.msg_list = mocker.Mock()
+        mocker.patch('zulipterminal.model.Model.notify_user')
+        create_msg_box_list = mocker.patch('zulipterminal.model.'
+                                           'create_msg_box_list',
+                                           return_value=["msg_w"])
+        model.msg_list.log = [mocker.Mock()]
+        model.msg_list.log[0].original_widget.message = previous_message
+        model.narrow = narrow
+        model.user_id = user_profile['user_id']
+        model.recipients = frozenset({5827, 100}) if\
+            response['type'] == 'private' else frozenset()
+        event = {'message': response}
+        model.append_message(event)
+        assert len(model.msg_list.log) == 1
+
     @pytest.mark.parametrize('response, narrow, recipients, log', [
         ({'type': 'stream', 'stream_id': 1, 'subject': 'FOO',
           'id': 1}, [], frozenset(), ['msg_w']),

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1453,6 +1453,52 @@ class TestMessageBox:
         assert header_bar.text.startswith(assert_header_bar)
         assert search_bar.text_to_fill == assert_search_bar
 
+    @pytest.mark.parametrize('index_value, split_character, \
+                                assert_string, message', [
+        (0, '>', 'Foo Foo', {
+            'type': 'stream',
+            'display_recipient': 'Foo Foo',
+            'subject': 'disription about foo',
+            'stream_id': 8,
+        }),
+        (0, ':', 'You and Boo Boo', {
+            'type': 'private',
+            'display_recipient': [{'full_name': 'Boo Boo',
+                                   'email': 'boo@zulip.com',
+                                   'id': None}],
+            'sender_id': 9,
+        })
+    ])
+    def test_main_view_generates_dummy_message(self, mocker, message,
+                                               index_value, split_character,
+                                               assert_string):
+        self.model.stream_dict = {
+            8: {
+                'color': '#bfd56f',
+            },
+        }
+        message.update({
+            'content': "<p> Dummy stream/PM message. </p>",
+            'sender_full_name': 'Welcome Bot',
+            'sender_email': 'welcome-bot@zulip.com',
+            'timestamp': 150989984,
+            'id': None,
+            'reactions': [],
+            'flags': ['read']
+            })
+        msg_box = MessageBox(message, self.model, None,
+                             is_empty_narrow=True)
+        view_components = msg_box.main_view()
+        assert len(view_components) == 3
+        assert isinstance(view_components[0], AttrWrap)
+        assert isinstance(view_components[1], Columns)
+        assert isinstance(view_components[2], Padding)
+        # Extracting label from header.
+        header = view_components[0].original_widget.get_text()[0].strip()
+        header_message = (header.split(split_character)
+                          [index_value].strip())
+        assert header_message == assert_string
+
     # Assume recipient (PM/stream/topic) header is unchanged below
     @pytest.mark.parametrize('message', [
         {

--- a/tests/ui/test_utils.py
+++ b/tests/ui/test_utils.py
@@ -89,7 +89,8 @@ def test_is_muted(mocker, msg, narrow, muted_streams, muted_topics, muted):
 
 
 @pytest.mark.parametrize('narrow, messages, focus_msg_id, muted,\
-                          unsubscribed, len_w_list', [
+                         unsubscribed, stream_details, pm_details,\
+                         len_w_list', [
     (
         # No muted messages
         [],
@@ -97,6 +98,8 @@ def test_is_muted(mocker, msg, narrow, muted_streams, muted_topics, muted):
         None,
         False,
         False,
+        None,
+        None,
         2,
     ),
     (
@@ -106,6 +109,8 @@ def test_is_muted(mocker, msg, narrow, muted_streams, muted_topics, muted):
         None,
         False,
         False,
+        None,
+        None,
         1,
     ),
     (
@@ -115,6 +120,8 @@ def test_is_muted(mocker, msg, narrow, muted_streams, muted_topics, muted):
         None,
         True,
         False,
+        None,
+        None,
         1,
     ),
     (
@@ -124,7 +131,38 @@ def test_is_muted(mocker, msg, narrow, muted_streams, muted_topics, muted):
         None,
         True,
         False,
+        None,
+        None,
         0,
+    ),
+    (
+        # Displays dummy stream message
+        [['stream', 'foo']],
+        [],
+        None,
+        False,
+        False,
+        {
+            'caption': 'Boo',
+            'description': 'News about Boo',
+        },
+        None,
+        1,
+    ),
+    (
+        # Displays dummy private message
+        [['pm_with', 'boo@zulip.com']],
+        [],
+        None,
+        False,
+        False,
+        None,
+        {
+            'caption': 'Boo Boo',
+            'recipient_email': 'bar@zulip.com',
+            'sender_id': 8
+        },
+        1,
     ),
     (
         # Unsubscribed messages
@@ -133,12 +171,21 @@ def test_is_muted(mocker, msg, narrow, muted_streams, muted_topics, muted):
         None,
         False,
         True,
+        None,
+        None,
         0,
-    ),
-
+    )], ids=[
+    'All Messages - no muted messages',
+    'Stream narrow - unmuted',
+    'Stream narrow - muted',
+    'All Messages - muted messages',
+    'Empty stream narrow - dummy message test',
+    'Empty pm narrow - dummy message test',
+    'Unsubscribed messages',
 ])
 def test_create_msg_box_list(mocker, narrow, messages, focus_msg_id,
-                             muted, unsubscribed, len_w_list):
+                             muted, unsubscribed, stream_details, pm_details,
+                             len_w_list):
     model = mocker.Mock()
     model.narrow = narrow
     model.index = {
@@ -163,5 +210,8 @@ def test_create_msg_box_list(mocker, narrow, messages, focus_msg_id,
     mocker.patch('zulipterminal.ui_tools.utils.is_muted', return_value=muted)
     mocker.patch('zulipterminal.ui_tools.utils.is_unsubscribed_message',
                  return_value=unsubscribed)
-    return_value = create_msg_box_list(model, messages, focus_msg_id)
+    return_value = create_msg_box_list(model, messages, focus_msg_id,
+                                       stream_details=stream_details,
+                                       pm_details=pm_details)
     assert len(return_value) == len_w_list
+    assert msg_box.call_count == len_w_list

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -144,6 +144,11 @@ class Controller:
                                                  mute_this_stream)
 
     def narrow_to_stream(self, button: Any) -> None:
+        stream_details = {
+                    'caption': button.stream_name,
+                    'description': self.model.stream_dict[button.stream_id]
+                    .get('description')
+                    }
         already_narrowed = self.model.set_narrow(stream=button.stream_name)
         if already_narrowed:
             return
@@ -164,9 +169,11 @@ class Controller:
 
         if hasattr(button, 'message'):
             w_list = create_msg_box_list(
-                self.model, msg_id_list, button.message['id'])
+                self.model, msg_id_list, button.message['id'],
+                stream_details=stream_details)
         else:
-            w_list = create_msg_box_list(self.model, msg_id_list)
+            w_list = create_msg_box_list(self.model, msg_id_list,
+                                         stream_details=stream_details)
 
         self._finalize_show(w_list)
 
@@ -198,6 +205,11 @@ class Controller:
         self._finalize_show(w_list)
 
     def narrow_to_user(self, button: Any) -> None:
+        pm_details = {
+                    'caption': button.user_name,
+                    'recipient_email': button.email,
+                    'sender_id': self.model.user_id
+                    }
         if hasattr(button, 'message'):
             emails = [recipient['email']
                       for recipient in button.message['display_recipient']
@@ -225,9 +237,11 @@ class Controller:
 
         if hasattr(button, 'message'):
             w_list = create_msg_box_list(
-                self.model, msg_id_list, button.message['id'])
+                self.model, msg_id_list, button.message['id'],
+                pm_details=pm_details)
         else:
-            w_list = create_msg_box_list(self.model, msg_id_list)
+            w_list = create_msg_box_list(
+                self.model, msg_id_list, pm_details=pm_details)
 
         self._finalize_show(w_list)
 

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -725,9 +725,10 @@ class Model:
                                          (len(self.narrow) == 2 and
                                           self.narrow[1][1] ==
                                           response['subject'])):
+                    self.msg_list.log.append(msg_w)
                     if dummy_message_found:
                         del self.msg_list.log[0]
-                    self.msg_list.log.append(msg_w)
+                        set_count([response['id']], self.controller, 1)
 
             elif response['type'] == 'private' and len(self.narrow) == 1 and\
                     self.narrow[0][0] == "pm_with":
@@ -735,9 +736,10 @@ class Model:
                 message_recipients = frozenset(
                     [user['id'] for user in response['display_recipient']])
                 if narrow_recipients == message_recipients:
+                    self.msg_list.log.append(msg_w)
                     if dummy_message_found:
                         del self.msg_list.log[0]
-                    self.msg_list.log.append(msg_w)
+                        set_count([response['id']], self.controller, 1)
             if 'read' not in response['flags']:
                 set_count([response['id']], self.controller, 1)
             self.controller.update_screen()

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -692,6 +692,15 @@ class Model:
                 last_message = self.msg_list.log[-1].original_widget.message
             else:
                 last_message = None
+            # We replace the dummy message in the current narrow
+            # if the incoming message is meant for the same narrow.
+            dummy_message_found = False
+            if self.msg_list.log:
+                possible_dummy_message = \
+                    self.msg_list.log[0].original_widget.message
+                if possible_dummy_message.get('id') is None:
+                    dummy_message_found = True
+
             msg_w_list = create_msg_box_list(self, [response['id']],
                                              last_message=last_message)
             if not msg_w_list:
@@ -716,6 +725,8 @@ class Model:
                                          (len(self.narrow) == 2 and
                                           self.narrow[1][1] ==
                                           response['subject'])):
+                    if dummy_message_found:
+                        del self.msg_list.log[0]
                     self.msg_list.log.append(msg_w)
 
             elif response['type'] == 'private' and len(self.narrow) == 1 and\
@@ -724,6 +735,8 @@ class Model:
                 message_recipients = frozenset(
                     [user['id'] for user in response['display_recipient']])
                 if narrow_recipients == message_recipients:
+                    if dummy_message_found:
+                        del self.msg_list.log[0]
                     self.msg_list.log.append(msg_w)
             if 'read' not in response['flags']:
                 set_count([response['id']], self.controller, 1)

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -180,13 +180,14 @@ class WriteBox(urwid.Pile):
 
 class MessageBox(urwid.Pile):
     def __init__(self, message: Dict[str, Any], model: Any,
-                 last_message: Any) -> None:
+                 last_message: Any, is_empty_narrow: bool=False) -> None:
         self.model = model
         self.message = message
         self.stream_name = ''
         self.stream_id = None  # type: Union[int, None]
         self.topic_name = ''
         self.email = ''
+        self.is_in_empty_narrow = is_empty_narrow
         self.user_id = None  # type: Union[int, None]
         self.last_message = last_message
         # if this is the first message
@@ -229,6 +230,8 @@ class MessageBox(urwid.Pile):
         return ctime(message['timestamp'])[:-8]
 
     def need_recipient_header(self) -> bool:
+        if self.is_in_empty_narrow:
+            return True
         # Prevent redundant information in recipient bar
         if len(self.model.narrow) == 1 and \
                 self.model.narrow[0][0] == 'pm_with':
@@ -236,7 +239,6 @@ class MessageBox(urwid.Pile):
         if len(self.model.narrow) == 2 and \
                 self.model.narrow[1][0] == 'topic':
             return False
-
         last_msg = self.last_message
         if self.message['type'] == 'stream':
             if (last_msg['type'] == 'stream' and
@@ -666,7 +668,8 @@ class MessageBox(urwid.Pile):
                 self.model.controller.view.write_box.stream_box_view(
                     caption=self.message['display_recipient']
                 )
-        elif is_command_key('STREAM_NARROW', key):
+        elif is_command_key('STREAM_NARROW', key) and \
+                not self.is_in_empty_narrow:
             if self.message['type'] == 'private':
                 self.model.controller.narrow_to_user(self)
             elif self.message['type'] == 'stream':
@@ -684,18 +687,21 @@ class MessageBox(urwid.Pile):
                     self.model.controller.narrow_to_stream(self)
                 else:
                     self.model.controller.narrow_to_topic(self)
-        elif is_command_key('TOPIC_NARROW', key):
+        elif is_command_key('TOPIC_NARROW', key) and \
+                not self.is_in_empty_narrow:
             if self.message['type'] == 'private':
                 self.model.controller.narrow_to_user(self)
             elif self.message['type'] == 'stream':
                 self.model.controller.narrow_to_topic(self)
         elif is_command_key('GO_BACK', key):
             self.model.controller.show_all_messages(self)
-        elif is_command_key('REPLY_AUTHOR', key):
+        elif is_command_key('REPLY_AUTHOR', key) and \
+                not self.is_in_empty_narrow:
             self.model.controller.view.write_box.private_box_view(
                 email=self.message['sender_email']
             )
-        elif is_command_key('MENTION_REPLY', key):
+        elif is_command_key('MENTION_REPLY', key) and \
+                not self.is_in_empty_narrow:
             self.keypress(size, 'enter')
             mention = '@**' + self.message['sender_full_name'] + '** '
             self.model.controller.view.write_box.msg_write_box.set_edit_text(
@@ -703,7 +709,8 @@ class MessageBox(urwid.Pile):
             self.model.controller.view.write_box.msg_write_box.set_edit_pos(
                 len(mention))
             self.model.controller.view.middle_column.set_focus('footer')
-        elif is_command_key('QUOTE_REPLY', key):
+        elif is_command_key('QUOTE_REPLY', key) and \
+                not self.is_in_empty_narrow:
             self.keypress(size, 'enter')
             quote = '```quote\n' + self.model.client.get_raw_message(
                 self.message['id'])['raw_content'] + '\n```\n'

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -209,6 +209,7 @@ class MessageBox(urwid.Pile):
                 self.recipients_names = \
                     self.message['display_recipient'][0]['full_name']
                 self.recipients_emails = self.model.user_email
+                self.user_name = self.recipients_names
             else:
                 self.recipients_names = ', '.join(list(
                             recipient['full_name']
@@ -220,7 +221,7 @@ class MessageBox(urwid.Pile):
                             for recipient in self.message['display_recipient']
                             if recipient['email'] != self.model.user_email
                         ))
-
+                self.user_name = self.recipients_names
         # mouse_event helper variable
         self.displaying_selection_hint = False
 

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -184,7 +184,7 @@ class UserButton(TopButton):
         # Properties accessed externally
         self.email = user['email']
         self.user_id = user['user_id']
-
+        self.user_name = user['full_name']
         self._view = view  # Used in _narrow_with_compose
 
         # FIXME Is this still needed?

--- a/zulipterminal/ui_tools/utils.py
+++ b/zulipterminal/ui_tools/utils.py
@@ -1,4 +1,4 @@
-from typing import Any, Iterable, List, Union, Dict
+from typing import Any, Iterable, List, Union, Dict, Optional
 
 import urwid
 
@@ -7,7 +7,10 @@ from zulipterminal.ui_tools.boxes import MessageBox
 
 def create_msg_box_list(model: Any, messages: Union[None, Iterable[Any]]=None,
                         focus_msg_id: Union[None, int]=None,
-                        last_message: Union[None, Any]=None) -> List[Any]:
+                        last_message: Union[None, Any]=None,
+                        stream_details: Optional[Dict[str, Any]]=None,
+                        pm_details: Optional[Dict[str, Any]]=None)\
+                        -> List[Any]:
     """
     MessageBox for every message displayed is created here.
     """

--- a/zulipterminal/ui_tools/utils.py
+++ b/zulipterminal/ui_tools/utils.py
@@ -1,6 +1,7 @@
 from typing import Any, Iterable, List, Union, Dict, Optional
 
 import urwid
+import time
 
 from zulipterminal.ui_tools.boxes import MessageBox
 
@@ -23,6 +24,42 @@ def create_msg_box_list(model: Any, messages: Union[None, Iterable[Any]]=None,
     focus_msg = None
     last_msg = last_message
     muted_msgs = 0  # No of messages that are muted.
+
+    # We create a dummy message to display in narrows with
+    # no previous messages. The 'author' of this being welcome
+    # bot and 'title' being the stream description.
+    if (message_list == [] and (stream_details is not None or
+                                pm_details is not None)):
+        if stream_details is not None:
+            msg = {
+                'type': 'stream',
+                'display_recipient': stream_details['caption'],
+                'stream_id': model.stream_id,
+                'subject': stream_details['description']
+                }
+        elif pm_details is not None:
+            msg = {
+                'type': 'private',
+                'display_recipient': [{'full_name': pm_details['caption'],
+                                       'email': pm_details['recipient_email'],
+                                       'id': None}],
+                'sender_id': pm_details['sender_id'],
+                }
+        msg.update({
+            'content': "<p> There are no messages in this " +
+            msg['type'] + " narrow. </p>",
+            'sender_full_name': 'Welcome Bot',
+            'sender_email': 'welcome-bot@zulip.com',
+            'timestamp': int(time.time()),
+            'id': None,
+            'reactions': [],
+            'flags': ['read']
+            })
+        message_list.append(msg)
+        is_empty_narrow = True
+    else:
+        is_empty_narrow = False
+
     for msg in message_list:
         # Remove messages of muted topics / streams.
         if is_muted(msg, model):
@@ -42,7 +79,7 @@ def create_msg_box_list(model: Any, messages: Union[None, Iterable[Any]]=None,
         if msg['id'] == focus_msg_id:
             focus_msg = message_list.index(msg) - muted_msgs
         w_list.append(urwid.AttrMap(
-                    MessageBox(msg, model, last_msg),
+                    MessageBox(msg, model, last_msg, is_empty_narrow),
                     msg_flag,
                     'msg_selected'
         ))

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -94,6 +94,9 @@ class MessageView(urwid.ListBox):
         ids_to_keep = self.model.get_message_ids_in_current_narrow()
         if self.log:
             top_message_id = self.log[0].original_widget.message['id']
+            # This for the dummy message
+            if top_message_id is None:
+                return
             ids_to_keep.remove(top_message_id)  # update this id
             no_update_baseline = {top_message_id}
         else:
@@ -130,6 +133,11 @@ class MessageView(urwid.ListBox):
         else:
             last_message = None
 
+        if self.log:
+            top_message_id = self.log[0].original_widget.message.get('id')
+            # This for the dummy message
+            if top_message_id is None:
+                return
         message_list = create_msg_box_list(self.model, new_ids,
                                            last_message=last_message)
         self.log.extend(message_list)

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -192,12 +192,14 @@ class MessageView(urwid.ListBox):
                 return super(MessageView, self).keypress(size, 'page down')
 
         elif is_command_key('THUMBS_UP', key):
+            # FIXME: Improve reactions for dummy messages.
             if self.focus is not None:
                 self.model.react_to_message(
                     self.focus.original_widget.message,
                     reaction_to_toggle='thumbs_up')
 
         elif is_command_key('TOGGLE_STAR_STATUS', key):
+            # FIXME: Improve reactions for dummy messages.
             if self.focus is not None:
                 message = self.focus.original_widget.message
                 self.model.toggle_message_star_status(message)
@@ -446,6 +448,7 @@ class MiddleColumnView(urwid.Frame):
             return key
 
         elif is_command_key('REPLY_MESSAGE', key):
+            # TODO: Prevent 'r' for dummy stream message.
             self.body.keypress(size, 'enter')
             if self.footer.focus is not None:
                 self.set_focus('footer')


### PR DESCRIPTION
This PR address setting labels in narrow's with no previous message. A dummy message is created for such narrows with Welcome-Bot as the author and a suitable content, This message gets discarded when the first message arrives. Further, it contains tests for the added features.
- [x] In streams with no previous messages. 
![new_stream_message](https://user-images.githubusercontent.com/30312566/52068277-602cf700-25a2-11e9-8ece-38f83eb98138.png)

- [x] In PM with no previous messages.
![post2](https://user-images.githubusercontent.com/30312566/52027980-4a341d80-2533-11e9-9254-2d980bccb2de.png)

Fixes : #259, #266