### PR TITLE
bugfix: Avoid crash on 'ctrl 4' by ignoring quit character

### DIFF
--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -286,8 +286,9 @@ class Controller:
         try:
             # TODO: Enable resuming? (in which case, remove ^Z below)
             disabled_keys = {
-                'susp': 'undefined',  # Disable ^Z for suspending
-                'stop': 'undefined',  # Disable ^S, enabling shortcut key use
+                'susp': 'undefined',  # Disable ^Z - no suspending
+                'stop': 'undefined',  # Disable ^S - enabling shortcut key use
+                'quit': 'undefined',  # Disable ^\, ^4
             }
             old_signal_list = screen.tty_signal_keys(**disabled_keys)
             self.loop.run()


### PR DESCRIPTION
In some terminals, 'ctrl 4' generates 'ctrl \', which sends a quit
control character, which abruptly exits zulip-terminal.

This is resolved by adding it to the list of keys to be ignored
externally and handled by urwid, as is already done for 'ctrl c' and
'ctrl s', via tty_signal_keys.