### PR TITLE
Add custom emoji support within messages.

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -945,6 +945,8 @@ class TestMessageBox:
         ('<span class="emoji">:smile:</span>', [':smile:']),
         ('<div class="inline-preview-twitter"',
             ['[TWITTER PREVIEW NOT RENDERED]']),
+        ('<img class="emoji" title="zulip"/>', [':zulip:']),
+        ('<img class="emoji" title="github"/>', [':github:']),
     ], ids=[
         'empty', 'p', 'user-mention', 'group-mention', 'code', 'codehilite',
         'strong', 'em', 'blockquote',
@@ -952,7 +954,7 @@ class TestMessageBox:
         'link_userupload', 'listitem', 'listitems',
         'br', 'br2', 'hr', 'hr2', 'img', 'img2', 'table', 'math', 'math2',
         'ul', 'strikethrough_del', 'inline_image', 'inline_ref',
-        'emoji', 'preview-twitter'
+        'emoji', 'preview-twitter', 'zulip_extra_emoji', 'custom_emoji'
     ])
     def test_soup2markup(self, content, markup):
         message = dict(display_recipient=['x'], stream_id=5, subject='hi',

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -344,6 +344,11 @@ class MessageBox(urwid.Pile):
                 text = unrendered_div_classes[matching_class.pop()]
                 if text:
                     markup.append(unrendered_template.format(text))
+            elif (element.name == 'img' and
+                    element.attrs.get('class', []) == ['emoji']):
+                # CUSTOM EMOJIS AND ZULIP_EXTRA_EMOJI
+                emoji_name = element.attrs.get('title', [])
+                markup.append(":"+emoji_name+":")
             elif element.name in unrendered_tags:
                 # UNRENDERED SIMPLE TAGS
                 text = unrendered_tags[element.name]

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -291,14 +291,15 @@ class MessageBox(urwid.Pile):
             for reaction in reactions:
                 if reaction['reaction_type'] == 'unicode_emoji':
                     reacts[reaction['emoji_code']] += 1
-                elif reaction['reaction_type'] == 'realm_emoji':
-                    custom_reacts[reaction['emoji_name']] += 1
+                else:
+                    # Includes realm_emoji and zulip_extra_emoji
+                    custom_reacts[":"+reaction['emoji_name']+":"] += 1
             dis = [
                 '\\U' + '0'*(8-len(emoji)) + emoji + ' ' + str(reacts[emoji]) +
                 ' ' for emoji in reacts]
             emojis = ''.join(e.encode().decode('unicode-escape') for e in dis)
             custom_emojis = ''.join(
-                ['{} {}'.format(r, custom_reacts[r]) for r in custom_reacts])
+                ['{} {} '.format(r, custom_reacts[r]) for r in custom_reacts])
             return urwid.Padding(
                 urwid.Text(([
                     ('emoji', emoji.demojize(emojis + custom_emojis))


### PR DESCRIPTION
This adds 2 commits:
1) Replacing [IMAGE NOT RENDERED] for custom_emojis with emoji title
2) Display zulip_extra_emoji when used as reaction and adjust spacing and display text.

Fixes: #238 