### PR TITLE
Select context based help tips shown at bottom-left

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Install-Module -Name BurntToast
 | ----------------------------------------------------- | --------------------------------------------- |
 | Show/hide help menu                                   | <kbd>?</kbd>                                  |
 | Go back                                               | <kbd>esc</kbd>                                |
+| Redraw screen                                         | <kbd>Ctrl</kbd> + <kbd>l</kbd>                |
 | Quit                                                  | <kbd>Ctrl</kbd> + <kbd>C</kbd>                |
 
 ### Navigation

--- a/README.md
+++ b/README.md
@@ -91,10 +91,16 @@ Install-Module -Name BurntToast
 ```
 
 ## Hot Keys
+### General
 | Command                                               | Key Combination                               |
 | ----------------------------------------------------- | --------------------------------------------- |
 | Show/hide help menu                                   | <kbd>?</kbd>                                  |
-| Go Back                                               | <kbd>esc</kbd>                                |
+| Go back                                               | <kbd>esc</kbd>                                |
+| Quit                                                  | <kbd>Ctrl</kbd> + <kbd>C</kbd>                |
+
+### Navigation
+| Command                                               | Key Combination                               |
+| ----------------------------------------------------- | --------------------------------------------- |
 | Previous message                                      | <kbd>Up</kbd> / <kbd>k</kbd>                  |
 | Next message                                          | <kbd>Down</kbd> / <kbd>j</kbd>                |
 | Go left                                               | <kbd>left</kbd> / <kbd>h</kbd>                |
@@ -102,6 +108,19 @@ Install-Module -Name BurntToast
 | Scroll up                                             | <kbd>PgUp</kbd> / <kbd>K</kbd>                |
 | Scroll down                                           | <kbd>PgDn</kbd> / <kbd>J</kbd>                |
 | Go to the last message                                | <kbd>G</kbd> / <kbd>end</kbd>                 |
+| Next unread topic                                     | <kbd>n</kbd>                                  |
+| Next unread private message                           | <kbd>p</kbd>                                  |
+
+### Searching
+| Command                                               | Key Combination                               |
+| ----------------------------------------------------- | --------------------------------------------- |
+| Search messages                                       | <kbd>/</kbd>                                  |
+| Search people                                         | <kbd>w</kbd>                                  |
+| Search streams                                        | <kbd>q</kbd>                                  |
+
+### Message actions
+| Command                                               | Key Combination                               |
+| ----------------------------------------------------- | --------------------------------------------- |
 | Reply to the current message                          | <kbd>r</kbd>                                  |
 | Reply mentioning the sender of the current message    | <kbd>@</kbd>                                  |
 | Reply quoting the current message text                | <kbd>></kbd>                                  |
@@ -115,7 +134,7 @@ Install-Module -Name BurntToast
 | Show message information                              | <kbd>i</kbd>                                  |
 | Narrow to the stream of the current message           | <kbd>s</kbd>                                  |
 | Narrow to the topic of the current message            | <kbd>S</kbd>                                  |
-| Narrow to a topic/private-chat, or stream/all-private-messages| <kbd>z</kbd>                                  |
+| Narrow to a topic/private-chat, or stream/all-private-messages| <kbd>z</kbd>                          |
 | Narrow to all private messages                        | <kbd>P</kbd>                                  |
 | Narrow to all starred messages                        | <kbd>f</kbd>                                  |
 | Next Unread Topic                                     | <kbd>n</kbd>                                  |
@@ -128,6 +147,13 @@ Install-Module -Name BurntToast
 | Add/remove star status of the current message         | <kbd>*</kbd>                                  |
 | Autocomplete @mentions and #stream_names              | <kbd>Ctrl</kbd> + <kbd>f</kbd>                |
 | Jump to the Beginning of line                         | <kbd>Ctrl</kbd> + <kbd>A</kbd>                |
+
+### Composing a message
+| Command                                               | Key Combination                               |
+| ----------------------------------------------------- | --------------------------------------------- |
+| Send a message                                        | <kbd>Alt Enter</kbd> / <kbd>Ctrl d</kbd>      |
+| Toggle focus box in compose box                       | <kbd>tab</kbd>                                |
+| Jump to the beginning of line                         | <kbd>Ctrl</kbd> + <kbd>A</kbd>                |
 | Jump backward one character                           | <kbd>Ctrl</kbd> + <kbd>B</kbd> / <kbd>←</kbd> |
 | Jump backward one word                                | <kbd>Meta</kbd> + <kbd>B</kbd>                |
 | Delete one character                                  | <kbd>Ctrl</kbd> + <kbd>D</kbd>                |
@@ -145,10 +171,10 @@ Install-Module -Name BurntToast
 | Undo last action                                      | <kbd>Ctrl</kbd> + <kbd>_</kbd>                |
 | Jump to previous line                                 | <kbd>Ctrl</kbd> + <kbd>P</kbd> / <kbd>↑</kbd> |
 | Jump to next line                                     | <kbd>Ctrl</kbd> + <kbd>N</kbd> / <kbd>↓</kbd> |
-| Quit                                                  | <kbd>Ctrl</kbd> + <kbd>C</kbd>                |
-| Clear screen                                          | <kbd>Ctrl</kbd> + <kbd>L</kbd>                |
+| Clear compose box                                     | <kbd>Ctrl</kbd> + <kbd>L</kbd>                |
 
-Note: You can use `arrows`, `home`, `end`, `Page up` and `Page down` keys to move around in Zulip-Terminal.
+
+**Note:** You can use `arrows`, `home`, `end`, `Page up` and `Page down` keys to move around in Zulip-Terminal.
 
 ## Troubleshooting: Common issues
 

--- a/tests/ui/test_ui.py
+++ b/tests/ui/test_ui.py
@@ -60,7 +60,7 @@ class TestView:
         view.controller.update_screen.assert_called_once_with()
 
     def test_set_footer_text_specific_text(self, view, text='blah'):
-        view.set_footer_text([text])
+        view.set_footer_text('', [text])
 
         view._w.footer.set_text.assert_called_once_with([text])
         view.controller.update_screen.assert_called_once_with()
@@ -71,7 +71,7 @@ class TestView:
                      return_value=['some help text'])
         mock_sleep = mocker.patch('time.sleep')
 
-        view.set_footer_text([custom_text], duration)
+        view.set_footer_text('', [custom_text], duration)
 
         view._w.footer.set_text.assert_has_calls([
             mocker.call([custom_text]),

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -6,6 +6,7 @@ KeyBinding = TypedDict('KeyBinding', {
     'keys': Set[str],
     'help_text': str,
     'excluded_from_random_tips': bool,
+    'key_category': str,
 }, total=False)
 
 KEY_BINDINGS = OrderedDict([
@@ -13,194 +14,249 @@ KEY_BINDINGS = OrderedDict([
         'keys': {'?'},
         'help_text': 'Show/hide help menu',
         'excluded_from_random_tips': True,
+        'key_category': 'general',
     }),
     ('GO_BACK', {
         'keys': {'esc'},
         'help_text': 'Go Back',
         'excluded_from_random_tips': False,
+        'key_category': 'general',
     }),
     ('PREVIOUS_MESSAGE', {
         'keys': {'k', 'up'},
         'help_text': 'Previous message',
+        'key_category': 'navigation',
     }),
     ('NEXT_MESSAGE', {
         'keys': {'j', 'down'},
         'help_text': 'Next message',
+        'key_category': 'navigation',
     }),
     ('GO_LEFT', {
         'keys': {'h', 'left'},
         'help_text': 'Go left',
+        'key_category': 'navigation',
     }),
     ('GO_RIGHT', {
         'keys': {'l', 'right'},
         'help_text': 'Go right',
+        'key_category': 'navigation',
     }),
     ('SCROLL_TO_TOP', {
         'keys': {'K', 'page up'},
         'help_text': 'Scroll to top',
+        'key_category': 'navigation',
     }),
     ('SCROLL_TO_BOTTOM', {
         'keys': {'J', 'page down'},
         'help_text': 'Scroll to bottom',
+        'key_category': 'navigation',
     }),
     ('END_MESSAGE', {
         'keys': {'G', 'end'},
         'help_text': 'Go to last message in view',
+        'key_category': 'navigation',
     }),
     ('REPLY_MESSAGE', {
         'keys': {'r', 'enter'},
         'help_text': 'Reply to the current message',
+        'key_category': 'msg_actions',
     }),
     ('MENTION_REPLY', {
         'keys': {'@'},
-        'help_text': 'Reply mentioning the sender of the current message'
+        'help_text': 'Reply mentioning the sender of the current message',
+        'key_category': 'msg_actions',
     }),
     ('QUOTE_REPLY', {
         'keys': {'>'},
         'help_text': 'Reply quoting the current message text',
+        'key_category': 'msg_actions',
     }),
     ('REPLY_AUTHOR', {
         'keys': {'R'},
         'help_text': 'Reply privately to the sender of the current message',
+        'key_category': 'msg_actions',
     }),
     ('EDIT_MESSAGE', {
         'keys': {'e'},
         'help_text': "Edit current message's text or topic",
+        'key_category': 'msg_actions'
     }),
     ('STREAM_MESSAGE', {
         'keys': {'c'},
         'help_text': 'New message to a stream',
+        'key_category': 'msg_actions',
     }),
     ('PRIVATE_MESSAGE', {
         'keys': {'x'},
         'help_text': 'New message to a person or group of people',
+        'key_category': 'msg_actions',
     }),
     ('TAB', {
         'keys': {'tab'},
-        'help_text': 'Toggle focus box in compose box'
+        'help_text': 'Toggle focus box in compose box',
+        'key_category': 'msg_compose',
     }),
     ('SEND_MESSAGE', {
         'keys': {'meta enter', 'ctrl d'},
         'help_text': 'Send a message',
+        'key_category': 'msg_compose',
     }),
     ('STREAM_NARROW', {
         'keys': {'s'},
         'help_text': 'Narrow to the stream of the current message',
+        'key_category': 'msg_actions',
     }),
     ('TOPIC_NARROW', {
         'keys': {'S'},
         'help_text': 'Narrow to the topic of the current message',
+        'key_category': 'msg_actions',
     }),
     ('TOGGLE_NARROW', {
         'keys': {'z'},
         'help_text':
             'Narrow to a topic/private-chat, or stream/all-private-messages',
+        'key_category': 'msg_actions',
     }),
     ('TOGGLE_TOPIC', {
         'keys': {'t'},
         'help_text': 'Toggle topics in a stream',
+        'key_category': 'navigation'
     }),
     ('ALL_PM', {
         'keys': {'P'},
         'help_text': 'Narrow to all private messages',
+        'key_category': 'msg_actions',
     }),
     ('ALL_STARRED', {
         'keys': {'f'},
         'help_text': 'Narrow to all starred messages',
+        'key_category': 'msg_actions',
     }),
     ('NEXT_UNREAD_TOPIC', {
         'keys': {'n'},
         'help_text': 'Next unread topic',
+        'key_category': 'navigation',
     }),
     ('NEXT_UNREAD_PM', {
         'keys': {'p'},
         'help_text': 'Next unread private message',
+        'key_category': 'navigation',
     }),
     ('SEARCH_PEOPLE', {
         'keys': {'w'},
         'help_text': 'Search users',
+        'key_category': 'searching',
     }),
     ('SEARCH_MESSAGES', {
         'keys': {'/'},
         'help_text': 'Search Messages',
+        'key_category': 'searching',
     }),
     ('SEARCH_STREAMS', {
         'keys': {'q'},
         'help_text': 'Search Streams',
+        'key_category': 'searching',
     }),
     ('TOGGLE_MUTE_STREAM', {
         'keys': {'m'},
-        'help_text': 'Mute/unmute Streams'
+        'help_text': 'Mute/unmute Streams',
+        'key_category': 'general',
     }),
     ('ENTER', {
         'keys': {'enter'},
         'help_text': 'Perform current action',
+        'key_category': 'navigation',
     }),
     ('THUMBS_UP', {
         'keys': {'+'},
         'help_text': 'Add/remove thumbs-up reaction to the current message',
+        'key_category': 'msg_actions',
     }),
     ('TOGGLE_STAR_STATUS', {
         'keys': {'ctrl s', '*'},
         'help_text': 'Add/remove star status of the current message',
+        'key_category': 'msg_actions',
     }),
     ('MSG_INFO', {
         'keys': {'i'},
         'help_text': 'View message information',
+        'key_category': 'msg_actions',
     }),
     ('QUIT', {
         'keys': {'ctrl c'},
         'help_text': 'Quit',
+        'key_category': 'general',
     }),
     ('BEGINNING_OF_LINE', {
         'keys': {'ctrl a'},
         'help_text': 'Jump to the beginning of the line',
+        'key_category': 'msg_compose',
     }),
     ('END_OF_LINE', {
         'keys': {'ctrl e'},
         'help_text': 'Jump to the end of the line',
+        'key_category': 'msg_compose',
     }),
     ('ONE_WORD_BACKWARD', {
         'keys': {'meta b'},
         'help_text': 'Jump backward one word',
+        'key_category': 'msg_compose',
     }),
     ('ONE_WORD_FORWARD', {
         'keys': {'meta f'},
         'help_text': 'Jump forward one word',
+        'key_category': 'msg_compose',
     }),
     ('CUT_TO_END_OF_LINE', {
         'keys': {'ctrl k'},
         'help_text': 'Cut forward to the end of the line',
+        'key_category': 'msg_compose',
     }),
     ('CUT_TO_START_OF_LINE', {
         'keys': {'ctrl u'},
         'help_text': 'Cut backward to the start of the line',
+        'key_category': 'msg_compose',
     }),
     ('CUT_TO_END_OF_WORD', {
         'keys': {'meta d'},
         'help_text': 'Cut forward to the end of the current word',
+        'key_category': 'msg_compose',
     }),
     ('CUT_TO_START_OF_WORD', {
         'keys': {'ctrl w'},
         'help_text': 'Cut backward to the start of the current word',
+        'key_category': 'msg_compose',
     }),
     ('PREV_LINE', {
         'keys': {'ctrl p', 'up'},
         'help_text': 'Jump to the previous line',
+        'key_category': 'msg_compose',
     }),
     ('NEXT_LINE', {
         'keys': {'ctrl n', 'down'},
         'help_text': 'Jump to the next line',
+        'key_category': 'msg_compose',
     }),
     ('CLEAR_MESSAGE', {
         'keys': {'ctrl l'},
-        'help_text': 'Clear message',
+        'help_text': 'Clear compose screen',
+        'key_category': 'msg_compose',
     }),
     ('AUTOCOMPLETE', {
         'keys': {'ctrl f'},
         'help_text': 'Autocomplete @mentions and #stream_names',
+        'key_category': 'msg_compose',
     }),
 ])  # type: OrderedDict[str, KeyBinding]
+
+HELP_CATEGORIES = OrderedDict([
+    ('general', 'General'),
+    ('navigation', 'Navigation'),
+    ('searching', 'Searching'),
+    ('msg_actions', 'Message Actions'),
+    ('msg_compose', 'Composing a Message'),
+])
 
 
 class InvalidCommand(Exception):

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -289,9 +289,15 @@ def keys_for_command(command: str) -> Set[str]:
         raise InvalidCommand(command)
 
 
-def commands_for_random_tips() -> List[KeyBinding]:
+def commands_for_random_tips(key_category: str='') -> List[KeyBinding]:
     """
     Return list of commands which may be displayed as a random tip
     """
-    return [key_binding for key_binding in KEY_BINDINGS.values()
-            if not key_binding.get('excluded_from_random_tips', False)]
+    if key_category == 'msg_compose':
+        return [key_binding for key_binding in KEY_BINDINGS.values()
+                if not key_binding.get('excluded_from_random_tips', False) and
+                'msg_compose' == key_binding.get('key_category', '')]
+    else:
+        return [key_binding for key_binding in KEY_BINDINGS.values()
+                if not key_binding.get('excluded_from_random_tips', False) and
+                not 'msg_compose' == key_binding.get('key_category', '')]

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -248,6 +248,11 @@ KEY_BINDINGS = OrderedDict([
         'help_text': 'Autocomplete @mentions and #stream_names',
         'key_category': 'msg_compose',
     }),
+    ('REDRAW', {
+        'keys': {'ctrl l'},
+        'help_text': 'Redraw screen',
+        'key_category': 'general',
+    })
 ])  # type: OrderedDict[str, KeyBinding]
 
 HELP_CATEGORIES = OrderedDict([

--- a/zulipterminal/config/themes.py
+++ b/zulipterminal/config/themes.py
@@ -70,6 +70,7 @@ THEMES = {
         ('bold',         'white, bold',     ''),
         ('footer',       'white',           'dark red',  'bold'),
         ('starred',      'light red, bold', ''),
+        ('category',     'light blue, bold', ''),
     ],
     'gruvbox': [
         # default colorscheme on 16 colors, gruvbox colorscheme
@@ -122,6 +123,8 @@ THEMES = {
          'bold',         WHITE,             DARKRED),
         ('starred',      'light red, bold', 'black',
          None,           LIGHTREDBOLD,      BLACK),
+        ('category',     'light blue, bold', 'black',
+         None,           LIGHTBLUE,         BLACK),
     ],
     'light': [
         (None,           'black',           'white'),
@@ -148,6 +151,7 @@ THEMES = {
         ('bold',         'white, bold',     'dark gray'),
         ('footer',       'white',           'dark red',   'bold'),
         ('starred',      'light red, bold', 'dark gray'),
+        ('category',     'dark gray, bold', 'light gray'),
     ],
     'blue': [
         (None,           'black',           'light blue'),
@@ -174,6 +178,7 @@ THEMES = {
         ('bold',         'white, bold',     'dark blue'),
         ('footer',       'white',           'dark red',   'bold'),
         ('starred',      'light red, bold', 'dark blue'),
+        ('category',     'light gray, bold', 'light blue'),
     ]
 }  # type: Dict[str, ThemeSpec]
 

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -58,9 +58,9 @@ class View(urwid.WidgetWrap):
             bline=u'', brcorner=u''
         )
 
-    def get_random_help(self) -> List[Any]:
+    def get_random_help(self, user_state: str='') -> List[Any]:
         # Get random allowed hotkey (ie. eligible for being displayed as a tip)
-        allowed_commands = commands_for_random_tips()
+        allowed_commands = commands_for_random_tips(user_state)
         if not allowed_commands:
             return ['Help(?): ', ]
         random_command = random.choice(allowed_commands)
@@ -71,10 +71,11 @@ class View(urwid.WidgetWrap):
         ]
 
     @asynch
-    def set_footer_text(self, text_list: Optional[List[Any]]=None,
+    def set_footer_text(self, user_state: str='',
+                        text_list: Optional[List[Any]]=None,
                         duration: Optional[float]=None) -> None:
         if text_list is None:
-            text = self.get_random_help()
+            text = self.get_random_help(user_state)
         else:
             text = text_list
         self._w.footer.set_text(text)
@@ -83,6 +84,8 @@ class View(urwid.WidgetWrap):
             assert duration > 0
             time.sleep(duration)
             self.set_footer_text()
+
+    user_state = property(fset=set_footer_text)
 
     def footer_view(self) -> Any:
         text_header = self.get_random_help()

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -43,6 +43,7 @@ class WriteBox(urwid.Pile):
             func=self.generic_autocomplete,
             key=keys_for_command('AUTOCOMPLETE').pop()
         )
+        self.view.user_state = 'msg_compose'
         to_write_box = urwid.LineBox(
             self.to_write_box, tlcorner=u'─', tline=u'─', lline=u'',
             trcorner=u'─', blcorner=u'─', rline=u'',
@@ -62,6 +63,7 @@ class WriteBox(urwid.Pile):
             func=self.generic_autocomplete,
             key=keys_for_command('AUTOCOMPLETE').pop()
         )
+        self.view.user_state = 'msg_compose'
         self.stream_write_box = ReadlineEdit(
             caption=u"Stream:  ",
             edit_text=caption
@@ -150,11 +152,13 @@ class WriteBox(urwid.Pile):
                 if self.msg_edit_id:
                     self.msg_edit_id = None
                     self.keypress(size, 'esc')
+                self.view.user_state = ''
         elif is_command_key('GO_BACK', key):
             self.msg_edit_id = None
             self.view.controller.editor_mode = False
             self.main_view(False)
             self.view.middle_column.set_focus('body')
+            self.view.user_state = ''
         elif is_command_key('TAB', key):
             if len(self.contents) == 0:
                 return key

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -5,7 +5,11 @@ import threading
 import urwid
 import time
 
-from zulipterminal.config.keys import KEY_BINDINGS, is_command_key
+from zulipterminal.config.keys import (
+    KEY_BINDINGS,
+    is_command_key,
+    HELP_CATEGORIES
+)
 from zulipterminal.helper import asynch, match_user
 from zulipterminal.ui_tools.buttons import (
     TopicButton,
@@ -723,14 +727,32 @@ class HelpView(urwid.ListBox):
         max_widths = [max(width) for width in zip(*widths)]
         self.width = sum(max_widths)
 
-        self.log = urwid.SimpleFocusListWalker(
-            [urwid.AttrWrap(
-                urwid.Columns([
-                    urwid.Text(binding['help_text']),
-                    (max_widths[1], urwid.Text(", ".join(binding['keys'])))
-                ], dividechars=2),
-                None if index % 2 else 'help')
-             for index, binding in enumerate(KEY_BINDINGS.values())])
+        help_menu_content = []  # type: List[urwid.AttrWrap]
+        for category in HELP_CATEGORIES:
+            if not len(help_menu_content) == 0:
+                # To separate categories by newline
+                help_menu_content.append(urwid.Text(''))
+
+            help_menu_content.append(urwid.AttrWrap(
+                                        urwid.Text(
+                                            HELP_CATEGORIES[category]),
+                                        'category'))
+
+            keys_in_category = (binding for binding in KEY_BINDINGS.values()
+                                if binding['key_category'] == category)
+            for help_item_number, binding in enumerate(keys_in_category):
+                help_menu_content.append(
+                            urwid.AttrWrap(
+                                urwid.Columns([
+                                    urwid.Text(binding['help_text']),
+                                    (max_widths[1],
+                                        urwid.Text(
+                                            ", ".join(binding['keys'])))
+                                    ], dividechars=2),
+                                None if help_item_number % 2 else 'help')
+                        )
+
+        self.log = urwid.SimpleFocusListWalker(help_menu_content)
 
         self.height = len(self.log)
 


### PR DESCRIPTION
Currently, ZT shows a random help tip in the footer. It would be useful if the tips were more context-based (for example, depending on what action the user is performing at the moment).