### PR TITLE
refactor: core: Use message.recipients_emails during narrow_to_user.

### DIFF
--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -199,12 +199,7 @@ class Controller:
 
     def narrow_to_user(self, button: Any) -> None:
         if hasattr(button, 'message'):
-            emails = [recipient['email']
-                      for recipient in button.message['display_recipient']
-                      if recipient['email'] != self.model.client.email]
-            if not emails and len(button.message['display_recipient']) == 1:
-                emails = [self.model.user_email]
-            user_emails = ', '.join(emails)
+            user_emails = button.recipients_emails
         else:
             user_emails = button.email
 


### PR DESCRIPTION
A quick refactor I noticed while working on #278. Separated it out into a PR.

When we narrow_to_user, we can do it from a `UserButton` or from a message (on s/S/z keypress). In the case of the latter, we do not need to recalculate the `recipient_emails` as we had previous calculated it while building a MessageBox.

#### Tested:
* Tested manually using s/S/z.
* Tested with narrowing to PM with user_buttons.