### PR TITLE
Add support for group typeahead (Eg: @*terminal*)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -454,6 +454,7 @@ def initial_data(logged_on_user, users_fixture, streams_fixture):
         },
         'last_event_id': -1,
         'muted_topics': [],
+        'realm_user_groups': [],
     }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,6 +97,19 @@ def users_fixture(logged_on_user):
 
 
 @pytest.fixture
+def user_groups_fixture():
+    user_groups = []
+    for i in range(1, 3):
+        user_groups.append({
+            'id': 10 + i,
+            'name': 'Group {}'.format(i),
+            'description': 'Core developers of Group {}'.format(i),
+            'members': [10+i, 11+i, 12+i]
+        })
+    return user_groups
+
+
+@pytest.fixture
 def logged_on_user():
     return {
         'user_id': 1001,

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -89,6 +89,7 @@ class TestModel:
             'update_message_flags',
             'muted_topics',
             'realm_user',
+            'realm_user_groups',
         ]
         model.client.register.assert_called_once_with(
                 event_types=event_types,
@@ -530,6 +531,18 @@ class TestModel:
         self.client.register.side_effect = Exception()
         with pytest.raises(Exception):
             model._update_initial_data()
+
+    def test__group_info_from_realm_user_groups(self, model,
+                                                user_groups_fixture):
+        user_group_names = model._group_info_from_realm_user_groups(
+            user_groups_fixture)
+        assert model.user_group_by_id == {
+            group['id']: {'members': group['members'],
+                          'name': group['name'],
+                          'description': group['description']}
+            for group in user_groups_fixture
+            }
+        assert user_group_names == ['Group 1', 'Group 2']
 
     def test_get_all_users(self, mocker, initial_data, user_list, user_dict,
                            user_id):

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -59,12 +59,24 @@ class TestWriteBox:
         ('@_Huma', 1, '@_', '@_**Human 1**'),
         ('@_Human', 1, '@_', '@_**Human 1**'),
         ('@_Human 1', 0, '@_', '@_**Human 1**'),
+        ('@Group', 0, '@', '@*Group 1*'),
+        ('@Group', 1, '@', '@*Group 2*'),
+        ('@G', 0, '@', '@*Group 1*'),
+        ('@Gr', 0, '@', '@*Group 1*'),
+        ('@Gro', 0, '@', '@*Group 1*'),
+        ('@Grou', 0, '@', '@*Group 1*'),
+        ('@G', 1, '@', '@*Group 2*'),
+        ('@Gr', 1, '@', '@*Group 2*'),
+        ('@Gro', 1, '@', '@*Group 2*'),
+        ('@Grou', 1, '@', '@*Group 2*'),
         ('No match', 1, '', None),
     ])
     def test_autocomplete_mentions(self, write_box, users_fixture,
                                    text, state, prefix_string,
-                                   required_typeahead):
+                                   required_typeahead, user_groups_fixture):
         write_box.view.users = users_fixture
+        write_box.model.user_group_names = [
+            groups['name'] for groups in user_groups_fixture]
         typeahead_string = write_box.autocomplete_mentions(
             text, state, prefix_string)
         assert typeahead_string == required_typeahead

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -404,6 +404,16 @@ def match_stream(stream: Any, text: str) -> bool:
     return False
 
 
+def match_groups(group_name: str, text: str) -> bool:
+    """
+    True if any group name matches with `text` (case insensitive),
+    False otherwise.
+    """
+    return (True
+            if group_name.lower().startswith(text.lower())
+            else False)
+
+
 def powerset(iterable: Iterable[Any],
              map_func: Callable[[Any], Any]=set) -> List[Any]:
     """

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -115,6 +115,11 @@ class Model:
          self.pinned_streams, self.unpinned_streams) = stream_data
 
         self.muted_topics = self.initial_data['muted_topics']
+
+        groups = self.initial_data['realm_user_groups']
+        self.user_group_by_id = {}  # type: Dict[int, Dict[str, Any]]
+        self.user_group_names = self._group_info_from_realm_user_groups(groups)
+
         self.unread_counts = classify_unread_counts(self)
 
         self.fetch_all_topics(workers=5)
@@ -555,6 +560,22 @@ class Model:
                    key=lambda s: s[0].lower())
         )
 
+    def _group_info_from_realm_user_groups(self,
+                                           groups: List[Dict[str, Any]]
+                                           ) -> List[str]:
+        """
+        Stores group information in the index and returns a list of
+        group_names which helps in group typeahead. (Eg: @*terminal*)
+        """
+        for sub_group in groups:
+            self.user_group_by_id[sub_group['id']] = {
+                key: sub_group[key] for key in sub_group if key != 'id'}
+        user_group_names = [self.user_group_by_id[group_id]['name']
+                            for group_id in self.user_group_by_id]
+        # Sort groups for typeahead to work alphabetically (case-insensitive)
+        user_group_names.sort(key=str.lower)
+        return user_group_names
+
     def update_subscription(self, event: Event) -> None:
         """
         Handle changes in subscription (Eg: muting/unmuting streams)
@@ -831,6 +852,7 @@ class Model:
             'update_message_flags',
             'muted_topics',
             'realm_user',  # Enables cross_realm_bots
+            'realm_user_groups'
         ]
         event_types = list(self.event_actions)
         try:

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -11,7 +11,7 @@ from bs4 import BeautifulSoup
 from bs4.element import NavigableString, Tag
 
 from zulipterminal.config.keys import is_command_key, keys_for_command
-from zulipterminal.helper import match_user, match_stream
+from zulipterminal.helper import match_user, match_stream, match_groups
 
 
 class WriteBox(urwid.Pile):
@@ -99,13 +99,19 @@ class WriteBox(urwid.Pile):
 
     def autocomplete_mentions(self, text: str, state: int,
                               prefix_string: str) -> Optional[str]:
-        # Handles both mentions and silent mentions.
+        # Handles user mentions (@ mentions and silent mentions)
+        # and group mentions.
+        group_typeahead = ['@*{}*'.format(group_name)
+                           for group_name in self.model.user_group_names
+                           if match_groups(group_name, text[1:])]
+
         users_list = self.view.users
         user_typeahead = [prefix_string+'**{}**'.format(user['full_name'])
                           for user in users_list
                           if match_user(user, text[len(prefix_string):])]
+        combined_typeahead = group_typeahead + user_typeahead
         try:
-            return user_typeahead[state]
+            return combined_typeahead[state]
         except IndexError:
             return None
 


### PR DESCRIPTION
This adds support for user_group_typeahead support using the 'AUTOCOMPLETE' keypress.

The commits have been broken down into
* First commit stores group_id to group_details mapping in the index.
* Second commit to add user_group_fixture in `conftest.py`.
* Third commit registers realm_user_groups event_type during intial_fetch to get info about user_groups in realms as well. We index this information so that it can be used in the future as well. 
* *Note* that I have not made use of the indexed information directly in this PR. We return back a list of user_group_names which have been sorted alphabetically - so that typeahead suggestions can be lexicographic.
* The last 2 commits - one introduces a helper to match user_groups and another extends `typeahead_mention` to handle logic of user_groups first and later users. The combined suggestions are pooled into a common list (`combined_typeahead`)

Tests have been added for the commits.