### PR TITLE
bugfix: Ensure 'self.update' property is set after messages are fetched.

### DIFF
--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -371,6 +371,13 @@ class TestModel:
         model.get_messages(num_after=0, num_before=0, anchor=0)
         assert model.update is False
 
+        # TEST `query_range` == no_of messages received
+        # len(messages_successful_response) = 3 so comparing this with
+        # num_after + num_before + 1 = 3, should set update to True.
+        model.update = False
+        model.get_messages(num_after=1, num_before=1, anchor=0)
+        assert model.update is True
+
     # FIXME This only tests the case where the get_messages is in __init__
     def test_fail_get_messages(self, mocker, error_response,
                                initial_data, num_before=30, num_after=10):

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -43,7 +43,7 @@ class TestModel:
         assert model.msg_view is None
         assert model.msg_list is None
         assert model.narrow == []
-        assert model.update is False
+        assert model.update_allowed is False
         assert model.stream_id == -1
         assert model.stream_dict == {}
         assert model.recipients == frozenset()
@@ -332,7 +332,7 @@ class TestModel:
         anchor = messages_successful_response['anchor']
         if anchor < 10000000000000000:
             assert model.index['pointer'][str(model.narrow)] == anchor
-        assert model.update is True
+        assert model.update_allowed is True
 
     def test_get_message_false_first_anchor(
             self, mocker, messages_successful_response, index_all_messages,
@@ -367,16 +367,16 @@ class TestModel:
         assert model.index['pointer'][str(model.narrow)] == 0
 
         # TEST `query_range` < no of messages received
-        model.update = False  # RESET model.update value
+        model.update_allowed = False  # RESET model.update_allowed value
         model.get_messages(num_after=0, num_before=0, anchor=0)
-        assert model.update is False
+        assert model.update_allowed is False
 
         # TEST `query_range` == no_of messages received
         # len(messages_successful_response) = 3 so comparing this with
-        # num_after + num_before + 1 = 3, should set update to True.
-        model.update = False
+        # num_after + num_before + 1 = 3, should set update_allowed to True.
+        model.update_allowed = False
         model.get_messages(num_after=1, num_before=1, anchor=0)
-        assert model.update is True
+        assert model.update_allowed is True
 
     # FIXME This only tests the case where the get_messages is in __init__
     def test_fail_get_messages(self, mocker, error_response,
@@ -491,7 +491,7 @@ class TestModel:
         assert unpinned == streams  # FIXME generalize/parametrize
 
     def test_append_message_with_Falsey_log(self, mocker, model):
-        model.update = True
+        model.update_allowed = True
         index_msg = mocker.patch('zulipterminal.model.index_messages',
                                  return_value={})
         model.msg_list = mocker.Mock()
@@ -508,7 +508,7 @@ class TestModel:
          assert_called_once_with(model, [0], last_message=None))
 
     def test_append_message_with_valid_log(self, mocker, model):
-        model.update = True
+        model.update_allowed = True
         index_msg = mocker.patch('zulipterminal.model.index_messages',
                                  return_value={})
         model.msg_list = mocker.Mock()
@@ -527,7 +527,7 @@ class TestModel:
          assert_called_once_with(model, [0], last_message=expected_last_msg))
 
     def test_append_message_event_flags(self, mocker, model):
-        model.update = True
+        model.update_allowed = True
         index_msg = mocker.patch('zulipterminal.model.index_messages',
                                  return_value={})
         model.msg_list = mocker.Mock()
@@ -583,7 +583,7 @@ class TestModel:
             'user_pm_x_does_not_appear_in_narrow_without_x'])
     def test_append_message(self, mocker, user_profile, response,
                             narrow, recipients, model, log):
-        model.update = True
+        model.update_allowed = True
         index_msg = mocker.patch('zulipterminal.model.index_messages',
                                  return_value={})
         create_msg_box_list = mocker.patch('zulipterminal.model.'
@@ -602,9 +602,9 @@ class TestModel:
         assert model.msg_list.log == log
         set_count.assert_called_once_with([response['id']], self.controller, 1)
 
-        model.update = False
+        model.update_allowed = False
         model.append_message(event)
-        # LOG REMAINS THE SAME IF UPDATE IS FALSE
+        # LOG REMAINS THE SAME IF UPDATE_ALLOWED IS FALSE
         assert model.msg_list.log == log
 
     @pytest.mark.parametrize('response, expected_message', [

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -105,7 +105,7 @@ class Controller:
         # Search for a text in messages
         self.model.set_narrow(search=text)
 
-        self.update = False
+        self.update_allowed = False
         self.model.get_messages(num_after=0, num_before=30, anchor=10000000000)
         msg_id_list = self.model.get_message_ids_in_current_narrow()
 
@@ -121,7 +121,7 @@ class Controller:
         if already_narrowed:
             return
 
-        self.update = False
+        self.update_allowed = False
         # store the steam id in the model (required for get_message_ids...)
         self.model.stream_id = button.stream_id
         msg_id_list = self.model.get_message_ids_in_current_narrow()
@@ -149,7 +149,7 @@ class Controller:
         if already_narrowed:
             return
 
-        self.update = False
+        self.update_allowed = False
         # store the steam id in the model (required for get_message_ids...)
         self.model.stream_id = button.stream_id
         msg_id_list = self.model.get_message_ids_in_current_narrow()
@@ -185,7 +185,7 @@ class Controller:
         if already_narrowed:
             return
 
-        self.update = False
+        self.update_allowed = False
         msg_id_list = self.model.get_message_ids_in_current_narrow()
 
         if len(msg_id_list) == 0:
@@ -209,7 +209,7 @@ class Controller:
         if already_narrowed:
             return
 
-        self.update = False
+        self.update_allowed = False
         msg_id_list = self.model.get_message_ids_in_current_narrow()
 
         if hasattr(button, 'message'):
@@ -225,7 +225,7 @@ class Controller:
         if already_narrowed:
             return
 
-        self.update = False
+        self.update_allowed = False
         msg_id_list = self.model.get_message_ids_in_current_narrow()
 
         if len(msg_id_list) == 0:
@@ -241,7 +241,7 @@ class Controller:
         if already_narrowed:
             return
 
-        self.update = False
+        self.update_allowed = False
         msg_id_list = self.model.get_message_ids_in_current_narrow()
 
         if len(msg_id_list) == 0:

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -300,7 +300,7 @@ class Model:
             if first_anchor and response['anchor'] != 10000000000000000:
                 self.index['pointer'][str(self.narrow)] = response['anchor']
             query_range = num_after + num_before + 1
-            if len(response['messages']) < (query_range):
+            if len(response['messages']) <= query_range:
                 self.update = True
             return True
         return False

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -73,7 +73,7 @@ class Model:
         self.msg_view = None  # type: Any
         self.msg_list = None  # type: Any
         self.narrow = []  # type: List[Any]
-        self.update = False
+        self.update_allowed = False
         self.stream_id = -1
         self.recipients = frozenset()  # type: FrozenSet[Any]
         self.index = initial_index
@@ -301,7 +301,7 @@ class Model:
                 self.index['pointer'][str(self.narrow)] = response['anchor']
             query_range = num_after + num_before + 1
             if len(response['messages']) <= query_range:
-                self.update = True
+                self.update_allowed = True
             return True
         return False
 
@@ -489,7 +489,7 @@ class Model:
         # sometimes `flags` are missing in `event` so initialize
         # an empty list of flags in that case.
         response['flags'] = event.get('flags', [])
-        if hasattr(self.controller, 'view') and self.update:
+        if hasattr(self.controller, 'view') and self.update_allowed:
             self.index = index_messages([response], self, self.index)
             if self.msg_list.log:
                 last_message = self.msg_list.log[-1].original_widget.message


### PR DESCRIPTION
On startup, the event handler for tracking incoming messages would
be registered with 'append message' as callback. However, the 'self.update'
variable would not be set to true yet. This is due to 'get_messages' not
setting the parameter within the conditional when 'query_range'
and length of response are equal.

I have added a failing test for the earlier seen bug here.

Steps to reproduce this:

* Logged in (as Hamlet) from ZT. I have around 75 unread messages across 5 streams.
* Remained in the default All messages view and do not enter any stream/PM.
* Log in from web-app as another user (aaron) and sent a message to a stream (devel). The unread messages don't change in ZT.

However, If after I login and select a stream (after narrowing), and then repeat this process, the unread message does increase.