### PR TITLE
regression: views: Fix PopUp width for confirmation box.

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -996,6 +996,7 @@ class TestPopUpConfirmationView:
     @pytest.fixture
     def popup_view(self, mocker, stream_button):
         self.controller = mocker.Mock()
+        self.controller.view.LEFT_WIDTH = 27
         self.callback = mocker.Mock()
         self.list_walker = mocker.patch(VIEWS + ".urwid.SimpleFocusListWalker",
                                         return_value=[])

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -738,7 +738,8 @@ class PopUpConfirmationView(urwid.Overlay):
                     [question, urwid.Divider(), wrapped_widget]
                 )))
         urwid.Overlay.__init__(self, prompt, self.controller.view,
-                               align="left", valign="top", width=26,
+                               align="left", valign="top",
+                               width=self.controller.view.LEFT_WIDTH+1,
                                height=8)
 
     def exit_popup_yes(self, args: Any) -> None:


### PR DESCRIPTION
With 3426854d11857f46173fc9f9f9c3a98bb58b9119 we adjusted the Left panel width but the
PopUpConfimation box width was fixed width. With this
we now set the popup width based on the Left Panel width
set in UI.

Tests amended.