### PR TITLE
Unread counts: Introduce UnreadCounts TypedDict & avoid mixed indices.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Make stream icons bold and correct background color
 
 ### Important bugfixes
+- Fix bug potentially mixing unread counts for messages from users & streams
 - Exit cleanly if cannot connect to zulip server
 - Avoid crash in rare case of empty message content
 - Set terminal locale to `utf-8` by default which removes issues with rendering double width characters.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Important bugfixes
 - Fix bug potentially mixing unread counts for messages from users & streams
+- Don't increase the unread counts if we sent the message
 - Exit cleanly if cannot connect to zulip server
 - Avoid crash in rare case of empty message content
 - Set terminal locale to `utf-8` by default which removes issues with rendering double width characters.

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -642,6 +642,12 @@ class TestRightColumnView:
         self.line_box = mocker.patch(VIEWS + ".urwid.LineBox")
         self.thread = mocker.patch(VIEWS + ".threading")
         self.super = mocker.patch(VIEWS + ".urwid.Frame.__init__")
+        self.view.model.unread_counts = {  # Minimal, though an UnreadCounts
+            'unread_pms': {
+                1: 1,
+                2: 1,
+            }
+        }
 
     @pytest.fixture
     def right_col_view(self, mocker, width=50):
@@ -707,7 +713,6 @@ class TestRightColumnView:
             'status': status
         }]
         self.view.controller.editor_mode = editor_mode
-        self.view.model.unread_counts.get.return_value = 1
         user_btn = mocker.patch(VIEWS + ".UserButton")
         mocker.patch(VIEWS + ".UsersView")
         list_w = mocker.patch(VIEWS + ".urwid.SimpleFocusListWalker")
@@ -716,7 +721,6 @@ class TestRightColumnView:
 
         if status != 'inactive':
             unread_counts = right_col_view.view.model.unread_counts
-            unread_counts.get.assert_called_once_with(1, 0)
             user_btn.assert_called_once_with(
                 self.view.users[0],
                 controller=self.view.controller,
@@ -759,12 +763,14 @@ class TestLeftColumnView:
     def mock_external_classes(self, mocker):
         self.view = mocker.Mock()
         self.view.model = mocker.Mock()
-        self.view.model.unread_counts = {
+        self.view.model.unread_counts = {  # Minimal, though an UnreadCounts
             'all_msg': 2,
             'all_pms': 0,
-            86: 1,
-            14: 1,
-            99: 1,
+            'streams': {
+                86: 1,
+                14: 1,
+                99: 1,
+            },
         }
         self.view.controller = mocker.Mock()
         self.super_mock = mocker.patch(VIEWS + ".urwid.Pile.__init__")

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -99,6 +99,12 @@ def set_count(id_list: List[int], controller: Any, new_count: int) -> None:
     all_msg = controller.view.home_button
     all_pm = controller.view.pm_button
     for id in id_list:
+        user_id = messages[id]['sender_id']
+
+        # If we sent this message, don't increase the count
+        if user_id == controller.model.user_id:
+            continue
+
         msg_type = messages[id]['type']
         if msg_type == 'stream':
             stream_id = messages[id]['stream_id']
@@ -109,9 +115,7 @@ def set_count(id_list: List[int], controller: Any, new_count: int) -> None:
                 if stream.stream_id == stream_id:
                     stream.update_count(stream.count + new_count)
                     break
-
         else:
-            user_id = messages[id]['sender_id']
             for user in users:
                 if user.user_id == user_id:
                     user.update_count(user.count + new_count)

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -438,8 +438,8 @@ class RightColumnView(urwid.Frame):
             if user['status'] == 'inactive' and\
                     not self.view.controller.editor_mode:
                 continue
-            unread_count = self.view.model.unread_counts.get(user['user_id'],
-                                                             0)
+            unread_count = (self.view.model.unread_counts['unread_pms'].
+                            get(user['user_id'], 0))
             users_btn_list.append(
                 UserButton(
                     user,
@@ -522,7 +522,7 @@ class LeftColumnView(urwid.Pile):
                     controller=self.controller,
                     view=self.view,
                     width=self.width,
-                    count=self.model.unread_counts.get(stream[1], 0)
+                    count=self.model.unread_counts['streams'].get(stream[1], 0)
                 ) for stream in self.view.pinned_streams]
 
         if len(streams_btn_list):
@@ -540,7 +540,7 @@ class LeftColumnView(urwid.Pile):
                     controller=self.controller,
                     view=self.view,
                     width=self.width,
-                    count=self.model.unread_counts.get(stream[1], 0)
+                    count=self.model.unread_counts['streams'].get(stream[1], 0)
                 ) for stream in self.view.unpinned_streams]
 
         self.view.stream_w = StreamsView(streams_btn_list, self.view)


### PR DESCRIPTION
This improves the situation regarding unread-counts, so that if you receive a message from a user who is in the right-panel, a count appears next to their name properly. It should also slightly improve stream unread counts, if there was a conflict present, which I'm not sure there often would be.

The second commit avoids the issue where a message sent by yourself would increase the unread count, which I'm fairly sure was also a bug.

See the commits for a little more detail.