### PR TITLE
ui: Send request to change column focus form the `View`.

### DIFF
--- a/tests/ui/test_ui.py
+++ b/tests/ui/test_ui.py
@@ -171,9 +171,11 @@ class TestView:
         view.keypress(size, 'down')
         super_view.assert_called_once_with(size, 'down')
 
-    def test_keypress_w(self, view, mocker):
+    @pytest.mark.parametrize('autohide', [True, False])
+    def test_keypress_w(self, view, mocker, autohide):
         view.users_view = mocker.Mock()
         view.body = mocker.Mock()
+        view.autohide = autohide
         view.body.contents = ['streams', 'messages', mocker.Mock()]
         view.user_search = mocker.Mock()
         view.left_panel = mocker.Mock()
@@ -191,10 +193,12 @@ class TestView:
         assert view.controller.editor_mode is True
         assert view.controller.editor == view.user_search
 
-    def test_keypress_q(self, view, mocker):
+    @pytest.mark.parametrize('autohide', [True, False])
+    def test_keypress_q(self, view, mocker, autohide):
         view.stream_w = mocker.Mock()
         view.left_col_w = mocker.Mock()
         view.stream_w.search_box = mocker.Mock()
+        view.autohide = autohide
         view.body = mocker.Mock()
         view.body.contents = [mocker.Mock(), 'messages', 'users']
         view.left_panel = mocker.Mock()

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -154,6 +154,7 @@ class View(urwid.WidgetWrap):
             self.model.controller.show_all_starred(self)
             self.body.focus_col = 1
         elif is_command_key('SEARCH_PEOPLE', key):
+            self.body.focus_col = 2
             # Start User Search if not in editor_mode
             self.users_view.keypress(size, 'w')
             self.show_left_panel(visible=False)
@@ -164,6 +165,7 @@ class View(urwid.WidgetWrap):
             return key
         elif is_command_key('SEARCH_STREAMS', key):
             # jump stream search
+            self.body.focus_col = 0
             self.left_panel.keypress(size, 'q')
             self.show_right_panel(visible=False)
             self.show_left_panel(visible=True)


### PR DESCRIPTION
urwid doesn't move cursor to the newly focused column if View doesn't
change it focus to the focused column.