### PR TITLE
requirements: Explicitly install pygments 2.3.1 for pudb on py 3.4.

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -18,6 +18,7 @@ pytest = "==3.4.2"
 pytest-pep8 = "==1.0.6"
 pytest-mock = "==1.7.1"
 pytest-cov = "==2.5.1"
+pygments= "==2.3.1"  # For pudb, python 3.4
 pudb = "==2017.1.4"
 tornado = "~=5.1"  # For snakeviz, python 3.4+
 snakeviz = "==0.4.2"

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ pytest==3.4.2
 pytest-cov==2.5.1
 pytest-pep8==1.0.6
 pytest-mock==1.7.1
+pygments==2.3.1
 pudb==2017.1.4
 tornado~=5.1
 snakeviz==0.4.2

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ testing_deps = [
 
 dev_helper_deps = [
     'mypy==0.641',
+    'pygments==2.3.1'
     'pudb==2017.1.4',
     'tornado~=5.1',
     'snakeviz==0.4.2',


### PR DESCRIPTION
The recent release of pygments 2.4.0 does not have support for python 3.4. It throws the following error in CI :
```
An error occurred while installing pygments==2.4.0! Will try again.
No matching distribution found for pygments==2.4.0
(from -r /tmp/pipenv-fafr2rmh-requirements/pipenv-if7u64fy-requirement.txt (line 1))
```
Setting the requirements of pygments explicitly to 2.3.1 is a workaround in this case.