### PR TITLE
shortcut: Add "z" to toggle between stream/topic narrow.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Allow <kbd>f</kbd> and <kbd>P</kbd> shortcut keys to work from side panels (narrow starred & private messages)
 - Warn on startup, if specified theme is lacking current required styles
 - Upon unexpected crash, exit cleanly and log traceback to `zulip-terminal-tracebacks.log`
+- Add the <kbd>z</kbd> shortcut to toggle between stream/topic narrow.
 
 ### Visual improvements
 - Right-align unread-counts in left & right panels (as in webapp)

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -77,6 +77,10 @@ KEY_BINDINGS = {
         'keys': {'S'},
         'help_text': 'Narrow to the topic of the current message',
     },
+    'TOGGLE_NARROW': {
+        'keys': {'z'},
+        'help_text': 'Toggle narrow of the current message to be stream/topic',
+    },
     'ALL_PM': {
         'keys': {'P'},
         'help_text': 'Narrow to all private messages',

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -450,6 +450,14 @@ class MessageBox(urwid.Pile):
                 self.model.controller.narrow_to_user(self)
             elif self.message['type'] == 'stream':
                 self.model.controller.narrow_to_stream(self)
+        elif is_command_key('TOGGLE_NARROW', key):
+            if self.message['type'] == 'private':
+                self.model.controller.narrow_to_user(self)
+            elif self.message['type'] == 'stream':
+                if len(self.model.narrow) > 1:  # in a topic
+                    self.model.controller.narrow_to_stream(self)
+                else:
+                    self.model.controller.narrow_to_topic(self)
         elif is_command_key('TOPIC_NARROW', key):
             if self.message['type'] == 'private':
                 self.model.controller.narrow_to_user(self)


### PR DESCRIPTION
Should I add a config param for enabling/disabling this? This doesn't seem to break any muscle memory in a bad way since anyone accustomed to pressing 's' to narrow to stream-wide can still do it.