### PR TITLE
Refactoring: Improve index naming 

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -431,14 +431,14 @@ def empty_index():
     return deepcopy({
         'pointer': defaultdict(set, {}),
         'private': defaultdict(set, {}),
-        'all_messages':  set(),
-        'all_private': set(),
+        'all_msg_ids':  set(),
+        'private_msg_ids': set(),
         'all_stream': defaultdict(set, {}),
         'stream': defaultdict(dict, {}),
         'topics': defaultdict(list),
         'edited_messages': set(),
         'search': set(),
-        'all_starred': set(),
+        'starred_msg_ids': set(),
         'messages': defaultdict(dict, {
             stream_msg_template['id']: stream_msg_template,
             pm_template['id']: pm_template,
@@ -452,7 +452,7 @@ def index_all_messages(empty_index):
     """
     Expected index of `initial_data` fixture when model.narrow = []
     """
-    return dict(empty_index, **{'all_messages': {537286, 537287, 537288}})
+    return dict(empty_index, **{'all_msg_ids': {537286, 537287, 537288}})
 
 
 @pytest.fixture
@@ -461,7 +461,7 @@ def index_stream(empty_index):
     Expected index of initial_data when model.narrow = [['stream', '7']]
     """
     diff = {'all_stream': defaultdict(set, {205: {537286}}),
-            'all_private': {537287, 537288}}
+            'private_msg_ids': {537287, 537288}}
     return dict(empty_index, **diff)
 
 
@@ -482,7 +482,7 @@ def index_user(empty_index):
                                                          'boo@zulip.com'],
     """
     diff = {'private': defaultdict(set, {frozenset({5179, 5140}): {537287}}),
-            'all_private': {537287, 537288}}
+            'private_msg_ids': {537287, 537288}}
     return dict(empty_index, **diff)
 
 
@@ -494,7 +494,7 @@ def index_user_multiple(empty_index):
     """
     diff = {'private': defaultdict(set,
                                    {frozenset({5179, 5140, 5180}): {537288}}),
-            'all_private': {537287, 537288}}
+            'private_msg_ids': {537287, 537288}}
     return dict(empty_index, **diff)
 
 
@@ -505,8 +505,8 @@ def index_user_multiple(empty_index):
 ])
 def index_all_starred(empty_index, request):
     msgs_with_stars = request.param
-    index = dict(empty_index, all_starred=msgs_with_stars,
-                 all_private={537287, 537288})
+    index = dict(empty_index, starred_msg_ids=msgs_with_stars,
+                 private_msg_ids={537287, 537288})
     for msg_id, msg in index['messages'].items():
         if msg_id in msgs_with_stars and 'starred' not in msg['flags']:
             msg['flags'].append('starred')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -430,15 +430,15 @@ def initial_index():
 def empty_index():
     return deepcopy({
         'pointer': defaultdict(set, {}),
-        'private_msg_ids_by_user_ids': defaultdict(set, {}),
         'all_msg_ids':  set(),
+        'starred_msg_ids': set(),
         'private_msg_ids': set(),
+        'private_msg_ids_by_user_ids': defaultdict(set, {}),
         'stream_msg_ids_by_stream_id': defaultdict(set, {}),
         'topic_msg_ids': defaultdict(dict, {}),
-        'topics': defaultdict(list),
         'edited_messages': set(),
+        'topics': defaultdict(list),
         'search': set(),
-        'starred_msg_ids': set(),
         'messages': defaultdict(dict, {
             stream_msg_template['id']: stream_msg_template,
             pm_template['id']: pm_template,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -430,11 +430,11 @@ def initial_index():
 def empty_index():
     return deepcopy({
         'pointer': defaultdict(set, {}),
-        'private': defaultdict(set, {}),
+        'private_msg_ids_by_user_ids': defaultdict(set, {}),
         'all_msg_ids':  set(),
         'private_msg_ids': set(),
-        'all_stream': defaultdict(set, {}),
-        'stream': defaultdict(dict, {}),
+        'stream_msg_ids_by_stream_id': defaultdict(set, {}),
+        'topic_msg_ids': defaultdict(dict, {}),
         'topics': defaultdict(list),
         'edited_messages': set(),
         'search': set(),
@@ -460,7 +460,7 @@ def index_stream(empty_index):
     """
     Expected index of initial_data when model.narrow = [['stream', '7']]
     """
-    diff = {'all_stream': defaultdict(set, {205: {537286}}),
+    diff = {'stream_msg_ids_by_stream_id': defaultdict(set, {205: {537286}}),
             'private_msg_ids': {537287, 537288}}
     return dict(empty_index, **diff)
 
@@ -471,7 +471,7 @@ def index_topic(empty_index):
     Expected index of initial_data when model.narrow = [['stream', '7'],
                                                         ['topic', 'Test']]
     """
-    diff = {'stream': defaultdict(dict, {205: {'Test': {537286}}})}
+    diff = {'topic_msg_ids': defaultdict(dict, {205: {'Test': {537286}}})}
     return dict(empty_index, **diff)
 
 
@@ -481,7 +481,9 @@ def index_user(empty_index):
     Expected index of initial_data when model.narrow = [['pm_with',
                                                          'boo@zulip.com'],
     """
-    diff = {'private': defaultdict(set, {frozenset({5179, 5140}): {537287}}),
+    user_ids = frozenset({5179, 5140})
+    diff = {'private_msg_ids_by_user_ids': defaultdict(set,
+                                                       {user_ids: {537287}}),
             'private_msg_ids': {537287, 537288}}
     return dict(empty_index, **diff)
 
@@ -492,8 +494,9 @@ def index_user_multiple(empty_index):
     Expected index of initial_data when model.narrow = [['pm_with',
                                             'boo@zulip.com, bar@zulip.com'],
     """
-    diff = {'private': defaultdict(set,
-                                   {frozenset({5179, 5140, 5180}): {537288}}),
+    user_ids = frozenset({5179, 5140, 5180})
+    diff = {'private_msg_ids_by_user_ids': defaultdict(set,
+                                                       {user_ids: {537288}}),
             'private_msg_ids': {537287, 537288}}
     return dict(empty_index, **diff)
 

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -55,8 +55,10 @@ class TestController:
         assert controller.model.stream_id == stream_button.stream_id
         assert controller.model.narrow == [['stream', stream_button.caption]]
         controller.model.msg_view.clear.assert_called_once_with()
+
         widget = controller.model.msg_view.extend.call_args_list[0][0][0][0]
-        id_list = index_stream['all_stream'][stream_button.stream_id]
+        stream_id = stream_button.stream_id
+        id_list = index_stream['stream_msg_ids_by_stream_id'][stream_id]
         assert {widget.original_widget.message['id']} == id_list
 
     def test_narrow_to_topic(self, mocker, controller,
@@ -78,8 +80,10 @@ class TestController:
         assert controller.model.stream_id == msg_box.stream_id
         assert controller.model.narrow == expected_narrow
         controller.model.msg_view.clear.assert_called_once_with()
+
         widget = controller.model.msg_view.extend.call_args_list[0][0][0][0]
-        id_list = index_topic['stream'][msg_box.stream_id][msg_box.title]
+        stream_id, topic_name = msg_box.stream_id, msg_box.title
+        id_list = index_topic['topic_msg_ids'][stream_id][topic_name]
         assert {widget.original_widget.message['id']} == id_list
 
     def test_narrow_to_user(self, mocker, controller, user_button, index_user):
@@ -100,7 +104,7 @@ class TestController:
         recipients = frozenset([controller.model.user_id, user_button.user_id])
         assert controller.model.recipients == recipients
         widget = controller.model.msg_view.extend.call_args_list[0][0][0][0]
-        id_list = index_user['private'][recipients]
+        id_list = index_user['private_msg_ids_by_user_ids'][recipients]
         assert {widget.original_widget.message['id']} == id_list
 
     def test_show_all_messages(self, mocker, controller, index_all_messages):

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -116,12 +116,14 @@ class TestController:
         }
         controller.model.muted_streams = []
         controller.model.muted_topics = []
+
         controller.show_all_messages('')
+
         assert controller.model.narrow == []
         controller.model.msg_view.clear.assert_called_once_with()
-        num_am = len(index_all_messages['all_messages'])
+
         widgets = controller.model.msg_view.extend.call_args_list[0][0][0]
-        id_list = index_all_messages['all_messages']
+        id_list = index_all_messages['all_msg_ids']
         msg_ids = {widget.original_widget.message['id'] for widget in widgets}
         assert msg_ids == id_list
 
@@ -136,9 +138,9 @@ class TestController:
 
         assert controller.model.narrow == [['is', 'private']]
         controller.model.msg_view.clear.assert_called_once_with()
-        num_pm = len(index_user['all_private'])
+
         widgets = controller.model.msg_view.extend.call_args_list[0][0][0]
-        id_list = index_user['all_private']
+        id_list = index_user['private_msg_ids']
         msg_ids = {widget.original_widget.message['id'] for widget in widgets}
         assert msg_ids == id_list
 
@@ -159,12 +161,9 @@ class TestController:
         controller.show_all_starred('')
 
         assert controller.model.narrow == [['is', 'starred']]
-
         controller.model.msg_view.clear.assert_called_once_with()
 
-        num_sm = len(index_all_starred['all_starred'])
-
-        id_list = index_all_starred['all_starred']
+        id_list = index_all_starred['starred_msg_ids']
         widgets = controller.model.msg_view.extend.call_args_list[0][0][0]
         msg_ids = {widget.original_widget.message['id'] for widget in widgets}
         assert msg_ids == id_list

--- a/tests/helper/test_helper.py
+++ b/tests/helper/test_helper.py
@@ -104,7 +104,7 @@ def test_index_edited_message(mocker,
     model.narrow = []
 
     expected_index = dict(empty_index, edited_messages=edited_msgs,
-                          all_messages={537286, 537287, 537288})
+                          all_msg_ids={537286, 537287, 537288})
     for msg_id, msg in expected_index['messages'].items():
         if msg_id in edited_msgs:
             msg['edit_history'] = []
@@ -132,8 +132,8 @@ def test_index_starred(mocker,
     model.index = initial_index
     model.narrow = [['is', 'starred']]
 
-    expected_index = dict(empty_index, all_private={537287, 537288},
-                          all_starred=msgs_with_stars)
+    expected_index = dict(empty_index, private_msg_ids={537287, 537288},
+                          starred_msg_ids=msgs_with_stars)
     for msg_id, msg in expected_index['messages'].items():
         if msg_id in msgs_with_stars and 'starred' not in msg['flags']:
             msg['flags'].append('starred')

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -176,7 +176,7 @@ class TestModel:
 
     @pytest.mark.parametrize("narrow, index, current_ids", [
         ([], {
-            "all_messages": {0, 1}
+            "all_msg_ids": {0, 1}
         }, {0, 1}),
         ([['stream', 'FOO']], {
             "all_stream": {
@@ -200,7 +200,7 @@ class TestModel:
              }
          }, set()),
         ([['is', 'private']], {
-            'all_private': {0, 1}
+            'private_msg_ids': {0, 1}
         }, {0, 1}),
         ([['pm_with', 'FOO@zulip.com']], {
             'private': {
@@ -216,7 +216,7 @@ class TestModel:
             'search': {0, 1}
         }, {0, 1}),
         ([['is', 'starred']], {
-            'all_starred': {0, 1}
+            'starred_msg_ids': {0, 1}
         }, {0, 1})
     ])
     def test_get_message_ids_in_current_narrow(self, mocker, model,

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -179,13 +179,13 @@ class TestModel:
             "all_msg_ids": {0, 1}
         }, {0, 1}),
         ([['stream', 'FOO']], {
-            "all_stream": {
+            "stream_msg_ids_by_stream_id": {
                 1: {0, 1}
             }
         }, {0, 1}),
         ([['stream', 'FOO'],
          ['topic', 'BOO']], {
-             'stream': {
+             'topic_msg_ids': {
                  1: {
                      'BOO': {0, 1}
                  }
@@ -193,7 +193,7 @@ class TestModel:
          }, {0, 1}),
         ([['stream', 'FOO'],  # Covers one empty-set case
          ['topic', 'BOOBOO']], {
-             'stream': {
+             'topic_msg_ids': {
                  1: {
                      'BOO': {0, 1}
                  }
@@ -203,12 +203,12 @@ class TestModel:
             'private_msg_ids': {0, 1}
         }, {0, 1}),
         ([['pm_with', 'FOO@zulip.com']], {
-            'private': {
+            'private_msg_ids_by_user_ids': {
                 frozenset({1, 2}): {0, 1}
             }
         }, {0, 1}),
         ([['pm_with', 'FOO@zulip.com']], {  # Covers recipient empty-set case
-            'private': {
+            'private_msg_ids_by_user_ids': {
                 frozenset({1, 3}): {0, 1}  # NOTE {1,3} not {1,2}
             }
         }, set()),

--- a/tests/ui/test_utils.py
+++ b/tests/ui/test_utils.py
@@ -140,7 +140,7 @@ def test_create_msg_box_list(mocker, narrow, messages, focus_msg_id,
     model = mocker.Mock()
     model.narrow = narrow
     model.index = {
-        'all_messages': {1, 2},
+        'all_msg_ids': {1, 2},
         'messages': {
             1: {
                 'id': 1,

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -13,32 +13,33 @@ Message = Dict[str, Any]
 
 Index = TypedDict('Index', {
     'pointer': Dict[str, Union[int, Set[None]]],  # narrow_str, message_id
-    # stream_id: topic_str: {message_id, ...}
-    'topic_msg_ids': Dict[int, Dict[str, Set[int]]],
-    # {user_id, ...}: {message_id, ...}
+    # Various sets of downloaded message ids (all, starred, ...)
+    'all_msg_ids': Set[int],
+    'starred_msg_ids': Set[int],
+    'private_msg_ids': Set[int],
     'private_msg_ids_by_user_ids': Dict[FrozenSet[int], Set[int]],
-    'topics': Dict[int, List[str]],  # {topic names, ...}
-    'all_msg_ids': Set[int],  # {message_id, ...}
-    'starred_msg_ids': Set[int],  # {message_id, ...}
-    'private_msg_ids': Set[int],  # {message_id, ...}
     'stream_msg_ids_by_stream_id': Dict[int, Set[int]],
+    'topic_msg_ids': Dict[int, Dict[str, Set[int]]],
+    # Extra cached information
     'edited_messages': Set[int],  # {message_ids, ...}
+    'topics': Dict[int, List[str]],  # {topic names, ...}
     'search': Set[int],  # {message_id, ...}
+    # Downloaded message data
     'messages': Dict[int, Message],  # message_id: Message
 })
 
 initial_index = Index(
     pointer=defaultdict(set),
-    topic_msg_ids=defaultdict(dict),
-    private_msg_ids_by_user_ids=defaultdict(set),
-    topics=defaultdict(list),
     all_msg_ids=set(),
     starred_msg_ids=set(),
     private_msg_ids=set(),
+    private_msg_ids_by_user_ids=defaultdict(set),
     stream_msg_ids_by_stream_id=defaultdict(set),
+    topic_msg_ids=defaultdict(dict),
     edited_messages=set(),
-    messages=defaultdict(dict),
+    topics=defaultdict(list),
     search=set(),
+    messages=defaultdict(dict),
 )
 
 

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -303,9 +303,10 @@ def index_messages(messages: List[Any],
         if msg['type'] == 'stream' and len(narrow) == 2 and\
                 narrow[1][1] == msg['subject']:
 
-            if not index['stream'][msg['stream_id']].get(msg['subject']):
-                index['stream'][msg['stream_id']][msg['subject']] = set()
-            index['stream'][msg['stream_id']][msg['subject']].add(msg['id'])
+            topics_in_stream = index['stream'][msg['stream_id']]
+            if not topics_in_stream.get(msg['subject']):
+                topics_in_stream[msg['subject']] = set()
+            topics_in_stream[msg['subject']].add(msg['id'])
 
     return index
 

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -18,9 +18,9 @@ Index = TypedDict('Index', {
     # {user_id, ...}: {message_id, ...}
     'private': Dict[FrozenSet[int], Set[int]],
     'topics': Dict[int, List[str]],  # {topic names, ...}
-    'all_messages': Set[int],  # {message_id, ...}
-    'all_starred': Set[int],  # {message_id, ...}
-    'all_private': Set[int],  # {message_id, ...}
+    'all_msg_ids': Set[int],  # {message_id, ...}
+    'starred_msg_ids': Set[int],  # {message_id, ...}
+    'private_msg_ids': Set[int],  # {message_id, ...}
     'all_stream': Dict[int, Set[int]],  # stream_id: {message_id, ...}
     'edited_messages': Set[int],  # {message_ids, ...}
     'search': Set[int],  # {message_id, ...}
@@ -32,13 +32,13 @@ initial_index = Index(
     stream=defaultdict(dict),
     private=defaultdict(set),
     topics=defaultdict(list),
-    all_messages=set(),
-    all_private=set(),
+    all_msg_ids=set(),
+    starred_msg_ids=set(),
+    private_msg_ids=set(),
     all_stream=defaultdict(set),
     edited_messages=set(),
     messages=defaultdict(dict),
     search=set(),
-    all_starred=set(),
 )
 
 
@@ -176,12 +176,12 @@ def index_messages(messages: List[Any],
                 ....
             ]
         },
-        'all_messages': {
+        'all_msg_ids': {
             14231,
             23423,
             ...
         },
-        'all_private': {
+        'private_msg_ids': {
             22334,
             23423,
             ...
@@ -272,7 +272,7 @@ def index_messages(messages: List[Any],
 
         index['messages'][msg['id']] = msg
         if not narrow:
-            index['all_messages'].add(msg['id'])
+            index['all_msg_ids'].add(msg['id'])
 
         elif narrow[0][0] == 'search':
             index['search'].add(msg['id'])
@@ -282,10 +282,10 @@ def index_messages(messages: List[Any],
 
             if narrow[0][1] == 'starred':
                 if 'starred' in msg['flags']:
-                    index['all_starred'].add(msg['id'])
+                    index['starred_msg_ids'].add(msg['id'])
 
             if msg['type'] == 'private':
-                index['all_private'].add(msg['id'])
+                index['private_msg_ids'].add(msg['id'])
                 recipients = frozenset(set(
                     recipient['id'] for recipient in msg['display_recipient']
                 ))

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -177,15 +177,15 @@ class Model:
         elif narrow[0][0] == 'stream':
             stream_id = self.stream_id
             if len(narrow) == 1:
-                ids = index['all_stream'][stream_id]
+                ids = index['stream_msg_ids_by_stream_id'][stream_id]
             elif len(narrow) == 2:
                 topic = narrow[1][1]
-                ids = index['stream'][stream_id].get(topic, set())
+                ids = index['topic_msg_ids'][stream_id].get(topic, set())
         elif narrow[0][1] == 'private':
             ids = index['private_msg_ids']
         elif narrow[0][0] == 'pm_with':
             recipients = self.recipients
-            ids = index['private'].get(recipients, set())
+            ids = index['private_msg_ids_by_user_ids'].get(recipients, set())
         elif narrow[0][0] == 'search':
             ids = index['search']
         elif narrow[0][1] == 'starred':

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -172,7 +172,7 @@ class Model:
     def get_message_ids_in_current_narrow(self) -> Set[int]:
         narrow = self.narrow
         if narrow == []:
-            current_ids = self.index['all_messages']
+            current_ids = self.index['all_msg_ids']
         elif narrow[0][0] == 'stream':
             stream_id = self.stream_id
             if len(narrow) == 1:
@@ -181,14 +181,14 @@ class Model:
                 topic = narrow[1][1]
                 current_ids = self.index['stream'][stream_id].get(topic, set())
         elif narrow[0][1] == 'private':
-            current_ids = self.index['all_private']
+            current_ids = self.index['private_msg_ids']
         elif narrow[0][0] == 'pm_with':
             recipients = self.recipients
             current_ids = self.index['private'].get(recipients, set())
         elif narrow[0][0] == 'search':
             current_ids = self.index['search']
         elif narrow[0][1] == 'starred':
-            current_ids = self.index['all_starred']
+            current_ids = self.index['starred_msg_ids']
         return current_ids.copy()
 
     def _notify_server_of_presence(self) -> Dict[str, Any]:

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -171,25 +171,26 @@ class Model:
 
     def get_message_ids_in_current_narrow(self) -> Set[int]:
         narrow = self.narrow
+        index = self.index
         if narrow == []:
-            current_ids = self.index['all_msg_ids']
+            ids = index['all_msg_ids']
         elif narrow[0][0] == 'stream':
             stream_id = self.stream_id
             if len(narrow) == 1:
-                current_ids = self.index['all_stream'][stream_id]
+                ids = index['all_stream'][stream_id]
             elif len(narrow) == 2:
                 topic = narrow[1][1]
-                current_ids = self.index['stream'][stream_id].get(topic, set())
+                ids = index['stream'][stream_id].get(topic, set())
         elif narrow[0][1] == 'private':
-            current_ids = self.index['private_msg_ids']
+            ids = index['private_msg_ids']
         elif narrow[0][0] == 'pm_with':
             recipients = self.recipients
-            current_ids = self.index['private'].get(recipients, set())
+            ids = index['private'].get(recipients, set())
         elif narrow[0][0] == 'search':
-            current_ids = self.index['search']
+            ids = index['search']
         elif narrow[0][1] == 'starred':
-            current_ids = self.index['starred_msg_ids']
-        return current_ids.copy()
+            ids = index['starred_msg_ids']
+        return ids.copy()
 
     def _notify_server_of_presence(self) -> Dict[str, Any]:
         response = self.client.update_presence(

--- a/zulipterminal/ui_tools/utils.py
+++ b/zulipterminal/ui_tools/utils.py
@@ -12,7 +12,7 @@ def create_msg_box_list(model: Any, messages: Union[None, Iterable[Any]]=None,
     MessageBox for every message displayed is created here.
     """
     if not model.narrow and messages is None:
-        messages = list(model.index['all_messages'])
+        messages = list(model.index['all_msg_ids'])
     if messages is not None:
         message_list = [model.index['messages'][id] for id in messages]
     message_list.sort(key=lambda msg: msg['timestamp'])


### PR DESCRIPTION
I mentioned making this change a while ago and it seemed to receive a positive response, so I've just fixed the tests and made some other minor adjustments which enable the line length to match our standards.

This PR makes the Index data a lot easier to `git grep` for, when following through the code, as well as being more descriptive, including in test fixtures.

The commits are broken into:
* One commit to update the 3 simple data structures and tests (ie. just sets of integers)
* Two renaming/refactoring commits to reduce verbosity (in preparation for...)
* One commit to update the 3 other more complex data structures, and tests
* The last commit to adjust the ordering and comments for clarify

The ordering is perhaps a little arbitrary, but I think it's important to group the 'indexed downloaded messages' separate from the other model data in the index.