### PR TITLE
refactor: Remove redundancy & improve consistency of UnreadCounts.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -709,15 +709,15 @@ def classified_unread_counts():
     return {
         'all_msg': 12,
         'all_pms': 8,
-        'unread_topics': {
+        'stream_topics': {
             (1000, 'Some general unread topic'): 3,
             (99, 'Some private unread topic'): 1
         },
-        'unread_pms': {
+        'solo_pms': {
             1: 2,
             2: 1,
         },
-        'unread_huddles': {
+        'group_pms': {
             frozenset({1001, 11, 12}): 3,
             frozenset({1001, 11, 12, 13}): 2
         },

--- a/tests/helper/test_helper.py
+++ b/tests/helper/test_helper.py
@@ -165,12 +165,12 @@ def test_powerset(iterable, map_func, expected_powerset):
     ([99], [['Some general stream', 'Some general unread topic']], {
         'all_msg': 9,
         'streams': {99: 1},
-        'unread_topics': {(99, 'Some private unread topic'): 1},
+        'stream_topics': {(99, 'Some private unread topic'): 1},
     }),
     ([1000], [['Secret stream', 'Some private unread topic']], {
         'all_msg': 11,
         'streams': {1000: 3},
-        'unread_topics': {(1000, 'Some general unread topic'): 3},
+        'stream_topics': {(1000, 'Some general unread topic'): 3},
     }),
     ([1], [], {})
 ], ids=['mute_private_stream_mute_general_stream_topic',

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -639,7 +639,7 @@ class TestMiddleColumnView:
 
     def test_get_next_unread_topic(self, mid_col_view):
         mid_col_view.model.unread_counts = {
-            'unread_topics': {1: 1, 2: 1}
+            'stream_topics': {1: 1, 2: 1}
         }
         return_value = mid_col_view.get_next_unread_topic()
         assert return_value == 1
@@ -647,7 +647,7 @@ class TestMiddleColumnView:
 
     def test_get_next_unread_topic_again(self, mid_col_view):
         mid_col_view.model.unread_counts = {
-            'unread_topics': {1: 1, 2: 1}
+            'stream_topics': {1: 1, 2: 1}
         }
         mid_col_view.last_unread_topic = 1
         return_value = mid_col_view.get_next_unread_topic()
@@ -656,7 +656,7 @@ class TestMiddleColumnView:
 
     def test_get_next_unread_topic_no_unread(self, mid_col_view):
         mid_col_view.model.unread_counts = {
-            'unread_topics': {}
+            'stream_topics': {}
         }
         return_value = mid_col_view.get_next_unread_topic()
         assert return_value is None
@@ -664,7 +664,7 @@ class TestMiddleColumnView:
 
     def test_get_next_unread_pm(self, mid_col_view):
         mid_col_view.model.unread_counts = {
-            'unread_pms': {1: 1, 2: 1}
+            'solo_pms': {1: 1, 2: 1}
         }
         return_value = mid_col_view.get_next_unread_pm()
         assert return_value == 1
@@ -672,7 +672,7 @@ class TestMiddleColumnView:
 
     def test_get_next_unread_pm_again(self, mid_col_view):
         mid_col_view.model.unread_counts = {
-            'unread_pms': {1: 1, 2: 1}
+            'solo_pms': {1: 1, 2: 1}
         }
         mid_col_view.last_unread_pm = 1
         return_value = mid_col_view.get_next_unread_pm()
@@ -681,7 +681,7 @@ class TestMiddleColumnView:
 
     def test_get_next_unread_pm_no_unread(self, mid_col_view):
         mid_col_view.model.unread_counts = {
-            'unread_pms': {}
+            'solo_pms': {}
         }
         return_value = mid_col_view.get_next_unread_pm()
         assert return_value is None
@@ -839,7 +839,7 @@ class TestRightColumnView:
         self.thread = mocker.patch(VIEWS + ".threading")
         self.super = mocker.patch(VIEWS + ".urwid.Frame.__init__")
         self.view.model.unread_counts = {  # Minimal, though an UnreadCounts
-            'unread_pms': {
+            'solo_pms': {
                 1: 1,
                 2: 1,
             }
@@ -972,7 +972,7 @@ class TestLeftColumnView:
                 2: 1,
                 1000: 1,
             },
-            'unread_topics': {
+            'stream_topics': {
                 (205, 'TOPIC1'): 34,
                 (205, 'TOPIC2'): 100,
             }

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -57,9 +57,9 @@ initial_index = Index(
 UnreadCounts = TypedDict('UnreadCounts', {
     'all_msg': int,
     'all_pms': int,
-    'unread_topics': Dict[Tuple[int, str], int],  # stream_id, topic
-    'unread_pms': Dict[int, int],  # sender_id
-    'unread_huddles': Dict[FrozenSet[int], int],  # Group pms
+    'stream_topics': Dict[Tuple[int, str], int],  # stream_id, topic
+    'solo_pms': Dict[int, int],  # sender_id
+    'group_pms': Dict[FrozenSet[int], int],
     'streams': Dict[int, int],  # stream_id
 })
 
@@ -94,17 +94,17 @@ def set_count(id_list: List[int], controller: Any, new_count: int) -> None:
 
         if msg['type'] == 'stream':
             key = (messages[id]['stream_id'], msg['subject'])
-            unreads = unread_counts['unread_topics']
+            unreads = unread_counts['stream_topics']
         # self-pm has only one display_recipient
         # 1-1 pms have 2 display_recipient
         elif len(msg['display_recipient']) <= 2:
             key = messages[id]['sender_id']
-            unreads = unread_counts['unread_pms']  # type: ignore
+            unreads = unread_counts['solo_pms']  # type: ignore
         else:  # If it's a group pm
             key = frozenset(  # type: ignore
                 recipient['id'] for recipient in msg['display_recipient']
             )
-            unreads = unread_counts['unread_huddles']  # type: ignore
+            unreads = unread_counts['group_pms']  # type: ignore
 
         # broader unread counts (for all_* and streams) are updated
         # later conditionally.
@@ -148,7 +148,7 @@ def set_count(id_list: List[int], controller: Any, new_count: int) -> None:
                         stream_button.update_count(stream_button.count +
                                                    new_count)
                         break
-            # FIXME: Update unread_counts['unread_topics']?
+            # FIXME: Update unread_counts['stream_topics']?
             if ([messages[id]['display_recipient'], msg_topic] in
                     controller.model.muted_topics):
                 add_to_counts = False
@@ -357,15 +357,15 @@ def classify_unread_counts(model: Any) -> UnreadCounts:
     unread_counts = UnreadCounts(
         all_msg=0,
         all_pms=0,
-        unread_topics=dict(),
-        unread_pms=dict(),
-        unread_huddles=dict(),
+        stream_topics=dict(),
+        solo_pms=dict(),
+        group_pms=dict(),
         streams=dict(),
     )
 
     for pm in unread_msg_counts['pms']:
         count = len(pm['unread_message_ids'])
-        unread_counts['unread_pms'][pm['sender_id']] = count
+        unread_counts['solo_pms'][pm['sender_id']] = count
         unread_counts['all_msg'] += count
         unread_counts['all_pms'] += count
 
@@ -376,7 +376,7 @@ def classify_unread_counts(model: Any) -> UnreadCounts:
                 stream['topic']] in model.muted_topics:
             continue
         stream_topic = (stream_id, stream['topic'])
-        unread_counts['unread_topics'][stream_topic] = count
+        unread_counts['stream_topics'][stream_topic] = count
         if not unread_counts['streams'].get(stream_id):
             unread_counts['streams'][stream_id] = count
         else:
@@ -388,7 +388,7 @@ def classify_unread_counts(model: Any) -> UnreadCounts:
         count = len(group_pm['unread_message_ids'])
         user_ids = group_pm['user_ids_string'].split(',')
         user_ids = frozenset(map(int, user_ids))
-        unread_counts['unread_huddles'][user_ids] = count
+        unread_counts['group_pms'][user_ids] = count
         unread_counts['all_msg'] += count
         unread_counts['all_pms'] += count
 

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -439,7 +439,7 @@ class MiddleColumnView(urwid.Frame):
                                                footer=write_box)
 
     def get_next_unread_topic(self) -> Optional[Tuple[int, str]]:
-        topics = list(self.model.unread_counts['unread_topics'].keys())
+        topics = list(self.model.unread_counts['stream_topics'].keys())
         next_topic = False
         for topic in topics:
             if next_topic is True:
@@ -454,7 +454,7 @@ class MiddleColumnView(urwid.Frame):
         return None
 
     def get_next_unread_pm(self) -> Optional[int]:
-        pms = list(self.model.unread_counts['unread_pms'].keys())
+        pms = list(self.model.unread_counts['solo_pms'].keys())
         next_pm = False
         for pm in pms:
             if next_pm is True:
@@ -600,7 +600,7 @@ class RightColumnView(urwid.Frame):
             if user['status'] == 'inactive' and\
                     not self.view.controller.editor_mode:
                 continue
-            unread_count = (self.view.model.unread_counts['unread_pms'].
+            unread_count = (self.view.model.unread_counts['solo_pms'].
                             get(user['user_id'], 0))
             users_btn_list.append(
                 UserButton(
@@ -731,7 +731,7 @@ class LeftColumnView(urwid.Pile):
                 topic=topic,
                 controller=self.controller,
                 width=self.width,
-                count=self.model.unread_counts['unread_topics'].
+                count=self.model.unread_counts['stream_topics'].
                 get((stream_id, topic), 0)
             ) for topic in self.model.index['topics'][stream_id]]
 


### PR DESCRIPTION
This PR is a follow-up to some renaming done for the `Index` data, now for `UnreadCounts`.

This improves how clearly and concisely the code reads by removing the redundant `unread_` prefix from 3 entries, while also making them more consistent with the other entries (eg `_pms` suffix).

While amending the tests it looks clear we would benefit from making more generalizations from `solo` to include `group` `pms` in more cases, both in tests and potentially in code.

Tests amended.