### PR TITLE
Fix recipient email footer for self-messages

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -850,9 +850,17 @@ class TestMessageBox:
     ])
     def test_init(self, mocker, message_type, set_fields):
         mocker.patch.object(MessageBox, 'main_view')
-        message = dict(display_recipient=['x'], stream_id=5, subject='hi',
-                       sender_email='foo@zulip.com', sender_id=4209,
-                       type=message_type)
+        message = dict(display_recipient=[
+            {
+                'id': 7,
+                'email': 'boo@zulip.com',
+                'full_name': 'Boo is awesome'
+            }],
+            stream_id=5,
+            subject='hi',
+            sender_email='foo@zulip.com',
+            sender_id=4209,
+            type=message_type)
 
         msg_box = MessageBox(message, self.model, None)
 

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -19,6 +19,7 @@ from urwid import AttrWrap, Columns, Padding, Text
 
 VIEWS = "zulipterminal.ui_tools.views"
 TOPBUTTON = "zulipterminal.ui_tools.buttons.TopButton"
+MESSAGEBOX = "zulipterminal.ui_tools.boxes.MessageBox"
 
 
 class TestMessageView:
@@ -873,6 +874,27 @@ class TestMessageBox:
 
         with pytest.raises(RuntimeError):
             msg_box = MessageBox(message, self.model, None)
+
+    def test_private_message_to_self(self, mocker):
+        message = dict(
+            type='private',
+            display_recipient=[{'full_name': 'Foo Foo',
+                                'email': 'foo@zulip.com',
+                                'id': None}],
+            sender_id=9,
+            content="<p> self message. </p>",
+            sender_full_name='Foo Foo',
+            sender_email='foo@zulip.com',
+            timestamp=150989984,
+        )
+        self.model.user_email = 'foo@zulip.com'
+        mocker.patch(MESSAGEBOX + '._is_private_message_to_self',
+                     return_value=True)
+        mocker.patch.object(MessageBox, 'main_view')
+        msg_box = MessageBox(message, self.model, None)
+
+        assert msg_box.recipients_emails == 'foo@zulip.com'
+        msg_box._is_private_message_to_self.assert_called_once_with()
 
     @pytest.mark.parametrize('content, markup', [
         ('', []),

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -141,16 +141,21 @@ class MessageBox(urwid.Pile):
             raise RuntimeError("Invalid message type")
 
         if self.message['type'] == 'private':
-            self.recipients_names = ', '.join(list(
-                        recipient['full_name']
-                        for recipient in self.message['display_recipient']
-                        if recipient['email'] != self.model.user_email
-                    ))
-            self.recipients_emails = ', '.join(list(
-                        recipient['email']
-                        for recipient in self.message['display_recipient']
-                        if recipient['email'] != self.model.user_email
-                    ))
+            if self._is_private_message_to_self():
+                self.recipients_names = \
+                    self.message['display_recipient'][0]['full_name']
+                self.recipients_emails = self.model.user_email
+            else:
+                self.recipients_names = ', '.join(list(
+                            recipient['full_name']
+                            for recipient in self.message['display_recipient']
+                            if recipient['email'] != self.model.user_email
+                        ))
+                self.recipients_emails = ', '.join(list(
+                            recipient['email']
+                            for recipient in self.message['display_recipient']
+                            if recipient['email'] != self.model.user_email
+                        ))
 
         super(MessageBox, self).__init__(self.main_view())
 
@@ -179,6 +184,12 @@ class MessageBox(urwid.Pile):
         else:
             raise RuntimeError("Invalid message type")
 
+    def _is_private_message_to_self(self) -> bool:
+        recipient_list = self.message['display_recipient']
+        return len(recipient_list) == 1 and \
+            recipient_list[0]['email'] == \
+            self.model.user_email
+
     def stream_header(self) -> Any:
         bar_color = self.model.stream_dict[self.stream_id]['color']
         bar_color = 's' + bar_color[:2] + bar_color[3] + bar_color[5]
@@ -192,6 +203,9 @@ class MessageBox(urwid.Pile):
         return header
 
     def private_header(self) -> Any:
+        if self._is_private_message_to_self():
+            self.recipients_names = \
+                self.message['display_recipient'][0]['full_name']
         title_markup = ('header', [
             ('custom', 'Private Messages with'),
             ('selected', ": "),


### PR DESCRIPTION
Reproduce bug: 
* Narrow to PM with yourself.
* click HotKey 'r' or 'c' on any of the messages sent.
* A footer appears with no email address in `To:` field.

Fix: 
* We explicitly check if a message is self message. We create a special recipient list for this.

(This Bug fix was solved as a part of #278. But to avoid bug-fix amidst feature adds, it was moved to this separate PR)