### PR TITLE
Improve recipient bar layout and design

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -313,6 +313,14 @@ class TestMessageView:
         assert msg_view.model.index['messages'][1]['flags'] == ['read']
         self.model.mark_message_ids_as_read.assert_called_once_with([1])
 
+    def test_message_calls_search_and_header_bar(self, mocker, msg_view):
+        msg_w = mocker.MagicMock()
+        msg_w.original_widget.message = {'id': 1}
+        msg_view.update_search_box_narrow(msg_w.original_widget)
+        msg_w.original_widget.top_header_bar.assert_called_once_with
+        (msg_w.original_widget)
+        msg_w.original_widget.top_search_bar.assert_called_once_with()
+
     def test_read_message_no_msgw(self, mocker, msg_view):
         # MSG_W is NONE CASE
         msg_view.body.get_focus.return_value = (None, 0)

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1108,6 +1108,34 @@ class TestMessageBox:
         assert isinstance(view_components[1], Columns)
         assert isinstance(view_components[2], Padding)
 
+    @pytest.mark.parametrize('msg_narrow, msg_type, assert_header_bar,\
+                              assert_search_bar', [
+        ([['stream', 'PTEST']], 0, 'PTEST >', ('bar', [('s#bd6', 'PTEST')])),
+        ([['pm_with', 'boo@zulip.com']], 1, 'Private Messages with: ',
+         'Private conversation'),
+        ([['pm_with', 'boo@zulip.com, bar@zulip.com']], 2,
+         'Private Messages with: ', 'Group private conversation')
+    ])
+    def test_msg_generates_search_and_header_bar(self, mocker,
+                                                 messages_successful_response,
+                                                 msg_type, msg_narrow,
+                                                 assert_header_bar,
+                                                 assert_search_bar):
+        self.model.stream_dict = {
+            205: {
+                'color': '#bfd56f',
+            },
+        }
+        self.model.narrow = msg_narrow
+        messages = messages_successful_response['messages']
+        current_message = messages[msg_type]
+        msg_box = MessageBox(current_message, self.model, messages[0])
+        search_bar = msg_box.top_search_bar()
+        header_bar = msg_box.top_header_bar(msg_box)
+
+        assert header_bar.text.startswith(assert_header_bar)
+        assert search_bar.text_to_fill == assert_search_bar
+
     # Assume recipient (PM/stream/topic) header is unchanged below
     @pytest.mark.parametrize('message', [
         {

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -845,7 +845,7 @@ class TestHelpMenu:
 class TestMessageBox:
     @pytest.fixture(autouse=True)
     def mock_external_classes(self, mocker, initial_index):
-        self.model = mocker.Mock()
+        self.model = mocker.MagicMock()
         self.model.index = initial_index
 
     @pytest.mark.parametrize('message_type, set_fields', [

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1119,10 +1119,10 @@ class TestMessageBox:
     @pytest.mark.parametrize('msg_narrow, msg_type, assert_header_bar,\
                               assert_search_bar', [
         ([['stream', 'PTEST']], 0, 'PTEST >', ('bar', [('s#bd6', 'PTEST')])),
-        ([['pm_with', 'boo@zulip.com']], 1, 'Private Messages with: ',
+        ([['pm_with', 'boo@zulip.com']], 1, 'You and ',
          'Private conversation'),
         ([['pm_with', 'boo@zulip.com, bar@zulip.com']], 2,
-         'Private Messages with: ', 'Group private conversation')
+         'You and ', 'Group private conversation')
     ])
     def test_msg_generates_search_and_header_bar(self, mocker,
                                                  messages_successful_response,

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -43,7 +43,8 @@ class View(urwid.WidgetWrap):
     def message_view(self) -> Any:
         self.middle_column = MiddleColumnView(self, self.model, self.write_box,
                                               self.search_box)
-        return urwid.LineBox(self.middle_column, bline="")
+        return urwid.LineBox(self.middle_column, bline="",
+                             title=u'Messages', tline=u'─')
 
     def right_column_view(self) -> Any:
         self.users_view = RightColumnView(View.RIGHT_WIDTH, self)

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -219,6 +219,45 @@ class MessageBox(urwid.Pile):
         header.markup = title_markup
         return header
 
+    def top_header_bar(self, message_view: Any) -> Any:
+        if self.message['type'] == 'stream':
+            return message_view.stream_header()
+        else:
+            return message_view.private_header()
+
+    def top_search_bar(self) -> Any:
+        curr_narrow = self.model.narrow
+        if curr_narrow == []:
+            text_to_fill = 'All messages'
+        elif len(curr_narrow) == 1 and curr_narrow[0][1] == 'private':
+            text_to_fill = 'All private messages'
+        elif len(curr_narrow) == 1 and curr_narrow[0][1] == 'starred':
+            text_to_fill = 'Starred messages'
+        elif self.message['type'] == 'stream':
+            bar_color = self.model.stream_dict[self.stream_id]['color']
+            bar_color = 's' + bar_color[:2] + bar_color[3] + bar_color[5]
+            if len(curr_narrow) == 2 and curr_narrow[1][0] == 'topic':
+                text_to_fill = ('bar', [  # type: ignore
+                    (bar_color, '{}'.format(self.caption)),
+                    (bar_color, ': topic narrow')
+                ])
+            else:
+                text_to_fill = ('bar', [  # type: ignore
+                    (bar_color, '{}'.format(self.caption))
+                ])
+        elif len(curr_narrow) == 1 and len(curr_narrow[0][1].split(",")) > 1:
+            text_to_fill = 'Group private conversation'
+        else:
+            text_to_fill = 'Private conversation'
+        title_markup = ('header', [
+            ('custom', text_to_fill)
+            ])
+        title = urwid.Text(title_markup)
+        header = urwid.AttrWrap(title, 'bar')
+        header.text_to_fill = text_to_fill
+        header.markup = title_markup
+        return header
+
     def reactions_view(self, reactions: List[Dict[str, Any]]) -> Any:
         if not reactions:
             return ''

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -167,6 +167,14 @@ class MessageBox(urwid.Pile):
         return ctime(message['timestamp'])[:-8]
 
     def need_recipient_header(self) -> bool:
+        # Prevent redundant information in recipient bar
+        if len(self.model.narrow) == 1 and \
+                self.model.narrow[0][0] == 'pm_with':
+            return False
+        if len(self.model.narrow) == 2 and \
+                self.model.narrow[1][0] == 'topic':
+            return False
+
         last_msg = self.last_message
         if self.message['type'] == 'stream':
             if (last_msg['type'] == 'stream' and

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -580,7 +580,10 @@ class SearchBox(urwid.Pile):
         self.text_box = ReadlineEdit(u"Search: ")
         # Add some text so that when packing,
         # urwid doesn't hide the widget.
+        self.conversation_focus = urwid.Text(" ")
         self.search_bar = urwid.Columns([
+            ('pack', self.conversation_focus),
+            ('pack', urwid.Text("  ")),
             self.text_box,
         ])
         self.msg_narrow = urwid.Text("DONT HIDE")

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -218,8 +218,7 @@ class MessageBox(urwid.Pile):
             self.recipients_names = \
                 self.message['display_recipient'][0]['full_name']
         title_markup = ('header', [
-            ('custom', 'Private Messages with'),
-            ('selected', ": "),
+            ('custom', 'You and '),
             ('custom', self.recipients_names)
         ])
         title = urwid.Text(title_markup)

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -541,17 +541,18 @@ class SearchBox(urwid.Pile):
         self.text_box = ReadlineEdit(u"Search: ")
         # Add some text so that when packing,
         # urwid doesn't hide the widget.
-        self.msg_narrow = urwid.Text("DONT HIDE")
-        w = urwid.Columns([
-            ('pack', self.msg_narrow),
-            ('pack', urwid.Text("  ")),
+        self.search_bar = urwid.Columns([
             self.text_box,
         ])
-        self.w = urwid.LineBox(
-            w, tlcorner=u'', tline=u'', lline=u'',
-            trcorner=u'', blcorner=u'─', rline=u'',
-            bline=u'─', brcorner=u'─')
-        return [self.w]
+        self.msg_narrow = urwid.Text("DONT HIDE")
+        recipient_bar = urwid.Columns([
+            ('pack', self.msg_narrow)
+        ])
+        self.recipient_bar = urwid.LineBox(
+            recipient_bar, title=u"Current message recipients",
+            tline=u'─', lline=u'', trcorner=u'─', tlcorner=u'─',
+            blcorner=u'─', rline=u'', bline=u'─', brcorner=u'─')
+        return [self.search_bar, self.recipient_bar]
 
     def keypress(self, size: Tuple[int, int], key: str) -> str:
         if is_command_key('GO_BACK', key):

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -167,14 +167,14 @@ class MessageView(urwid.ListBox):
             return
         # if view is ready display current narrow
         # at the bottom of the view.
-        is_stream = message_view.message['type'] == 'stream'
-        if is_stream:
-            footer = message_view.stream_header()
-        else:
-            footer = message_view.private_header()
+        recipient_bar = message_view.top_header_bar(message_view)
+        top_header = message_view.top_search_bar()
+        self.model.controller.view.search_box.conversation_focus.set_text(
+            top_header.markup
+            )
         self.model.controller.view.search_box.msg_narrow.set_text(
-            footer.markup
-        )
+            recipient_bar.markup
+            )
         self.model.controller.update_screen()
 
     def read_message(self) -> None:


### PR DESCRIPTION
This involves redoing the top bar, to better represent the current narrow and remove redundant information.
*All message view* - 

![all_msg](https://user-images.githubusercontent.com/30312566/56845730-56860780-68e3-11e9-8bc6-815dfde69cc1.png)

*Stream view* -
![stream](https://user-images.githubusercontent.com/30312566/56845732-600f6f80-68e3-11e9-93ec-dcf554636b64.png)

Currently it supports for :
* All messages,
* All Private messages,
* Streams
* Stream and topic
* PM's
* Group PM's
* Starred messages

Fixes: #340 
**Based on discussion in** - https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/top.20recipient.20bar/near/733211