### PR TITLE
BUGFIX: Fix sending to multiple recipients when narrowed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Avoid crash on receiving multiple starred-message events
 - Fix quoting original message, not rendered version 
 - Avoid crash by supporting short color format for streams from older Zulip servers
+- Avoid traceback on sending to multiple private recipients when narrowed to that conversation
 
 ### Infrastructure changes
 - Improve installation, development & troubleshooting notes in README

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -494,10 +494,11 @@ class Model:
             elif response['type'] == 'private' and len(self.narrow) == 1 and\
                     self.narrow[0][0] == "pm_with":
                 recipients = self.recipients
-                msg_recipients = frozenset([
-                    self.user_id,
-                    self.user_dict[self.narrow[0][1]]['user_id']
-                ])
+                users = self.narrow[0][1].split(", ")
+                msg_recipients = frozenset(
+                    [self.user_dict[user]['user_id'] for user in users] +
+                    [self.user_id]
+                )
                 if recipients == msg_recipients:
                     self.msg_list.log.append(msg_w)
             if 'read' not in response['flags']:


### PR DESCRIPTION
In Model.append_message we now split the recipient email string from the
narrow into a list which is mapped to frozenset of user-id, instead of
previously assuming we could look up the recipient string as a single
recipient email.

CHANGELOG.md updated.