### PR TITLE
views: Avoid wrapping users_btn_list in SimpleFocusListWalker twice.

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -871,11 +871,8 @@ class TestRightColumnView:
         }]
         self.view.controller.editor_mode = editor_mode
         user_btn = mocker.patch(VIEWS + ".UserButton")
-        mocker.patch(VIEWS + ".UsersView")
-        list_w = mocker.patch(VIEWS + ".urwid.SimpleFocusListWalker")
-
+        users_view = mocker.patch(VIEWS + ".UsersView")
         right_col_view = RightColumnView(width, self.view)
-
         if status != 'inactive':
             unread_counts = right_col_view.view.model.unread_counts
             user_btn.assert_called_once_with(
@@ -886,7 +883,7 @@ class TestRightColumnView:
                 color=self.view.users[0]['status'],
                 count=1
             )
-        list_w.assert_called_once_with(right_col_view.users_btn_list)
+        users_view.assert_called_once_with(right_col_view.users_btn_list)
         assert len(right_col_view.users_btn_list) == users_btn_len
 
     def test_keypress_w(self, right_col_view, mocker):
@@ -900,7 +897,6 @@ class TestRightColumnView:
         key = 'esc'
         size = (20,)
         mocker.patch(VIEWS + ".UsersView")
-        list_w = mocker.patch(VIEWS + ".urwid.SimpleFocusListWalker")
         mocker.patch(VIEWS + ".RightColumnView.set_focus")
         mocker.patch(VIEWS + ".RightColumnView.set_body")
         right_col_view.users_btn_list = []
@@ -909,7 +905,6 @@ class TestRightColumnView:
 
         right_col_view.set_body.assert_called_once_with(right_col_view.body)
         right_col_view.set_focus.assert_called_once_with('body')
-        list_w.assert_called_once_with([])
 
 
 class TestLeftColumnView:

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -574,8 +574,7 @@ class RightColumnView(urwid.Frame):
                     count=unread_count
                 )
             )
-        user_w = UsersView(
-            urwid.SimpleFocusListWalker(users_btn_list))
+        user_w = UsersView(users_btn_list)
         # Donot reset them while searching.
         if reset_default_view_users:
             self.users_btn_list = users_btn_list
@@ -589,8 +588,7 @@ class RightColumnView(urwid.Frame):
             return key
         elif is_command_key('GO_BACK', key):
             self.allow_update_user_list = True
-            self.body = UsersView(
-                urwid.SimpleFocusListWalker(self.users_btn_list))
+            self.body = UsersView(self.users_btn_list)
             self.set_body(self.body)
             self.set_focus('body')
             self.view.controller.update_screen()


### PR DESCRIPTION
Class `UsersView` wraps up incoming `users_btn_list` in a
SimpleFocusListWalker object. It is not necessary for the
incoming data to be wrapped in the ListWalker as well.

Tests amended to support changes.

Tested:
Previous behaviour of
* User search
* Updating user list at 60-second intervals 

are intact.