### PR TITLE
 Exclude specified key(s) from 'random tip' selection.

### DIFF
--- a/tests/config/test_keys.py
+++ b/tests/config/test_keys.py
@@ -43,3 +43,37 @@ def test_is_command_key_nonmatching_keys(valid_command):
 def test_is_command_key_invalid_command(invalid_command):
     with pytest.raises(keys.InvalidCommand):
         keys.is_command_key(invalid_command, 'esc')  # key doesn't matter
+
+
+def test_HELP_is_not_allowed_as_tip():
+    assert (keys.KEY_BINDINGS['HELP']['excluded_from_random_tips'] is True)
+    assert (keys.KEY_BINDINGS['HELP'] not in keys.commands_for_random_tips())
+
+
+def test_commands_for_random_tips(mocker):
+    new_key_bindings = {
+        'ALPHA': {
+            'keys': {'a'},
+            'help_text': 'alpha',
+            'excluded_from_random_tips': True,
+            },
+        'BETA': {
+            'keys': {'b'},
+            'help_text': 'beta',
+            'excluded_from_random_tips': False,
+            },
+        'GAMMA': {
+            'keys': {'g'},
+            'help_text': 'gamma',
+            },
+        'DELTA': {
+            'keys': {'d'},
+            'help_text': 'delta',
+            'excluded_from_random_tips': True,
+            },
+    }  # type: Dict[str, KeyBinding]
+    mocker.patch.dict(keys.KEY_BINDINGS, new_key_bindings, clear=True)
+    result = keys.commands_for_random_tips()
+    assert len(result) == 2
+    assert new_key_bindings['BETA'] in result
+    assert new_key_bindings['GAMMA'] in result

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -1,13 +1,22 @@
-from typing import Set
+from typing import Set, Dict, List
+from mypy_extensions import TypedDict
+
+KeyBinding = TypedDict('KeyBinding', {
+    'keys': Set[str],
+    'help_text': str,
+    'excluded_from_random_tips': bool,
+}, total=False)
 
 KEY_BINDINGS = {
     'HELP': {
         'keys': {'?'},
         'help_text': 'Show/hide help menu',
+        'excluded_from_random_tips': True,
     },
     'GO_BACK': {
         'keys': {'esc'},
         'help_text': 'Go Back',
+        'excluded_from_random_tips': False,
     },
     'PREVIOUS_MESSAGE': {
         'keys': {'k', 'up'},
@@ -121,7 +130,7 @@ KEY_BINDINGS = {
         'keys': {'ctrl c'},
         'help_text': 'Quit',
     },
-}
+}  # type: Dict[str, KeyBinding]
 
 
 class InvalidCommand(Exception):
@@ -147,3 +156,12 @@ def keys_for_command(command: str) -> Set[str]:
         return set(KEY_BINDINGS[command]['keys'])
     except KeyError as exception:
         raise InvalidCommand(command)
+
+
+def commands_for_random_tips() -> List[KeyBinding]:
+    """
+    Return list of commands which may be displayed as a random tip
+    """
+    result = [v for k, v in KEY_BINDINGS.items()
+              if not v.get('excluded_from_random_tips', False)]
+    return result

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -5,7 +5,10 @@ import random
 
 import urwid
 
-from zulipterminal.config.keys import is_command_key, KEY_BINDINGS
+from zulipterminal.config.keys import (
+    is_command_key,
+    commands_for_random_tips
+)
 from zulipterminal.config.themes import THEMES
 from zulipterminal.ui_tools.boxes import WriteBox, SearchBox
 from zulipterminal.ui_tools.views import (
@@ -53,14 +56,16 @@ class View(urwid.WidgetWrap):
         )
 
     def get_random_help(self) -> List[Any]:
-        # Get a hotkey randomly from KEY_BINDINGS
-        random_int = random.randint(0, len(KEY_BINDINGS) - 1)
-        hotkey = list(KEY_BINDINGS.items())[random_int]
-        return [
-            'Help(?): ',
-            ('code', ' ' + ', '.join(hotkey[1]['keys']) + ' '),
-            ' ' + hotkey[1]['help_text'],  # type: ignore
-        ]
+        # Get an allowed (ie. elligible for being displayed as a tip)
+        # hotkey randomly from KEY_BINDINGS
+        allowed_commands = commands_for_random_tips()
+        if not allowed_commands:
+            return ['Help(?): ', ]
+        random_command = random.choice(allowed_commands)
+        return ['Help(?): ',
+                ('code', ' ' + ', '.join(random_command['keys']) + ' '),
+                ' ' + random_command['help_text'],
+                ]
 
     def set_footer_text(self, text_list: Optional[List[Any]]=None) -> None:
         if text_list is None:


### PR DESCRIPTION
Specified commands will not be selected as a 'random tip/key' in the footer.
Issue #290. 