### PR TITLE
Model: rename 2 methods, use client API

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,7 +6,7 @@ name = "pypi"
 [packages]
 typing = {version="==3.6.4", markers="python_version < '3.5'"}
 urwid = "==2.0.1"
-zulip = "==0.5.7"
+zulip = "==0.5.9"
 emoji = "==0.5.0"
 urwid-readline = "==0.8"
 beautifulsoup4 = "==4.6.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 typing==3.6.4; python_version < '3.5'
 urwid==2.0.1
-zulip==0.5.7
+zulip==0.5.9
 pytest==3.4.2
 pytest-cov==2.5.1
 pytest-pep8==1.0.6

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setup(
     install_requires=[
         "typing==3.6.4; python_version < '3.5'",
         'urwid==2.0.1',
-        'zulip==0.5.7',
+        'zulip==0.5.9',
         'emoji==0.5.0',
         'urwid_readline==0.8',
         'beautifulsoup4==4.6.0',

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -401,11 +401,7 @@ class TestModel:
             'messages': [99],
             'op': expected_operator
         }
-        model.client.call_endpoint.assert_called_once_with(
-            url="messages/flags",
-            method="POST",
-            request=request
-        )
+        model.client.update_message_flags.assert_called_once_with(request)
 
     def test_update_flag(self, model, mocker: Any) -> None:
         mock_api_query = mocker.patch('zulipterminal.core.Controller'

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -18,7 +18,7 @@ class TestModel:
         self.client = mocker.patch('zulipterminal.core.'
                                    'Controller.client')
         self.client.base_url = 'chat.zulip.zulip'
-        mocker.patch('zulipterminal.model.Model.update_presence')
+        mocker.patch('zulipterminal.model.Model._start_presence_updates')
 
     @pytest.fixture
     def model(self, mocker, initial_data, user_profile):

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -242,12 +242,17 @@ class TestModel:
         reaction_spec = dict(
             emoji_name='thumbs_up',
             reaction_type='unicode_emoji',
-            emoji_code='1f44d')
+            emoji_code='1f44d',
+            message_id=str(msg_id))
+
         model.react_to_message(message, 'thumbs_up')
-        model.client.call_endpoint.assert_called_once_with(
-            url='messages/{}/reactions'.format(msg_id),
-            method=expected_method,
-            request=reaction_spec)
+
+        if expected_method == 'POST':
+            model.client.add_reaction.assert_called_once_with(reaction_spec)
+            model.client.delete_reaction.assert_not_called()
+        elif expected_method == 'DELETE':
+            model.client.remove_reaction.assert_called_once_with(reaction_spec)
+            model.client.add_reaction.assert_not_called()
 
     def test_react_to_message_for_not_thumbs_up(self, model):
         with pytest.raises(AssertionError):

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -307,7 +307,7 @@ class TestModel:
             return_value=[])
 
         # Setup mocks before calling get_messages
-        self.client.do_api_query.return_value = messages_successful_response
+        self.client.get_messages.return_value = messages_successful_response
         mocker.patch('zulipterminal.model.index_messages',
                      return_value=index_all_messages)
         model = Model(self.controller)
@@ -320,8 +320,8 @@ class TestModel:
             'client_gravatar': True,
             'narrow': json.dumps(model.narrow),
         }
-        model.client.do_api_query.assert_called_once_with(
-            request, '/json/messages', method="GET")
+        (model.client.get_messages.
+         assert_called_once_with(message_filters=request))
         assert model.index == index_all_messages
         anchor = messages_successful_response['anchor']
         if anchor < 10000000000000000:
@@ -348,14 +348,14 @@ class TestModel:
 
         # Setup mocks before calling get_messages
         messages_successful_response['anchor'] = 0
-        self.client.do_api_query.return_value = messages_successful_response
+        self.client.get_messages.return_value = messages_successful_response
         mocker.patch('zulipterminal.model.index_messages',
                      return_value=index_all_messages)
 
         model = Model(self.controller)
         model.get_messages(num_before=num_before, num_after=num_after,
                            anchor=0)
-        self.client.do_api_query.return_value = messages_successful_response
+        self.client.get_messages.return_value = messages_successful_response
         # anchor should have remained the same
         anchor = messages_successful_response['anchor']
         assert model.index['pointer'][str(model.narrow)] == 0
@@ -380,7 +380,8 @@ class TestModel:
             return_value=[])
 
         # Setup mock before calling get_messages
-        self.client.do_api_query.return_value = error_response
+        # FIXME This has no influence on the result
+        # self.client.do_api_query.return_value = error_response
 
         with pytest.raises(ServerConnectionFailure):
             model = Model(self.controller)

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -403,20 +403,18 @@ class TestModel:
         }
         model.client.update_message_flags.assert_called_once_with(request)
 
-    def test_update_flag(self, model, mocker: Any) -> None:
+    def test_mark_message_ids_as_read(self, model, mocker: Any) -> None:
         mock_api_query = mocker.patch('zulipterminal.core.Controller'
-                                      '.client.do_api_query')
+                                      '.client.update_message_flags')
 
-        model.update_flag([1, 2])
+        model.mark_message_ids_as_read([1, 2])
 
         mock_api_query.assert_called_once_with(
             {'flag': 'read', 'messages': [1, 2], 'op': 'add'},
-            '/json/messages/flags',
-            method='POST'
         )
 
-    def test_update_flag_empty_msg_list(self, model) -> None:
-        assert model.update_flag([]) is None
+    def test_mark_message_ids_as_read_empty_msg_list(self, model) -> None:
+        assert model.mark_message_ids_as_read([]) is None
 
     def test__update_initial_data(self, model, initial_data):
         assert model.initial_data == initial_data

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -309,7 +309,7 @@ class TestMessageView:
         msg_view.read_message()
         assert msg_view.update_search_box_narrow.called
         assert msg_view.model.index['messages'][1]['flags'] == ['read']
-        self.model.update_flag.assert_called_once_with([1])
+        self.model.mark_message_ids_as_read.assert_called_once_with([1])
 
     def test_read_message_no_msgw(self, mocker, msg_view):
         # MSG_W is NONE CASE
@@ -317,7 +317,7 @@ class TestMessageView:
 
         msg_view.read_message()
 
-        self.model.update_flag.assert_not_called()
+        self.model.mark_message_ids_as_read.assert_not_called()
 
 
 class TestStreamsView:

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -229,9 +229,7 @@ class Model:
             request = dict(base_request, op='remove')
         else:
             request = dict(base_request, op='add')
-        response = self.client.call_endpoint(url='messages/flags',
-                                             method='POST',
-                                             request=request)
+        response = self.client.update_message_flags(request)
 
     @asynch
     def update_flag(self, id_list: List[int]) -> None:

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -232,16 +232,14 @@ class Model:
         response = self.client.update_message_flags(request)
 
     @asynch
-    def update_flag(self, id_list: List[int]) -> None:
+    def mark_message_ids_as_read(self, id_list: List[int]) -> None:
         if not id_list:
             return
-        request = {
+        self.client.update_message_flags({
             'messages': id_list,
             'flag': 'read',
             'op': 'add',
-        }
-        self.client.do_api_query(request, '/json/messages/flags',
-                                 method="POST")
+        })
         set_count(id_list, self.controller, -1)  # FIXME Update?
 
     def send_private_message(self, recipients: str,

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -205,22 +205,19 @@ class Model:
         # FIXME Only support thumbs_up for now
         assert reaction_to_toggle == 'thumbs_up'
 
-        endpoint = 'messages/{}/reactions'.format(message['id'])
         reaction_to_toggle_spec = dict(
             emoji_name='thumbs_up',
+            emoji_code='1f44d',
             reaction_type='unicode_emoji',
-            emoji_code='1f44d')
+            message_id=str(message['id']))
         existing_reactions = [reaction['emoji_code']
                               for reaction in message['reactions']
                               if ('user_id' in reaction['user'] and
                                   reaction['user']['user_id'] == self.user_id)]
         if reaction_to_toggle_spec['emoji_code'] in existing_reactions:
-            method = 'DELETE'
+            response = self.client.remove_reaction(reaction_to_toggle_spec)
         else:
-            method = 'POST'
-        response = self.client.call_endpoint(url=endpoint,
-                                             method=method,
-                                             request=reaction_to_toggle_spec)
+            response = self.client.add_reaction(reaction_to_toggle_spec)
 
     @asynch
     def toggle_message_star_status(self, message: Dict[str, Any]) -> None:

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -276,8 +276,7 @@ class Model:
             'client_gravatar': True,
             'narrow': json.dumps(self.narrow),
         }
-        response = self.client.do_api_query(request, '/json/messages',
-                                            method="GET")
+        response = self.client.get_messages(message_filters=request)
         if response['result'] == 'success':
             self.index = index_messages(response['messages'], self, self.index)
             if first_anchor and response['anchor'] != 10000000000000000:

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -196,7 +196,7 @@ class MessageView(urwid.ListBox):
             msg_w, curr_pos = self.body.get_prev(curr_pos)
             if msg_w is None:
                 break
-        self.model.update_flag(read_msg_ids)
+        self.model.mark_message_ids_as_read(read_msg_ids)
 
 
 class StreamsView(urwid.Frame):


### PR DESCRIPTION
This moves ZT to using the specific API calls available in the latest `zulip` package; this makes the code more concise.

We do need to depend upon a later zulip package, since there was a bug in an earlier version which meant that one of these changes didn't work.

I've also renamed two methods for clarity:
* `update_flags` -> `mark_message_ids_as_read`
* `update_presence` -> `_start_presence_updates`

The latter has additional documentation on what I think is the likely route to improve the way that presence updates occur.