### PR TITLE
Event-based support for muting streams.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,6 +39,7 @@ def stream_button(mocker):
         controller=mocker.patch('zulipterminal.core.Controller'),
         width=40,
         view=view_mock,
+        count=30
     )
     return button
 

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1434,11 +1434,13 @@ class TestStreamButton:
                           is_private, expected_prefix,
                           width, count, short_text, caption='caption'):
         mocker.patch(STREAMBUTTON + ".mark_muted")
+        controller = mocker.Mock()
+        controller.model.muted_streams = {}
         properties = [caption, 5, '#ffffff', is_private]
         view_mock = mocker.Mock()
         view_mock.palette = [(None, 'black', 'white')]
         stream_button = StreamButton(properties,
-                                     controller=mocker.Mock(),
+                                     controller=controller,
                                      view=view_mock,
                                      width=width,
                                      count=count)
@@ -1457,13 +1459,15 @@ class TestStreamButton:
     ])
     def test_color_formats(self, mocker, color):
         mocker.patch(STREAMBUTTON + ".mark_muted")
+        controller = mocker.Mock()
+        controller.model.muted_streams = {}
         properties = ["", 1, color, False]  # only color is important
         view_mock = mocker.Mock()
         background = (None, 'white', 'black')
         view_mock.palette = [background]
 
         stream_button = StreamButton(properties,
-                                     controller=mocker.Mock(),
+                                     controller=controller,
                                      view=view_mock,
                                      width=10,
                                      count=5)
@@ -1479,12 +1483,14 @@ class TestStreamButton:
     def test_invalid_color_format(self, mocker, color):
         properties = ["", 1, color, False]  # only color is important
         view_mock = mocker.Mock()
+        controller = mocker.Mock()
+        controller.model.muted_streams = {}
         background = (None, 'white', 'black')
         view_mock.palette = [background]
 
         with pytest.raises(RuntimeError) as e:
             StreamButton(properties,
-                         controller=mocker.Mock(),
+                         controller=controller,
                          view=view_mock,
                          width=10,
                          count=5)

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -18,6 +18,7 @@ from zulipterminal.config.keys import keys_for_command
 from urwid import AttrWrap, Columns, Padding, Text
 
 VIEWS = "zulipterminal.ui_tools.views"
+TOPBUTTON = "zulipterminal.ui_tools.buttons.TopButton"
 STREAMBUTTON = "zulipterminal.ui_tools.buttons.StreamButton"
 MESSAGEBOX = "zulipterminal.ui_tools.boxes.MessageBox"
 
@@ -1495,6 +1496,33 @@ class TestStreamButton:
                          width=10,
                          count=5)
         assert str(e.value) == "Unknown color format: '{}'".format(color)
+
+    @pytest.mark.parametrize('stream_id, muted_streams, called_value,\
+                              is_action_muting', [
+        (86, {}, 204, False),
+        (86, {86, 205}, -1, True),
+        (205, {14, 99}, 0, False),
+    ], ids=[
+        'unmuting stream 86 - 204 unreads',
+        'muting stream 86',
+        'unmuting stream 205 - 0 unreads',
+    ])
+    def test_mark_stream_muted(self, mocker, stream_button, is_action_muting,
+                               stream_id, muted_streams, called_value) -> None:
+        stream_button.stream_id = stream_id
+        update_count = mocker.patch(TOPBUTTON + ".update_count")
+        stream_button.controller.model.unread_counts = {
+            'streams': {
+                86: 204,
+                14: 34,
+            }
+        }
+        stream_button.controller.model.muted_streams = muted_streams
+        if is_action_muting:
+            stream_button.mark_muted()
+        else:
+            stream_button.mark_unmuted()
+        stream_button.update_count.assert_called_once_with(called_value)
 
 
 class TestUserButton:

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -18,7 +18,7 @@ from zulipterminal.config.keys import keys_for_command
 from urwid import AttrWrap, Columns, Padding, Text
 
 VIEWS = "zulipterminal.ui_tools.views"
-TOPBUTTON = "zulipterminal.ui_tools.buttons.TopButton"
+STREAMBUTTON = "zulipterminal.ui_tools.buttons.StreamButton"
 MESSAGEBOX = "zulipterminal.ui_tools.boxes.MessageBox"
 
 
@@ -796,7 +796,7 @@ class TestLeftColumnView:
         pm_button = mocker.patch(VIEWS + ".PMButton")
         mocker.patch(VIEWS + ".urwid.ListBox")
         mocker.patch(VIEWS + ".urwid.SimpleFocusListWalker")
-        mocker.patch(TOPBUTTON + ".set_muted_streams")
+        mocker.patch(STREAMBUTTON + ".mark_muted")
         left_col_view = LeftColumnView(width, self.view)
         home_button.assert_called_once_with(left_col_view.controller,
                                             count=2, width=width)
@@ -813,7 +813,7 @@ class TestLeftColumnView:
         stream_view = mocker.patch(VIEWS + '.StreamsView')
         line_box = mocker.patch(VIEWS + '.urwid.LineBox')
         divider = mocker.patch(VIEWS + '.urwid.Divider')
-        mocker.patch(TOPBUTTON + ".set_muted_streams")
+        mocker.patch(STREAMBUTTON + ".mark_muted")
 
         left_col_view = LeftColumnView(width, self.view)
 
@@ -1364,7 +1364,7 @@ class TestTopButton:
     def test_text_content(self, mocker,
                           prefix,
                           width, count, short_text, caption='caption'):
-        mocker.patch(TOPBUTTON + ".set_muted_streams")
+        mocker.patch(STREAMBUTTON + ".mark_muted")
         show_function = mocker.Mock()
 
         if isinstance(prefix, tuple):
@@ -1433,7 +1433,7 @@ class TestStreamButton:
     def test_text_content(self, mocker,
                           is_private, expected_prefix,
                           width, count, short_text, caption='caption'):
-        mocker.patch(TOPBUTTON + ".set_muted_streams")
+        mocker.patch(STREAMBUTTON + ".mark_muted")
         properties = [caption, 5, '#ffffff', is_private]
         view_mock = mocker.Mock()
         view_mock.palette = [(None, 'black', 'white')]
@@ -1456,7 +1456,7 @@ class TestStreamButton:
         '#ffffff', '#f0f0f0', '#f0f1f2', '#fff'
     ])
     def test_color_formats(self, mocker, color):
-        mocker.patch(TOPBUTTON + ".set_muted_streams")
+        mocker.patch(STREAMBUTTON + ".mark_muted")
         properties = ["", 1, color, False]  # only color is important
         view_mock = mocker.Mock()
         background = (None, 'white', 'black')
@@ -1522,7 +1522,7 @@ class TestUserButton:
     ])
     def test_text_content(self, mocker,
                           width, count, short_text, caption='caption'):
-        mocker.patch(TOPBUTTON + ".set_muted_streams")
+        mocker.patch(STREAMBUTTON + ".mark_muted")
         user = {
             'email': 'some_email',  # value unimportant
             'user_id': 5,           # value unimportant

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1498,17 +1498,18 @@ class TestStreamButton:
         assert str(e.value) == "Unknown color format: '{}'".format(color)
 
     @pytest.mark.parametrize('stream_id, muted_streams, called_value,\
-                              is_action_muting', [
-        (86, {}, 204, False),
-        (86, {86, 205}, -1, True),
-        (205, {14, 99}, 0, False),
+                             is_action_muting, updated_all_msgs', [
+        (86, {}, 204, False, 380),
+        (86, {86, 205}, -1, True, 320),
+        (205, {14, 99}, 0, False, 350),
     ], ids=[
         'unmuting stream 86 - 204 unreads',
         'muting stream 86',
         'unmuting stream 205 - 0 unreads',
     ])
     def test_mark_stream_muted(self, mocker, stream_button, is_action_muting,
-                               stream_id, muted_streams, called_value) -> None:
+                               stream_id, muted_streams, called_value,
+                               updated_all_msgs) -> None:
         stream_button.stream_id = stream_id
         update_count = mocker.patch(TOPBUTTON + ".update_count")
         stream_button.controller.model.unread_counts = {
@@ -1517,12 +1518,17 @@ class TestStreamButton:
                 14: 34,
             }
         }
+        stream_button.model.unread_counts['all_msg'] = 350
         stream_button.controller.model.muted_streams = muted_streams
         if is_action_muting:
             stream_button.mark_muted()
         else:
             stream_button.mark_unmuted()
         stream_button.update_count.assert_called_once_with(called_value)
+        if called_value:
+            stream_button.view.home_button.update_count.\
+                assert_called_once_with(updated_all_msgs)
+        assert stream_button.model.unread_counts['all_msg'] == updated_all_msgs
 
 
 class TestUserButton:

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -84,6 +84,8 @@ def set_count(id_list: List[int], controller: Any, new_count: int) -> None:
             key = messages[id]['sender_id']
             unreads = unread_counts['unread_pms']  # type: ignore
 
+        # broader unread counts (for all_* and streams) are updated
+        # later conditionally.
         if key in unreads:
             unreads[key] += new_count
             if unreads[key] == 0:
@@ -115,6 +117,7 @@ def set_count(id_list: List[int], controller: Any, new_count: int) -> None:
             else:
                 for stream in streams:
                     if stream.stream_id == stream_id:
+                        # FIXME: Update unread_count[streams]?
                         stream.update_count(stream.count + new_count)
                         break
         else:
@@ -122,10 +125,12 @@ def set_count(id_list: List[int], controller: Any, new_count: int) -> None:
                 if user.user_id == user_id:
                     user.update_count(user.count + new_count)
                     break
-            all_pm.update_count(all_pm.count + new_count)
+            unread_counts['all_pms'] += new_count
+            all_pm.update_count(unread_counts['all_pms'])
 
         if add_to_counts:
-            all_msg.update_count(all_msg.count + new_count)
+            unread_counts['all_msg'] += new_count
+            all_msg.update_count(unread_counts['all_msg'])
 
     while not hasattr(controller, 'loop'):
         time.sleep(0.1)

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -317,8 +317,6 @@ def classify_unread_counts(model: Any) -> UnreadCounts:
     for stream in unread_msg_counts['streams']:
         count = len(stream['unread_message_ids'])
         stream_id = stream['stream_id']
-        if stream_id in model.muted_streams:
-            continue
         if [model.stream_dict[stream_id]['name'],
                 stream['topic']] in model.muted_topics:
             continue

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -102,6 +102,8 @@ class StreamButton(TopButton):
         # (self.stream_id is used elsewhere)
         caption, self.stream_id, orig_color, is_private = properties
         self.model = controller.model
+        self.count = count
+        self.view = view
 
         # Simplify the color from the original version & add to palette
         # TODO Should this occur elsewhere and more intelligently?
@@ -132,12 +134,18 @@ class StreamButton(TopButton):
             self.mark_muted()
 
     def mark_muted(self) -> None:
+        self.model.unread_counts['all_msg'] -= self.count
         self.update_count(-1)
+        self.view.home_button.update_count(
+            self.model.unread_counts['all_msg'])
 
     def mark_unmuted(self) -> None:
         if self.stream_id in self.model.unread_counts['streams']:
             unmuted_count = self.model.unread_counts['streams'][self.stream_id]
             self.update_count(unmuted_count)
+            self.model.unread_counts['all_msg'] += self.count
+            self.view.home_button.update_count(
+                self.model.unread_counts['all_msg'])
         else:
             # All messages in this stream are read.
             self.update_count(0)

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -29,13 +29,7 @@ class TopButton(urwid.Button):
         super().__init__("")
         self._w = self.widget(count)
         self.controller = controller
-        self.set_muted_streams()
         urwid.connect_signal(self, 'click', self.activate)
-
-    def set_muted_streams(self) -> None:
-        if self.caption in [self.controller.model.stream_dict[ele]['name']
-                            for ele in self.controller.model.muted_streams]:
-            self.update_count(-1)
 
     def update_count(self, count: int) -> None:
         self.count = count
@@ -107,6 +101,7 @@ class StreamButton(TopButton):
         # FIXME Is having self.stream_id the best way to do this?
         # (self.stream_id is used elsewhere)
         caption, self.stream_id, orig_color, is_private = properties
+        self.model = controller.model
 
         # Simplify the color from the original version & add to palette
         # TODO Should this occur elsewhere and more intelligently?
@@ -131,6 +126,13 @@ class StreamButton(TopButton):
                          prefix_character=(color, 'P' if is_private else '#'),
                          width=width,
                          count=count)
+
+        # Mark muted streams 'M' during button creation.
+        self.mark_muted()
+
+    def mark_muted(self) -> None:
+        if self.stream_id in self.model.muted_streams:
+            self.update_count(-1)
 
 
 class UserButton(TopButton):

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -128,11 +128,11 @@ class StreamButton(TopButton):
                          count=count)
 
         # Mark muted streams 'M' during button creation.
-        self.mark_muted()
+        if self.stream_id in self.model.muted_streams:
+            self.mark_muted()
 
     def mark_muted(self) -> None:
-        if self.stream_id in self.model.muted_streams:
-            self.update_count(-1)
+        self.update_count(-1)
 
 
 class UserButton(TopButton):

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -134,6 +134,14 @@ class StreamButton(TopButton):
     def mark_muted(self) -> None:
         self.update_count(-1)
 
+    def mark_unmuted(self) -> None:
+        if self.stream_id in self.model.unread_counts['streams']:
+            unmuted_count = self.model.unread_counts['streams'][self.stream_id]
+            self.update_count(unmuted_count)
+        else:
+            # All messages in this stream are read.
+            self.update_count(0)
+
 
 class UserButton(TopButton):
     def __init__(self, user: Dict[str, Any], controller: Any,

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -558,6 +558,10 @@ class LeftColumnView(urwid.Pile):
                     count=self.model.unread_counts['streams'].get(stream[1], 0)
                 ) for stream in self.view.unpinned_streams]
 
+        self.view.stream_id_to_button = {stream.stream_id: stream
+                                         for stream in streams_btn_list
+                                         if hasattr(stream, 'stream_id')}
+
         self.view.stream_w = StreamsView(streams_btn_list, self.view)
         w = urwid.LineBox(
             self.view.stream_w, title="Streams",


### PR DESCRIPTION
Currently in ZT, We receive initial data of subscriptions like (which streams the user has muted and which he hasn't). We do not register this event with the event queue, to handle further changes when ZT is running. In this PR, we register an event handler for subscription changes (currently only limited to muting/unmuting streams) and display the changes by marking the respective streams as muted/unmuted in ZT UI.

* This is a precursor to #367.
* The first two commits (refactor) here have been cherry-picked from the #367. And the rest of the code has been built on top of it.

**TESTING**:
* Manual tested against the web-app
* Tests added for changes which have been introduced.