### PR TITLE
Use response from server to update user list after application has started.

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -694,6 +694,16 @@ class TestRightColumnView:
         right_col_view.users_view.assert_called_with(assert_list)
         set_body.assert_called_once_with(right_col_view.body)
 
+    def test_update_user_presence(self, right_col_view, mocker,
+                                  user_list):
+        set_body = mocker.patch(VIEWS + ".urwid.Frame.set_body")
+
+        right_col_view.update_user_list(user_list=user_list)
+
+        right_col_view.search_lock.acquire.assert_called_once_with()
+        right_col_view.users_view.assert_called_with(user_list)
+        set_body.assert_called_once_with(right_col_view.body)
+
     @pytest.mark.parametrize('users, users_btn_len, editor_mode, status', [
         (None, 1, False, 'active'),
         ([{

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -189,6 +189,16 @@ class Model:
             current_ids = self.index['all_starred']
         return current_ids.copy()
 
+    def _notify_server_of_presence(self) -> None:
+        response = self.client.update_presence(
+                request={
+                    # TODO: Determinal `status` from terminal tab focus.
+                    'status': 'active' if self.new_user_input else 'idle',
+                    'new_user_input': self.new_user_input,
+                }
+            )
+        self.new_user_input = False
+
     @asynch
     def _start_presence_updates(self) -> None:
         """
@@ -198,14 +208,7 @@ class Model:
         # FIXME: Version 2: call endpoint with ping_only=True only when
         #        needed, and rely on presence events to update
         while True:
-            response = self.client.update_presence(
-                request={
-                    # TODO: Determinal `status` from terminal tab focus.
-                    'status': 'active' if self.new_user_input else 'idle',
-                    'new_user_input': self.new_user_input,
-                }
-            )
-            self.new_user_input = False
+            self._notify_server_of_presence()
             time.sleep(60)
 
     @asynch

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -189,7 +189,7 @@ class Model:
             current_ids = self.index['all_starred']
         return current_ids.copy()
 
-    def _notify_server_of_presence(self) -> None:
+    def _notify_server_of_presence(self) -> Dict[str, Any]:
         response = self.client.update_presence(
                 request={
                     # TODO: Determinal `status` from terminal tab focus.
@@ -198,17 +198,24 @@ class Model:
                 }
             )
         self.new_user_input = False
+        return response
 
     @asynch
     def _start_presence_updates(self) -> None:
         """
-        Notify server of user's presence each minute (version 1a)
+        Call `_notify_server_of_presence` every minute (version 1a).
+        Use 'response' to update user list (version 1b).
         """
-        # FIXME: version 1b: Also use 'response' to update user list
         # FIXME: Version 2: call endpoint with ping_only=True only when
         #        needed, and rely on presence events to update
         while True:
-            self._notify_server_of_presence()
+            response = self._notify_server_of_presence()
+            if response['result'] == 'success':
+                self.initial_data['presences'] = response['presences']
+                self.users = self.get_all_users()
+                if hasattr(self.controller, 'view'):
+                    self.controller.view.users_view.update_user_list(
+                        user_list=self.users)
             time.sleep(60)
 
     @asynch

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -411,17 +411,27 @@ class RightColumnView(urwid.Frame):
                                               header=search_box)
 
     @asynch
-    def update_user_list(self, search_box: Any, new_text: str) -> None:
-        if not self.view.controller.editor_mode:
+    def update_user_list(self, search_box: Any=None,
+                         new_text: str="",
+                         user_list: Any=None) -> None:
+
+        assert ((user_list is None and search_box is not None) or
+                (user_list is not None and search_box is None and
+                 new_text == ""))
+
+        if not self.view.controller.editor_mode and not user_list:
             return
         # wait for any previously started search to finish to avoid
         # displaying wrong user list.
         self.search_lock.acquire()
+        if user_list:
+            self.view.users = user_list
         users = self.view.users.copy()
         users_display = users.copy()
-        for user in users:
-            if not match_user(user, new_text):
-                users_display.remove(user)
+        if new_text:
+            for user in users:
+                if not match_user(user, new_text):
+                    users_display.remove(user)
         self.body = self.users_view(users_display)
         self.set_body(self.body)
         self.view.controller.update_screen()

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -406,6 +406,7 @@ class RightColumnView(urwid.Frame):
             trcorner=u'─', blcorner=u'─', rline=u'',
             bline=u'─', brcorner=u'─'
             )
+        self.allow_update_user_list = True
         self.search_lock = threading.Lock()
         super(RightColumnView, self).__init__(self.users_view(),
                                               header=search_box)
@@ -420,6 +421,8 @@ class RightColumnView(urwid.Frame):
                  new_text == ""))
 
         if not self.view.controller.editor_mode and not user_list:
+            return
+        if not self.allow_update_user_list and new_text == "":
             return
         # wait for any previously started search to finish to avoid
         # displaying wrong user list.
@@ -470,9 +473,11 @@ class RightColumnView(urwid.Frame):
 
     def keypress(self, size: Tuple[int, int], key: str) -> str:
         if is_command_key('SEARCH_PEOPLE', key):
+            self.allow_update_user_list = False
             self.set_focus('header')
             return key
         elif is_command_key('GO_BACK', key):
+            self.allow_update_user_list = True
             self.user_search.set_edit_text("Search People")
             self.body = UsersView(
                 urwid.SimpleFocusListWalker(self.users_btn_list))


### PR DESCRIPTION
Version 1a included only notifying the server of user presence. Version 1b now includes using the response obtained by the server to refresh the users list once the application has started.

Fixes: #330

**TODO**: Focus jumps to left column view at the interval of every minute. This is more likely to be because of `self.body = urwid.Columns(body, focus_column=0)` statement in `build_window_frame` function. Any suggestions on how to handle the jump?