### PR TITLE
model: Re-render messages after editing.

### DIFF
--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -587,11 +587,12 @@ class TestModel:
         ({
             'message_id': 1,
             'content': 'Foo is Boo',
+            'rendered_content': '<p>Foo is Boo</p>'
         }, {
             'messages': {
                 1: {
                     'id': 1,
-                    'content': 'Boo is Foo',
+                    'content': 'Boo is Foo'
                 },
                 2: {
                     'id': 2,
@@ -611,7 +612,8 @@ class TestModel:
         mocker.patch('zulipterminal.model.create_msg_box_list',
                      return_value=[mock_msg])
         model.update_message(response)
-        assert model.index['messages'][1]['content'] == response['content']
+        assert model.index['messages'][1]['content'] == \
+            response['rendered_content']
         assert model.msg_list.log[0] == mock_msg
         self.controller.update_screen.assert_called_once_with()
 

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -41,6 +41,7 @@ Event = TypedDict('Event', {
     'message_id': int,
     # update_message:
     'content': str,
+    'rendered_content': str,
     # update_message_flags:
     'messages': List[int],
     'operation': str,
@@ -532,7 +533,7 @@ class Model:
             return
 
         message_id = response['message_id']
-        content = response['content']
+        content = response['rendered_content']
         # If the message is indexed
         if self.index['messages'][message_id] != {}:
             message = self.index['messages'][message_id]


### PR DESCRIPTION
Display the rendered version of a messages instead
of the 'raw' message, after they are edited.

Tests amended.

Fixes: #308