### PR TITLE
Include all recipients in group PM notifications

### DIFF
--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -748,19 +748,22 @@ class TestModel:
         model.update_topic_index(86, topic_name)
         assert model.index['topics'][86] == topic_order_final
 
-    @pytest.mark.parametrize('vary_each_msg, types_when_notify_called', [
-        ({'sender_id': 1}, []),  # model.user_id is 1
-        ({'sender_id': 2, 'flags': ['mentioned']}, ['stream', 'private']),
-        ({'sender_id': 2, 'flags': ['wildcard_mentioned']},
-         ['stream', 'private']),
-        ({'sender_id': 2, 'flags': []}, ['private']),
+    # TODO: Ideally message_fixture would use standardized ids?
+    @pytest.mark.parametrize('user_id, vary_each_msg, \
+                              types_when_notify_called', [
+        (5140, {}, []),  # message_fixture sender_id is 5140
+        (5179, {'flags': ['mentioned']}, ['stream', 'private']),
+        (5179, {'flags': ['wildcard_mentioned']}, ['stream', 'private']),
+        (5179, {'flags': []}, ['private']),
     ], ids=['self_message', 'mentioned_msg', 'wildcard_mentioned',
             'not_mentioned'])
     def test_notify_users_calling_msg_type(self, mocker, model,
-                                           message_fixture, vary_each_msg,
+                                           message_fixture,
+                                           user_id,
+                                           vary_each_msg,
                                            types_when_notify_called):
         message_fixture.update(vary_each_msg)
-        model.user_id = 1
+        model.user_id = user_id
         notify = mocker.patch('zulipterminal.model.notify')
         model.notify_user(message_fixture)
         if message_fixture['type'] in types_when_notify_called:

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -767,8 +767,16 @@ class TestModel:
         notify = mocker.patch('zulipterminal.model.notify')
         model.notify_user(message_fixture)
         if message_fixture['type'] in types_when_notify_called:
-            # TODO: Add parameters with which notify is called.
-            assert notify.called
+            who = message_fixture['type']
+            if who == 'stream':
+                target = 'PTEST -> Test'
+            elif who == 'private':
+                target = 'you'
+                if len(message_fixture['display_recipient']) > 2:
+                    target += ', Bar Bar'
+            title = 'Foo Foo (to {})'.format(target)
+            # TODO: Test message content too?
+            notify.assert_called_once_with(title, mocker.ANY)
         else:
             notify.assert_not_called
 

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -654,7 +654,15 @@ class Model:
 
         recipient = ''
         if message['type'] == 'private':
-            recipient = ' (to you)'
+            target = 'you'
+            if len(message['display_recipient']) > 2:
+                extra_targets = [target] + [
+                    recip['full_name']
+                    for recip in message['display_recipient']
+                    if recip['id'] not in (self.user_id, message['sender_id'])
+                ]
+                target = ', '.join(extra_targets)
+            recipient = ' (to {})'.format(target)
         elif {'mentioned', 'wildcard_mentioned'}.intersection(
                 set(message['flags'])) and message['type'] == 'stream':
             recipient = ' (to {} -> {})'.format(message['display_recipient'],


### PR DESCRIPTION
Previously we just indicated private messages (PMs) were directed to 'you', even if it was a group PM. This commit updates this to use a comma-delimited list of full names.

Tests extended to include title parameter.

(The first commit is a test refactor to enable the test extensions associated with the main commit.)