### PR TITLE
Shows/updates content header for message when starred

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1252,8 +1252,12 @@ class TestMessageBox:
         varied_message = dict(message, **to_vary_in_each_message)
         msg_box = MessageBox(varied_message, self.model, varied_message)
         view_components = msg_box.main_view()
-        assert len(view_components) == 1
-        assert isinstance(view_components[0], Padding)
+        if to_vary_in_each_message == {'flags': ['starred']}:
+            assert len(view_components) == 2
+            assert isinstance(view_components[1], Padding)
+        else:
+            assert len(view_components) == 1
+            assert isinstance(view_components[0], Padding)
 
     def test_main_view_generates_EDITED_label(self, mocker,
                                               messages_successful_response):


### PR DESCRIPTION
Part of #171

Splits and shows content header for a message (having a similar timestamp as the previous message(s)) when starred.

For multiple messages in succession having similar timestamps, initially, often times, it would not show that a message is starred when the user presses `*`, although it updates on other Zulip platforms.

Now, however, in such cases, the message is shown as starred along with the timestamp of that message.

~~_What's left:_ When a message is starred, the messages following it do not split from the starred message, making it difficult for the user to figure out if it is one big message which is starred or if there are multiple messages and only one is starred.~~ Fixed.