### PR TITLE
[WIP] - Mute topics from within ZT

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,11 @@ Install-Module -Name BurntToast
 | Toggle topics in a stream                             | <kbd>t</kbd>                                  |
 | Mute/unmute Streams                                   | <kbd>m</kbd>                                  |
 
+### Topic list actions
+| Command                                               | Key Combination                               |
+|------------------------------------------------------ | --------------------------------------------- |
+| Mute/unmute Topics                                    | <kbd>M</kbd>                                  |
+
 ### Composing a message
 | Command                                               | Key Combination                               |
 | ----------------------------------------------------- | --------------------------------------------- |

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -168,6 +168,11 @@ KEY_BINDINGS = OrderedDict([
         'help_text': 'Mute/unmute Streams',
         'key_category': 'stream_list',
     }),
+    ('TOGGLE_MUTE_TOPIC', {
+        'keys': {'M'},
+        'help_text': 'Mute/unmute Topics',
+        'key_category': 'stream_list',
+    }),
     ('ENTER', {
         'keys': {'enter'},
         'help_text': 'Perform current action',
@@ -261,6 +266,7 @@ HELP_CATEGORIES = OrderedDict([
     ('searching', 'Searching'),
     ('msg_actions', 'Actions for the selected message'),
     ('stream_list', 'Stream list actions'),
+    ('topic_list', 'Topic list actions'),
     ('msg_compose', 'Composing a Message'),
 ])
 

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -142,6 +142,20 @@ class Controller:
         self.loop.widget = PopUpConfirmationView(self, question,
                                                  mute_this_stream)
 
+    def topic_muting_confirmation_popup(self, button: Any) -> None:
+        currently_muted = self.model.is_muted_topic(button.stream_id,
+                                                    button.topic_name)
+        type_of_action = "unmuting" if currently_muted else "muting"
+        question = urwid.Text(("bold", "Confirm " + type_of_action +
+                               " of topic '" + button.topic_name +
+                               "' under the '" + button.stream_name +
+                               " stream ?'"))
+        mute_this_topic = partial(self.model.toggle_topic_muted_status,
+                                  button.stream_id, button.stream_name,
+                                  button.topic_name)
+        self.loop.widget = PopUpConfirmationView(self, question,
+                                                 mute_this_topic)
+
     def narrow_to_stream(self, button: Any) -> None:
         already_narrowed = self.model.set_narrow(stream=button.stream_name)
         if already_narrowed:

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -97,6 +97,7 @@ class Model:
             ('update_message', self.update_message),
             ('reaction', self.update_reaction),
             ('subscription', self.update_subscription),
+            ('muted_topics', self.update_topic_muting),
             ('typing', self.handle_typing_event),
             ('update_message_flags', self.update_message_flag_status),
         ])  # type: OrderedDict[str, Callable[[Event], None]]
@@ -594,6 +595,39 @@ class Model:
         # Sort groups for typeahead to work alphabetically (case-insensitive)
         user_group_names.sort(key=str.lower)
         return user_group_names
+
+    def update_topic_muting(self, event:Event) -> None:
+        """
+        Handle Topic muting events
+        """
+        if hasattr(self.controller, 'view'):
+            if (event['type'] == 'muted_topics' and
+                    'muted_topics' in event):
+                new_muted_topics = event['muted_topics']
+                added_topic, is_mute_topic = self._get_muted_topic(new_muted_topics)
+                self.muted_topics = new_muted_topics
+                if (self.controller.view.left_panel.is_in_topic_view and
+                    added_topic[0] == self.controller.view.
+                    topic_w.stream_button.stream_name):
+                    topic_button = self.controller.view.topic_name_to_button[added_topic[1]]
+                    if is_mute_topic:
+                        topic_button.mark_muted()
+                    else:
+                        topic_button.mark_unmuted()
+                self.controller.update_screen()
+
+    def _get_muted_topic(self, muted_topics: List[List[str]]) -> Tuple[List[str], bool]:
+        """
+        We figure out which topic has been muted/unmuted and return the extra
+        topic and whether it is muting/unmuting.
+        """
+        for topic in muted_topics:
+            if topic not in self.muted_topics:
+                return (topic, True)
+        # If it reaches here, then we must have unmuted a topic.
+        for topic in self.muted_topics:
+            if topic not in muted_topics:
+                return (topic, False)
 
     def update_subscription(self, event: Event) -> None:
         """

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -617,6 +617,15 @@ class Model:
 
                 self.controller.update_screen()
 
+    def toggle_topic_muted_status(self, stream_id: int, stream_name:str, topic_name :str) -> bool:
+        request = {
+            'stream': stream_name,
+            'topic': topic_name,
+            'op': 'remove' if self.is_muted_topic(stream_id, topic_name) else 'add'
+        }
+        response = self.client.mute_topic(request)
+        return response['result'] == 'success'
+
     def toggle_stream_muted_status(self, stream_id: int) -> bool:
         request = [{
             'stream_id': stream_id,

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -263,6 +263,11 @@ class TopicButton(TopButton):
             # All messages in this topic are read.
             self.update_count(0)
 
+    def keypress(self, size: Tuple[int, int], key: str) -> str:
+        if is_command_key('TOGGLE_MUTE_TOPIC', key):
+            self.controller.topic_muting_confirmation_popup(self)
+        return super().keypress(size, key)
+
 
 class UnreadPMButton(urwid.Button):
     def __init__(self, user_id: int, email: str) -> None:

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -213,6 +213,7 @@ class TopicButton(TopButton):
         self.topic_name = topic
         self.stream_id = stream_id
         self.model = controller.model
+        self.view = controller.view
 
         super().__init__(controller=controller,
                          caption=self.topic_name,
@@ -224,10 +225,43 @@ class TopicButton(TopButton):
         if [self.stream_name, self.topic_name] in \
                 controller.model.muted_topics:
             self.mark_muted()
+            # TODO: Handle event-based approach for topic-muting.
 
     def mark_muted(self) -> None:
+        '''
+        We do not decrease the count of topic button (or
+        unread_counts['unread_topics']) but only mark it as M since
+        we would require the correct count while unmuting.
+        However, we decrease the all msg count and the topic's stream
+        count by the unread counts.
+        '''
         self.update_widget('M')
-    # TODO: Handle event-based approach for topic-muting.
+        if self.stream_id in self.model.unread_counts['streams']:
+            self.model.unread_counts['streams'][self.stream_id] -= self.count
+            stream_button = self.view.stream_id_to_button[self.stream_id]
+            stream_button.update_count(
+                self.model.unread_counts['streams'][self.stream_id])
+        self.model.unread_counts['all_msg'] -= self.count
+        self.view.home_button.update_count(
+            self.model.unread_counts['all_msg'])
+
+    def mark_unmuted(self) -> None:
+        if ((self.stream_id, self.topic_name) in
+                self.model.unread_counts['unread_topics']):
+            unmuted_count = (self.model.unread_counts
+                             ['unread_topics'][(self.stream_id,
+                                                self.topic_name)])
+            self.update_count(unmuted_count)
+            self.model.unread_counts['streams'][self.stream_id] += self.count
+            stream_button = self.view.stream_id_to_button[self.stream_id]
+            stream_button.update_count(
+                self.model.unread_counts['streams'][self.stream_id])
+            self.model.unread_counts['all_msg'] += self.count
+            self.view.home_button.update_count(
+                self.model.unread_counts['all_msg'])
+        else:
+            # All messages in this topic are read.
+            self.update_count(0)
 
 
 class UnreadPMButton(urwid.Button):

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -697,6 +697,9 @@ class LeftColumnView(urwid.Pile):
                 get((stream_id, topic), 0)
             ) for topic in self.model.index['topics'][stream_id]]
 
+        self.view.topic_name_to_button = {topic.topic_name: topic
+                                          for topic in topics_btn_list}
+
         self.view.topic_w = TopicsView(topics_btn_list, self.view,
                                        stream_button)
         w = urwid.LineBox(


### PR DESCRIPTION
This PR adds support to mute topics from within ZT on `M` keypress:
* The first commit here introduces API call to toggle muted status.
* The second adds a method in core which builds the text and calls the PopUpconfirmationView
with the model function passed in as callback.
* We add functionality in buttons to restore/decrease unread count during appropriate events like (un)muting.
* We register the handler for muted topic event which handeles and event-based approach as well. This intern calls the mark_(un)muted methods of each buttons.
* We introduce the 'TOGGLE_MUTE_TOPIC' hotkey and maps it to its own category.
* Last commit involve connecting the Key added  earlier on a topic button so that it will be able to perform action of muting/unmuting a topic.