### PR TITLE
Refactor locking & search filters

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -816,10 +816,13 @@ class TestRightColumnView:
                                                right_col_view.user_search
         ))
 
-    def test_update_user_list_editor_mode(self, right_col_view):
+    def test_update_user_list_editor_mode(self, mocker, right_col_view):
+        right_col_view.view.controller.update_screen = mocker.Mock()
         right_col_view.view.controller.editor_mode = False
+
         right_col_view.update_user_list("SEARCH_BOX", "NEW_TEXT")
-        right_col_view.search_lock.acquire.assert_not_called()
+
+        right_col_view.view.controller.update_screen.assert_not_called()
 
     @pytest.mark.parametrize('search_string, assert_list, \
                               match_return_value', [
@@ -839,7 +842,6 @@ class TestRightColumnView:
 
         right_col_view.update_user_list("SEARCH_BOX", search_string)
 
-        right_col_view.search_lock.acquire.assert_called_once_with()
         right_col_view.users_view.assert_called_with(assert_list)
         set_body.assert_called_once_with(right_col_view.body)
 
@@ -849,7 +851,6 @@ class TestRightColumnView:
 
         right_col_view.update_user_list(user_list=user_list)
 
-        right_col_view.search_lock.acquire.assert_called_once_with()
         right_col_view.users_view.assert_called_with(user_list)
         set_body.assert_called_once_with(right_col_view.body)
 

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -270,15 +270,14 @@ class StreamsView(urwid.Frame):
             return
         # wait for any previously started search to finish to avoid
         # displaying wrong stream list.
-        self.search_lock.acquire()
-        streams_display = self.streams_btn_list.copy()
-        for stream in self.streams_btn_list:
-            if not stream.stream_name.lower().startswith(new_text.lower()):
-                streams_display.remove(stream)
-        self.log.clear()
-        self.log.extend(streams_display)
-        self.view.controller.update_screen()
-        self.search_lock.release()
+        with self.search_lock:
+            streams_display = self.streams_btn_list.copy()
+            for stream in self.streams_btn_list:
+                if not stream.stream_name.lower().startswith(new_text.lower()):
+                    streams_display.remove(stream)
+            self.log.clear()
+            self.log.extend(streams_display)
+            self.view.controller.update_screen()
 
     def mouse_event(self, size: Any, event: str, button: int, col: int,
                     row: int, focus: Any) -> Any:
@@ -533,19 +532,18 @@ class RightColumnView(urwid.Frame):
             return
         # wait for any previously started search to finish to avoid
         # displaying wrong user list.
-        self.search_lock.acquire()
-        if user_list:
-            self.view.users = user_list
-        users = self.view.users.copy()
-        users_display = users.copy()
-        if new_text:
-            for user in users:
-                if not match_user(user, new_text):
-                    users_display.remove(user)
-        self.body = self.users_view(users_display)
-        self.set_body(self.body)
-        self.view.controller.update_screen()
-        self.search_lock.release()
+        with self.search_lock:
+            if user_list:
+                self.view.users = user_list
+            users = self.view.users.copy()
+            users_display = users.copy()
+            if new_text:
+                for user in users:
+                    if not match_user(user, new_text):
+                        users_display.remove(user)
+            self.body = self.users_view(users_display)
+            self.set_body(self.body)
+            self.view.controller.update_screen()
 
     def users_view(self, users: Any=None) -> Any:
         reset_default_view_users = False

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -271,10 +271,11 @@ class StreamsView(urwid.Frame):
         # wait for any previously started search to finish to avoid
         # displaying wrong stream list.
         with self.search_lock:
-            streams_display = self.streams_btn_list.copy()
-            for stream in self.streams_btn_list:
-                if not stream.stream_name.lower().startswith(new_text.lower()):
-                    streams_display.remove(stream)
+            streams_display = [
+                stream
+                for stream in self.streams_btn_list.copy()
+                if stream.stream_name.lower().startswith(new_text.lower())
+            ]
             self.log.clear()
             self.log.extend(streams_display)
             self.view.controller.update_screen()
@@ -536,11 +537,12 @@ class RightColumnView(urwid.Frame):
             if user_list:
                 self.view.users = user_list
             users = self.view.users.copy()
-            users_display = users.copy()
             if new_text:
-                for user in users:
-                    if not match_user(user, new_text):
-                        users_display.remove(user)
+                users_display = [
+                    user for user in users if match_user(user, new_text)
+                ]
+            else:
+                users_display = users
             self.body = self.users_view(users_display)
             self.set_body(self.body)
             self.view.controller.update_screen()


### PR DESCRIPTION
This PR comprises two changes to improve search code, that I first saw some time ago:
* Simplifying locking using contextmanagers
* Tidying up the searching code, which used a lot of copying, using list comprehensions

The first needs a little change to the tests; the latter looks cleaner to me, but also seems a lot faster, at least on chat.zulip.org - possibly due to the number of users.

The improvement in search speed exposes a small bug - which I don't believe is caused by these changes.