### PR TITLE
buttons: Improve logic for marking button with 'M'.

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1634,33 +1634,26 @@ class TestTopButton:
     @pytest.mark.parametrize('width, count, short_text', [
         (8, 0, 'ca…'),
         (9, 0, 'cap…'),
-        (9, -1, 'ca…'),
         (9, 1, 'ca…'),
         (10, 0, 'capt…'),
-        (10, -1, 'cap…'),
         (10, 1, 'cap…'),
         (11, 0, 'capti…'),
-        (11, -1, 'capt…'),
         (11, 1, 'capt…'),
         (11, 10, 'cap…'),
         (12, 0, 'caption'),
-        (12, -1, 'capti…'),
         (12, 1, 'capti…'),
         (12, 10, 'capt…'),
         (12, 100, 'cap…'),
         (13, 0, 'caption'),
-        (13, -1, 'caption'),
         (13, 10, 'capti…'),
         (13, 100, 'capt…'),
         (13, 1000, 'cap…'),
         (15, 0, 'caption'),
-        (15, -1, 'caption'),
         (15, 1, 'caption'),
         (15, 10, 'caption'),
         (15, 100, 'caption'),
         (15, 1000, 'capti…'),
         (25, 0, 'caption'),
-        (25, -1, 'caption'),
         (25, 1, 'caption'),
         (25, 19, 'caption'),
         (25, 199, 'caption'),
@@ -1697,8 +1690,6 @@ class TestTopButton:
 
         text = top_button._w._original_widget.get_text()
         count_str = '' if count == 0 else str(count)
-        if count < 0:
-            count_str = 'M'
         expected_text = ' {}{}{}{}'.format(
                 (prefix + ' ') if prefix else '',
                 short_text,
@@ -1769,7 +1760,7 @@ class TestStreamButton:
     @pytest.mark.parametrize('stream_id, muted_streams, called_value,\
                              is_action_muting, updated_all_msgs', [
         (86, set(), 50, False, 400),
-        (86, {86, 205}, -1, True, 300),
+        (86, {86, 205}, None, True, 300),
         (205, {14, 99}, 0, False, 350),
     ], ids=[
         'unmuting stream 86 - 204 unreads',
@@ -1799,7 +1790,8 @@ class TestStreamButton:
         else:
             stream_button.mark_unmuted()
 
-        stream_button.update_count.assert_called_once_with(called_value)
+        if called_value:
+            stream_button.update_count.assert_called_once_with(called_value)
         if called_value != 0:
             stream_button.view.home_button.update_count.\
                 assert_called_once_with(updated_all_msgs)

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -43,9 +43,7 @@ class TopButton(urwid.Button):
 
     def update_count(self, count: int) -> None:
         self.count = count
-        if count < 0:
-            count_text = 'M'
-        elif count == 0:
+        if count == 0:
             count_text = ''
         else:
             count_text = str(count)
@@ -149,9 +147,13 @@ class StreamButton(TopButton):
         if self.model.is_muted_stream(self.stream_id):
             self.mark_muted()
 
+    def mark_button_M(self) -> None:
+        count_text = 'M'
+        self._w = self.widget(count_text)
+
     def mark_muted(self) -> None:
+        self.mark_button_M()
         self.model.unread_counts['all_msg'] -= self.count
-        self.update_count(-1)
         self.view.home_button.update_count(
             self.model.unread_counts['all_msg'])
 

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -37,22 +37,21 @@ class TopButton(urwid.Button):
         self.text_color = text_color
         self.show_function = show_function
         super().__init__("")
-        self._w = self.widget(count)
+        self.update_count(count)
         self.controller = controller
         urwid.connect_signal(self, 'click', self.activate)
 
     def update_count(self, count: int) -> None:
         self.count = count
-        self._w = self.widget(count)
-
-    def widget(self, count: int) -> Any:
         if count < 0:
-            count_text = 'M'  # Muted
+            count_text = 'M'
         elif count == 0:
             count_text = ''
         else:
             count_text = str(count)
+        self._w = self.widget(count_text)
 
+    def widget(self, count_text: str) -> Any:
         # Note that we don't modify self._caption
         max_caption_length = (self.width_for_text_and_count -
                               len(count_text))


### PR DESCRIPTION
This is a different approach towards marking streams as muted 'M'; We don't need to have the `-1` approach now and have a separate method in `TopButton` to do this. Further, we handle the logic of converting unread_count -> text in their respective functions.

Wanted feedback on this since before adjusting the tests to support the same.