### PR TITLE
WIP: Barely working zforms support.

### DIFF
--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -305,6 +305,11 @@ def classify_unread_counts(model: Any) -> Dict[str, Any]:
     return unread_counts
 
 
+def check_submessage_syntax(submessage: object):
+    if submessage:
+        return True  # Trust server's code checks.
+    return False
+
 def match_user(user: Any, text: str) -> bool:
     """
     Matches if the user full name, last name or email matches

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -3,6 +3,7 @@ from time import ctime
 from datetime import datetime
 from typing import Any, Dict, List, Tuple, Union, Optional
 
+import json
 import emoji
 import urwid
 from urwid_readline import ReadlineEdit
@@ -10,6 +11,7 @@ from bs4 import BeautifulSoup
 from bs4.element import NavigableString, Tag
 
 from zulipterminal.config.keys import is_command_key
+from zulipterminal.helper import check_submessage_syntax
 
 
 class WriteBox(urwid.Pile):
@@ -194,6 +196,28 @@ class MessageBox(urwid.Pile):
         header = urwid.AttrWrap(title, 'bar')
         header.markup = title_markup
         return header
+
+    def submessages_view(self, submessages: List[Dict[str, Any]], active_char) -> Any:
+        if not check_submessage_syntax(submessages):
+            return ''
+        content = json.loads(submessages[0]['content'])['extra_data']
+
+        pile_widgets = []
+        pile_widgets.append(urwid.Text(content['heading']))
+        count = 1
+        for choice in content['choices']:
+            string = '- ({}) {}. {}'.format(count, choice['short_name'], choice['long_name'])
+            count = count + 1
+            # choice_widget = urwid.Button(urwid.Text(string))
+            pile_widgets.append(urwid.Text(string))
+
+        widget = urwid.Padding(urwid.LineBox(urwid.Columns([
+                                            (1, urwid.Text('')),
+                                            urwid.Pile(pile_widgets),
+                                            ]),tline='', bline='', rline='', lline=active_char),
+                               align='left', left=15, width=('relative', 100),
+                               min_width=50, right=8)
+        return widget
 
     def reactions_view(self, reactions: List[Dict[str, Any]]) -> Any:
         if not reactions:
@@ -393,6 +417,9 @@ class MessageBox(urwid.Pile):
             align='left', left=15, width=('relative', 100),
             min_width=50, right=8)
 
+        # Submessages
+        submessages = self.submessages_view(self.message.get('submessages', []), active_char)
+
         # Reactions
         reactions = self.reactions_view(self.message['reactions'])
 
@@ -400,7 +427,8 @@ class MessageBox(urwid.Pile):
         parts = [
             (recipient_header, recipient_header is not None),
             (content_header, any_differences),
-            (content, True),
+            (content, submessages == ''),
+            (submessages, submessages != ''),
             (reactions, reactions != ''),
         ]
         return [part for part, condition in parts if condition]
@@ -425,6 +453,28 @@ class MessageBox(urwid.Pile):
                 continue
             emails.append(recipient['email'])
         return ', '.join(emails)
+
+    def get_zform_reply(self, key):
+        data = json.loads(self.message['submessages'][0]['content'])
+        return data['extra_data']['choices'][int(key)-1]['reply']
+        try:
+           return json.loads(self.message['submessages'][0]['content'])['extra_data']['choices'][key-1]['reply']
+        except Exception:
+            return False
+
+
+    def get_reply_info(self):
+        reply_info = {
+            type: self.message['type'],
+        }
+        reply_info['mention'] = '@**' + self.message['sender_full_name'] + '** '
+        if self.message['type'] == 'private':
+            reply_info['to'] = self.get_recipients()
+        else:
+            reply_info['stream'] = self.message['display_recipient']
+            reply_info['to'] = self.message['display_recipient']
+            reply_info['topic'] = self.message['subject']
+        return reply_info
 
     def keypress(self, size: Tuple[int, int], key: str) -> str:
         if is_command_key('ENTER', key):

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -159,6 +159,18 @@ class MessageView(urwid.ListBox):
                 message = self.focus.original_widget.message
                 self.model.toggle_message_star_status(message)
 
+        elif key in ['1', '2', '3', '4']:
+            if self.focus is not None:
+                message = self.focus.original_widget.message
+                self.model.toggle_message_star_status(message)
+                reply_info = self.focus.original_widget.get_reply_info()
+                content = self.focus.original_widget.get_zform_reply(key)
+                if content:
+                    content = reply_info['mention'] + ' ' + content
+                    response = self.model.send_stream_message(stream=reply_info['stream'],
+                                                              topic=reply_info['topic'],
+                                                              content=content)
+
         key = super(MessageView, self).keypress(size, key)
         return key
 


### PR DESCRIPTION
This is just a proof of concept. I'm not sure where to add what code and I essentially wrote a lot of unneeded functions to export things from the message for now. I'll clean this up in the next few commits.

The current interface is to press a number key from 1 to 9 to select one of the choices available in a message:

![image](https://user-images.githubusercontent.com/8033238/52079114-df2e2980-25ba-11e9-9a6f-176021ad9540.png)

This creates an obvious restriction of maximum 9 choices per message. I wonder if a popup menu to choose would be a better UI?