### PR TITLE
Compact the HelpView.

### DIFF
--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -84,6 +84,7 @@ class Controller:
         self.loop.draw_screen()
 
     def show_help(self) -> None:
+        cols, rows = self.loop.screen.get_cols_rows()
         help_view = HelpView(self)
         self.loop.widget = urwid.Overlay(
             urwid.LineBox(help_view,
@@ -92,7 +93,7 @@ class Controller:
             align='center',
             width=help_view.width+2,  # +2 from LineBox
             valign='middle',
-            height=('relative', 100)
+            height=rows//2
         )
 
     def exit_help(self) -> None:

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -580,7 +580,7 @@ class HelpView(urwid.ListBox):
                     (max_widths[1], urwid.Text(", ".join(binding['keys'])))
                               ], dividechars=2),
                 tlcorner='', brcorner='', trcorner='', blcorner='',
-                rline=' ', lline=' ', bline='-', tline='',
+                rline=' ', lline=' ', bline='', tline='',
              )
              for binding in KEY_BINDINGS.values()])
 


### PR DESCRIPTION
Define the height attribute (default to the number of key bindings) and
remove the bottom line character.