### PR TITLE
boxes: Reduce message padding after introduction of (EDITED).

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1232,8 +1232,8 @@ class TestMessageBox:
             view_components = msg_box.main_view()
 
             label = view_components[0].original_widget.contents[0]
-            assert label[0].text == '(EDITED)'
-            assert label[1][1] == 11
+            assert label[0].text == 'EDITED'
+            assert label[1][1] == 7
 
 
 class TestTopButton:

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -463,16 +463,16 @@ class MessageBox(urwid.Pile):
         content = (None, self.soup2markup(body))
 
         if self.message['id'] in self.model.index['edited_messages']:
-            edited_label_size = 11
+            edited_label_size = 7
             left_padding = 1
         else:
             edited_label_size = 0
-            left_padding = 12
+            left_padding = 8
 
         content = urwid.Padding(
             urwid.Columns([
                 (edited_label_size,
-                 urwid.Text('(EDITED)')),
+                 urwid.Text('EDITED')),
                 urwid.LineBox(
                     urwid.Columns([
                         (1, urwid.Text('')),
@@ -481,7 +481,7 @@ class MessageBox(urwid.Pile):
                 )
             ]),
             align='left', left=left_padding,
-            width=('relative', 100), min_width=10, right=8)
+            width=('relative', 100), min_width=10, right=5)
 
         # Reactions
         reactions = self.reactions_view(self.message['reactions'])


### PR DESCRIPTION
This makes a little more space for the message text, but would appreciate what people think compared to master after the merge of #328.