### PR TITLE
Display 'topics' in a stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ autohide=autohide
 | Search Users                                          | <kbd>w</kbd>                                  |
 | Search Messages                                       | <kbd>/</kbd>                                  |
 | Search Streams                                        | <kbd>q</kbd>                                  |
+| Search Topics in Stream                               | <kbd>q</kbd>                                  |
 | Mute/unmute Streams                                   | <kbd>m</kbd>                                  |
 | Add/remove thumbs-up reaction to the current message  | <kbd>+</kbd>                                  |
 | Add/remove star status of the current message         | <kbd>*</kbd>                                  |

--- a/tests/ui/test_ui.py
+++ b/tests/ui/test_ui.py
@@ -221,7 +221,7 @@ class TestView:
     def test_keypress_q(self, view, mocker, autohide):
         view.stream_w = mocker.Mock()
         view.left_col_w = mocker.Mock()
-        view.stream_w.search_box = mocker.Mock()
+        view.stream_w.stream_search_box = mocker.Mock()
         view.controller.autohide = autohide
         view.body = mocker.Mock()
         view.body.contents = [mocker.Mock(), 'messages', 'users']
@@ -239,9 +239,10 @@ class TestView:
 
         view.left_panel.keypress.assert_called_once_with(size, "q")
         assert view.body.focus_position == 0
-        view.stream_w.search_box.set_edit_text.assert_called_once_with("")
+        view.stream_w.stream_search_box.set_edit_text.\
+            assert_called_once_with("")
         assert view.controller.editor_mode is True
-        assert view.controller.editor == view.stream_w.search_box
+        assert view.controller.editor == view.stream_w.stream_search_box
 
     def test_keypress_edit_mode(self, view, mocker):
         view.users_view = mocker.Mock()

--- a/tests/ui/test_ui.py
+++ b/tests/ui/test_ui.py
@@ -226,6 +226,7 @@ class TestView:
         view.body = mocker.Mock()
         view.body.contents = [mocker.Mock(), 'messages', 'users']
         view.left_panel = mocker.Mock()
+        view.left_panel.is_in_topic_view = False
         view.right_panel = mocker.Mock()
         size = (20,)
 

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -406,7 +406,7 @@ class TestStreamsView:
         mocker.patch(VIEWS + ".urwid.connect_signal")
         mocker.patch(VIEWS + ".threading.Lock")
         self.view = mocker.Mock()
-        self.search_box = mocker.patch(VIEWS + ".PanelSearchBox")
+        self.stream_search_box = mocker.patch(VIEWS + ".PanelSearchBox")
         stream_btn = mocker.Mock()
         stream_btn.stream_name = "FOO"
         self.streams_btn_list = [stream_btn]
@@ -416,8 +416,9 @@ class TestStreamsView:
         assert stream_view.view == self.view
         assert stream_view.log == []
         assert stream_view.streams_btn_list == self.streams_btn_list
-        assert stream_view.search_box
-        self.search_box.assert_called_once_with(stream_view, 'SEARCH_STREAMS')
+        assert stream_view.stream_search_box
+        self.stream_search_box.assert_called_once_with(
+            stream_view, 'SEARCH_STREAMS')
 
     @pytest.mark.parametrize('new_text, expected_log', [
         ('f', ['FOO', 'foo', 'fan']),

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -406,7 +406,7 @@ class TestStreamsView:
         mocker.patch(VIEWS + ".urwid.connect_signal")
         mocker.patch(VIEWS + ".threading.Lock")
         self.view = mocker.Mock()
-        self.search_box = mocker.patch(VIEWS + ".StreamSearchBox")
+        self.search_box = mocker.patch(VIEWS + ".PanelSearchBox")
         stream_btn = mocker.Mock()
         stream_btn.stream_name = "FOO"
         self.streams_btn_list = [stream_btn]
@@ -417,7 +417,7 @@ class TestStreamsView:
         assert stream_view.log == []
         assert stream_view.streams_btn_list == self.streams_btn_list
         assert stream_view.search_box
-        self.search_box.assert_called_once_with(stream_view)
+        self.search_box.assert_called_once_with(stream_view, 'SEARCH_STREAMS')
 
     @pytest.mark.parametrize('new_text, expected_log', [
         ('f', ['FOO', 'foo', 'fan']),
@@ -789,7 +789,7 @@ class TestRightColumnView:
     @pytest.fixture(autouse=True)
     def mock_external_classes(self, mocker):
         self.view = mocker.Mock()
-        self.user_search = mocker.patch(VIEWS + ".UserSearchBox")
+        self.user_search = mocker.patch(VIEWS + ".PanelSearchBox")
         self.connect_signal = mocker.patch(VIEWS + ".urwid.connect_signal")
         self.line_box = mocker.patch(VIEWS + ".urwid.LineBox")
         self.thread = mocker.patch(VIEWS + ".threading")

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -482,6 +482,8 @@ class TestTopicsView:
         topic_btn = mocker.Mock()
         topic_btn.caption = "BOO"
         self.topics_btn_list = [topic_btn]
+        self.header_list = mocker.patch(VIEWS + ".urwid.Pile")
+        self.divider = mocker.patch(VIEWS + ".urwid.Divider")
         return TopicsView(self.topics_btn_list, self.view, self.stream_button)
 
     def test_init(self, mocker, topic_view):
@@ -491,6 +493,9 @@ class TestTopicsView:
         assert topic_view.topic_search_box
         self.topic_search_box.assert_called_once_with(
             topic_view, 'SEARCH_TOPICS')
+        self.header_list.assert_called_once_with([topic_view.stream_button,
+                                                  self.divider('─'),
+                                                  topic_view.topic_search_box])
 
     @pytest.mark.parametrize('new_text, expected_log', [
         ('f', ['FOO', 'foo', 'fan']),
@@ -561,7 +566,7 @@ class TestTopicsView:
         size = (200, 20)
         mocker.patch(VIEWS + '.TopicsView.set_focus')
         topic_view.keypress(size, key)
-        topic_view.set_focus.assert_called_once_with('header')
+        topic_view.header_list.set_focus.assert_called_once_with(2)
 
     def test_keypress_esc(self, mocker, topic_view):
         key = "esc"

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -552,11 +552,24 @@ class TestTopicsView:
         size = (200, 20)
         mocker.patch(VIEWS + '.urwid.Frame.keypress')
         topic_view.view.body.focus_col = None
-
         topic_view.keypress(size, key)
-
         assert topic_view.view.body.focus_col == 1
         topic_view.view.show_left_panel.assert_called_once_with(visible=False)
+
+    def test_keypress_SEARCH_TOPICS(self, mocker, topic_view):
+        key = 'q'
+        size = (200, 20)
+        mocker.patch(VIEWS + '.TopicsView.set_focus')
+        topic_view.keypress(size, key)
+        topic_view.set_focus.assert_called_once_with('header')
+
+    def test_keypress_esc(self, mocker, topic_view):
+        key = "esc"
+        size = (200, 20)
+        mocker.patch(VIEWS + '.TopicsView.set_focus')
+        topic_view.keypress(size, key)
+        topic_view.set_focus.assert_called_once_with("body")
+        assert topic_view.log == self.topics_btn_list
 
 
 class TestUsersView:

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -128,6 +128,10 @@ KEY_BINDINGS = OrderedDict([
         'keys': {'q'},
         'help_text': 'Search Streams',
     }),
+    ('SEARCH_TOPICS', {
+        'keys': {'q'},
+        'help_text': 'Search Topics in Stream',
+    }),
     ('TOGGLE_MUTE_STREAM', {
         'keys': {'m'},
         'help_text': 'Mute/unmute Streams'

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -183,9 +183,9 @@ class View(urwid.WidgetWrap):
             self.left_panel.keypress(size, 'q')
             self.show_right_panel(visible=False)
             self.show_left_panel(visible=True)
-            self.stream_w.search_box.set_edit_text("")
+            self.stream_w.stream_search_box.set_edit_text("")
             self.controller.editor_mode = True
-            self.controller.editor = self.stream_w.search_box
+            self.controller.editor = self.stream_w.stream_search_box
             return key
         elif is_command_key('HELP', key):
             # Show help menu

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -177,15 +177,20 @@ class View(urwid.WidgetWrap):
             self.controller.editor_mode = True
             self.controller.editor = self.user_search
             return key
-        elif is_command_key('SEARCH_STREAMS', key):
+        elif (is_command_key('SEARCH_STREAMS', key) or
+                is_command_key('SEARCH_TOPICS', key)):
             # jump stream search
             self.body.focus_position = 0
             self.left_panel.keypress(size, 'q')
             self.show_right_panel(visible=False)
             self.show_left_panel(visible=True)
-            self.stream_w.stream_search_box.set_edit_text("")
+            if self.left_panel.is_in_topic_view:
+                search_box = self.topic_w.topic_search_box
+            else:
+                search_box = self.stream_w.stream_search_box
+            search_box.set_edit_text("")
             self.controller.editor_mode = True
-            self.controller.editor = self.stream_w.stream_search_box
+            self.controller.editor = search_box
             return key
         elif is_command_key('HELP', key):
             # Show help menu

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -767,54 +767,28 @@ class SearchBox(urwid.Pile):
         return key
 
 
-class UserSearchBox(urwid.Edit):
+class PanelSearchBox(urwid.Edit):
     """
-    Search Box to search users in real-time.
+    Search Box to search streams, topics or users in real-time.
     """
-
-    search_text = ("Search [" +
-                   ", ".join(keys_for_command("SEARCH_PEOPLE")) +
-                   "]: ")
-
-    def __init__(self, user_view: Any) -> None:
-        self.user_view = user_view
-        super(UserSearchBox, self).__init__(edit_text=self.search_text)
+    def __init__(self, panel_view: Any,
+                 search_command: str='SEARCH_STREAMS') -> None:
+        self.panel_view = panel_view
+        self.search_command = search_command
+        self.search_text = ("Search [" +
+                            ", ".join(keys_for_command(search_command)) +
+                            "]: ")
+        super(PanelSearchBox, self).__init__(edit_text=self.search_text)
 
     def keypress(self, size: Tuple[int, int], key: str) -> str:
         if is_command_key('ENTER', key):
-            self.user_view.view.controller.editor_mode = False
-            self.user_view.set_focus("body")
-        if is_command_key('GO_BACK', key):
-            self.user_view.view.controller.editor_mode = False
+            self.panel_view.view.controller.editor_mode = False
+            self.panel_view.set_focus("body")
+            if hasattr(self.panel_view, 'log') and len(self.panel_view.log):
+                self.panel_view.body.set_focus(0)
+        elif is_command_key('GO_BACK', key):
+            self.panel_view.view.controller.editor_mode = False
             self.set_edit_text(self.search_text)
-            self.user_view.set_focus("body")
-            self.user_view.keypress(size, 'esc')
-
-        return super(UserSearchBox, self).keypress(size, key)
-
-
-class StreamSearchBox(urwid.Edit):
-    """
-    Search Box to search streams in real-time.urwid
-    """
-
-    search_text = ("Search [" +
-                   ", ".join(keys_for_command("SEARCH_STREAMS")) +
-                   "]: ")
-
-    def __init__(self, stream_view: Any) -> None:
-        self.stream_view = stream_view
-        super(StreamSearchBox, self).__init__(edit_text=self.search_text)
-
-    def keypress(self, size: Tuple[int, int], key: str) -> str:
-        if is_command_key('ENTER', key) and len(self.stream_view.log):
-            self.stream_view.view.controller.editor_mode = False
-            self.stream_view.set_focus("body")
-            self.stream_view.body.set_focus(0)
-        if is_command_key('GO_BACK', key):
-            self.stream_view.view.controller.editor_mode = False
-            self.set_edit_text(self.search_text)
-            self.stream_view.set_focus("body")
-            self.stream_view.keypress(size, 'esc')
-
-        return super(StreamSearchBox, self).keypress(size, key)
+            self.panel_view.set_focus("body")
+            self.panel_view.keypress(size, 'esc')
+        return super(PanelSearchBox, self).keypress(size, key)

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -255,10 +255,11 @@ class StreamsView(urwid.Frame):
         self.log = urwid.SimpleFocusListWalker(streams_btn_list)
         self.streams_btn_list = streams_btn_list
         list_box = urwid.ListBox(self.log)
-        self.search_box = PanelSearchBox(self, 'SEARCH_STREAMS')
-        urwid.connect_signal(self.search_box, 'change', self.update_streams)
+        self.stream_search_box = PanelSearchBox(self, 'SEARCH_STREAMS')
+        urwid.connect_signal(self.stream_search_box,
+                             'change', self.update_streams)
         super(StreamsView, self).__init__(list_box, header=urwid.LineBox(
-            self.search_box, tlcorner=u'─', tline=u'', lline=u'',
+            self.stream_search_box, tlcorner=u'─', tline=u'', lline=u'',
             trcorner=u'─', blcorner=u'─', rline=u'',
             bline=u'─', brcorner=u'─'
         ))

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -311,9 +311,34 @@ class TopicsView(urwid.Frame):
                  stream_button: Any) -> None:
         self.view = view
         self.log = urwid.SimpleFocusListWalker(topics_btn_list)
+        self.topics_btn_list = topics_btn_list
         self.stream_button = stream_button
         self.list_box = urwid.ListBox(self.log)
-        super(TopicsView, self).__init__(self.list_box)
+        self.topic_search_box = PanelSearchBox(self, 'SEARCH_TOPICS')
+        urwid.connect_signal(self.topic_search_box,
+                             'change', self.update_topics)
+        super(TopicsView, self).__init__(self.list_box, header=urwid.LineBox(
+            self.topic_search_box, tlcorner=u'─', tline=u'', lline=u'',
+            trcorner=u'─', blcorner=u'─', rline=u'',
+            bline=u'─', brcorner=u'─'
+        ))
+        self.search_lock = threading.Lock()
+
+    @asynch
+    def update_topics(self, search_box: Any, new_text: str) -> None:
+        if not self.view.controller.editor_mode:
+            return
+        # wait for any previously started search to finish to avoid
+        # displaying wrong topics list.
+        with self.search_lock:
+            topics_to_display = [
+                topic
+                for topic in self.topics_btn_list.copy()
+                if topic.topic_name.lower().startswith(new_text.lower())
+            ]
+            self.log.clear()
+            self.log.extend(topics_to_display)
+            self.view.controller.update_screen()
 
     def update_topics_list(self, stream_id: int, topic_name: str,
                            sender_id: int) -> None:

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -17,7 +17,7 @@ from zulipterminal.ui_tools.buttons import (
     StreamButton,
 )
 from zulipterminal.ui_tools.utils import create_msg_box_list
-from zulipterminal.ui_tools.boxes import UserSearchBox, StreamSearchBox
+from zulipterminal.ui_tools.boxes import PanelSearchBox
 
 
 class ModListWalker(urwid.SimpleFocusListWalker):
@@ -255,7 +255,7 @@ class StreamsView(urwid.Frame):
         self.log = urwid.SimpleFocusListWalker(streams_btn_list)
         self.streams_btn_list = streams_btn_list
         list_box = urwid.ListBox(self.log)
-        self.search_box = StreamSearchBox(self)
+        self.search_box = PanelSearchBox(self, 'SEARCH_STREAMS')
         urwid.connect_signal(self.search_box, 'change', self.update_streams)
         super(StreamsView, self).__init__(list_box, header=urwid.LineBox(
             self.search_box, tlcorner=u'─', tline=u'', lline=u'',
@@ -504,7 +504,7 @@ class RightColumnView(urwid.Frame):
     def __init__(self, width: int, view: Any) -> None:
         self.width = width
         self.view = view
-        self.user_search = UserSearchBox(self)
+        self.user_search = PanelSearchBox(self, 'SEARCH_PEOPLE')
         urwid.connect_signal(self.user_search, 'change',
                              self.update_user_list)
         self.view.user_search = self.user_search

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -386,6 +386,15 @@ class TopicsView(urwid.Frame):
         elif is_command_key('GO_RIGHT', key):
             self.view.show_left_panel(visible=False)
             self.view.body.focus_col = 1
+        elif is_command_key('SEARCH_TOPICS', key):
+            self.set_focus('header')
+            return key
+        elif is_command_key('GO_BACK', key):
+            self.log.clear()
+            self.log.extend(self.topics_btn_list)
+            self.set_focus('body')
+            self.view.controller.update_screen()
+            return key
         return super(TopicsView, self).keypress(size, key)
 
 
@@ -730,9 +739,13 @@ class LeftColumnView(urwid.Pile):
         return w
 
     def keypress(self, size: Tuple[int, int], key: str) -> str:
-        if is_command_key('SEARCH_STREAMS', key):
+        if (is_command_key('SEARCH_STREAMS', key) or
+                is_command_key('SEARCH_TOPICS', key)):
             self.focus_position = 1
-            self.view.stream_w.keypress(size, key)
+            if self.is_in_topic_view:
+                self.view.topic_w.keypress(size, key)
+            else:
+                self.view.stream_w.keypress(size, key)
             return key
         elif is_command_key('GO_RIGHT', key):
             self.view.show_left_panel(visible=False)

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -315,10 +315,13 @@ class TopicsView(urwid.Frame):
         self.stream_button = stream_button
         self.list_box = urwid.ListBox(self.log)
         self.topic_search_box = PanelSearchBox(self, 'SEARCH_TOPICS')
+        self.header_list = urwid.Pile([self.stream_button,
+                                       urwid.Divider('─'),
+                                       self.topic_search_box])
         urwid.connect_signal(self.topic_search_box,
                              'change', self.update_topics)
         super(TopicsView, self).__init__(self.list_box, header=urwid.LineBox(
-            self.topic_search_box, tlcorner=u'─', tline=u'', lline=u'',
+            self.header_list, tlcorner=u'─', tline=u'', lline=u'',
             trcorner=u'─', blcorner=u'─', rline=u'',
             bline=u'─', brcorner=u'─'
         ))
@@ -386,8 +389,8 @@ class TopicsView(urwid.Frame):
         elif is_command_key('GO_RIGHT', key):
             self.view.show_left_panel(visible=False)
             self.view.body.focus_col = 1
-        elif is_command_key('SEARCH_TOPICS', key):
-            self.set_focus('header')
+        if is_command_key('SEARCH_TOPICS', key):
+            self.header_list.set_focus(2)
             return key
         elif is_command_key('GO_BACK', key):
             self.log.clear()


### PR DESCRIPTION
### **List of aspects this PR covers**:
* View topics in a stream by toggling `t` on a stream button.
* Scroll through topic list with `up/down` or `j/k`.
* Clicking `Enter` on any topic button, brings you to the topic narrow.
* Navigating between Open topic view and messages can be done with `left` and `right`. This restores the focus.
* Scroll through the topics with mouse.
* Unread_counts are shown for topic buttons.
* When a new message arrives, we update the UI to show the re-arranged order.
* Search for a topic in topic_list with `q` (Same as stream hostkey).
* Muted topics are marked so. Their messages are not added to the message view.
* Topic names are extended to the corners to provide as much space as possible.
* Toggle `t` on open topic View, closes it and brings you back to the streambutton you clicked on.

### Follow-ups
* Handle topic edits.
* Event based approach for muting topics.