### PR TITLE
bugfix: Avoid calls to 'update_screen' before setting 'update_pipe'.

### DIFF
--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -78,7 +78,8 @@ class Controller:
 
     def update_screen(self) -> None:
         # Write something to update pipe to trigger draw_screen
-        os.write(self.update_pipe, b'1')
+        if hasattr(self, 'update_pipe'):
+            os.write(self.update_pipe, b'1')
 
     def draw_screen(self, *args: Any, **kwargs: Any) -> None:
         self.loop.draw_screen()


### PR DESCRIPTION
A race condition exists between calling `update_user_list` from `_start_presence_updates` (asynch) which in turn calls 'Controller.update_screen' before setting 'update_pipe' property during initialisation of
Controller.main(). This causes the following traceback during some cases.
```
Loading -Exception in thread Thread-5:
Traceback (most recent call last):
  File "/home/sumanthvrao/.pyenv/versions/3.6.5/lib/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "/home/sumanthvrao/.pyenv/versions/3.6.5/lib/python3.6/threading.py", line 864, in run
    self._target(*self._args, **self._kwargs)
  File "/home/sumanthvrao/Git_Hub/zulip-terminal/zulipterminal/ui_tools/views.py", line 440, in update_user_list
    self.view.controller.update_screen()
  File "/home/sumanthvrao/Git_Hub/zulip-terminal/zulipterminal/core.py", line 81, in update_screen
    os.write(self.update_pipe, b'1')
AttributeError: 'Controller' object has no attribute 'update_pipe'
```

We now check for the attribute explicitly before calling 'update_user_list'.

Fixes: #391 