### PR TITLE
cli: Add functionality to check version from command line. Fixes #280

### DIFF
--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -1,6 +1,7 @@
 import pytest
 from zulipterminal.cli.run import main, in_color, THEMES
 from zulipterminal.model import ServerConnectionFailure
+from zulipterminal.version import ZT_VERSION
 
 
 @pytest.mark.parametrize('color, code', [
@@ -31,7 +32,8 @@ def test_main_help(capsys, options):
         '-h, --help',
         '-d, --debug',
         '--profile',
-        '--config-file CONFIG_FILE, -c CONFIG_FILE'
+        '--config-file CONFIG_FILE, -c CONFIG_FILE',
+        '-v, --version'
     }
     optional_argument_lines = {line[2:] for line in lines
                                if len(line) > 2 and line[2] == '-'}
@@ -107,5 +109,20 @@ def test_warning_regarding_incomplete_theme(capsys, mocker, monkeypatch,
             format(server_connection_error)),
     ]
     assert lines == expected_lines
+
+    assert captured.err == ""
+
+
+@pytest.mark.parametrize('options', ['-v', '--version'])
+def test_zt_version(capsys, options):
+    with pytest.raises(SystemExit) as e:
+        main([options])
+        assert str(e.value) == "0"
+
+    captured = capsys.readouterr()
+
+    lines = captured.out.strip('\n')
+    expected = 'Zulip Terminal ' + ZT_VERSION
+    assert lines == expected
 
     assert captured.err == ""

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -14,6 +14,7 @@ from zulipterminal.model import ServerConnectionFailure
 from zulipterminal.config.themes import (
     THEMES, all_themes, complete_and_incomplete_themes
 )
+from zulipterminal.version import ZT_VERSION
 
 LOG_FILENAME = 'zulip-terminal-tracebacks.log'
 logging.basicConfig(filename=LOG_FILENAME, level=logging.DEBUG)
@@ -55,6 +56,12 @@ def parse_args(argv: List[str]) -> argparse.Namespace:
     parser.add_argument('--profile', dest='profile',
                         action="store_true",
                         default=False, help='Profile runtime.')
+
+    parser.add_argument('-v',
+                        '--version',
+                        action='store_true',
+                        default=False,
+                        help='Print zulip-terminal version and exit')
 
     return parser.parse_args(argv)
 
@@ -151,6 +158,10 @@ def main(options: Optional[List[str]]=None) -> None:
         import cProfile
         prof = cProfile.Profile()
         prof.enable()
+
+    if args.version:
+        print('Zulip Terminal ' + ZT_VERSION)
+        sys.exit(0)
 
     if args.config_file:
         zuliprc_path = args.config_file


### PR DESCRIPTION
Print the version of the terminal client, also prints out the git short hash if on a git version.
Fixes #280 