### PR TITLE
writebox: Set msg_edit_id to None if user exits from the compose box.

### DIFF
--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -113,6 +113,7 @@ class WriteBox(urwid.Pile):
                     self.msg_edit_id = None
                     self.keypress(size, 'esc')
         elif is_command_key('GO_BACK', key):
+            self.msg_edit_id = None
             self.view.controller.editor_mode = False
             self.main_view(False)
             self.view.middle_column.set_focus('body')


### PR DESCRIPTION
```quote
Looks like there is a bug in the editing message feature we have. To repro :

send a message in a stream
Click e and add some text
Press 'ESC' before you send the message.
Press 'r' on the last message, which you wanted to edit
And type another message and send it
Observe that this message replaces (the original message) and acts as if you were editing the message.
```
Thanks @neiljp and @sumanthvrao for informing. This should fix it.