### PR TITLE
ui/views: Set title lines in columns in bold

### DIFF
--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -46,15 +46,15 @@ class View(urwid.WidgetWrap):
         self.middle_column = MiddleColumnView(self, self.model, self.write_box,
                                               self.search_box)
         return urwid.LineBox(self.middle_column, title=u'Messages',
-                             bline=u'', tline=u'─',
+                             bline=u'', tline=u'━',
                              trcorner=u'│', tlcorner=u'│')
 
     def right_column_view(self) -> Any:
         self.users_view = RightColumnView(View.RIGHT_WIDTH, self)
         return urwid.LineBox(
             self.users_view, title=u"Users",
-            tlcorner=u'─', tline=u'─', lline=u'',
-            trcorner=u'─', blcorner=u'─', rline=u'',
+            tlcorner=u'━', tline=u'━', lline=u'',
+            trcorner=u'━', blcorner=u'─', rline=u'',
             bline=u'', brcorner=u''
         )
 

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -561,8 +561,8 @@ class LeftColumnView(urwid.Pile):
         self.view.stream_w = StreamsView(streams_btn_list, self.view)
         w = urwid.LineBox(
             self.view.stream_w, title="Streams",
-            tlcorner=u'─', tline=u'─', lline=u'',
-            trcorner=u'─', blcorner=u'', rline=u'',
+            tlcorner=u'━', tline=u'━', lline=u'',
+            trcorner=u'━', blcorner=u'', rline=u'',
             bline=u'', brcorner=u'─'
             )
         return w


### PR DESCRIPTION
This is something of a follow-up to the recent UI changes in #T408 to keep the columns separated, where it minimized the lines and made the UI more columnar, but now perhaps became a bit less clear which elements were 'titles'.

This small commit emphasizes the Streams, Messages and Users titles, by using a different line around it.