### PR TITLE
Add support to mute streams from ZT.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ autohide=autohide
 | Search Users                                          | <kbd>w</kbd>                                  |
 | Search Messages                                       | <kbd>/</kbd>                                  |
 | Search Streams                                        | <kbd>q</kbd>                                  |
+| Mute/unmute Streams                                   | <kbd>m</kbd>                                  |
 | Add/remove thumbs-up reaction to the current message  | <kbd>+</kbd>                                  |
 | Add/remove star status of the current message         | <kbd>*</kbd>                                  |
 | Jump to the Beginning of line                         | <kbd>Ctrl</kbd> + <kbd>A</kbd>                |

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -448,6 +448,27 @@ class TestModel:
         with pytest.raises(ServerConnectionFailure):
             model = Model(self.controller)
 
+    @pytest.mark.parametrize('initial_muted_streams, value', [
+        ({315}, True),
+        ({205, 315}, False),
+        (set(), True),
+        ({205}, False),
+    ], ids=['muting_205', 'unmuting_205', 'first_muted_205',
+            'last_unmuted_205'])
+    def test_toggle_stream_muted_status(self, mocker, model,
+                                        initial_muted_streams, value):
+        model.muted_streams = initial_muted_streams
+        model.client.update_subscription_settings.return_value = \
+            {'result': "success"}
+        model.toggle_stream_muted_status(205)
+        request = [{
+            'stream_id': 205,
+            'property': 'is_muted',
+            'value': value
+        }]
+        model.client.update_subscription_settings.\
+            assert_called_once_with(request)
+
     @pytest.mark.parametrize('flags_before, expected_operator', [
         ([], 'add'),
         (['starred'], 'remove'),

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -979,13 +979,13 @@ class TestHelpMenu:
         key = "a"
         size = (200, 20)
         self.help_view.keypress(size, key)
-        assert not self.controller.exit_help.called
+        assert not self.controller.exit_popup.called
 
     @pytest.mark.parametrize('key', keys_for_command("GO_BACK"))
     def test_keypress_goback(self, key):
         size = (200, 20)
         self.help_view.keypress(size, key)
-        assert self.controller.exit_help.called
+        assert self.controller.exit_popup.called
 
 
 class TestMessageBox:

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -12,6 +12,7 @@ from zulipterminal.ui_tools.views import (
     LeftColumnView,
     HelpView,
     ModListWalker,
+    PopUpConfirmationView,
 )
 from zulipterminal.ui_tools.boxes import MessageBox
 from zulipterminal.ui_tools.buttons import (
@@ -985,6 +986,40 @@ class TestHelpMenu:
     def test_keypress_goback(self, key):
         size = (200, 20)
         self.help_view.keypress(size, key)
+        assert self.controller.exit_popup.called
+
+
+class TestPopUpConfirmationView:
+    @pytest.fixture
+    def popup_view(self, mocker, stream_button):
+        self.controller = mocker.Mock()
+        self.callback = mocker.Mock()
+        self.list_walker = mocker.patch(VIEWS + ".urwid.SimpleFocusListWalker",
+                                        return_value=[])
+        self.divider = mocker.patch(VIEWS + '.urwid.Divider')
+        self.text = mocker.patch(VIEWS + '.urwid.Text')
+        self.wrapper_w = mocker.patch(VIEWS + '.urwid.WidgetWrap')
+        return PopUpConfirmationView(
+            self.controller,
+            self.text,
+            self.callback,
+        )
+
+    def test_init(self, popup_view):
+        assert popup_view.controller == self.controller
+        assert popup_view.success_callback == self.callback
+        self.divider.assert_called_once_with()
+        self.list_walker.assert_called_once_with(
+            [self.text, self.divider(), self.wrapper_w()])
+
+    def test_exit_popup_yes(self, mocker, popup_view):
+        popup_view.exit_popup_yes(mocker.Mock())
+        self.callback.assert_called_once_with()
+        assert self.controller.exit_popup.called
+
+    def test_exit_popup_no(self, mocker, popup_view):
+        popup_view.exit_popup_no(mocker.Mock())
+        self.callback.assert_not_called()
         assert self.controller.exit_popup.called
 
 

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1735,6 +1735,14 @@ class TestStreamButton:
         (stream_button.view.left_panel.
             options.assert_called_once_with(height_type="weight"))
 
+    def test_keypress_TOGGLE_MUTE_STREAM(self, mocker, stream_button):
+        key = 'm'
+        size = (20,)
+        pop_up = mocker.patch(
+            'zulipterminal.core.Controller.stream_muting_confirmation_popup')
+        stream_button.keypress(size, key)
+        pop_up.assert_called_once_with(stream_button)
+
 
 class TestUserButton:
     @pytest.mark.parametrize('width, count, short_text', [

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -128,6 +128,10 @@ KEY_BINDINGS = OrderedDict([
         'keys': {'q'},
         'help_text': 'Search Streams',
     }),
+    ('TOGGLE_MUTE_STREAM', {
+        'keys': {'m'},
+        'help_text': 'Mute/unmute Streams'
+    }),
     ('ENTER', {
         'keys': {'enter'},
         'help_text': 'Perform current action',

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -102,7 +102,7 @@ class Controller:
             height=min(3*rows//4, help_view.number_of_actions)+2
         )
 
-    def exit_help(self) -> None:
+    def exit_popup(self) -> None:
         self.loop.widget = self.view
 
     def search_messages(self, text: str) -> None:

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -4,6 +4,7 @@ import os
 import sys
 import time
 import signal
+from functools import partial
 
 import urwid
 import zulip
@@ -15,6 +16,7 @@ from zulipterminal.ui import View, Screen
 from zulipterminal.ui_tools.utils import create_msg_box_list
 from zulipterminal.ui_tools.views import HelpView
 from zulipterminal.config.themes import ThemeSpec
+from zulipterminal.ui_tools.views import PopUpConfirmationView
 
 
 class Controller:
@@ -119,6 +121,17 @@ class Controller:
         focus_position = 0
         if focus_position >= 0 and focus_position < len(w_list):
             self.model.msg_list.set_focus(focus_position)
+
+    def stream_muting_confirmation_popup(self, button: Any) -> None:
+        type_of_action = "unmuting" if button.stream_id in \
+            self.model.muted_streams else "muting"
+        question = urwid.Text(("bold", "Confirm " + type_of_action +
+                               " of stream '" + button.stream_name+"' ?"),
+                              "center")
+        mute_this_stream = partial(self.model.toggle_stream_muted_status,
+                                   button.stream_id)
+        self.loop.widget = PopUpConfirmationView(self, question,
+                                                 mute_this_stream)
 
     def narrow_to_stream(self, button: Any) -> None:
         already_narrowed = self.model.set_narrow(stream=button.stream_name)

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -559,6 +559,16 @@ class Model:
 
                 self.controller.update_screen()
 
+    def toggle_stream_muted_status(self, stream_id: int) -> bool:
+        request = [{
+            'stream_id': stream_id,
+            'property': 'is_muted',
+            'value':  stream_id not in self.muted_streams
+            # True for muting and False for unmuting.
+        }]
+        response = self.client.update_subscription_settings(request)
+        return response['result'] == 'success'
+
     def handle_typing_event(self, event: Event) -> None:
         if hasattr(self.controller, 'view'):
             # If the user is in pm narrow with the person typing

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -159,6 +159,8 @@ class StreamButton(TopButton):
                 topic_view,
                 self.view.left_panel.options(height_type="weight")
                 )
+        elif is_command_key('TOGGLE_MUTE_STREAM', key):
+            self.controller.stream_muting_confirmation_popup(self)
         return super().keypress(size, key)
 
 

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -714,5 +714,5 @@ class HelpView(urwid.ListBox):
 
     def keypress(self, size: Tuple[int, int], key: str) -> str:
         if is_command_key('GO_BACK', key) or is_command_key('HELP', key):
-            self.controller.exit_help()
+            self.controller.exit_popup()
         return super(HelpView, self).keypress(size, key)

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import Any, List, Tuple, Optional
+from typing import Any, List, Tuple, Optional, Callable
 import threading
 
 import urwid
@@ -716,3 +716,38 @@ class HelpView(urwid.ListBox):
         if is_command_key('GO_BACK', key) or is_command_key('HELP', key):
             self.controller.exit_popup()
         return super(HelpView, self).keypress(size, key)
+
+
+class PopUpConfirmationView(urwid.Overlay):
+    def __init__(self, controller: Any, question: Any,
+                 success_callback: Callable[[], bool]):
+        self.controller = controller
+        self.success_callback = success_callback
+        yes = urwid.Button(u'Yes', self.exit_popup_yes)
+        no = urwid.Button(u'No', self.exit_popup_no)
+        yes._w = urwid.AttrMap(urwid.SelectableIcon(
+            'Yes', 4), None, 'selected')
+        no._w = urwid.AttrMap(urwid.SelectableIcon(
+            'No', 4), None, 'selected')
+        display_widget = urwid.GridFlow([yes, no], 3, 5, 1, 'center')
+        wrapped_widget = urwid.WidgetWrap(display_widget)
+        prompt = urwid.LineBox(
+            urwid.ListBox(
+                urwid.SimpleFocusListWalker(
+                    [question, urwid.Divider(), wrapped_widget]
+                )))
+        urwid.Overlay.__init__(self, prompt, self.controller.view,
+                               align="left", valign="top", width=26,
+                               height=8)
+
+    def exit_popup_yes(self, args: Any) -> None:
+        self.success_callback()
+        self.controller.exit_popup()
+
+    def exit_popup_no(self, args: Any) -> None:
+        self.controller.exit_popup()
+
+    def keypress(self, size: Tuple[int, int], key: str) -> str:
+        if is_command_key('GO_BACK', key):
+            self.controller.loop.widget = self.controller.view
+        return super(PopUpConfirmationView, self).keypress(size, key)


### PR DESCRIPTION
**Muting and Un-muting (muted) streams from ZT.**

`m` keypress on stream buttons triggers a pop-up which can be used to confirm whether to mute streams or not. We mark muted streams as 'M' in the Left Bar, unmuting a muted stream replaces the 'M' with the current message count for the stream.

![Muting streams](https://user-images.githubusercontent.com/30312566/59325790-fe278f80-8d01-11e9-8fbf-90f751e1771d.png)

