### PR TITLE
core: Fix action of 'z' on self-messages.

### DIFF
--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -174,6 +174,8 @@ class Controller:
             emails = [recipient['email']
                       for recipient in button.message['display_recipient']
                       if recipient['email'] != self.model.client.email]
+            if not emails and len(button.message['display_recipient']) == 1:
+                emails = [self.model.user_email]
             user_emails = ', '.join(emails)
             user_ids = {user['id']
                         for user in button.message['display_recipient']}


### PR DESCRIPTION
**Steps to repro the bug**: 
* Send a test message to yourself (PM)
* Go to All Private messages narrow.
* Use z on any message with self.
The narrow does not change to message with self instead switched to All messages.

**Commit message**: 
When 'z' hotkey was used on in the All private messages
narrow, on self messages, it did not switch narrow
to PM with oneself. We now handle this logic explicitly.