### PR TITLE
Add tests for 'classify_unread_count'

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -209,7 +209,7 @@ def messages_successful_response() -> Dict[str, Any]:
 
 
 @pytest.fixture(scope="module")
-def initial_data(logged_on_user):
+def initial_data(logged_on_user, unread_msgs_template):
     """
     Response from /register API request.
     """
@@ -368,13 +368,7 @@ def initial_data(logged_on_user):
             'is_old_stream': True,
             'stream_weekly_traffic': 0
         }],
-        'unread_msgs': {
-            'pms': [],
-            'count': 0,
-            'mentions': [],
-            'streams': [],
-            'huddles': []
-        },
+        'unread_msgs': unread_msgs_template['unread_msgs'],
         'presences': {
             'nyan.salmon+sns@gmail.com': {
                 'ZulipElectron': {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -512,6 +512,31 @@ def index_all_starred(empty_index, request):
 
 
 @pytest.fixture(scope="module")
+def unread_msgs_template():
+    return deepcopy({
+       'unread_msgs': {
+            'pms': [{'sender_id': 6086, 'unread_message_ids':
+                     [206, 207, 208, 209, 210]},
+                    {'sender_id': 6087, 'unread_message_ids':
+                     [306, 307, 308, 309, 310]}],
+            'mentions': [212],
+            'streams': [
+                {'stream_id': 86, 'unread_message_ids': [100, 101, 102, 103],
+                    'sender_ids': [7, 10], 'topic':'commits'},
+                {'stream_id': 86, 'unread_message_ids': [104, 105, 106],
+                    'sender_ids': [7, 10], 'topic':'templates'},
+                {'stream_id': 14, 'unread_message_ids': [301, 302, 303],
+                    'sender_ids': [7], 'topic': 'Facts'},
+                {'stream_id': 99, 'unread_message_ids': [400],
+                    'sender_ids': [10], 'topic': 'secret'}
+                ],
+            'huddles': [{'user_ids_string': '1,4,5',
+                        'unread_message_ids': [213, 214]}]
+        }
+    })
+
+
+@pytest.fixture(scope="module")
 def user_profile(logged_on_user):
     return {  # FIXME These should all be self-consistent with others?
         'max_message_id': 589270,

--- a/tests/helper/test_helper.py
+++ b/tests/helper/test_helper.py
@@ -2,6 +2,7 @@ import pytest
 
 from zulipterminal.helper import (
     index_messages,
+    classify_unread_counts
 )
 from typing import Any
 
@@ -139,3 +140,25 @@ def test_index_starred(mocker,
             msg['flags'].append('starred')
 
     assert index_messages(messages, model, model.index) == expected_index
+
+
+def test_classify_unread_count(mocker, unread_msgs_template):
+    model = mocker.patch('zulipterminal.model.Model.__init__',
+                         return_value=None)
+    model.initial_data = unread_msgs_template
+    model.muted_streams = {99}
+    model.muted_topics = [['Django', 'commits']]
+    model.stream_dict = {
+        99: {'name': 'Secret stream'},
+        86: {'name': 'Django'},
+        14: {'name': 'GSoC'}
+    }
+    expected_unread_counts = dict(
+        all_msg=16,
+        all_pms=10,
+        unread_topics={(86, 'templates'): 3, (14, 'Facts'): 3},
+        unread_pms={6086: 5, 6087: 5},
+        streams={86: 3, 14: 3}
+    )
+    unread_counts = classify_unread_counts(model)
+    assert classify_unread_counts(model) == expected_unread_counts


### PR DESCRIPTION
This adds tests for 'classify unread count' functions in `helper.py` which seems to be missing; 