### PR TITLE
Improve user experience of reading messages.

### DIFF
--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -17,6 +17,8 @@ class TestController:
                                  return_value=None)
         self.model.poll_for_events = mocker.patch('zulipterminal.model.Model'
                                                   '.poll_for_events')
+        self.model.view = self.view
+        self.view.focus_col = 1
         mocker.patch('zulipterminal.core.Controller.show_loading')
 
     @pytest.fixture
@@ -53,7 +55,6 @@ class TestController:
         assert controller.model.stream_id == stream_button.stream_id
         assert controller.model.narrow == [['stream', stream_button.caption]]
         controller.model.msg_view.clear.assert_called_once_with()
-        controller.model.msg_list.set_focus.assert_called_once_with(0)
         widget = controller.model.msg_view.extend.call_args_list[0][0][0][0]
         id_list = index_stream['all_stream'][stream_button.stream_id]
         assert {widget.original_widget.message['id']} == id_list
@@ -77,7 +78,6 @@ class TestController:
         assert controller.model.stream_id == msg_box.stream_id
         assert controller.model.narrow == expected_narrow
         controller.model.msg_view.clear.assert_called_once_with()
-        controller.model.msg_list.set_focus.assert_called_once_with(0)
         widget = controller.model.msg_view.extend.call_args_list[0][0][0][0]
         id_list = index_topic['stream'][msg_box.stream_id][msg_box.title]
         assert {widget.original_widget.message['id']} == id_list
@@ -97,7 +97,6 @@ class TestController:
         controller.narrow_to_user(user_button)
         assert controller.model.narrow == [["pm_with", user_button.email]]
         controller.model.msg_view.clear.assert_called_once_with()
-        controller.model.msg_list.set_focus.assert_called_once_with(0)
         recipients = frozenset([controller.model.user_id, user_button.user_id])
         assert controller.model.recipients == recipients
         widget = controller.model.msg_view.extend.call_args_list[0][0][0][0]
@@ -121,7 +120,6 @@ class TestController:
         assert controller.model.narrow == []
         controller.model.msg_view.clear.assert_called_once_with()
         num_am = len(index_all_messages['all_messages'])
-        controller.model.msg_list.set_focus.assert_called_once_with(num_am - 1)
         widgets = controller.model.msg_view.extend.call_args_list[0][0][0]
         id_list = index_all_messages['all_messages']
         msg_ids = {widget.original_widget.message['id'] for widget in widgets}
@@ -139,7 +137,6 @@ class TestController:
         assert controller.model.narrow == [['is', 'private']]
         controller.model.msg_view.clear.assert_called_once_with()
         num_pm = len(index_user['all_private'])
-        controller.model.msg_list.set_focus.assert_called_once_with(num_pm - 1)
         widgets = controller.model.msg_view.extend.call_args_list[0][0][0]
         id_list = index_user['all_private']
         msg_ids = {widget.original_widget.message['id'] for widget in widgets}
@@ -166,7 +163,6 @@ class TestController:
         controller.model.msg_view.clear.assert_called_once_with()
 
         num_sm = len(index_all_starred['all_starred'])
-        controller.model.msg_list.set_focus.assert_called_once_with(num_sm - 1)
 
         id_list = index_all_starred['all_starred']
         widgets = controller.model.msg_view.extend.call_args_list[0][0][0]

--- a/tests/ui/test_ui.py
+++ b/tests/ui/test_ui.py
@@ -117,6 +117,8 @@ class TestView:
                 ('weight', 10, center()),
                 (0, right()),
                 ], focus_column=0),
+            mocker.call()._contents.set_focus_changed_callback(
+                view.model.msg_list.read_message),
             mocker.call([
                 title_divider(),
                 (title_length, text()),

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -309,6 +309,7 @@ class TestMessageView:
         mocker.patch(VIEWS + ".MessageView.focus_position")
         msg_view.focus_position = 1
         msg_view.model.controller.view.body.focus_col = 1
+        msg_view.log = list(msg_view.model.index['messages'])
         msg_view.read_message()
         assert msg_view.update_search_box_narrow.called
         assert msg_view.model.index['messages'][1]['flags'] == ['read']
@@ -329,6 +330,30 @@ class TestMessageView:
         msg_view.read_message()
 
         self.model.mark_message_ids_as_read.assert_not_called()
+
+    def test_read_message_last_unread_message_focused(self, mocker,
+                                                      message_fixture,
+                                                      empty_index, msg_box):
+        mocker.patch(VIEWS + ".MessageView.main_view", return_value=[msg_box])
+        mocker.patch(VIEWS + ".MessageView.set_focus")
+        msg_view = MessageView(self.model)
+        msg_view.log = [0, 1]
+        msg_view.body = mocker.Mock()
+        msg_view.update_search_box_narrow = mocker.Mock()
+
+        self.model.controller.view = mocker.Mock()
+        self.model.controller.view.body.focus_col = 0
+        self.model.index = empty_index
+
+        msg_w = mocker.Mock()
+        msg_w.attr_map = {None: 'unread'}
+        msg_w.original_widget.message = message_fixture
+
+        msg_view.body.get_focus.return_value = (msg_w, 1)
+        msg_view.body.get_prev.return_value = (None, 0)
+        msg_view.read_message(1)
+        self.model.mark_message_ids_as_read.assert_called_once_with(
+            [message_fixture['id']])
 
 
 class TestStreamsView:

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -22,6 +22,32 @@ TOPBUTTON = "zulipterminal.ui_tools.buttons.TopButton"
 MESSAGEBOX = "zulipterminal.ui_tools.boxes.MessageBox"
 
 
+class TestModListWalker:
+    @pytest.fixture
+    def mod_walker(self):
+        return ModListWalker([list(range(1))])
+
+    @pytest.mark.parametrize("num_items, focus_position", [
+        (5, 0),
+        (0, 0),
+    ])
+    def test_extend(self, num_items, focus_position, mod_walker, mocker):
+        items = list(range(num_items))
+        mocker.patch.object(mod_walker, "_set_focus")
+        mod_walker.extend(items)
+        mod_walker._set_focus.assert_called_once_with(focus_position)
+
+    def test__set_focus(self, mod_walker, mocker):
+        mod_walker.read_message = mocker.Mock()
+        mod_walker._set_focus(0)
+        mod_walker.read_message.assert_called_once_with()
+
+    def test_set_focus(self, mod_walker, mocker):
+        mod_walker.read_message = mocker.Mock()
+        mod_walker.set_focus(0)
+        mod_walker.read_message.assert_called_once_with()
+
+
 class TestMessageView:
 
     @pytest.fixture(autouse=True)

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -10,6 +10,7 @@ from zulipterminal.ui_tools.views import (
     RightColumnView,
     LeftColumnView,
     HelpView,
+    ModListWalker,
 )
 from zulipterminal.ui_tools.boxes import MessageBox
 from zulipterminal.ui_tools.buttons import TopButton, StreamButton, UserButton
@@ -59,14 +60,14 @@ class TestMessageView:
     def msg_view(self, mocker, msg_box):
         mocker.patch(VIEWS + ".MessageView.main_view", return_value=[msg_box])
         mocker.patch(VIEWS + ".MessageView.read_message")
-        self.urwid.SimpleFocusListWalker.return_value = mocker.Mock()
         mocker.patch(VIEWS + ".MessageView.set_focus")
         msg_view = MessageView(self.model)
+        msg_view.log = mocker.Mock()
+        msg_view.body = mocker.Mock()
         return msg_view
 
     def test_init(self, mocker, msg_view, msg_box):
         assert msg_view.model == self.model
-        self.urwid.SimpleFocusListWalker.assert_called_once_with([msg_box])
         msg_view.set_focus.assert_called_once_with(0)
         assert msg_view.old_loading is False
         assert msg_view.new_loading is False
@@ -315,7 +316,11 @@ class TestMessageView:
         mocker.patch(VIEWS + ".MessageView.set_focus")
         mocker.patch(VIEWS + ".MessageView.update_search_box_narrow")
         msg_view = MessageView(self.model)
+        msg_view.log = mocker.Mock()
+        msg_view.body = mocker.Mock()
         msg_w = mocker.MagicMock()
+        msg_view.model.controller.view = mocker.Mock()
+        msg_view.model.controller.view.body.focus_col = 1
         msg_w.attr_map = {None: 'unread'}
         msg_w.original_widget.message = {'id': 1}
         msg_w.set_attr_map.return_value = None

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -308,6 +308,7 @@ class TestMessageView:
         }
         mocker.patch(VIEWS + ".MessageView.focus_position")
         msg_view.focus_position = 1
+        msg_view.model.controller.view.body.focus_col = 1
         msg_view.read_message()
         assert msg_view.update_search_box_narrow.called
         assert msg_view.model.index['messages'][1]['flags'] == ['read']

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -254,15 +254,15 @@ class Controller:
 
     def _finalize_show(self, w_list: List[Any]) -> None:
         focus_position = self.model.get_focus_in_current_narrow()
-
         if focus_position == set():
             focus_position = len(w_list) - 1
         assert not isinstance(focus_position, set)
         self.model.msg_view.clear()
-        self.model.msg_view.extend(w_list)
-        self.editor_mode = False
         if focus_position >= 0 and focus_position < len(w_list):
-            self.model.msg_list.set_focus(focus_position)
+            self.model.msg_view.extend(w_list, focus_position)
+        else:
+            self.model.msg_view.extend(w_list)
+        self.editor_mode = False
 
     def deregister_client(self) -> None:
         queue_id = self.model.queue_id

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -104,7 +104,11 @@ class View(urwid.WidgetWrap):
                 (View.RIGHT_WIDTH, self.right_panel),
             ]
         self.body = urwid.Columns(body, focus_column=0)
-
+        # NOTE: set_focus_changed_callback is actually called before the
+        # focus is set, so the message is not read yet, it will be read when
+        # the focus is changed again either vertically or horizontally.
+        self.body._contents.set_focus_changed_callback(
+            self.model.msg_list.read_message)
         div_char = '═'
 
         title_text = " {full_name} ({email}) - {server} ".format(

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -177,12 +177,21 @@ class MessageView(urwid.ListBox):
             )
         self.model.controller.update_screen()
 
-    def read_message(self) -> None:
+    def read_message(self, index: int=-1) -> None:
         # Message currently in focus
+        if hasattr(self.model.controller, "view"):
+            view = self.model.controller.view
+        else:
+            return
         msg_w, curr_pos = self.body.get_focus()
         if msg_w is None:
             return
         self.update_search_box_narrow(msg_w.original_widget)
+        # Only allow reading a message when middle column is
+        # in focus. Changing the contents of self.log also changes
+        # focus automatically.
+        if view.body.focus_col != 1:
+            return
         # save the current focus
         self.model.set_focus_in_current_narrow(self.focus_position)
         # msg ids that have been read

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -187,10 +187,12 @@ class MessageView(urwid.ListBox):
         if msg_w is None:
             return
         self.update_search_box_narrow(msg_w.original_widget)
+        # If this the last message in the view and focus is set on this message
+        # then read the message.
+        last_message_focused = (curr_pos == len(self.log) - 1)
         # Only allow reading a message when middle column is
-        # in focus. Changing the contents of self.log also changes
-        # focus automatically.
-        if view.body.focus_col != 1:
+        # in focus.
+        if not(view.body.focus_col == 1 or last_message_focused):
             return
         # save the current focus
         self.model.set_focus_in_current_narrow(self.focus_position)

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -62,8 +62,9 @@ class MessageView(urwid.ListBox):
         self.model = model
         # Initialize for reference
         self.focus_msg = 0
-        self.log = urwid.SimpleFocusListWalker(self.main_view())
-        urwid.connect_signal(self.log, 'modified', self.read_message)
+        self.log = ModListWalker(self.main_view())
+        self.log.read_message = self.read_message
+        # urwid.connect_signal(self.log, 'modified', self.read_message)
         # This Function completely controls the messages
         # shown in the MessageView
         self.model.msg_view = self.log


### PR DESCRIPTION
This changes following behaviors:
* Don't read the first unread messages when zt starts.
* Don't read all the message in `self.log` when narrowing.