### PR TITLE
requirements: Remove support for python 3.4.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ cache:
     - $HOME/.cache/pipenv
 matrix:
   include:
-    - python: 3.4
-      name: "Python 3.4 pytest (default linux)"
     - python: 3.5
       name: "Python 3.5 pytest (default linux)"
     - python: 3.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Avoid traceback on sending to multiple private recipients when narrowed to that conversation
 
 ### Infrastructure changes
+- Remove support for python 3.4, which will have no further releases
 - Improve installation, development & troubleshooting notes in README
 - Minimized initial registration & communication with zulip server
 - Internal refactoring & centralization of code handling zulip server communication

--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,6 @@ url = "https://pypi.python.org/simple"
 name = "pypi"
 
 [packages]
-typing = {version="==3.6.4", markers="python_version < '3.5'"}
 urwid = "==2.0.1"
 zulip = "==0.5.9"
 emoji = "==0.5.0"
@@ -18,9 +17,7 @@ pytest = "==3.4.2"
 pytest-pep8 = "==1.0.6"
 pytest-mock = "==1.7.1"
 pytest-cov = "==2.5.1"
-pygments = "==2.3.1"  # For pudb, python 3.4
 pudb = "==2017.1.4"
-tornado = "~=5.1"  # For snakeviz, python 3.4+
 snakeviz = "==0.4.2"
 mypy = "==0.641"
 gitlint = "==0.10.0"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ An interactive terminal interface for [Zulip](https://zulipchat.com).
 
 ## Installation & Running
 
-We recommend installing `zulip-term` in a new python virtual environment (venv); with the required python 3.4+, the following should work on most systems:
+We recommend installing `zulip-term` in a new python virtual environment (venv); with the required python 3.5+, the following should work on most systems:
 1. `python3 -m venv zulip-terminal-venv` (creates a venv named `zulip-terminal-venv` in the current directory)
 2. `source zulip-terminal-venv/bin/activate` (activates the venv; this assumes a bash-like shell)
 3. `pip3 install zulip-term` (downloads and installs the latest zulip-terminal release from PyPI)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,10 @@
-typing==3.6.4; python_version < '3.5'
 urwid==2.0.1
 zulip==0.5.9
 pytest==3.4.2
 pytest-cov==2.5.1
 pytest-pep8==1.0.6
 pytest-mock==1.7.1
-pygments==2.3.1
 pudb==2017.1.4
-tornado~=5.1
 snakeviz==0.4.2
 gitlint==0.10.0
 mypy==0.641

--- a/setup.py
+++ b/setup.py
@@ -37,9 +37,7 @@ testing_deps = [
 
 dev_helper_deps = [
     'mypy==0.641',
-    'pygments==2.3.1',
     'pudb==2017.1.4',
-    'tornado~=5.1',
     'snakeviz==0.4.2',
     'gitlint>=0.10',
 ]
@@ -63,12 +61,11 @@ setup(
         'License :: OSI Approved :: Apache Software License',
 
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
     ],
-    python_requires='>=3.4, <3.8',
+    python_requires='>=3.5, <3.8',
     keywords='',
     packages=find_packages(exclude=['test', 'test.*']),
     zip_safe=True,
@@ -84,7 +81,6 @@ setup(
     },
     tests_require=testing_deps,
     install_requires=[
-        "typing==3.6.4; python_version < '3.5'",
         'urwid==2.0.1',
         'zulip==0.5.9',
         'emoji==0.5.0',


### PR DESCRIPTION
Python 3.4 is now end-of-line, and dependencies (those below & requests)
are now expected to support 3.5+. This simplifies things as below, but
also may enable removal of old compatibility code and new features only
available in python 3.5+.

Removes:
* testing 3.4 in Travis CI
* labelled python version support in setup.py for 3.4
* pinning of pygments & tornado package versions in setup.py/Pipfile/requirements.txt
* need to explicitly install typing package in setup.py/Pipfile/requirements.txt

Also updates reference to 3.5 in README.md, and adds to CHANGELOG.md.

This is a first stage towards #360.