### PR TITLE
Improve unread counts (refactor/simplify & fix few bugs)

### DIFF
--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -65,6 +65,10 @@ def asynch(func: Any) -> Any:
 
 
 def set_count(id_list: List[int], controller: Any, new_count: int) -> None:
+    # This method applies new_count for 'new message' (1) or 'read' (-1)
+    # (we could ensure this in a different way by a different type)
+    assert new_count == 1 or new_count == -1
+
     messages = controller.model.index['messages']
     for id in id_list:
         msg = messages[id]

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -70,15 +70,15 @@ def set_count(id_list: List[int], controller: Any, new_count: int) -> None:
     assert new_count == 1 or new_count == -1
 
     messages = controller.model.index['messages']
+    unread_counts = controller.model.unread_counts  # type: UnreadCounts
+
     for id in id_list:
         msg = messages[id]
-        msg_type = msg['type']
-        if msg_type == 'stream':
+
+        if msg['type'] == 'stream':
             unread_id = messages[id]['stream_id']
             stream_topic = (unread_id, msg['subject'])  # type: Tuple[int, str]
-            unread_counts = (controller.model.
-                             unread_counts)  # type: UnreadCounts
-            if stream_topic in unread_counts['unread_topics'].keys():
+            if stream_topic in unread_counts['unread_topics']:
                 unread_counts['unread_topics'][stream_topic] += new_count
                 if unread_counts['unread_topics'][stream_topic] == 0:
                     unread_counts['unread_topics'].pop(stream_topic)
@@ -86,8 +86,7 @@ def set_count(id_list: List[int], controller: Any, new_count: int) -> None:
                 unread_counts['unread_topics'][stream_topic] = new_count
         else:
             unread_id = messages[id]['sender_id']
-            unread_counts = controller.model.unread_counts
-            if unread_id in unread_counts['unread_pms'].keys():
+            if unread_id in unread_counts['unread_pms']:
                 unread_counts['unread_pms'][unread_id] += new_count
                 if unread_counts['unread_pms'][unread_id] == 0:
                     unread_counts['unread_pms'].pop(unread_id)

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -105,11 +105,13 @@ def set_count(id_list: List[int], controller: Any, new_count: int) -> None:
             continue
 
         msg_type = messages[id]['type']
+        add_to_counts = True
         if msg_type == 'stream':
             stream_id = messages[id]['stream_id']
             for stream in streams:
                 if stream.stream_id in controller.model.muted_streams:
                     stream.update_count(-1)
+                    add_to_counts = False  # if muted, don't add to eg. all_msg
                     break
                 if stream.stream_id == stream_id:
                     stream.update_count(stream.count + new_count)
@@ -120,7 +122,9 @@ def set_count(id_list: List[int], controller: Any, new_count: int) -> None:
                     user.update_count(user.count + new_count)
                     break
             all_pm.update_count(all_pm.count + new_count)
-        all_msg.update_count(all_msg.count + new_count)
+
+        if add_to_counts:
+            all_msg.update_count(all_msg.count + new_count)
 
     while not hasattr(controller, 'loop'):
         time.sleep(0.1)

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -76,21 +76,18 @@ def set_count(id_list: List[int], controller: Any, new_count: int) -> None:
         msg = messages[id]
 
         if msg['type'] == 'stream':
-            key_topic = (messages[id]['stream_id'], msg['subject'])
-            if key_topic in unread_counts['unread_topics']:
-                unread_counts['unread_topics'][key_topic] += new_count
-                if unread_counts['unread_topics'][key_topic] == 0:
-                    unread_counts['unread_topics'].pop(key_topic)
-            elif new_count == 1:
-                unread_counts['unread_topics'][key_topic] = new_count
+            key = (messages[id]['stream_id'], msg['subject'])
+            unreads = unread_counts['unread_topics']
         else:
-            key_pm = messages[id]['sender_id']
-            if key_pm in unread_counts['unread_pms']:
-                unread_counts['unread_pms'][key_pm] += new_count
-                if unread_counts['unread_pms'][key_pm] == 0:
-                    unread_counts['unread_pms'].pop(key_pm)
-            elif new_count == 1:
-                unread_counts['unread_pms'][key_pm] = new_count
+            key = messages[id]['sender_id']
+            unreads = unread_counts['unread_pms']  # type: ignore
+
+        if key in unreads:
+            unreads[key] += new_count
+            if unreads[key] == 0:
+                unreads.pop(key)
+        elif new_count == 1:
+            unreads[key] = new_count
 
     # if view is not yet loaded. Usually the case when first message is read.
     while not hasattr(controller, 'view'):

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -76,22 +76,21 @@ def set_count(id_list: List[int], controller: Any, new_count: int) -> None:
         msg = messages[id]
 
         if msg['type'] == 'stream':
-            unread_id = messages[id]['stream_id']
-            stream_topic = (unread_id, msg['subject'])  # type: Tuple[int, str]
-            if stream_topic in unread_counts['unread_topics']:
-                unread_counts['unread_topics'][stream_topic] += new_count
-                if unread_counts['unread_topics'][stream_topic] == 0:
-                    unread_counts['unread_topics'].pop(stream_topic)
+            key_topic = (messages[id]['stream_id'], msg['subject'])
+            if key_topic in unread_counts['unread_topics']:
+                unread_counts['unread_topics'][key_topic] += new_count
+                if unread_counts['unread_topics'][key_topic] == 0:
+                    unread_counts['unread_topics'].pop(key_topic)
             elif new_count == 1:
-                unread_counts['unread_topics'][stream_topic] = new_count
+                unread_counts['unread_topics'][key_topic] = new_count
         else:
-            unread_id = messages[id]['sender_id']
-            if unread_id in unread_counts['unread_pms']:
-                unread_counts['unread_pms'][unread_id] += new_count
-                if unread_counts['unread_pms'][unread_id] == 0:
-                    unread_counts['unread_pms'].pop(unread_id)
+            key_pm = messages[id]['sender_id']
+            if key_pm in unread_counts['unread_pms']:
+                unread_counts['unread_pms'][key_pm] += new_count
+                if unread_counts['unread_pms'][key_pm] == 0:
+                    unread_counts['unread_pms'].pop(key_pm)
             elif new_count == 1:
-                unread_counts['unread_pms'][unread_id] = new_count
+                unread_counts['unread_pms'][key_pm] = new_count
 
     # if view is not yet loaded. Usually the case when first message is read.
     while not hasattr(controller, 'view'):


### PR DESCRIPTION
This effort started as an attempt to simplify `set_count`, and in doing so the code looks a lot clearer.

Some of these commits could likely be combined, but since this code isn't well-tested in CI then I've left them separate for now to enhance clarity.

Two commits should address apparent bugs:
* Don't add counts to the total if it's muted
* Only reduce unread counts if the server reports success on marking messages as read