### PR TITLE
gitlint: Allow certain filenames to be capitalized in commit title.

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -29,7 +29,7 @@ line-length=76
 
 [area-formatting]
 # This is a ZT custom rule; these are excluded from the lower-case area rule
-exclusions=WIP, DEBUG
+exclusions=WIP, DEBUG, README, CHANGELOG, LICENSE
 
 [ignore-by-title]
 # Ignore all rules for commits of which the title matches below

--- a/tools/gitlint-extra-rules.py
+++ b/tools/gitlint-extra-rules.py
@@ -39,8 +39,17 @@ class AreaFormatting(CommitRule):
             exclusions_text = " (or {})".format(exclusions_text)
         error = ("Areas at start of title should be lower case{}, "
                  "followed by ': '".format(exclusions_text))
+
+        def deny_capital_text(text: str) -> bool:
+            if text in exclusions:
+                return False
+            if not text.islower():
+                return True
+            return False
+
         for area in title_components[:-1]:
-            if not (area.islower() or area in exclusions) or ' ' in area:
+            if (any(deny_capital_text(word) for word in area.split('/')) or
+                    ' ' in area):
                 violations += [RuleViolation(self.id, error, line_nr=1)]
 
         error = "Summary of change, after area(s), should be capitalized"


### PR DESCRIPTION
This is as-per discussions here (https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/edit.20gitlint.20rules/near/775070)

* We relax the rule for capitalization for words such as (README, CHANGELOG, LICENSE) so that gitlint doesn't throw errors when these are used in their capital forms in the commit titles.
* We add the above words to the exclusion list and check if any captial word occuring in the title does not belong to this list. (In which case we raise an error)