### PR TITLE
model: Alter message search for searching in current narrow.

### DIFF
--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -204,3 +204,38 @@ class TestController:
                                  stream_button.stream_name +
                                  "' ?"), "center")
         pop_up.assert_called_once_with(controller, text(), partial())
+
+    @pytest.mark.parametrize('initial_narrow, final_narrow', [
+        ([], [['search', 'FOO']]),
+        ([['search', 'BOO']], [['search', 'FOO']]),
+        ([['stream', 'PTEST']], [['search', 'FOO']]),
+        ([['pm_with', 'foo@zulip.com'], ['search', 'BOO']],
+            [['search', 'FOO']]),
+        ([['stream', 'PTEST'], ['topic', 'RDS']],
+            [['search', 'FOO']]),
+    ], ids=[
+        'Default_all_msg_search', 'redo_default_search',
+        'search_within_stream', 'pm_search_again',
+        'search_within_topic_narrow',
+    ])
+    @pytest.mark.parametrize('msg_ids', [
+        ({200, 300, 400}),
+        ({}),
+        ({100})
+    ])
+    def test_search_message(self, initial_narrow, final_narrow,
+                            controller, mocker, msg_ids):
+        get_message = mocker.patch('zulipterminal.model.Model.get_messages')
+        create_msg = mocker.patch('zulipterminal.core.create_msg_box_list')
+        mocker.patch(
+            'zulipterminal.model.Model.get_message_ids_in_current_narrow',
+            return_value=msg_ids)
+        controller.model.index = {'search': msg_ids}
+        controller.model.msg_view = []
+        controller.model.narrow = initial_narrow
+        controller.search_messages('FOO')
+
+        assert controller.model.narrow == final_narrow
+        get_message.assert_called_once_with(
+            num_after=0, num_before=30, anchor=10000000000)
+        create_msg.assert_called_once_with(controller.model, msg_ids)

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -208,11 +208,11 @@ class TestController:
     @pytest.mark.parametrize('initial_narrow, final_narrow', [
         ([], [['search', 'FOO']]),
         ([['search', 'BOO']], [['search', 'FOO']]),
-        ([['stream', 'PTEST']], [['search', 'FOO']]),
+        ([['stream', 'PTEST']], [['stream', 'PTEST'], ['search', 'FOO']]),
         ([['pm_with', 'foo@zulip.com'], ['search', 'BOO']],
-            [['search', 'FOO']]),
+         [['pm_with', 'foo@zulip.com'], ['search', 'FOO']]),
         ([['stream', 'PTEST'], ['topic', 'RDS']],
-            [['search', 'FOO']]),
+         [['stream', 'PTEST'], ['topic', 'RDS'], ['search', 'FOO']]),
     ], ids=[
         'Default_all_msg_search', 'redo_default_search',
         'search_within_stream', 'pm_search_again',

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -239,3 +239,4 @@ class TestController:
         get_message.assert_called_once_with(
             num_after=0, num_before=30, anchor=10000000000)
         create_msg.assert_called_once_with(controller.model, msg_ids)
+        assert controller.model.index == {'search': msg_ids}

--- a/tests/helper/test_helper.py
+++ b/tests/helper/test_helper.py
@@ -30,6 +30,7 @@ def test_index_messages_narrow_stream(mocker,
                          return_value=None)
     model.index = initial_index
     model.narrow = [['stream', 'PTEST']]
+    model.is_search_narrow.return_value = False
     model.stream_id = 205
     assert index_messages(messages, model, model.index) == index_stream
 
@@ -44,6 +45,7 @@ def test_index_messages_narrow_topic(mocker,
     model.index = initial_index
     model.narrow = [['stream', '7'],
                     ['topic', 'Test']]
+    model.is_search_narrow.return_value = False
     model.stream_id = 205
     assert index_messages(messages, model, model.index) == index_topic
 
@@ -57,6 +59,7 @@ def test_index_messages_narrow_user(mocker,
                          return_value=None)
     model.index = initial_index
     model.narrow = [['pm_with', 'boo@zulip.com']]
+    model.is_search_narrow.return_value = False
     model.user_id = 5140
     model.user_dict = {
         'boo@zulip.com': {
@@ -75,6 +78,7 @@ def test_index_messages_narrow_user_multiple(mocker,
                          return_value=None)
     model.index = initial_index
     model.narrow = [['pm_with', 'boo@zulip.com, bar@zulip.com']]
+    model.is_search_narrow.return_value = False
     model.user_id = 5140
     model.user_dict = {
         'boo@zulip.com': {
@@ -134,7 +138,7 @@ def test_index_starred(mocker,
                          return_value=None)
     model.index = initial_index
     model.narrow = [['is', 'starred']]
-
+    model.is_search_narrow.return_value = False
     expected_index = dict(empty_index, private_msg_ids={537287, 537288},
                           starred_msg_ids=msgs_with_stars)
     for msg_id, msg in expected_index['messages'].items():

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -129,6 +129,23 @@ class TestModel:
         model.set_focus_in_current_narrow(msg_id)
         assert model.index['pointer'][str(narrow)] == msg_id
 
+    @pytest.mark.parametrize('narrow, is_search_narrow', [
+        ([], False),
+        ([['search', 'FOO']], True),
+        ([['is', 'private']], False),
+        ([['is', 'private'], ['search', 'FOO']], True),
+        ([['search', 'FOO'], ['is', 'private']], True),
+        ([['stream', 'PTEST']], False),
+        ([['stream', 'PTEST'], ['search', 'FOO']], True),
+        ([['stream', '7'], ['topic', 'Test']], False),
+        ([['stream', '7'], ['topic', 'Test'], ['search', 'FOO']], True),
+        ([['stream', '7'], ['search', 'FOO'], ['topic', 'Test']], True),
+        ([['search', 'FOO'], ['stream', '7'], ['topic', 'Test']], True)
+    ])
+    def test_is_search_narrow(self, model, narrow, is_search_narrow):
+        model.narrow = narrow
+        assert model.is_search_narrow() == is_search_narrow
+
     @pytest.mark.parametrize('bad_args', [
         dict(topic='some topic'),
         dict(stream='foo', search='text'),

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -148,8 +148,8 @@ class TestModel:
 
     @pytest.mark.parametrize('bad_args', [
         dict(topic='some topic'),
-        dict(stream='foo', search='text'),
-        dict(topic='blah', search='text'),
+        dict(stream='foo', pm_with='someone'),
+        dict(topic='blah', pm_with='someone'),
         dict(pm_with='someone', topic='foo')
     ])
     def test_set_narrow_bad_input(self, model, bad_args):
@@ -161,8 +161,6 @@ class TestModel:
         ([['stream', 'some stream']], dict(stream='some stream')),
         ([['stream', 'some stream'], ['topic', 'some topic']],
          dict(stream='some stream', topic='some topic')),
-        ([['search', 'something interesting']],
-         dict(search='something interesting')),
         ([['is', 'starred']], dict(starred=True)),
         ([['is', 'private']], dict(pms=True)),
         ([['pm_with', 'FOO@zulip.com']], dict(pm_with='FOO@zulip.com')),

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1429,6 +1429,9 @@ class TestMessageBox:
         ([['is', 'starred']], 0, 'PTEST >', 'Starred messages'),
         ([['is', 'starred']], 1, 'You and ', 'Starred messages'),
         ([['is', 'starred']], 2, 'You and ', 'Starred messages'),
+        ([['is', 'starred'], ['search', 'FOO']], 1, 'You and ',
+         'Starred messages'),
+        ([['search', 'FOO']], 0, 'PTEST >', 'All messages')
     ])
     def test_msg_generates_search_and_header_bar(self, mocker,
                                                  messages_successful_response,

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -117,7 +117,7 @@ class Controller:
 
     def search_messages(self, text: str) -> None:
         # Search for a text in messages
-        self.model.set_narrow(search=text)
+        self.model.set_search_narrow(text)
 
         self.model.found_newest = False
         self.model.get_messages(num_after=0, num_before=30, anchor=10000000000)

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -117,6 +117,7 @@ class Controller:
 
     def search_messages(self, text: str) -> None:
         # Search for a text in messages
+        self.model.index['search'].clear()
         self.model.set_search_narrow(text)
 
         self.model.found_newest = False

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -295,7 +295,7 @@ def index_messages(messages: List[Any],
         if not narrow:
             index['all_msg_ids'].add(msg['id'])
 
-        elif narrow[0][0] == 'search':
+        elif model.is_search_narrow():
             index['search'].add(msg['id'])
             continue
 

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -131,6 +131,15 @@ class Model:
     def set_focus_in_current_narrow(self, focus_message: int) -> None:
         self.index['pointer'][str(self.narrow)] = focus_message
 
+    def is_search_narrow(self) -> bool:
+        """
+        Checks if the current narrow is a result of a previous search for
+        a messages in a different narrow.
+        """
+        return (True
+                if 'search' in [subnarrow[0] for subnarrow in self.narrow]
+                else False)
+
     def set_narrow(self, *,
                    stream: Optional[str]=None,
                    topic: Optional[str]=None,
@@ -176,6 +185,8 @@ class Model:
         index = self.index
         if narrow == []:
             ids = index['all_msg_ids']
+        elif self.is_search_narrow():
+            ids = index['search']
         elif narrow[0][0] == 'stream':
             stream_id = self.stream_id
             if len(narrow) == 1:
@@ -188,8 +199,6 @@ class Model:
         elif narrow[0][0] == 'pm_with':
             recipients = self.recipients
             ids = index['private_msg_ids_by_user_ids'].get(recipients, set())
-        elif narrow[0][0] == 'search':
-            ids = index['search']
         elif narrow[0][1] == 'starred':
             ids = index['starred_msg_ids']
         return ids.copy()

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -143,14 +143,12 @@ class Model:
     def set_narrow(self, *,
                    stream: Optional[str]=None,
                    topic: Optional[str]=None,
-                   search: Optional[str]=None,
                    pms: bool=False,
                    pm_with: Optional[str]=None,
                    starred: bool=False) -> bool:
         selected_params = {k for k, v in locals().items() if k != 'self' and v}
         valid_narrows = {
             frozenset(): [],
-            frozenset(['search']): [['search', search]],
             frozenset(['stream']): [['stream', stream]],
             frozenset(['stream', 'topic']): [['stream', stream],
                                              ['topic', topic]],
@@ -179,6 +177,18 @@ class Model:
             return False
         else:
             return True
+
+    def set_search_narrow(self, search_query: str) -> None:
+        self.unset_search_narrow()
+        self.narrow.append(['search', search_query])
+
+    def unset_search_narrow(self) -> None:
+        # If current narrow is a result of a previous started search,
+        # we pop the ['search', 'text'] term in the narrow, before
+        # setting a new narrow.
+        if self.is_search_narrow():
+            self.narrow = [item for item in self.narrow
+                           if item[0] != 'search']
 
     def get_message_ids_in_current_narrow(self) -> Set[int]:
         narrow = self.narrow

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -294,6 +294,8 @@ class MessageBox(urwid.Pile):
         if is_search_narrow:
             curr_narrow = [sub_narrow for sub_narrow in curr_narrow
                            if sub_narrow[0] != 'search']
+        else:
+            self.model.controller.view.search_box.text_box.set_edit_text("")
         if curr_narrow == []:
             text_to_fill = 'All messages'
         elif len(curr_narrow) == 1 and curr_narrow[0][1] == 'private':

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -290,6 +290,10 @@ class MessageBox(urwid.Pile):
 
     def top_search_bar(self) -> Any:
         curr_narrow = self.model.narrow
+        is_search_narrow = self.model.is_search_narrow()
+        if is_search_narrow:
+            curr_narrow = [sub_narrow for sub_narrow in curr_narrow
+                           if sub_narrow[0] != 'search']
         if curr_narrow == []:
             text_to_fill = 'All messages'
         elif len(curr_narrow) == 1 and curr_narrow[0][1] == 'private':
@@ -312,8 +316,15 @@ class MessageBox(urwid.Pile):
             text_to_fill = 'Group private conversation'
         else:
             text_to_fill = 'Private conversation'
-        title_markup = ('header', [
-            ('custom', text_to_fill)
+
+        if is_search_narrow:
+            title_markup = ('header', [
+                ('custom', text_to_fill),
+                ('span', ' Search Results')
+            ])
+        else:
+            title_markup = ('header', [
+                ('custom', text_to_fill)
             ])
         title = urwid.Text(title_markup)
         header = urwid.AttrWrap(title, 'bar')

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -666,6 +666,7 @@ class MessageBox(urwid.Pile):
             elif self.message['type'] == 'stream':
                 self.model.controller.narrow_to_stream(self)
         elif is_command_key('TOGGLE_NARROW', key):
+            self.model.unset_search_narrow()
             if self.message['type'] == 'private':
                 if (len(self.model.narrow) == 1 and
                         self.model.narrow[0][0] == 'pm_with'):


### PR DESCRIPTION
The earlier logic of message search [/], searched for messages
in the default view by setting the narrow to [['search', text]].

We now alter this, to search for messages in current narrow
by extending the narrow before fetching messages from
the server. This is the syntax required by get_messages
for searching within narrow.