### PR TITLE
ZT redesign UI layout for stream and user search boxes

### DIFF
--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -45,8 +45,8 @@ class View(urwid.WidgetWrap):
     def message_view(self) -> Any:
         self.middle_column = MiddleColumnView(self, self.model, self.write_box,
                                               self.search_box)
-        return urwid.LineBox(self.middle_column, bline="",
-                             title=u'Messages', tline=u'─')
+        return urwid.LineBox(self.middle_column, bline="", title=u'Messages',
+                             tline=u'─', trcorner=u'│', tlcorner=u'│')
 
     def right_column_view(self) -> Any:
         self.users_view = RightColumnView(View.RIGHT_WIDTH, self)

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -682,7 +682,7 @@ class SearchBox(urwid.Pile):
         super(SearchBox, self).__init__(self.main_view())
 
     def main_view(self) -> Any:
-        self.text_box = ReadlineEdit(u"Search: ")
+        self.text_box = ReadlineEdit(u"Search messages: ")
         # Add some text so that when packing,
         # urwid doesn't hide the widget.
         self.conversation_focus = urwid.Text(" ")

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -208,7 +208,7 @@ class StreamsView(urwid.Frame):
         self.search_box = StreamSearchBox(self)
         urwid.connect_signal(self.search_box, 'change', self.update_streams)
         super(StreamsView, self).__init__(list_box, header=urwid.LineBox(
-            self.search_box, tlcorner=u'─', tline=u'─', lline=u'',
+            self.search_box, tlcorner=u'─', tline=u'', lline=u'',
             trcorner=u'─', blcorner=u'─', rline=u'',
             bline=u'─', brcorner=u'─'
         ))
@@ -402,7 +402,7 @@ class RightColumnView(urwid.Frame):
                              self.update_user_list)
         self.view.user_search = self.user_search
         search_box = urwid.LineBox(
-            self.user_search, tlcorner=u'─', tline=u'─', lline=u'',
+            self.user_search, tlcorner=u'─', tline=u'', lline=u'',
             trcorner=u'─', blcorner=u'─', rline=u'',
             bline=u'─', brcorner=u'─'
             )


### PR DESCRIPTION
This tweaks the UI layout my making th following adjustments
* Avoids top border line in user and stream search box
* Rewords the search message in MessageSearch Box to extend to `Search messages: `
* Extend the top-left and top-right borders of central message view to make them look more vertical
![redesign_UI_layout](https://user-images.githubusercontent.com/30312566/60308923-db83b080-9968-11e9-9a66-2e473dd75782.png)
