### PR TITLE
model: Fix append message event for streams.

### DIFF
--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -545,7 +545,10 @@ class TestModel:
         ({'type': 'stream', 'id': 1}, [], frozenset(), ['msg_w']),
         ({'type': 'private', 'id': 1},
          [['is', 'private']], frozenset(), ['msg_w']),
-        ({'type': 'stream', 'id': 1, 'subject': 'b'},
+        ({'type': 'stream', 'id': 1, 'display_recipient': 'a'},
+         [['stream', 'a']], frozenset(), ['msg_w']),
+        ({'type': 'stream', 'id': 1, 'subject': 'b',
+          'display_recipient': 'a'},
          [['stream', 'a'], ['topic', 'b']],
          frozenset(), ['msg_w']),
         ({'type': 'private', 'id': 1},
@@ -557,8 +560,8 @@ class TestModel:
         ({'type': 'private', 'id': 1},
          [['pm_with', 'notification-bot@zulip.com']],
          frozenset({5827, 3212}), []),
-    ], ids=['stream', 'all_private', 'topic', 'pm_existing_conv',
-            'search', 'pm_no_existing_conv'])
+    ], ids=['all_messages', 'all_private', 'stream', 'topic',
+            'pm_existing_conv', 'search', 'pm_no_existing_conv'])
     def test_append_message(self, mocker, user_dict, user_profile, response,
                             narrow, recipients, model, log):
         model.update = True

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -488,9 +488,17 @@ class Model:
                     len(self.narrow) == 1:
                 self.msg_list.log.append(msg_w)
 
-            elif response['type'] == 'stream' and len(self.narrow) == 2 and\
-                    self.narrow[1][1] == response['subject']:
-                self.msg_list.log.append(msg_w)
+            elif response['type'] == 'stream' and \
+                    self.narrow[0][0] == "stream":
+                recipient_stream = response['display_recipient']
+                msg_recipient = self.narrow[0][1]
+                append_to_stream = recipient_stream == msg_recipient
+
+                if append_to_stream and (len(self.narrow) == 1 or
+                                         (len(self.narrow) == 2 and
+                                          self.narrow[1][1] ==
+                                          response['subject'])):
+                    self.msg_list.log.append(msg_w)
 
             elif response['type'] == 'private' and len(self.narrow) == 1 and\
                     self.narrow[0][0] == "pm_with":


### PR DESCRIPTION
Ensure that a new stream message gets appended to the current stream (or topic in current stream) only
if the recipient and current narrow matches. Tests have been added.