### PR TITLE
ui: Restrict max width of center column for easier reading.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ If you see further text, like the following, `zulip-term` should be loading!
 Loading with:
    theme 'default' specified with no config.
    autohide setting 'autohide' specified with no config.
+   layout setting 'fill' specified with no config.
 Welcome to Zulip.
 ```
 
@@ -67,6 +68,10 @@ site=https://realm.zulipchat.com
 theme=default
 # Autohide can also be set to 'no_autohide', to always show the left and right panels
 autohide=autohide
+# Layout can be set to:
+# - 'fill': Fill the whole screen (default).
+# - 'space-between': Make the center column less wide for easier reading on wider screens.
+layout=fill
 ```
 
 ## Hot Keys

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -67,6 +67,7 @@ def test_valid_zuliprc_but_no_connection(capsys, mocker, minimal_zuliprc,
         "Loading with:",
         "   theme 'default' specified with no config.",
         "   autohide setting 'autohide' specified with no config.",
+        "   layout setting 'fill' specified with no config.",
         "\x1b[91m",
         ("Error connecting to Zulip server: {}.\x1b[0m".
             format(server_connection_error)),
@@ -104,6 +105,7 @@ def test_warning_regarding_incomplete_theme(capsys, mocker, monkeypatch,
         "      (you could try: {}, {})"
         "\x1b[0m".format('a', 'b'),
         "   autohide setting 'autohide' specified with no config.",
+        "   layout setting 'fill' specified with no config.",
         "\x1b[91m",
         ("Error connecting to Zulip server: {}.\x1b[0m".
             format(server_connection_error)),

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -24,7 +24,9 @@ class TestController:
         self.config_file = 'path/to/zuliprc'
         self.theme = 'default'
         self.autohide = True  # FIXME Add tests for no-autohide
-        return Controller(self.config_file, self.theme, self.autohide)
+        self.layout = 'fill'
+        return Controller(self.config_file, self.theme,
+                          self.autohide, self.layout)
 
     def test_initialize_controller(self, controller, mocker) -> None:
         self.client.assert_called_once_with(

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -156,6 +156,7 @@ def parse_zuliprc(zuliprc_str: str) -> Dict[str, Any]:
     settings = {
         'theme': ('default', NO_CONFIG),
         'autohide': ('autohide', NO_CONFIG),
+        'layout': ('fill', NO_CONFIG),
     }
 
     if 'zterm' in zuliprc:
@@ -165,6 +166,8 @@ def parse_zuliprc(zuliprc_str: str) -> Dict[str, Any]:
             settings['theme'] = (config['theme'], ZULIPRC_CONFIG)
         if 'autohide' in config:
             settings['autohide'] = (config['autohide'], ZULIPRC_CONFIG)
+        if 'layout' in config:
+            settings['layout'] = (config['layout'], ZULIPRC_CONFIG)
 
     return settings
 
@@ -222,6 +225,17 @@ def main(options: Optional[List[str]]=None) -> None:
             sys.exit(1)
         autohide_setting = (zterm['autohide'][0] == 'autohide')
 
+        valid_layout_settings = {'fill', 'space-between'}
+        if zterm['layout'][0] not in valid_layout_settings:
+            print("Invalid layout setting '{}' was specified {}."
+                  .format(*zterm['layout']))
+            print("The following options are available:")
+            for option in valid_layout_settings:
+                print("  ", option)
+            print("Specify the layout option in zuliprc file.")
+            sys.exit(1)
+        layout_setting = (zterm['layout'][0])
+
         print("Loading with:")
         print("   theme '{}' specified {}.".format(*theme_to_use))
         complete, incomplete = complete_and_incomplete_themes()
@@ -233,9 +247,11 @@ def main(options: Optional[List[str]]=None) -> None:
                            format(", ".join(complete))))
         print("   autohide setting '{}' specified {}."
               .format(*zterm['autohide']))
+        print("   layout setting '{}' specified {}."
+              .format(*zterm['layout']))
         Controller(zuliprc_path,
                    THEMES[theme_to_use[0]],
-                   autohide_setting).main()
+                   autohide_setting, layout_setting).main()
     except ServerConnectionFailure as e:
         print(in_color('red',
                        "\nError connecting to Zulip server: {}.".format(e)))

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -24,9 +24,10 @@ class Controller:
     """
 
     def __init__(self, config_file: str, theme: ThemeSpec,
-                 autohide: bool) -> None:
+                 autohide: bool, layout: str) -> None:
         self.theme = theme
         self.autohide = autohide
+        self.layout = layout
         self.editor_mode = False  # type: bool
         self.editor = None  # type: Any
 

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -27,6 +27,7 @@ class View(urwid.WidgetWrap):
 
     LEFT_WIDTH = 25
     RIGHT_WIDTH = 25
+    CENTER_WIDTH = 100
 
     def __init__(self, controller: Any) -> None:
         self.controller = controller
@@ -91,6 +92,12 @@ class View(urwid.WidgetWrap):
         self.left_panel = self.left_column_view()
         self.center_panel = self.message_view()
         self.right_panel = self.right_column_view()
+
+        if self.controller.layout == 'space-between':
+            self.center_panel = urwid.Padding(self.center_panel,
+                                              align='center',
+                                              width=View.CENTER_WIDTH)
+
         if self.controller.autohide:
             body = [
                 (View.LEFT_WIDTH, self.left_panel),


### PR DESCRIPTION
Adds a config option layout=space-between to make the center
column fix width and add space between the three columns on
wider screens. On smaller screens, the original behavior is
preserved.

This mimics the webapp's idea of having the line-length be
small so that the text is easy to read even on larger screens.

## Screenshots:

1. Small Width:
![image](https://user-images.githubusercontent.com/8033238/59549991-2671f100-8f83-11e9-814b-1417f6c2b399.png)

2. Medium Width:
![image](https://user-images.githubusercontent.com/8033238/59549999-4acdcd80-8f83-11e9-9a20-f368214b8121.png)

3. Large Width:
![image](https://user-images.githubusercontent.com/8033238/59550007-6d5fe680-8f83-11e9-82e1-88e811913d30.png)

