### PR TITLE
Display 'Edited' label for edited messages.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -415,6 +415,7 @@ def empty_index():
         'all_private': set(),
         'all_stream': defaultdict(set, {}),
         'stream': defaultdict(dict, {}),
+        'edited_messages': set(),
         'search': set(),
         'all_starred': set(),
         'messages': defaultdict(dict, {

--- a/tests/helper/test_helper.py
+++ b/tests/helper/test_helper.py
@@ -84,6 +84,34 @@ def test_index_messages_narrow_user_multiple(mocker,
     assert index_messages(messages, model, model.index) == index_user_multiple
 
 
+@pytest.mark.parametrize('edited_msgs', [
+    {537286, 537287, 537288},
+    {537286}, {537287}, {537288},
+    {537286, 537287}, {537286, 537288}, {537287, 537288},
+])
+def test_index_edited_message(mocker,
+                              messages_successful_response,
+                              empty_index,
+                              edited_msgs,
+                              initial_index):
+    messages = messages_successful_response['messages']
+    for msg in messages:
+        if msg['id'] in edited_msgs:
+            msg['edit_history'] = []
+    model = mocker.patch('zulipterminal.model.Model.__init__',
+                         return_value=None)
+    model.index = initial_index
+    model.narrow = []
+
+    expected_index = dict(empty_index, edited_messages=edited_msgs,
+                          all_messages={537286, 537287, 537288})
+    for msg_id, msg in expected_index['messages'].items():
+        if msg_id in edited_msgs:
+            msg['edit_history'] = []
+
+    assert index_messages(messages, model, model.index) == expected_index
+
+
 @pytest.mark.parametrize('msgs_with_stars', [
     {537286, 537287, 537288},
     {537286}, {537287}, {537288},

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -597,7 +597,8 @@ class TestModel:
                     'id': 2,
                     'content': "Boo is not Foo"
                 }
-            }
+            },
+            'edited_messages': set()
         })
     ])
     def test_update_message(self, mocker, model, response, index):
@@ -614,6 +615,8 @@ class TestModel:
         assert model.index['messages'][1]['content'] == \
             response['rendered_content']
         assert model.msg_list.log[0] == mock_msg
+        # Test for updation of edited_message in index
+        assert model.index['edited_messages'] == {1}
         self.controller.update_screen.assert_called_once_with()
 
         # TEST FOR FALSE CASES

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -842,8 +842,9 @@ class TestHelpMenu:
 
 class TestMessageBox:
     @pytest.fixture(autouse=True)
-    def mock_external_classes(self, mocker):
+    def mock_external_classes(self, mocker, initial_index):
         self.model = mocker.Mock()
+        self.model.index = initial_index
 
     @pytest.mark.parametrize('message_type, set_fields', [
         ('stream', [('caption', ''), ('stream_id', None), ('title', '')]),
@@ -943,7 +944,7 @@ class TestMessageBox:
     ])
     def test_soup2markup(self, content, markup):
         message = dict(display_recipient=['x'], stream_id=5, subject='hi',
-                       sender_email='foo@zulip.com', sender_id=4209,
+                       sender_email='foo@zulip.com', id=4, sender_id=4209,
                        type='stream',  # NOTE Output should not vary with PM
                        flags=[], content=content, sender_full_name='bob smith',
                        timestamp=99, reactions=[])
@@ -1027,6 +1028,7 @@ class TestMessageBox:
 
     @pytest.mark.parametrize('message', [
         {
+            'id': 4,
             'type': 'stream',
             'display_recipient': 'Verona',
             'stream_id': 5,
@@ -1062,6 +1064,7 @@ class TestMessageBox:
 
     @pytest.mark.parametrize('message', [
         {
+            'id': 4,
             'type': 'private',
             'sender_email': 'iago@zulip.com',
             'sender_id': 5,
@@ -1114,6 +1117,7 @@ class TestMessageBox:
     # Assume recipient (PM/stream/topic) header is unchanged below
     @pytest.mark.parametrize('message', [
         {
+            'id': 4,
             'type': 'stream',
             'display_recipient': 'Verona',
             'stream_id': 5,
@@ -1194,11 +1198,21 @@ class TestMessageBox:
             'common_unchanged_message', 'both_starred'])
     def test_main_view_compact_output(self, mocker, message,
                                       to_vary_in_each_message):
+        message.update({'id': 4})
         varied_message = dict(message, **to_vary_in_each_message)
         msg_box = MessageBox(varied_message, self.model, varied_message)
         view_components = msg_box.main_view()
         assert len(view_components) == 1
         assert isinstance(view_components[0], Padding)
+
+    def test_main_view_generates_EDITED_label(self, mocker,
+                                              messages_successful_response):
+        messages = messages_successful_response['messages']
+        for message in messages:
+            self.model.index['edited_messages'].add(message['id'])
+            msg_box = MessageBox(message, self.model, message)
+            view_components = msg_box.main_view()
+            assert view_components[0].original_widget.contents[0][1][1] == 11
 
 
 class TestTopButton:

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -21,6 +21,7 @@ Index = TypedDict('Index', {
     'all_starred': Set[int],  # {message_id, ...}
     'all_private': Set[int],  # {message_id, ...}
     'all_stream': Dict[int, Set[int]],  # stream_id: {message_id, ...}
+    'edited_messages': Set[int],  # {message_ids, ...}
     'search': Set[int],  # {message_id, ...}
     'messages': Dict[int, Message],  # message_id: Message
 })
@@ -32,6 +33,7 @@ initial_index = Index(
     all_messages=set(),
     all_private=set(),
     all_stream=defaultdict(set),
+    edited_messages=set(),
     messages=defaultdict(dict),
     search=set(),
     all_starred=set(),
@@ -181,7 +183,12 @@ def index_messages(messages: List[Any],
                 23423,
                 ...
             }
-        }
+        },
+        'edited_messages':{
+            51234,
+            23423,
+            ...
+        },
         'search': {
             13242,
             23423,
@@ -245,6 +252,9 @@ def index_messages(messages: List[Any],
     """
     narrow = model.narrow
     for msg in messages:
+
+        if 'edit_history' in msg.keys():
+            index['edited_messages'].add(msg['id'])
 
         index['messages'][msg['id']] = msg
         if not narrow:

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -515,6 +515,7 @@ class Model:
             message = self.index['messages'][message_id]
             message['content'] = content
             self.index['messages'][message_id] = message
+            self.index['edited_messages'].add(message_id)
             self.update_rendered_view(message_id)
 
     def update_reaction(self, response: Event) -> None:

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -402,15 +402,27 @@ class MessageBox(urwid.Pile):
         soup = BeautifulSoup(self.message['content'], 'lxml')
         content = (None, self.soup2markup(soup.find(name='body')))
         active_char = '▒'  # Options are '█', '▓', '▒', '░'
+
+        if self.message['id'] in self.model.index['edited_messages']:
+            edited_label_size = 11
+            left_padding = 1
+        else:
+            edited_label_size = 0
+            left_padding = 12
+
         content = urwid.Padding(
-            urwid.LineBox(
-                urwid.Columns([
-                    (1, urwid.Text('')),
-                    urwid.Text(content),
-                ]), tline='', bline='', rline='', lline=active_char
-            ),
-            align='left', left=15, width=('relative', 100),
-            min_width=50, right=8)
+            urwid.Columns([
+                (edited_label_size,
+                 urwid.Text('(EDITED)')),
+                urwid.LineBox(
+                    urwid.Columns([
+                        (1, urwid.Text('')),
+                        urwid.Text(content),
+                    ]), tline='', bline='', rline='', lline=active_char
+                )
+            ]),
+            align='left', left=left_padding,
+            width=('relative', 100), min_width=10, right=8)
 
         # Reactions
         reactions = self.reactions_view(self.message['reactions'])


### PR DESCRIPTION
According to conversation https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/Design.20for.20edit.20message/near/720136 
We use the '(EDITED)' label to mark those messages which have previously been edited. 
The message layout now looks like this : 
![edited_whole](https://user-images.githubusercontent.com/30312566/54692758-85be9180-4b4b-11e9-8c5d-633858237405.png)
 