### PR TITLE
Opens message links popup menu

### DIFF
--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -196,6 +196,10 @@ KEY_BINDINGS = OrderedDict([
         'keys': {'ctrl l'},
         'help_text': 'Clear message',
     }),
+    ('MSG_LINKS', {
+        'keys': {'v'},
+        'help_text': 'View all links in the current message',
+    }),
 ])  # type: OrderedDict[str, KeyBinding]
 
 

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -137,6 +137,7 @@ class MessageBox(urwid.Pile):
         self.model = model
         self.message = message
         self.stream_name = ''
+        self.message['links'] = dict()  # type: Dict
         self.stream_id = None  # type: Union[int, None]
         self.topic_name = ''
         self.email = ''
@@ -370,6 +371,7 @@ class MessageBox(urwid.Pile):
                      'user-group-mention' in element.attrs.get('class', [])):
                 # USER MENTIONS & USER-GROUP MENTIONS
                 markup.append(('span', element.text))
+                self.message['links'][element.text] = element.text
             elif element.name == 'a':
                 # LINKS
                 link = element.attrs['href']
@@ -380,12 +382,15 @@ class MessageBox(urwid.Pile):
                     # a link then just display the link
                     markup.append(text)
                 else:
+                    if link.startswith('user_uploads/'):
+                        link = self.model.server_url + link
                     if link.startswith('/user_uploads/'):
                         # Append org url to before user_uploads to convert it
                         # into a link.
-                        link = self.model.server_url + link
+                        link = self.model.server_url + link[1:]
                     markup.append(
                         ('link', '[' + text + ']' + '(' + link + ')'))
+                self.message['links'][text] = link
             elif element.name == 'blockquote':
                 # BLOCKQUOTE TEXT
                 markup.append((
@@ -681,6 +686,8 @@ class MessageBox(urwid.Pile):
             self.model.controller.view.middle_column.set_focus('footer')
         elif is_command_key('MSG_INFO', key):
             self.model.controller.show_msg_info(self.message)
+        elif is_command_key('MSG_LINKS', key):
+            self.model.controller.show_msg_links(self.message)
         return key
 
 

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -86,6 +86,14 @@ class TopButton(urwid.Button):
         return super().keypress(size, key)
 
 
+class MsgLinkButton(TopButton):
+    def __init__(self, controller: Any, width: int, count: int,
+                 caption: str, function: Callable) -> None:
+        super().__init__(controller, caption,
+                         function, count=count,
+                         width=width)
+
+
 class HomeButton(TopButton):
     def __init__(self, controller: Any, width: int, count: int=0) -> None:
         button_text = ("All messages   [" +


### PR DESCRIPTION
As of now, this does the following:
- Opens menu with links on pressing `v`
- Narrows to a stream (but does nothing if not subscribed to stream)
- Narrows to PM with a user (has an issue for users with whom no previous private conversation has taken place)

**_Final functionality includes:_**
_Pressing enter on one of the buttons in the links popup menu does one of the following, depending on the link:_
_* narrow to stream_
_* narrow to user_
_* open image in system's default viewer_
_* open link in system's default browser_