### PR TITLE
Refactor extra captions to streams and topics

### DIFF
--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -53,7 +53,8 @@ class TestController:
         controller.model.muted_topics = []
         controller.narrow_to_stream(stream_button)
         assert controller.model.stream_id == stream_button.stream_id
-        assert controller.model.narrow == [['stream', stream_button.caption]]
+        assert controller.model.narrow == [['stream',
+                                            stream_button.stream_name]]
         controller.model.msg_view.clear.assert_called_once_with()
 
         widget = controller.model.msg_view.extend.call_args_list[0][0][0][0]
@@ -63,8 +64,8 @@ class TestController:
 
     def test_narrow_to_topic(self, mocker, controller,
                              msg_box, index_topic):
-        expected_narrow = [['stream', msg_box.caption],
-                           ['topic', msg_box.title]]
+        expected_narrow = [['stream', msg_box.stream_name],
+                           ['topic', msg_box.topic_name]]
         controller.model.narrow = []
         controller.model.index = index_topic
         controller.model.msg_view = mocker.patch('urwid.SimpleFocusListWalker')
@@ -82,7 +83,7 @@ class TestController:
         controller.model.msg_view.clear.assert_called_once_with()
 
         widget = controller.model.msg_view.extend.call_args_list[0][0][0][0]
-        stream_id, topic_name = msg_box.stream_id, msg_box.title
+        stream_id, topic_name = msg_box.stream_id, msg_box.topic_name
         id_list = index_topic['topic_msg_ids'][stream_id][topic_name]
         assert {widget.original_widget.message['id']} == id_list
 

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -399,7 +399,7 @@ class TestStreamsView:
         self.view = mocker.Mock()
         self.search_box = mocker.patch(VIEWS + ".StreamSearchBox")
         stream_btn = mocker.Mock()
-        stream_btn.caption = "FOO"
+        stream_btn.stream_name = "FOO"
         self.streams_btn_list = [stream_btn]
         return StreamsView(self.streams_btn_list, view=self.view)
 
@@ -917,8 +917,10 @@ class TestMessageBox:
         self.model.index = initial_index
 
     @pytest.mark.parametrize('message_type, set_fields', [
-        ('stream', [('caption', ''), ('stream_id', None), ('title', '')]),
-        ('private', [('email', ''), ('user_id', None)]),
+        ('stream',
+            [('stream_name', ''), ('stream_id', None), ('topic_name', '')]),
+        ('private',
+            [('email', ''), ('user_id', None)]),
     ])
     def test_init(self, mocker, message_type, set_fields):
         mocker.patch.object(MessageBox, 'main_view')

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -121,7 +121,7 @@ class Controller:
             self.model.msg_list.set_focus(focus_position)
 
     def narrow_to_stream(self, button: Any) -> None:
-        already_narrowed = self.model.set_narrow(stream=button.caption)
+        already_narrowed = self.model.set_narrow(stream=button.stream_name)
         if already_narrowed:
             return
 
@@ -148,8 +148,8 @@ class Controller:
         self._finalize_show(w_list)
 
     def narrow_to_topic(self, button: Any) -> None:
-        already_narrowed = self.model.set_narrow(stream=button.caption,
-                                                 topic=button.title)
+        already_narrowed = self.model.set_narrow(stream=button.stream_name,
+                                                 topic=button.topic_name)
         if already_narrowed:
             return
 

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -139,9 +139,9 @@ class MessageBox(urwid.Pile):
                  last_message: Any) -> None:
         self.model = model
         self.message = message
-        self.caption = ''
+        self.stream_name = ''
         self.stream_id = None  # type: Union[int, None]
-        self.title = ''
+        self.topic_name = ''
         self.email = ''
         self.user_id = None  # type: Union[int, None]
         self.last_message = last_message
@@ -150,9 +150,9 @@ class MessageBox(urwid.Pile):
             self.last_message = defaultdict(dict)
 
         if self.message['type'] == 'stream':
-            self.caption = self.message['display_recipient']
+            self.stream_name = self.message['display_recipient']
             self.stream_id = self.message['stream_id']
-            self.title = self.message['subject']
+            self.topic_name = self.message['subject']
         elif self.message['type'] == 'private':
             self.email = self.message['sender_email']
             self.user_id = self.message['sender_id']
@@ -196,8 +196,8 @@ class MessageBox(urwid.Pile):
         last_msg = self.last_message
         if self.message['type'] == 'stream':
             if (last_msg['type'] == 'stream' and
-                    self.title == last_msg['subject'] and
-                    self.caption == last_msg['display_recipient']):
+                    self.topic_name == last_msg['subject'] and
+                    self.stream_name == last_msg['display_recipient']):
                 return False
             return True
         elif self.message['type'] == 'private':
@@ -223,8 +223,8 @@ class MessageBox(urwid.Pile):
         bar_color = self.model.stream_dict[self.stream_id]['color']
         bar_color = 's' + bar_color[:2] + bar_color[3] + bar_color[5]
         stream_title_markup = ('bar', [
-            (bar_color, '{} >'.format(self.caption)),
-            ('title', ' {} '.format(self.title))
+            (bar_color, '{} >'.format(self.stream_name)),
+            ('title', ' {} '.format(self.topic_name))
         ])
         stream_title = urwid.Text(stream_title_markup)
         header = urwid.AttrWrap(stream_title, 'bar')
@@ -263,12 +263,12 @@ class MessageBox(urwid.Pile):
             bar_color = 's' + bar_color[:2] + bar_color[3] + bar_color[5]
             if len(curr_narrow) == 2 and curr_narrow[1][0] == 'topic':
                 text_to_fill = ('bar', [  # type: ignore
-                    (bar_color, '{}'.format(self.caption)),
+                    (bar_color, '{}'.format(self.stream_name)),
                     (bar_color, ': topic narrow')
                 ])
             else:
                 text_to_fill = ('bar', [  # type: ignore
-                    (bar_color, '{}'.format(self.caption))
+                    (bar_color, '{}'.format(self.stream_name))
                 ])
         elif len(curr_narrow) == 1 and len(curr_narrow[0][1].split(",")) > 1:
             text_to_fill = 'Group private conversation'

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -101,7 +101,7 @@ class StreamButton(TopButton):
                  count: int=0) -> None:
         # FIXME Is having self.stream_id the best way to do this?
         # (self.stream_id is used elsewhere)
-        self.caption, self.stream_id, orig_color, is_private = properties
+        self.stream_name, self.stream_id, orig_color, is_private = properties
         self.model = controller.model
         self.count = count
         self.view = view
@@ -124,7 +124,7 @@ class StreamButton(TopButton):
         view.palette.append(('s' + color, '', '', '', inverse_text, color))
 
         super().__init__(controller,
-                         caption=self.caption,
+                         caption=self.stream_name,
                          show_function=controller.narrow_to_stream,
                          prefix_character=(color, 'P' if is_private else '#'),
                          width=width,
@@ -165,9 +165,8 @@ class UserButton(TopButton):
         # FIXME Is this still needed?
         self.recipients = frozenset({self.user_id, view.model.user_id})
 
-        caption = user['full_name']
         super().__init__(controller,
-                         caption=caption,
+                         caption=user['full_name'],
                          show_function=self._narrow_with_compose,
                          prefix_character=(color, '\N{BULLET}'),
                          text_color=color,
@@ -184,8 +183,8 @@ class UserButton(TopButton):
 
 class TopicButton(urwid.Button):
     def __init__(self, stream_id: int, topic: str, model: Any) -> None:
-        self.caption = model.stream_dict[stream_id]['name']  # stream name
-        self.title = topic
+        self.stream_name = model.stream_dict[stream_id]['name']
+        self.topic_name = topic
         self.stream_id = stream_id
 
 

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -20,7 +20,7 @@ class TopButton(urwid.Button):
                  prefix_character: Union[str, Tuple[Any, str]]='\N{BULLET}',
                  text_color: Optional[str]=None,
                  count: int=0) -> None:
-        self.caption = caption
+        self._caption = caption
         self.prefix_character = prefix_character
         self.count = count
         self.width_for_text_space_count = width - 4
@@ -44,12 +44,13 @@ class TopButton(urwid.Button):
             count_text = str(count)
 
         # Shrink text, but always require at least one space
+        # Note that we don't modify self._caption
         max_caption_length = (self.width_for_text_space_count -
                               len(str(count_text)) - 1)
-        if len(self.caption) > max_caption_length:
-            caption = self.caption[:max_caption_length-2] + '..'
+        if len(self._caption) > max_caption_length:
+            caption = self._caption[:max_caption_length-2] + '..'
         else:
-            caption = self.caption
+            caption = self._caption
         num_spaces = max_caption_length - len(caption) + 1
 
         return urwid.AttrMap(urwid.SelectableIcon(
@@ -100,7 +101,7 @@ class StreamButton(TopButton):
                  count: int=0) -> None:
         # FIXME Is having self.stream_id the best way to do this?
         # (self.stream_id is used elsewhere)
-        caption, self.stream_id, orig_color, is_private = properties
+        self.caption, self.stream_id, orig_color, is_private = properties
         self.model = controller.model
         self.count = count
         self.view = view
@@ -123,7 +124,7 @@ class StreamButton(TopButton):
         view.palette.append(('s' + color, '', '', '', inverse_text, color))
 
         super().__init__(controller,
-                         caption=caption,
+                         caption=self.caption,
                          show_function=controller.narrow_to_stream,
                          prefix_character=(color, 'P' if is_private else '#'),
                          width=width,

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -272,7 +272,7 @@ class StreamsView(urwid.Frame):
         self.search_lock.acquire()
         streams_display = self.streams_btn_list.copy()
         for stream in self.streams_btn_list:
-            if not stream.caption.lower().startswith(new_text):
+            if not stream.stream_name.lower().startswith(new_text):
                 streams_display.remove(stream)
         self.log.clear()
         self.log.extend(streams_display)


### PR DESCRIPTION
In reviewing early commits of #382 I was examining the use of 'caption' on the buttons/boxes.
This PR is an attempt to make this clearer, and lead in to the (now) early commit of #382.

I would particularly be interested in @amanagr reviewing this, to give insight into whether this is moving away from some original design or not - though it seems cleaner to me :)

I think it may be worth examining the objects/types we pass to the narrow methods; the duck-typing works fine, but at least renaming of the 'button' parameters to the narrow methods, would definitely help developers reading the code understand that boxes can be passed too (for example)?