### PR TITLE
[WIP] views/utils: Fetch last 30 non-muted messages.

### DIFF
--- a/zulipterminal/ui_tools/utils.py
+++ b/zulipterminal/ui_tools/utils.py
@@ -45,6 +45,9 @@ def create_msg_box_list(model: Any, messages: Union[None, Iterable[Any]]=None,
         last_msg = msg
     if focus_msg is not None:
         model.set_focus_in_current_narrow(focus_msg)
+    model.muted_msg_count = muted_msgs
+    if message_list:
+        model.last_msg_id = message_list[0]['id']
     return w_list
 
 

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -38,11 +38,29 @@ class MessageView(urwid.ListBox):
 
     def main_view(self) -> List[Any]:
         msg_btn_list = create_msg_box_list(self.model)
+        new_ids_to_process = self.model.get_message_ids_in_current_narrow()
+        msg_btn_list_without_muted_msgs = []  # type: List[Any]
+        while len(msg_btn_list_without_muted_msgs) < 30:
+            if (len(msg_btn_list_without_muted_msgs) +
+                    len(msg_btn_list) > 30):
+                msg_btn_list_without_muted_msgs[0:0] = msg_btn_list[len(
+                    msg_btn_list_without_muted_msgs):]
+            else:
+                msg_btn_list_without_muted_msgs[0:0] = msg_btn_list
+
+            old_ids_to_process = self.model.get_message_ids_in_current_narrow()
+            self.model.get_messages(
+                num_before=30, num_after=0, anchor=self.model.last_msg_id)
+            new_ids_to_process = (
+                self.model.get_message_ids_in_current_narrow() -
+                old_ids_to_process)
+            msg_btn_list = create_msg_box_list(self.model, new_ids_to_process)
+
         focus_msg = self.model.get_focus_in_current_narrow()
         if focus_msg == set():
             focus_msg = len(msg_btn_list) - 1
         self.focus_msg = focus_msg
-        return msg_btn_list
+        return msg_btn_list_without_muted_msgs
 
     @asynch
     def load_old_messages(self, anchor: int=10000000000) -> None:


### PR DESCRIPTION
Muted messages are not displayed in default All_message view. This causes less then 30 messages to be displayed in case there were any previous muted messages. We now keep on fetching until there are 30 non-muted messages, which can be displayed in default view.

(This is a step in the direction of solving #326)