### PR TITLE
model: Prevent user from reacting to their own message.

### DIFF
--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -240,6 +240,7 @@ class TestModel:
             for er in existing_reactions
         ]
         message = dict(
+            sender_id=5,  # any
             id=msg_id,
             reactions=full_existing_reactions)
         reaction_spec = dict(

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -205,6 +205,8 @@ class Model:
         # FIXME Only support thumbs_up for now
         assert reaction_to_toggle == 'thumbs_up'
 
+        if message['sender_id'] == self.user_id:
+            return
         reaction_to_toggle_spec = dict(
             emoji_name='thumbs_up',
             emoji_code='1f44d',


### PR DESCRIPTION
In the web-app users cannot react to their own message;
This is done by not providing the option in the UI;
We do a similar approach here by doing a noop when
the hotkey is used to react on a user's own message.

Tests amended.