### PR TITLE
show_help: Use double-lines around help to improve contrast.

### DIFF
--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -85,11 +85,15 @@ class Controller:
         self.loop.draw_screen()
 
     def show_help(self) -> None:
+        double_lines = dict(tlcorner='╔', tline='═', trcorner='╗',
+                            rline='║', lline='║',
+                            blcorner='╚', bline='═', brcorner='╝')
         cols, rows = self.loop.screen.get_cols_rows()
         help_view = HelpView(self)
         self.loop.widget = urwid.Overlay(
             urwid.LineBox(help_view,
-                          title="Help Menu (up/down scrolls)"),
+                          title="Help Menu (up/down scrolls)",
+                          **double_lines),
             self.view,
             align='center',
             valign='middle',

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -88,12 +88,17 @@ class Controller:
         double_lines = dict(tlcorner='╔', tline='═', trcorner='╗',
                             rline='║', lline='║',
                             blcorner='╚', bline='═', brcorner='╝')
+        blank_lines = dict(tlcorner=' ', tline=' ', trcorner=' ',
+                            rline=' ', lline=' ',
+                            blcorner=' ', bline=' ', brcorner=' ')
         cols, rows = self.loop.screen.get_cols_rows()
         help_view = HelpView(self)
         self.loop.widget = urwid.Overlay(
+            urwid.LineBox(
             urwid.LineBox(help_view,
                           title="Help Menu (up/down scrolls)",
                           **double_lines),
+            **blank_lines),
             self.view,
             align='center',
             valign='middle',


### PR DESCRIPTION
These line characters don't take up extra space, but make the menu stand out better.