### PR TITLE
Add Ctrl+C ('quit') to in-app help documentation

### DIFF
--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -117,6 +117,10 @@ KEY_BINDINGS = {
         'keys': {'ctrl s', '*'},
         'help_text': 'Add/remove star status of the current message',
     },
+    'QUIT': {
+        'keys': {'ctrl c'},
+        'help_text': 'Quit',
+    },
 }
 
 


### PR DESCRIPTION
Partially fixes  #208 (partially, since one of open PRs (https://github.com/zulip/zulip-terminal/pull/261 ) contains the remaining changes necessary to fix issue #208) . 