### PR TITLE
help: Allow '?' to show/hide (toggle) help view, not just show it.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next Release
 
 ### Interactivity improvements
+- Use <kbd>?</kbd> to show *and* hide help menu (<kbd>esc</kbd> continues to exit)
 - Add additional shortcut key for sending messages (<kbd>ctrl</kbd>+<kbd>d</kbd>)
 - Allow <kbd>f</kbd> and <kbd>P</kbd> shortcut keys to work from side panels (narrow starred & private messages)
 - Warn on startup, if specified theme is lacking current required styles

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ autohide=autohide
 ## Hot Keys
 | Command                                               | Key Combination                               |
 | ----------------------------------------------------- | --------------------------------------------- |
-| Display help menu                                     | <kbd>?</kbd>                                  |
+| Show/hide help menu                                   | <kbd>?</kbd>                                  |
 | Go Back                                               | <kbd>esc</kbd>                                |
 | Previous message                                      | <kbd>Up</kbd> / <kbd>k</kbd>                  |
 | Next message                                          | <kbd>Down</kbd> / <kbd>j</kbd>                |

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -3,7 +3,7 @@ from typing import Set
 KEY_BINDINGS = {
     'HELP': {
         'keys': {'?'},
-        'help_text': 'Display help menu',
+        'help_text': 'Show/hide help menu',
     },
     'GO_BACK': {
         'keys': {'esc'},

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -87,7 +87,7 @@ class Controller:
         help_view = HelpView(self)
         self.loop.widget = urwid.Overlay(
             urwid.LineBox(help_view,
-                          title="Help Menu ('esc' quits, up/down scrolls)"),
+                          title="Help Menu (up/down scrolls)"),
             self.view,
             align='center',
             width=help_view.width+2,  # +2 from LineBox

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -587,6 +587,6 @@ class HelpView(urwid.ListBox):
         super(HelpView, self).__init__(self.log)
 
     def keypress(self, size: Tuple[int, int], key: str) -> str:
-        if is_command_key('GO_BACK', key):
+        if is_command_key('GO_BACK', key) or is_command_key('HELP', key):
             self.controller.exit_help()
         return super(HelpView, self).keypress(size, key)


### PR DESCRIPTION
This was inspired by a suggestion from @rishig; where possible using the same key again can make things simple - here we retain the ability to exit the help menu with 'esc' (at least for now) but allow '?' ('HELP') to also do so. This also allows the help menu to be simplified slightly.

Changes spread across multiple locations:
* allow '?' to exit the help view via 'HELP' key (views.py)
* 'HELP' key description (keys.py & README.md)
* title of Help view (core.py)
* add note in CHANGELOG.md