### PR TITLE
model: Report connection error at startup

### DIFF
--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -322,13 +322,21 @@ class Model:
                                                 anchor=None),
                 'register': executor.submit(self._register_desired_events,
                                             fetch_data=True),
-            }  # Dict[str, Future[Any]]
+            }  # Dict[str, Future[bool]]
 
             # Wait for threads to complete
             wait(futures.values())  # type: ignore
 
-        results = {name: future.result()  # type: ignore
-                   for name, future in futures.items()}
+        def exception_safe_result(future: 'Future[bool]') -> bool:
+            try:
+                return future.result()
+            except zulip.ZulipError:
+                return False
+
+        results = {
+            name: exception_safe_result(future)
+            for name, future in futures.items()
+        }  # type: Dict[str, bool]
         if all(results.values()):
             self.user_id = self.initial_data['user_id']
             self.user_email = self.initial_data['email']


### PR DESCRIPTION
When I launched zulip-term with no internet connection, I got a general crash message even though there's a special message defined for `ServerConnectionFailure` (`run:239-245`). The exception was thrown from `model/_update_initial_data`, where I think it was meant to be captured and reported as `ServerConnectionFailure`, and that's the exact change I've made.