### PR TITLE
bugfix: model: Fix is_muted_topic helper using list instead of tuples.

### DIFF
--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -1286,8 +1286,8 @@ class TestModel:
         model.stream_dict = stream_dict
         model.muted_streams = [1]
         model.muted_topics = [
-            ('Stream 2', 'muted topic'),
-            ('Stream 1', 'muted stream muted topic'),
+            ['Stream 2', 'muted topic'],
+            ['Stream 1', 'muted stream muted topic'],
         ]
         assert model.is_muted_topic(stream_id=topic[0],
                                     topic=topic[1]) == is_muted

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -114,7 +114,8 @@ class Model:
         (self.stream_dict, self.muted_streams,
          self.pinned_streams, self.unpinned_streams) = stream_data
 
-        self.muted_topics = self.initial_data['muted_topics']
+        self.muted_topics = (
+            self.initial_data['muted_topics'])  # type: List[List[str]]
 
         groups = self.initial_data['realm_user_groups']
         self.user_group_by_id = {}  # type: Dict[int, Dict[str, Any]]
@@ -416,7 +417,8 @@ class Model:
         if stream_id in self.muted_streams:
             return True
         stream_name = self.stream_dict[stream_id]['name']
-        return (stream_name, topic) in self.muted_topics
+        topic_to_search = [stream_name, topic]  # type: List[str]
+        return topic_to_search in self.muted_topics
 
     def _update_initial_data(self) -> None:
         # Thread Processes to reduce start time.


### PR DESCRIPTION
Each element of `self.muted_topics` is a two element list containing stream_name and topic name. This patch fixes the `is_muted_topic` helper which checks if a given topic of a stream is muted or not.

Type annotations added.

Tests amended.