### PR TITLE
Support #fff style for stream colors on older zulip servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Set terminal locale to `utf-8` by default which removes issues with rendering double width characters.
 - Avoid crash on receiving multiple starred-message events
 - Fix quoting original message, not rendered version 
+- Avoid crash by supporting short color format for streams from older Zulip servers
 
 ### Infrastructure changes
 - Improve installation, development & troubleshooting notes in README

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1296,6 +1296,43 @@ class TestStreamButton:
         assert len(text[0]) == len(expected_text) == (width - 1)
         assert text[0] == expected_text
 
+    @pytest.mark.parametrize('color', [
+        '#ffffff', '#f0f0f0', '#f0f1f2', '#fff'
+    ])
+    def test_color_formats(self, mocker, color):
+        properties = ["", 1, color, False]  # only color is important
+        view_mock = mocker.Mock()
+        background = (None, 'white', 'black')
+        view_mock.palette = [background]
+
+        stream_button = StreamButton(properties,
+                                     controller=mocker.Mock(),
+                                     view=view_mock,
+                                     width=10,
+                                     count=5)
+
+        expected_palette = ([background] +
+                            [('#fff', '', '', '', '#fff, bold', 'black')] +
+                            [('s#fff', '', '', '', 'black', '#fff')])
+        assert view_mock.palette == expected_palette
+
+    @pytest.mark.parametrize('color', [
+        '#', '#f', '#ff', '#ffff', '#fffff', '#fffffff'
+    ])
+    def test_invalid_color_format(self, mocker, color):
+        properties = ["", 1, color, False]  # only color is important
+        view_mock = mocker.Mock()
+        background = (None, 'white', 'black')
+        view_mock.palette = [background]
+
+        with pytest.raises(RuntimeError) as e:
+            StreamButton(properties,
+                         controller=mocker.Mock(),
+                         view=view_mock,
+                         width=10,
+                         count=5)
+        assert str(e.value) == "Unknown color format: '{}'".format(color)
+
 
 class TestUserButton:
     @pytest.mark.parametrize('width, count, short_text', [

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -104,7 +104,13 @@ class StreamButton(TopButton):
 
         # Simplify the color from the original version & add to palette
         # TODO Should this occur elsewhere and more intelligently?
-        color = ''.join(orig_color[i] for i in (0, 1, 3, 5))  # 0 -> '#'
+        if len(orig_color) == 7:  # modern zulip server format
+            color = ''.join(orig_color[i] for i in (0, 1, 3, 5))
+        elif len(orig_color) == 4:  # possible with zulip servers <=1.9.0 ?
+            color = orig_color
+        else:
+            raise RuntimeError("Unknown color format: '{}'".format(orig_color))
+
         for entry in view.palette:
             if entry[0] is None:
                 background = entry[5] if len(entry) > 4 else entry[2]


### PR DESCRIPTION
Fixes #273.

Add tests.
Add note to CHANGELOG.

@n-cc I placed this in a pull-request to make things easier :)