### PR TITLE
Further README improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Fix quoting original message, not rendered version 
 
 ### Infrastructure changes
+- Improve installation, development & troubleshooting notes in README
 - Minimized initial registration & communication with zulip server
 - Internal refactoring & centralization of code handling zulip server communication
 - Centralize server event callbacks into Model

--- a/README.md
+++ b/README.md
@@ -2,16 +2,14 @@
 
 An interactive terminal interface for [Zulip](https://zulipchat.com).
 
+[Recent changes](CHANGELOG.md) | [Installation & Running](#Installation--running) | [Hot Keys](#hot-keys) | [Troubleshooting](#troubleshooting-common-issues) | [Development](#contributor-guidelines)
+
 [![Zulip chat](https://img.shields.io/badge/zulip-join_chat-brightgreen.svg)](https://chat.zulip.org/#narrow/stream/206-zulip-terminal)
 [![PyPI](https://img.shields.io/pypi/v/zulip-term.svg)](https://pypi.python.org/pypi/zulip-term)
 [![Python Versions](https://img.shields.io/pypi/pyversions/zulip-term.svg)](https://pypi.python.org/pypi/zulip-term)
 [![Build Status](https://travis-ci.org/zulip/zulip-terminal.svg?branch=master)](https://travis-ci.org/zulip/zulip-terminal)
 [![Coverage status](https://img.shields.io/codecov/c/github/zulip/zulip-terminal/master.svg)](https://codecov.io/gh/zulip/zulip-terminal)
 [![Checked with mypy](http://www.mypy-lang.org/static/mypy_badge.svg)](http://mypy-lang.org/)
-
-## Changes
-
-Please see the [CHANGELOG](CHANGELOG.md) for released & recent changes.
 
 ## Installation & Running
 

--- a/README.md
+++ b/README.md
@@ -195,15 +195,24 @@ it to understand the how to implement a new feature for zulip-terminal.
 
 ### Debugging Tips
 
-The stdout for zulip-terminal is set to `./debug.log` by default.
-If you want to check the value of a variable, you can simply write
-```
-print(variable)
+#### Output using `print`
+
+The stdout for zulip-terminal is redirected to `./debug.log` by default.
+
+If you want to check the value of a variable, or perhaps indicate reaching a certain point in the code, you can simply write
+```python3
+print(variable, flush=True)
 ```
 and the value of the variable will be printed to `./debug.log`.
 
+We suggest the `flush=True` to ensure it prints straight away.
+
+If you have a bash-like terminal, you can run something like `tail -f debug.log` in another terminal, to see the output from `print` as it happens.
+
+#### Interactive debugging using pudb & telnet
+
 If you want to debug zulip-terminal while it is running, or in a specific state, you can insert
-```
+```python3
 from pudb.remote import set_trace
 set_trace()
 ```

--- a/README.md
+++ b/README.md
@@ -151,6 +151,14 @@ for it mentioning your terminal name, version, and OS.
 
 If any of the above mentioned hotkeys don't work for you, feel free to open an issue or discuss it on [#zulip-terminal](https://chat.zulip.org/#narrow/stream/206-zulip-terminal).
 
+### Zulip-term crashed!
+
+We hope this doesn't happen, but would love to hear about this in order to fix it, since the application should be increasingly stable! Please let us know the problem, and if you're able to duplicate the issue, on the github issue-tracker or at [#zulip-terminal](https://chat.zulip.org/#narrow/stream/206-zulip-terminal).
+
+This process would be helped if you could send us the 'traceback' showing the cause of the error, which should be output in such cases:
+* version 0.3.1 and earlier: the error is shown on the terminal;
+* versions 0.3.2+: the error is present/appended to the file `zulip-terminal-tracebacks.log`.
+
 ### Something looks wrong! Where's this feature? There's a bug!
 Come meet us on the [#zulip-terminal](https://chat.zulip.org/#narrow/stream/206-zulip-terminal) stream on *chat.zulip.org*.
 

--- a/README.md
+++ b/README.md
@@ -225,6 +225,15 @@ $ telnet 127.0.0.1 6899
 ```
 in another terminal, where `127.0.0.1` is the IP address and `6899` is port you find in `./debug.log`.
 
+#### There's no effect in Zulip Terminal after making local changes!
+
+This likely means that you have installed both normal and development versions of zulip-terminal.
+
+To ensure you run the development version:
+* If using pipenv, call `pipenv run zulip-term` from the cloned/downloaded `zulip-terminal` directory;
+* If using pip (pip3), ensure you have activated the correct virtual environment (venv); depending on how your shell is configured, the name of the venv may appear in the command prompt. Note that not including the `-e` in the pip3 command will also cause this problem.
+
+
 ### **Need Help?**
 Come meet us at [Zulip](https://chat.zulip.org/#narrow/stream/206-zulip-terminal).
 
@@ -246,11 +255,6 @@ If you are unable to open links in messages, then try double right-click on the 
 If you are still facing problems, please discuss it at
 [#zulip-terminal](https://chat.zulip.org/#narrow/stream/206-zulip-terminal) or open an issue
 for it mentioning your terminal name, version, and OS.
-
-##### [DEV] No effect on Zulip Terminal on making local changes
-
-This means that you have installed both Normal and development versions of zulip-terminal. For running the development version, call
-`pipenv run zulip-term` from the cloned / downloaded `zulip-terminal` directory.
 
 ##### Above mentioned hotkeys don't work as described
 

--- a/README.md
+++ b/README.md
@@ -154,8 +154,21 @@ If any of the above mentioned hotkeys don't work for you, feel free to open an i
 ### Something looks wrong! Where's this feature? There's a bug!
 Come meet us on the [#zulip-terminal](https://chat.zulip.org/#narrow/stream/206-zulip-terminal) stream on *chat.zulip.org*.
 
+## Contributor Guidelines
 
-## Setting up a development environment
+Zulip Terminal is being built by the awesome [Zulip](https://zulipchat.com/team) community.
+
+To be a part of it and to contribute to the code, feel free to work on any [issue](https://github.com/zulip/zulip-terminal/issues) or propose your idea on
+[#zulip-terminal](https://chat.zulip.org/#narrow/stream/206-zulip-terminal).
+
+Please read our [commit message guidelines](http://zulip.readthedocs.io/en/latest/contributing/version-control.html) and
+[git guide](http://zulip.readthedocs.io/en/latest/git/index.html).
+
+A simple tutorial for implementing the `typing` indicator is available
+in the [wiki](https://github.com/zulip/zulip-terminal/wiki/Developer-Documentation). Follow
+it to understand the how to implement a new feature for zulip-terminal.
+
+### Setting up a development environment
 
 Various options are available; we are exploring the benefits of each and would appreciate feedback on which you use or feel works best.
 
@@ -167,7 +180,7 @@ $ git clone git@github.com:zulip/zulip-terminal.git
 ```
 The following commands should be run in the repository directory, which can be achieved with `cd zulip-terminal`.
 
-### Pipenv
+#### Pipenv
 
 1. Install pipenv (see the [recommended installation notes](https://pipenv.readthedocs.io/en/latest/install/#pragmatic-installation-of-pipenv); pipenv can be installed in a virtual environment, if you wish)
 ```
@@ -186,7 +199,7 @@ $ pipenv install --dev
 $ pipenv run pip3 install -e .[dev]
 ```
 
-### Pip
+#### Pip
 
 1. Manually create & activate a virtual environment; any method should work, such as that used in the above simple installation
 
@@ -198,7 +211,7 @@ $ pipenv run pip3 install -e .[dev]
 $ pip3 install -e .[dev]
 ```
 
-## Development tasks
+### Development tasks
 
 Once you have a development environment set up, you might find the following useful, depending upon your type of environment:
 
@@ -211,20 +224,6 @@ Once you have a development environment set up, you might find the following use
 | Build test coverage report | `pytest --cov-report html:cov_html --cov=./` | `pipenv run pytest --cov-report html:cov_html --cov=./` |
 | Check type annotations | `./tools/run-mypy` | `pipenv run ./tools/run-mypy` |
 
-
-## Contributor Guidelines
-
-Zulip Terminal is being build by an awesome community of [Zulip](https://zulipchat.com/team).
-
-To be a part of it and to contribute to the code, feel free to work on any [issue](https://github.com/zulip/zulip-terminal/issues) or propose your idea on
-[#zulip-terminal](https://chat.zulip.org/#narrow/stream/206-zulip-terminal).
-
-Do checkout our [commit message guidelines](http://zulip.readthedocs.io/en/latest/contributing/version-control.html) and
-[git guide](http://zulip.readthedocs.io/en/latest/git/index.html).
-
-A simple tutorial for implementing `typing` indicator is available
-in the [wiki](https://github.com/zulip/zulip-terminal/wiki/Developer-Documentation). Follow
-it to understand the how to implement a new feature for zulip-terminal.
 
 ### Debugging Tips
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,37 @@ autohide=autohide
 
 Note: You can use `arrows`, `home`, `end`, `Page up` and `Page down` keys to move around in Zulip-Terminal.
 
+## Troubleshooting: Common issues
+
+### Unable to render non-ASCII characters
+
+**NOTE** Releases of 0.3.2 onwards should not have this issue, or require this solution.
+
+If you see `?` in place of emojis or Zulip Terminal gives a `UnicodeError` / `CanvasError`, you haven't enabled utf-8
+encoding in your terminal. To enable it by default, add this to the end of you `~/.bashrc`:
+
+```
+export LANG=en_US.utf-8
+```
+
+### Unable to open links
+
+If you are unable to open links in messages, then try double right-click on the link.
+
+Alternatively, you might try different modifier keys (eg. shift, ctrl, alt) with a right-click.
+
+If you are still facing problems, please discuss it at
+[#zulip-terminal](https://chat.zulip.org/#narrow/stream/206-zulip-terminal) or open an issue
+for it mentioning your terminal name, version, and OS.
+
+### Above mentioned hotkeys don't work as described
+
+If any of the above mentioned hotkeys don't work for you, feel free to open an issue or discuss it on [#zulip-terminal](https://chat.zulip.org/#narrow/stream/206-zulip-terminal).
+
+### Something looks wrong! Where's this feature? There's a bug!
+Come meet us on the [#zulip-terminal](https://chat.zulip.org/#narrow/stream/206-zulip-terminal) stream on *chat.zulip.org*.
+
+
 ## Setting up a development environment
 
 Various options are available; we are exploring the benefits of each and would appreciate feedback on which you use or feel works best.
@@ -232,30 +263,3 @@ This likely means that you have installed both normal and development versions o
 To ensure you run the development version:
 * If using pipenv, call `pipenv run zulip-term` from the cloned/downloaded `zulip-terminal` directory;
 * If using pip (pip3), ensure you have activated the correct virtual environment (venv); depending on how your shell is configured, the name of the venv may appear in the command prompt. Note that not including the `-e` in the pip3 command will also cause this problem.
-
-
-### **Need Help?**
-Come meet us at [Zulip](https://chat.zulip.org/#narrow/stream/206-zulip-terminal).
-
-Troubleshooting: Common issues
-------------------------------
-
-##### Unable to render non-ASCII characters
-
-If you see `?` in place of emojis or Zulip Terminal gives a `UnicodeError` / `CanvasError`, you haven't enabled utf-8
-encoding in your terminal. To enable it by default, add this to the end of you `~/.bashrc`:
-
-```
-export LANG=en_US.utf-8
-```
-
-##### Unable to open links
-
-If you are unable to open links in messages, then try double right-click on the link.
-If you are still facing problems, please discuss it at
-[#zulip-terminal](https://chat.zulip.org/#narrow/stream/206-zulip-terminal) or open an issue
-for it mentioning your terminal name, version, and OS.
-
-##### Above mentioned hotkeys don't work as described
-
-If any of the above mentioned hotkeys don't work for you, feel free to open an issue or discuss it on [#zulip-terminal](https://chat.zulip.org/#narrow/stream/206-zulip-terminal).

--- a/README.md
+++ b/README.md
@@ -138,19 +138,21 @@ The following commands should be run in the repository directory, which can be a
 
 ### Pipenv
 
-1. Install pipenv
+1. Install pipenv (see the [recommended installation notes](https://pipenv.readthedocs.io/en/latest/install/#pragmatic-installation-of-pipenv); pipenv can be installed in a virtual environment, if you wish)
 ```
-$ curl https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py
-$ python3 /tmp/get-pip.py --user
-$ printf '\nexport PATH="%s:$PATH"\n' '${HOME}/.local/bin' | tee -a ~/.bashrc
-$ python3 -m pip install --user pipenv
+$ pip3 install --user pipenv
 ```
+2. Initialize the pipenv virtual environment for zulip-term (using the default python 3; use eg. `--python 3.6` to be more specific)
 
-2. Install zulip-term, with the development requirements
 ```
 $ pipenv --three
+```
+
+3. Install zulip-term, with the development requirements
+
+```
 $ pipenv install --dev
-$ pipenv run python setup.py develop
+$ pipenv run pip3 install -e .[dev]
 ```
 
 ### Pip


### PR DESCRIPTION
This incorporates some of the recently-raised points with some tidying & reorganising; briefly:
* Add `flush=True` (@sumanthvrao) to debugging tips, and add subsections
* Simplify/clarify the pipenv setup for development install (@punchagan ; not using pip3 yet, could do?)
* Move the 'edits aren't affecting zulip-term' section into debugging tips
* Move the remaining 'troubleshooting' section above the development section
* Make the 'Contributor guidelines' the start of the development section

The final result looks like this:
https://github.com/neiljp/zulip-terminal/tree/dev-docs-improvements