### PR TITLE
bugfx: buttons: Fix marking 'M' in muted topics.

### DIFF
--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -226,7 +226,7 @@ class TopicButton(TopButton):
             self.mark_muted()
 
     def mark_muted(self) -> None:
-        self.update_count(-1)
+        self.update_widget('M')
     # TODO: Handle event-based approach for topic-muting.
 
 


### PR DESCRIPTION
With 0b8052b we moved the logic to 'mark button
as muted' from TopButton into respective button classes
(StreamButtons).

However, we forgot to update the same call for muted TopicButtons.
This patch fixes the same.