### PR TITLE
Model: Consolidate register calls & improve error handling

### DIFF
--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -296,32 +296,9 @@ class Model:
                                                 num_after=10,
                                                 num_before=30,
                                                 anchor=None),
+                'register': executor.submit(self._register_desired_events,
+                                            fetch_data=True),
             }  # Dict[str, Future[Any]]
-            try:
-                response = self.client.register(
-                    event_types=Model.event_types,
-                    fetch_event_types=[
-                        'presence',
-                        'subscription',
-                        'message',
-                        'update_message_flags',
-                        'muted_topics',
-                        'realm_user',  # Enables cross_realm_bots
-                    ],
-                    client_gravatar=True,
-                    apply_markdown=True,
-                )
-                self.initial_data.update(response)
-                self.max_message_id = response['max_message_id']
-                self.queue_id = response['queue_id']
-                self.last_event_id = response['last_event_id']
-            except zulip.ZulipError as e:
-                raise ServerConnectionFailure(e)
-            except Exception as e:
-                # There was some error in the request sent.
-                if response['result'] == 'error':
-                    e.extra_info = response['msg']  # type: ignore
-                raise e
 
             # Wait for threads to complete
             wait(futures.values())  # type: ignore

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -608,15 +608,26 @@ class Model:
                 self.msg_list.log[msg_pos] = new_msg_w
                 self.controller.update_screen()
 
-    def _register_desired_events(self) -> bool:
+    def _register_desired_events(self, *, fetch_data: bool=False) -> bool:
+        fetch_types = None if not fetch_data else [
+            'presence',
+            'subscription',
+            'message',
+            'update_message_flags',
+            'muted_topics',
+            'realm_user',  # Enables cross_realm_bots
+        ]
         try:
             response = self.client.register(event_types=Model.event_types,
+                                            fetch_event_types=fetch_types,
                                             client_gravatar=True,
                                             apply_markdown=True)
         except zulip.ZulipError:
             return False
 
         if response['result'] == 'success':
+            if fetch_data:
+                self.initial_data.update(response)
             self.max_message_id = response['max_message_id']
             self.queue_id = response['queue_id']
             self.last_event_id = response['last_event_id']

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -625,14 +625,17 @@ class Model:
 
     @asynch
     def poll_for_events(self) -> None:
+        reregister_timeout = 10
         queue_id = self.queue_id
         last_event_id = self.last_event_id
         while True:
             if queue_id is None:
-                if not self._register_desired_events():
-                    raise ServerConnectionFailure("register desired events")
-                queue_id = self.queue_id
-                last_event_id = self.last_event_id
+                while True:
+                    if self._register_desired_events():
+                        queue_id = self.queue_id
+                        last_event_id = self.last_event_id
+                        break
+                    time.sleep(reregister_timeout)
 
             response = self.client.get_events(
                 queue_id=queue_id,


### PR DESCRIPTION
This is a follow-up on some earlier refactoring I worked on, inspired by a bug-report by @omi10859 on the #zulip-terminal stream recently. This is not directly targeted at this bug, but brings all the event-registration code into one method, which was previously only used for re-registration, with common error-handling too. This also adds retries for re-connecting, since previously if this failed we just raised an Exception (leaving the thread boundary!)