### PR TITLE
Improve inline item rendering

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -888,7 +888,8 @@ class TestMessageBox:
         ('<del>text</del>', ['', 'text']),  # FIXME Strikethrough
         ('<div class="message_inline_image">'
          '<a href="x"><img src="x"></a></div>', ['', 'x']),
-        ('<div class="message_inline_ref">blah</div>', []),
+        ('<div class="message_inline_ref">blah</div>',
+            ['[MESSAGE INLINE REF NOT RENDERED]']),
         ('<span class="emoji">:smile:</span>', [':smile:']),
         ('<div class="inline-preview-twitter"',
             ['[TWITTER PREVIEW NOT RENDERED]']),

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -886,7 +886,8 @@ class TestMessageBox:
         ('<span class="katex">some-math</span>', ['some-math']),
         ('<ul><li>text</li></ul>', ['', '  * ', '', 'text']),
         ('<del>text</del>', ['', 'text']),  # FIXME Strikethrough
-        ('<div class="message_inline_image">blah</div>', []),
+        ('<div class="message_inline_image">'
+         '<a href="x"><img src="x"></a></div>', ['', 'x']),
         ('<div class="message_inline_ref">blah</div>', []),
         ('<span class="emoji">:smile:</span>', [':smile:']),
         ('<div class="inline-preview-twitter"',

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -237,7 +237,6 @@ class MessageBox(urwid.Pile):
             # TODO: Support embedded content & twitter preview?
             'message_embed': 'EMBEDDED CONTENT',
             'inline-preview-twitter': 'TWITTER PREVIEW',
-            'message_inline_image': '',
             'message_inline_ref': '',
         }
         unrendered_template = '[{} NOT RENDERED]'
@@ -279,7 +278,7 @@ class MessageBox(urwid.Pile):
             elif element.name == 'a':
                 # LINKS
                 link = element.attrs['href']
-                text = element.text
+                text = element.img['src'] if element.img else element.text
                 if link == text:
                     # If the link and text are same
                     # usually the case when user just pastes

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -237,7 +237,7 @@ class MessageBox(urwid.Pile):
             # TODO: Support embedded content & twitter preview?
             'message_embed': 'EMBEDDED CONTENT',
             'inline-preview-twitter': 'TWITTER PREVIEW',
-            'message_inline_ref': '',
+            'message_inline_ref': 'MESSAGE INLINE REF',
         }
         unrendered_template = '[{} NOT RENDERED]'
         for element in soup:


### PR DESCRIPTION
I noticed while browsing the #**test here** stream that some messages were rendering as blank. I quoted the message, which showed the original (quoted) source message; these were just image URLs.

When updating the soup2markup code previously, I had included these in the group of tags handled a certain way, but was not sure how to handle them.
* For 'refs', I'm still not sure, but for now I think we should just show them
* For image urls, the other commit now identifies if a link contains an img with the same src as the href, which shows the link just as the text, using existing code.

This shouldn't be a controversial merge, but certainly open for review :)