### PR TITLE
Improve help menu: compact further, style lines, adapt height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - Truncate text in left & right panels cleanly with '..', avoiding text overflow
 - Show user status as `active` (Green), `idle` (Yellow) or `offline` (White) using different colors.
 - Further improvement/reordering of shortcut keys in README & help menu (<kbd>?</kbd>)
-- Improve styling of help menu, and how the menu scales with application width
+- Improve styling of help menu, and how the menu scales with application width & height
 - Make stream icons bold and correct background color
 
 ### Important bugfixes

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -91,9 +91,10 @@ class Controller:
                           title="Help Menu (up/down scrolls)"),
             self.view,
             align='center',
-            width=help_view.width+2,  # +2 from LineBox
             valign='middle',
-            height=rows//2
+            # +2 to both of the following, due to LineBox
+            width=help_view.width+2,
+            height=min(3*rows//4, help_view.number_of_actions)+2
         )
 
     def exit_help(self) -> None:

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -581,6 +581,8 @@ class HelpView(urwid.ListBox):
                 None if index % 2 else 'bar')
              for index, binding in enumerate(KEY_BINDINGS.values())])
 
+        self.number_of_actions = len(self.log)
+
         super(HelpView, self).__init__(self.log)
 
     def keypress(self, size: Tuple[int, int], key: str) -> str:

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -573,11 +573,13 @@ class HelpView(urwid.ListBox):
         self.width = sum(max_widths)
 
         self.log = urwid.SimpleFocusListWalker(
-            [urwid.Columns([
-                urwid.Text(binding['help_text']),
-                (max_widths[1], urwid.Text(", ".join(binding['keys'])))
-                          ], dividechars=2)
-             for binding in KEY_BINDINGS.values()])
+            [urwid.AttrWrap(
+                urwid.Columns([
+                    urwid.Text(binding['help_text']),
+                    (max_widths[1], urwid.Text(", ".join(binding['keys'])))
+                ], dividechars=2),
+                None if index % 2 else 'bar')
+             for index, binding in enumerate(KEY_BINDINGS.values())])
 
         super(HelpView, self).__init__(self.log)
 

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -573,15 +573,10 @@ class HelpView(urwid.ListBox):
         self.width = sum(max_widths)
 
         self.log = urwid.SimpleFocusListWalker(
-            [urwid.Text('')] +
-            [urwid.LineBox(
-                urwid.Columns([
-                    urwid.Text(binding['help_text']),
-                    (max_widths[1], urwid.Text(", ".join(binding['keys'])))
-                              ], dividechars=2),
-                tlcorner='', brcorner='', trcorner='', blcorner='',
-                rline=' ', lline=' ', bline='', tline='',
-             )
+            [urwid.Columns([
+                urwid.Text(binding['help_text']),
+                (max_widths[1], urwid.Text(", ".join(binding['keys'])))
+                          ], dividechars=2)
              for binding in KEY_BINDINGS.values()])
 
         super(HelpView, self).__init__(self.log)


### PR DESCRIPTION
This is a quick follow-up to the help menu observation and contribution by @matrixise in #298 and #297.

This PR:
* Removes side/top spaces
* Sets alternating background colors (using 'bar' style for now)
* Adjusts the menu height to be between (the minimum) of 3/4 window height (rows), and the number of help menu actions

The latter does increase the menu height slightly (it was set to 1/2 in #298), so any feedback through testing would be good.

Tagging @amanagr & @rht who also gave feedback on the PR by @matrixise.