### PR TITLE
Improve blue highlight contrast, remove blinking cursor & fix icon background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Show user status as `active` (Green), `idle` (Yellow) or `offline` (White) using different colors.
 - Further improvement/reordering of shortcut keys in README & help menu (<kbd>?</kbd>)
 - Improve styling of help menu, and how the menu scales with application width
+- Make stream icons bold and correct background color
 
 ### Important bugfixes
 - Exit cleanly if cannot connect to zulip server

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Visual improvements
 - Right-align unread-counts in left & right panels (as in webapp)
-- Move intrusive flashing cursor in left panel to far left side
+- Remove intrusive flashing cursor in side panels
 - Truncate text in left & right panels cleanly with '..', avoiding text overflow
 - Show user status as `active` (Green), `idle` (Yellow) or `offline` (White) using different colors.
 - Further improvement/reordering of shortcut keys in README & help menu (<kbd>?</kbd>)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,11 +32,13 @@ def stream_button(mocker):
     """
     Mocked stream button.
     """
+    view_mock = mocker.Mock()
+    view_mock.palette = [(None, 'black', 'white')]
     button = StreamButton(
         properties=['PTEST', 205, '#bfd56f', False],
         controller=mocker.patch('zulipterminal.core.Controller'),
         width=40,
-        view=mocker.patch('zulipterminal.ui.View')
+        view=view_mock,
     )
     return button
 

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1271,9 +1271,11 @@ class TestStreamButton:
                           is_private, expected_prefix,
                           width, count, short_text, caption='caption'):
         properties = [caption, 5, '#ffffff', is_private]
+        view_mock = mocker.Mock()
+        view_mock.palette = [(None, 'black', 'white')]
         stream_button = StreamButton(properties,
                                      controller=mocker.Mock(),
-                                     view=mocker.Mock(),
+                                     view=view_mock,
                                      width=width,
                                      count=count)
 

--- a/zulipterminal/config/themes.py
+++ b/zulipterminal/config/themes.py
@@ -46,7 +46,7 @@ GRAY = 'h244'  # gray_244
 THEMES = {
     'default': [
         (None,           'white',           'black'),
-        ('selected',     'light magenta',   'dark blue'),
+        ('selected',     'white',           'dark blue'),
         ('msg_selected', 'light green',     'black'),
         ('header',       'dark cyan',       'dark blue',  'bold'),
         ('custom',       'white',           'dark blue',  'underline'),
@@ -74,8 +74,8 @@ THEMES = {
         # on 256 colors
         (None,           'white',           'black',
          None,           WHITE,             BLACK),
-        ('selected',     'light magenta',   'dark blue',
-         None,           'light magenta',   DARKBLUE),
+        ('selected',     'white',           'dark blue',
+         None,           WHITE,             DARKBLUE),
         ('msg_selected', 'light green',     'black',
          None,           LIGHTGREEN,        BLACK),
         ('header',       'dark cyan',       'dark blue',

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -56,7 +56,7 @@ class TopButton(urwid.Button):
             [' ', self.prefix_character,
              ' {}{}'.format(caption, num_spaces*' '),
              ('idle',  count_text)],
-            0),  # cursor location
+            self.width_for_text_space_count+4),  # cursor location
             self.text_color,
             'selected')
 

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -105,8 +105,12 @@ class StreamButton(TopButton):
         # Simplify the color from the original version & add to palette
         # TODO Should this occur elsewhere and more intelligently?
         color = ''.join(orig_color[i] for i in (0, 1, 3, 5))  # 0 -> '#'
-        view.palette.append((color, '', '', '', color, 'black'))
-        view.palette.append(('s' + color, '', '', '', 'black', color))
+        for entry in view.palette:
+            if entry[0] is None:
+                background = entry[5] if len(entry) > 4 else entry[2]
+                break
+        view.palette.append((color, '', '', '', color+', bold', background))
+        view.palette.append(('s' + color, '', '', '', background, color))
 
         super().__init__(controller,
                          caption=caption,


### PR DESCRIPTION
These 3 fixes comprise fixes for issues that have been bugging me a little, two of which were mentioned by @rishig and itemized in #225.

To summarize:
* Use a white text, rather than 'light magenta' for selected buttons - this seems much clearer (in default/gruvbox)
* Solve the blinking cursor issue by placing the cursor beyond the text
* Set the background of stream icons to be the background color, and icons themselves as 'bold'

The last change should improve the gruvbox theme (@rht), though looks a little strange on the light/blue themes since they don't have as good contrast - and previously this was always a black background.

These should be rather straightforward good fixes, but any feedback would be appreciated :)