### PR TITLE
Displays message info on pressing `i`, edit history on pressing `e`

### DIFF
--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -148,6 +148,11 @@ KEY_BINDINGS = OrderedDict([
         'keys': {'i'},
         'help_text': 'View message information',
     }),
+    ('EDIT_HISTORY', {
+        'keys': {'e'},
+        'help_text': 'View edit history from message information box',
+        'excluded_from_random_tips': True,
+    }),
     ('QUIT', {
         'keys': {'ctrl c'},
         'help_text': 'Quit',

--- a/zulipterminal/config/themes.py
+++ b/zulipterminal/config/themes.py
@@ -43,6 +43,7 @@ LIGHTGREEN = 'h142'  # bright_green
 LIGHTRED = 'h167'  # bright_red
 LIGHTREDBOLD = '%s, bold' % LIGHTRED
 GRAY = 'h244'  # gray_244
+LIGHTBLUEBOLD = '%s, bold' % LIGHTBLUE
 
 THEMES = {
     'default': [
@@ -70,6 +71,9 @@ THEMES = {
         ('bold',         'white, bold',     ''),
         ('footer',       'white',           'dark red',  'bold'),
         ('starred',      'light red, bold', ''),
+        ('edit_history', 'light red',       ''),
+        ('edit_time',    'light blue, bold', 'dark gray'),
+        ('edit_topic',   'white, bold',     'dark gray'),
     ],
     'gruvbox': [
         # default colorscheme on 16 colors, gruvbox colorscheme
@@ -122,6 +126,12 @@ THEMES = {
          'bold',         WHITE,             DARKRED),
         ('starred',      'light red, bold', 'black',
          None,           LIGHTREDBOLD,      BLACK),
+        ('edit_history', 'light red',       'black',
+         None,           LIGHTRED,          BLACK),
+        ('edit_time',    'light blue, bold', 'dark gray',
+         None,           LIGHTBLUEBOLD,     GRAY),
+        ('edit_topic',   'white, bold',     'dark gray',
+         None,           WHITEBOLD,         GRAY),
     ],
     'light': [
         (None,           'black',           'white'),
@@ -148,6 +158,9 @@ THEMES = {
         ('bold',         'white, bold',     'dark gray'),
         ('footer',       'white',           'dark red',   'bold'),
         ('starred',      'light red, bold', 'dark gray'),
+        ('edit_history', 'light red',       'white'),
+        ('edit_time',    'white, bold',     'dark gray'),
+        ('edit_topic',   'white, bold',     'dark gray'),
     ],
     'blue': [
         (None,           'black',           'light blue'),
@@ -174,6 +187,9 @@ THEMES = {
         ('bold',         'white, bold',     'dark blue'),
         ('footer',       'white',           'dark red',   'bold'),
         ('starred',      'light red, bold', 'dark blue'),
+        ('edit_history', 'light red',       'light blue'),
+        ('edit_time',    'white, bold',     'dark blue'),
+        ('edit_topic',   'white, bold',     'dark blue'),
     ]
 }  # type: Dict[str, ThemeSpec]
 

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -14,7 +14,7 @@ from zulipterminal.helper import asynch
 from zulipterminal.model import Model, GetMessagesArgs, ServerConnectionFailure
 from zulipterminal.ui import View, Screen
 from zulipterminal.ui_tools.utils import create_msg_box_list
-from zulipterminal.ui_tools.views import HelpView, MsgInfoView
+from zulipterminal.ui_tools.views import HelpView, MsgInfoView, EditHistoryView
 from zulipterminal.config.themes import ThemeSpec
 from zulipterminal.ui_tools.views import PopUpConfirmationView
 
@@ -114,6 +114,10 @@ class Controller:
         msg_info_view = MsgInfoView(self, msg)
         self.show_pop_up(msg_info_view,
                          "Message Information (up/down scrolls)")
+
+    def show_edit_history(self, msg: Any) -> None:
+        edit_history_view = EditHistoryView(self, msg)
+        self.show_pop_up(edit_history_view, "Edit History (up/down scrolls)")
 
     def search_messages(self, text: str) -> None:
         # Search for a text in messages

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -484,6 +484,8 @@ class MessageBox(urwid.Pile):
             edited_label_size = 0
             left_padding = 8
 
+        self.message['content_to_show'] = content
+
         content = urwid.Padding(
             urwid.Columns([
                 (edited_label_size,


### PR DESCRIPTION
As of now, the following details are shown when a user presses `i` on a message:
* date/time (with seconds)
* sender
* sender's email ID
* recipient (`stream -> message` in case of a stream message, `recipient name` in case of a private message, "`Self`" in case of a message to oneself or a private message sent to them by someone else)
* reactions (of the form - `name of reaction: name of user who reacted` sorted alphabetically, "`---None---`" if no reactions)
* edit history (pressing `e` shows another window with the edit history)

Issues:
* When displaying reactions, the 'thumbs-up' reaction is shown as `+1` sometimes, and as `thumbs_up` other times. I can't seem to figure out the reason behind this behavior.

Issue #135