### PR TITLE
utils: Avoid displaying messages from unsubscribed streams.

### DIFF
--- a/tests/ui/test_utils.py
+++ b/tests/ui/test_utils.py
@@ -86,12 +86,14 @@ def test_is_muted(mocker, msg, narrow, muted_streams, muted_topics, muted):
     assert return_value is muted
 
 
-@pytest.mark.parametrize('narrow, messages, focus_msg_id, muted, len_w_list', [
+@pytest.mark.parametrize('narrow, messages, focus_msg_id, muted,\
+                          unsubscribed, len_w_list', [
     (
         # No muted messages
         [],
         None,
         None,
+        False,
         False,
         2,
     ),
@@ -101,6 +103,7 @@ def test_is_muted(mocker, msg, narrow, muted_streams, muted_topics, muted):
         [1],
         None,
         False,
+        False,
         1,
     ),
     (
@@ -109,6 +112,7 @@ def test_is_muted(mocker, msg, narrow, muted_streams, muted_topics, muted):
         [1],
         None,
         True,
+        False,
         1,
     ),
     (
@@ -117,11 +121,22 @@ def test_is_muted(mocker, msg, narrow, muted_streams, muted_topics, muted):
         [1],
         None,
         True,
+        False,
         0,
-    )
+    ),
+    (
+        # Unsubscribed messages
+        [],
+        [1],
+        None,
+        False,
+        True,
+        0,
+    ),
+
 ])
 def test_create_msg_box_list(mocker, narrow, messages, focus_msg_id,
-                             muted, len_w_list):
+                             muted, unsubscribed, len_w_list):
     model = mocker.Mock()
     model.narrow = narrow
     model.index = {
@@ -144,5 +159,7 @@ def test_create_msg_box_list(mocker, narrow, messages, focus_msg_id,
     mocker.patch('zulipterminal.ui_tools.utils.urwid.AttrMap',
                  return_value='MSG')
     mocker.patch('zulipterminal.ui_tools.utils.is_muted', return_value=muted)
+    mocker.patch('zulipterminal.ui_tools.utils.is_unsubscribed_message',
+                 return_value=unsubscribed)
     return_value = create_msg_box_list(model, messages, focus_msg_id)
     assert len(return_value) == len_w_list

--- a/zulipterminal/ui_tools/utils.py
+++ b/zulipterminal/ui_tools/utils.py
@@ -26,7 +26,8 @@ def create_msg_box_list(model: Any, messages: Union[None, Iterable[Any]]=None,
             muted_msgs += 1
             if model.narrow == []:  # Don't show in 'All messages'.
                 continue
-
+        if is_unsubscribed_message(msg, model):
+            continue
         msg_flag = 'unread'  # type: Union[str, None]
         flags = msg.get('flags')
         # update_messages sends messages with no flags
@@ -58,5 +59,13 @@ def is_muted(msg: Dict[Any, Any], model: Any) -> bool:
     elif msg['stream_id'] in model.muted_streams:
         return True
     elif [msg['display_recipient'], msg['subject']] in model.muted_topics:
+        return True
+    return False
+
+
+def is_unsubscribed_message(msg: Dict[Any, Any], model: Any) -> bool:
+    if msg['type'] == 'private':
+        return False
+    if msg['stream_id'] not in model.stream_dict:
         return True
     return False


### PR DESCRIPTION
This is a bugfix to the issue reported at 
* https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/Dealing.20with.20unsubscribed.20streams/near/754229
* https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/how.20to/near/736274

In this PR, we tackle this issue, by not displaying messages which belong to 'unsubscribed' streams. Further, we could also first build the stream_dict with data from all streams and then update it with more information from subscribed streams. This has some challenges (Eg:  there is no 'color' mentioned for unsubscribed streams as the API call for get_all_streams returns minimal information). This was partly the reason a simpler fix like this PR was introduced.