### PR TITLE
Fix crash caused by typing a message after searching streams 

### DIFF
--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -263,6 +263,7 @@ class Controller:
         assert not isinstance(focus_position, set)
         self.model.msg_view.clear()
         self.model.msg_view.extend(w_list)
+        self.editor_mode = False
         if focus_position >= 0 and focus_position < len(w_list):
             self.model.msg_list.set_focus(focus_position)
 


### PR DESCRIPTION
Currently Zulip will crash if you do the following:
- press `q` to search streams
- mouse click on any channel or private messages in the left column
- select a message to reply to and type something (it has to return no results in the stream search, as discovered by @sumanthvrao)
- press `Enter`

The reason, as I see it, is that the correct editor is not set in `WriteBox:set_editor_mode` because `controller.editor_mode` remains set to `True` after the mouse click (see `boxes.py:30`). Pressing `Esc` would've turned it off. My suggestion is to set this variable to `False` in a suitable function that also gets called after a mouse click, and it seems `Controller:_finalize_show` is a good one. What do you think?