### PR TITLE
Search box improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ autohide=autohide
 | Narrow to all starred messages                        | <kbd>f</kbd>                                  |
 | Next Unread Topic                                     | <kbd>n</kbd>                                  |
 | Next Unread private message                           | <kbd>p</kbd>                                  |
-| Search People                                         | <kbd>w</kbd>                                  |
+| Search Users                                          | <kbd>w</kbd>                                  |
 | Search Messages                                       | <kbd>/</kbd>                                  |
 | Search Streams                                        | <kbd>q</kbd>                                  |
 | Add/remove thumbs-up reaction to the current message  | <kbd>+</kbd>                                  |

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -820,9 +820,6 @@ class TestRightColumnView:
 
         right_col_view.keypress(size, key)
 
-        right_col_view.user_search.set_edit_text.assert_called_once_with(
-            "Search People"
-        )
         right_col_view.set_body.assert_called_once_with(right_col_view.body)
         right_col_view.set_focus.assert_called_once_with('body')
         list_w.assert_called_once_with([])

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -444,8 +444,6 @@ class TestStreamsView:
         mocker.patch.object(stream_view, 'set_focus')
         stream_view.keypress(size, key)
         stream_view.set_focus.assert_called_once_with("body")
-        stream_view.search_box.set_edit_text.assert_called_once_with(
-            "Search streams")
         assert stream_view.log == self.streams_btn_list
 
 

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -114,7 +114,7 @@ KEY_BINDINGS = OrderedDict([
     }),
     ('SEARCH_PEOPLE', {
         'keys': {'w'},
-        'help_text': 'Search People',
+        'help_text': 'Search users',
     }),
     ('SEARCH_MESSAGES', {
         'keys': {'/'},

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -10,7 +10,7 @@ from urwid_readline import ReadlineEdit
 from bs4 import BeautifulSoup
 from bs4.element import NavigableString, Tag
 
-from zulipterminal.config.keys import is_command_key
+from zulipterminal.config.keys import is_command_key, keys_for_command
 
 
 class WriteBox(urwid.Pile):
@@ -689,7 +689,10 @@ class SearchBox(urwid.Pile):
         super(SearchBox, self).__init__(self.main_view())
 
     def main_view(self) -> Any:
-        self.text_box = ReadlineEdit(u"Search: ")
+        search_text = ("Search [" +
+                       ", ".join(keys_for_command("SEARCH_MESSAGES")) +
+                       "]: ")
+        self.text_box = ReadlineEdit(search_text + " ")
         # Add some text so that when packing,
         # urwid doesn't hide the widget.
         self.conversation_focus = urwid.Text(" ")
@@ -727,7 +730,9 @@ class UserSearchBox(urwid.Edit):
     Search Box to search users in real-time.
     """
 
-    search_text = "Search:"
+    search_text = ("Search [" +
+                   ", ".join(keys_for_command("SEARCH_PEOPLE")) +
+                   "]: ")
 
     def __init__(self, user_view: Any) -> None:
         self.user_view = user_view
@@ -751,7 +756,9 @@ class StreamSearchBox(urwid.Edit):
     Search Box to search streams in real-time.urwid
     """
 
-    search_text = "Search:"
+    search_text = ("Search [" +
+                   ", ".join(keys_for_command("SEARCH_STREAMS")) +
+                   "]: ")
 
     def __init__(self, stream_view: Any) -> None:
         self.stream_view = stream_view

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -727,9 +727,11 @@ class UserSearchBox(urwid.Edit):
     Search Box to search users in real-time.
     """
 
+    search_text = "Search People"
+
     def __init__(self, user_view: Any) -> None:
         self.user_view = user_view
-        super(UserSearchBox, self).__init__(edit_text="Search people")
+        super(UserSearchBox, self).__init__(edit_text=self.search_text)
 
     def keypress(self, size: Tuple[int, int], key: str) -> str:
         if is_command_key('ENTER', key):
@@ -737,7 +739,7 @@ class UserSearchBox(urwid.Edit):
             self.user_view.set_focus("body")
         if is_command_key('GO_BACK', key):
             self.user_view.view.controller.editor_mode = False
-            self.set_edit_text("Search people")
+            self.set_edit_text(self.search_text)
             self.user_view.set_focus("body")
             self.user_view.keypress(size, 'esc')
 

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -749,9 +749,11 @@ class StreamSearchBox(urwid.Edit):
     Search Box to search streams in real-time.urwid
     """
 
+    search_text = "Search streams"
+
     def __init__(self, stream_view: Any) -> None:
         self.stream_view = stream_view
-        super(StreamSearchBox, self).__init__(edit_text="Search streams")
+        super(StreamSearchBox, self).__init__(edit_text=self.search_text)
 
     def keypress(self, size: Tuple[int, int], key: str) -> str:
         if is_command_key('ENTER', key) and len(self.stream_view.log):
@@ -760,7 +762,7 @@ class StreamSearchBox(urwid.Edit):
             self.stream_view.body.set_focus(0)
         if is_command_key('GO_BACK', key):
             self.stream_view.view.controller.editor_mode = False
-            self.set_edit_text("Search streams")
+            self.set_edit_text(self.search_text)
             self.stream_view.set_focus("body")
             self.stream_view.keypress(size, 'esc')
 

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -727,7 +727,7 @@ class UserSearchBox(urwid.Edit):
     Search Box to search users in real-time.
     """
 
-    search_text = "Search People"
+    search_text = "Search:"
 
     def __init__(self, user_view: Any) -> None:
         self.user_view = user_view
@@ -751,7 +751,7 @@ class StreamSearchBox(urwid.Edit):
     Search Box to search streams in real-time.urwid
     """
 
-    search_text = "Search streams"
+    search_text = "Search:"
 
     def __init__(self, stream_view: Any) -> None:
         self.stream_view = stream_view

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -296,7 +296,6 @@ class StreamsView(urwid.Frame):
             self.set_focus('header')
             return key
         elif is_command_key('GO_BACK', key):
-            self.search_box.set_edit_text("Search streams")
             self.log.clear()
             self.log.extend(self.streams_btn_list)
             self.set_focus('body')

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -526,7 +526,6 @@ class RightColumnView(urwid.Frame):
             return key
         elif is_command_key('GO_BACK', key):
             self.allow_update_user_list = True
-            self.user_search.set_edit_text("Search People")
             self.body = UsersView(
                 urwid.SimpleFocusListWalker(self.users_btn_list))
             self.set_body(self.body)


### PR DESCRIPTION
This is an attempt to work upon the remaining concept in #408, namely to improve the consistency between the search boxes.

Since each area (streams, messages, users) appears clearer with the 'bold headers' of #413, it seems more feasible to reduce text duplication in the UI and simplify the search text to the minimal form used in the message search box. This PR first extracts the common locations for that text, then:
* unifies the documentation/help to the title of the right panel (Users vs People)
* simplifies the text to just 'Search:' for the Streams and Users areas
* Adds shortcut key 'labels' to each search box, as suggested by @rishig (?)

The last change could be diverted to another PR with similar changes, but it's search-box related and easier with shorter search-box text, so feedback on that would be useful even if it's not merged as part of this PR.