### PR TITLE
requirements: Explicitly install tornado ~5.1 for snakeviz on py 3.4.

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -19,5 +19,6 @@ pytest-pep8 = "==1.0.6"
 pytest-mock = "==1.7.1"
 pytest-cov = "==2.5.1"
 pudb = "==2017.1.4"
+tornado = "~=5.1"  # For snakeviz, python 3.4+
 snakeviz = "==0.4.2"
 mypy = "==0.641"

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ pytest-cov==2.5.1
 pytest-pep8==1.0.6
 pytest-mock==1.7.1
 pudb==2017.1.4
+tornado~=5.1
 snakeviz==0.4.2
 mypy==0.641
 emoji==0.5.0

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ testing_deps = [
 dev_helper_deps = [
     'mypy==0.641',
     'pudb==2017.1.4',
+    'tornado~=5.1',
     'snakeviz==0.4.2',
 ]
 


### PR DESCRIPTION
The latest tornado is now 6.0, which doesn't support python 3.5.

Rather than remove snakeviz or only install in some python versions, this requires installation of the earlier tornado version, which is still available.