### PR TITLE
Fix quoting original message, not rendered version 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Avoid crash in rare case of empty message content
 - Set terminal locale to `utf-8` by default which removes issues with rendering double width characters.
 - Avoid crash on receiving multiple starred-message events
+- Fix quoting of messages to quote the original message, not the rendered version. 
 
 ### Infrastructure changes
 - Minimized initial registration & communication with zulip server

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -472,7 +472,7 @@ class MessageBox(urwid.Pile):
             self.model.controller.view.middle_column.set_focus('footer')
         elif is_command_key('QUOTE_REPLY', key):
             self.keypress(size, 'enter')
-            quote = '```quote\n' + self.message['content'] + '\n```\n'
+            quote = '```quote\n' + self.model.client.get_raw_message(self.message['id'])['raw_content'] + '\n```\n'
             self.model.controller.view.write_box.msg_write_box.set_edit_text(
                 quote)
             self.model.controller.view.write_box.msg_write_box.set_edit_pos(


### PR DESCRIPTION
Fixed the issue of quoting resulting in quoting the rendered version rather than the original message.  
Fixes issue-239. 
 
QUOTE_TEXT used to get quote from self.message 
It now gets raw_content from the model.  