### PR TITLE
Handle thread colors of the form '#xxx'

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -319,7 +319,7 @@ def initial_data(logged_on_user):
             'name': 'Django',
             'push_notifications': False,
             'email_address': '',
-            'color': '#94c849',
+            'color': '#94c849',     # Color in '#xxxxxx' format
             'in_home_view': True
         }, {
             'audible_notifications': False,
@@ -333,7 +333,7 @@ def initial_data(logged_on_user):
             'name': 'GSoC',
             'push_notifications': False,
             'email_address': '',
-            'color': '#c2c2c2',
+            'color': '#ccc',        # Color in '#xxx' format
             'in_home_view': True
         }, {
             # This is a private stream;
@@ -640,9 +640,9 @@ def streams():
     `initial_data` fixture.
     """
     return [
-        ['Django', 86, '#94c849', False],
-        ['GSoC', 14, '#c2c2c2', False],
-        ['Secret stream', 99, '#c3c3c3', True],
+        ['Django', 86, '#9c4', False],
+        ['GSoC', 14, '#ccc', False],
+        ['Secret stream', 99, '#ccc', True],
     ]
 
 

--- a/tests/helper/test_helper.py
+++ b/tests/helper/test_helper.py
@@ -2,6 +2,7 @@ import pytest
 
 from zulipterminal.helper import (
     index_messages,
+    canonicalize_color
 )
 from typing import Any
 
@@ -139,3 +140,20 @@ def test_index_starred(mocker,
             msg['flags'].append('starred')
 
     assert index_messages(messages, model, model.index) == expected_index
+
+
+@pytest.mark.parametrize('color', [
+    '#ffffff', '#f0f0f0', '#f0f1f2', '#fff', '#FFF', '#F3F5FA'
+])
+def test_color_formats(mocker, color):
+    canon = canonicalize_color(color)
+    assert canon == '#fff'
+
+
+@pytest.mark.parametrize('color', [
+    '#', '#f', '#ff', '#ffff', '#fffff', '#fffffff', '#abj', '#398a0s'
+])
+def test_invalid_color_format(mocker, color):
+    with pytest.raises(ValueError) as e:
+        canon = canonicalize_color(color)
+    assert str(e.value) == 'Unknown format for color "{}"'.format(color)

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -965,7 +965,7 @@ class TestMessageBox:
                        timestamp=99, reactions=[])
         self.model.stream_dict = {
             5: {  # matches stream_id above
-                'color': '#bfd56f',
+                'color': '#bd6',
             },
         }
         self.model.server_url = "SOME_BASE_URL"
@@ -1036,7 +1036,7 @@ class TestMessageBox:
     def test_main_view(self, mocker, message, last_message):
         self.model.stream_dict = {
             5: {
-                'color': '#bfd56f',
+                'color': '#bd6',
             },
         }
         msg_box = MessageBox(message, self.model, last_message)
@@ -1065,7 +1065,7 @@ class TestMessageBox:
         mocker.patch(VIEWS + ".urwid.Text")
         self.model.stream_dict = {
             5: {
-                'color': '#bfd56f',
+                'color': '#bd6',
             },
         }
         last_message = dict(message, **to_vary_in_last_message)
@@ -1154,7 +1154,7 @@ class TestMessageBox:
                                                  assert_search_bar):
         self.model.stream_dict = {
             205: {
-                'color': '#bfd56f',
+                'color': '#bd6',
             },
         }
         self.model.narrow = msg_narrow
@@ -1454,48 +1454,6 @@ class TestStreamButton:
                 count_str)
         assert len(text[0]) == len(expected_text) == (width - 1)
         assert text[0] == expected_text
-
-    @pytest.mark.parametrize('color', [
-        '#ffffff', '#f0f0f0', '#f0f1f2', '#fff'
-    ])
-    def test_color_formats(self, mocker, color):
-        mocker.patch(STREAMBUTTON + ".mark_muted")
-        controller = mocker.Mock()
-        controller.model.muted_streams = {}
-        properties = ["", 1, color, False]  # only color is important
-        view_mock = mocker.Mock()
-        background = (None, 'white', 'black')
-        view_mock.palette = [background]
-
-        stream_button = StreamButton(properties,
-                                     controller=controller,
-                                     view=view_mock,
-                                     width=10,
-                                     count=5)
-
-        expected_palette = ([background] +
-                            [('#fff', '', '', '', '#fff, bold', 'black')] +
-                            [('s#fff', '', '', '', 'black', '#fff')])
-        assert view_mock.palette == expected_palette
-
-    @pytest.mark.parametrize('color', [
-        '#', '#f', '#ff', '#ffff', '#fffff', '#fffffff'
-    ])
-    def test_invalid_color_format(self, mocker, color):
-        properties = ["", 1, color, False]  # only color is important
-        view_mock = mocker.Mock()
-        controller = mocker.Mock()
-        controller.model.muted_streams = {}
-        background = (None, 'white', 'black')
-        view_mock.palette = [background]
-
-        with pytest.raises(RuntimeError) as e:
-            StreamButton(properties,
-                         controller=controller,
-                         view=view_mock,
-                         width=10,
-                         count=5)
-        assert str(e.value) == "Unknown color format: '{}'".format(color)
 
     @pytest.mark.parametrize('stream_id, muted_streams, called_value,\
                              is_action_muting, updated_all_msgs', [

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -1,6 +1,7 @@
 import time
 from collections import defaultdict
 from functools import wraps
+from re import match, ASCII
 from threading import Thread
 from typing import (
     Any, Dict, List, Set, Tuple, Optional, DefaultDict, FrozenSet, Union
@@ -350,3 +351,17 @@ def match_user(user: Any, text: str) -> bool:
         if keyword.startswith(text.lower()):
             return True
     return False
+
+
+def canonicalize_color(color: str) -> str:
+    ''' Given a color of the format '#xxxxxx' or '#xxx', produces one of the
+    format '#xxx'. Always produces lowercase hex digits. '''
+    if match('^#[0-9A-Fa-f]{6}$', color, ASCII) is not None:
+        # '#xxxxxx' color, stored by current zulip server
+        return (color[:2] + color[3] + color[5]).lower()
+    elif match('^#[0-9A-Fa-f]{3}$', color, ASCII) is not None:
+        # '#xxx' color, which may be stored by the zulip server <= 2.0.0
+        # Potentially later versions too
+        return color.lower()
+    else:
+        raise ValueError('Unknown format for color "{}"'.format(color))

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -15,6 +15,7 @@ import zulip
 from zulipterminal.helper import (
     asynch,
     classify_unread_counts,
+    canonicalize_color,
     index_messages,
     set_count,
     initial_index,
@@ -478,6 +479,12 @@ class Model:
             subscriptions: List[Dict[str, Any]]
     ) -> Tuple[Dict[int, Any], Set[int], List[List[str]], List[List[str]]]:
         stream_keys = ('name', 'stream_id', 'color', 'invite_only')
+
+        # Canonicalize color formats, since zulip server versions may use
+        # different formats
+        for subscription in subscriptions:
+            subscription['color'] = canonicalize_color(subscription['color'])
+
         # Mapping of stream-id to all available stream info
         # Stream IDs for muted streams
         # Limited stream info sorted by name (used in display)

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -221,7 +221,7 @@ class MessageBox(urwid.Pile):
 
     def stream_header(self) -> Any:
         bar_color = self.model.stream_dict[self.stream_id]['color']
-        bar_color = 's' + bar_color[:2] + bar_color[3] + bar_color[5]
+        bar_color = 's' + bar_color
         stream_title_markup = ('bar', [
             (bar_color, '{} >'.format(self.caption)),
             ('title', ' {} '.format(self.title))
@@ -260,7 +260,7 @@ class MessageBox(urwid.Pile):
             text_to_fill = 'Starred messages'
         elif self.message['type'] == 'stream':
             bar_color = self.model.stream_dict[self.stream_id]['color']
-            bar_color = 's' + bar_color[:2] + bar_color[3] + bar_color[5]
+            bar_color = 's' + bar_color
             if len(curr_narrow) == 2 and curr_narrow[1][0] == 'topic':
                 text_to_fill = ('bar', [  # type: ignore
                     (bar_color, '{}'.format(self.caption)),

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -100,19 +100,10 @@ class StreamButton(TopButton):
                  count: int=0) -> None:
         # FIXME Is having self.stream_id the best way to do this?
         # (self.stream_id is used elsewhere)
-        caption, self.stream_id, orig_color, is_private = properties
+        caption, self.stream_id, color, is_private = properties
         self.model = controller.model
         self.count = count
         self.view = view
-
-        # Simplify the color from the original version & add to palette
-        # TODO Should this occur elsewhere and more intelligently?
-        if len(orig_color) == 7:  # modern zulip server format
-            color = ''.join(orig_color[i] for i in (0, 1, 3, 5))
-        elif len(orig_color) == 4:  # possible with zulip servers <=1.9.0 ?
-            color = orig_color
-        else:
-            raise RuntimeError("Unknown color format: '{}'".format(orig_color))
 
         for entry in view.palette:
             if entry[0] is None:


### PR DESCRIPTION
Our machinery for rendering thread colors in
   1. the thread list in the left column and
   2. thread titles in the center column

assumed that colors would be strings of the form '#xxxxxx'.

However, the web interface allows users to specifiy colors of the form
'#xxx', the rendering of which would cause the terminal client to crash.

Now the terminal client knows how to handle both forms, and will produce
a targetted error message in the face of future unknown formats.

Credits to #273 for originally discovering the problem, and @sadjad for
bringing it to my attention and helping me solve it.