### PR TITLE
Fixes issues regarding muted streams. 

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -18,6 +18,7 @@ from zulipterminal.config.keys import keys_for_command
 from urwid import AttrWrap, Columns, Padding, Text
 
 VIEWS = "zulipterminal.ui_tools.views"
+TOPBUTTON = "zulipterminal.ui_tools.buttons.TopButton"
 
 
 class TestMessageView:
@@ -782,6 +783,7 @@ class TestLeftColumnView:
         pm_button = mocker.patch(VIEWS + ".PMButton")
         mocker.patch(VIEWS + ".urwid.ListBox")
         mocker.patch(VIEWS + ".urwid.SimpleFocusListWalker")
+        mocker.patch(TOPBUTTON + ".set_muted_streams")
         left_col_view = LeftColumnView(width, self.view)
         home_button.assert_called_once_with(left_col_view.controller,
                                             count=2, width=width)
@@ -798,6 +800,7 @@ class TestLeftColumnView:
         stream_view = mocker.patch(VIEWS + '.StreamsView')
         line_box = mocker.patch(VIEWS + '.urwid.LineBox')
         divider = mocker.patch(VIEWS + '.urwid.Divider')
+        mocker.patch(TOPBUTTON + ".set_muted_streams")
 
         left_col_view = LeftColumnView(width, self.view)
 
@@ -1210,6 +1213,7 @@ class TestTopButton:
     def test_text_content(self, mocker,
                           prefix,
                           width, count, short_text, caption='caption'):
+        mocker.patch(TOPBUTTON + ".set_muted_streams")
         show_function = mocker.Mock()
 
         if isinstance(prefix, tuple):
@@ -1278,6 +1282,7 @@ class TestStreamButton:
     def test_text_content(self, mocker,
                           is_private, expected_prefix,
                           width, count, short_text, caption='caption'):
+        mocker.patch(TOPBUTTON + ".set_muted_streams")
         properties = [caption, 5, '#ffffff', is_private]
         view_mock = mocker.Mock()
         view_mock.palette = [(None, 'black', 'white')]
@@ -1300,6 +1305,7 @@ class TestStreamButton:
         '#ffffff', '#f0f0f0', '#f0f1f2', '#fff'
     ])
     def test_color_formats(self, mocker, color):
+        mocker.patch(TOPBUTTON + ".set_muted_streams")
         properties = ["", 1, color, False]  # only color is important
         view_mock = mocker.Mock()
         background = (None, 'white', 'black')
@@ -1365,6 +1371,7 @@ class TestUserButton:
     ])
     def test_text_content(self, mocker,
                           width, count, short_text, caption='caption'):
+        mocker.patch(TOPBUTTON + ".set_muted_streams")
         user = {
             'email': 'some_email',  # value unimportant
             'user_id': 5,           # value unimportant

--- a/tests/ui/test_utils.py
+++ b/tests/ui/test_utils.py
@@ -110,6 +110,14 @@ def test_is_muted(mocker, msg, narrow, muted_streams, muted_topics, muted):
         [1],
         None,
         True,
+        1,
+    ),
+    (
+        # Don't show in 'All messages'
+        [],
+        [1],
+        None,
+        True,
         0,
     )
 ])

--- a/tests/ui/test_utils.py
+++ b/tests/ui/test_utils.py
@@ -86,27 +86,11 @@ def test_is_muted(mocker, msg, narrow, muted_streams, muted_topics, muted):
     assert return_value is muted
 
 
-@pytest.mark.parametrize('narrow, index, messages, focus_msg_id, muted,\
+@pytest.mark.parametrize('narrow, messages, focus_msg_id, muted,\
                          len_w_list', [
     (
         # No muted messages
         [],
-        {
-            'all_messages': {1, 2},
-            'messages': {
-                1: {
-                    'id': 1,
-                    'flags': ['read'],
-                    'timestamp': 10,
-                },
-                2: {
-                    'id': 2,
-                    'flags': [],
-                    'timestamp': 10,
-                }
-            },
-            'pointer': {},
-        },
         None,
         None,
         False,
@@ -115,22 +99,6 @@ def test_is_muted(mocker, msg, narrow, muted_streams, muted_topics, muted):
     (
         # No muted messages
         [['stream', 'foo']],
-        {
-            'all_messages': {1, 2},
-            'messages': {
-                1: {
-                    'id': 1,
-                    'flags': ['read'],
-                    'timestamp': 10,
-                },
-                2: {
-                    'id': 2,
-                    'flags': [],
-                    'timestamp': 10,
-                }
-            },
-            'pointer': {},
-        },
         [1],
         None,
         False,
@@ -139,33 +107,32 @@ def test_is_muted(mocker, msg, narrow, muted_streams, muted_topics, muted):
     (
         # No muted messages
         [['stream', 'foo']],
-        {
-            'all_messages': {1, 2},
-            'messages': {
-                1: {
-                    'id': 1,
-                    'flags': ['read'],
-                    'timestamp': 10,
-                },
-                2: {
-                    'id': 2,
-                    'flags': [],
-                    'timestamp': 10,
-                }
-            },
-            'pointer': {},
-        },
         [1],
         None,
         True,
         0,
     )
 ])
-def test_create_msg_box_list(mocker, narrow, index,  messages, focus_msg_id,
+def test_create_msg_box_list(mocker, narrow, messages, focus_msg_id,
                              muted, len_w_list):
     model = mocker.Mock()
     model.narrow = narrow
-    model.index = index
+    model.index = {
+        'all_messages': {1, 2},
+        'messages': {
+            1: {
+                'id': 1,
+                'flags': ['read'],
+                'timestamp': 10,
+            },
+            2: {
+                'id': 2,
+                'flags': [],
+                'timestamp': 10,
+            }
+        },
+        'pointer': {},
+        }
     msg_box = mocker.patch('zulipterminal.ui_tools.utils.MessageBox')
     mocker.patch('zulipterminal.ui_tools.utils.urwid.AttrMap',
                  return_value='MSG')

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -110,7 +110,6 @@ def set_count(id_list: List[int], controller: Any, new_count: int) -> None:
             stream_id = messages[id]['stream_id']
             for stream in streams:
                 if stream.stream_id in controller.model.muted_streams:
-                    stream.update_count(-1)
                     add_to_counts = False  # if muted, don't add to eg. all_msg
                     break
                 if stream.stream_id == stream_id:

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -108,13 +108,13 @@ def set_count(id_list: List[int], controller: Any, new_count: int) -> None:
         add_to_counts = True
         if msg_type == 'stream':
             stream_id = messages[id]['stream_id']
-            for stream in streams:
-                if stream.stream_id in controller.model.muted_streams:
-                    add_to_counts = False  # if muted, don't add to eg. all_msg
-                    break
-                if stream.stream_id == stream_id:
-                    stream.update_count(stream.count + new_count)
-                    break
+            if stream_id in controller.model.muted_streams:
+                add_to_counts = False  # if muted, don't add to eg. all_msg
+            else:
+                for stream in streams:
+                    if stream.stream_id == stream_id:
+                        stream.update_count(stream.count + new_count)
+                        break
         else:
             for user in users:
                 if user.user_id == user_id:

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -29,7 +29,13 @@ class TopButton(urwid.Button):
         super().__init__("")
         self._w = self.widget(count)
         self.controller = controller
+        self.set_muted_streams()
         urwid.connect_signal(self, 'click', self.activate)
+
+    def set_muted_streams(self) -> None:
+        if self.caption in [self.controller.model.stream_dict[ele]['name']
+                            for ele in self.controller.model.muted_streams]:
+            self.update_count(-1)
 
     def update_count(self, count: int) -> None:
         self.count = count

--- a/zulipterminal/ui_tools/utils.py
+++ b/zulipterminal/ui_tools/utils.py
@@ -24,7 +24,8 @@ def create_msg_box_list(model: Any, messages: Union[None, Iterable[Any]]=None,
         # Remove messages of muted topics / streams.
         if is_muted(msg, model):
             muted_msgs += 1
-            continue
+            if model.narrow == []:  # Don't show in 'All messages'.
+                continue
 
         msg_flag = 'unread'  # type: Union[str, None]
         flags = msg.get('flags')


### PR DESCRIPTION
The following patch is a step in the direction of fixing issues in Muted streams. 
It mainly focuses on the following thing:
* Ensures that muted streams are marked as such. ('M')
* Displays the messages in muted streams.
* Fixes the crash on pressing `Up` button on muted streams.

Fixes: #272, #236 