### PR TITLE
requirements: Upgrade pytest from 3.4.2 to 3.10.1.

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -13,7 +13,7 @@ lxml = "==4.2.3"
 mypy_extensions = ">=0.4"
 
 [dev-packages]
-pytest = "==3.4.2"
+pytest = "==3.10.1"
 pytest-pep8 = "==1.0.6"
 pytest-mock = "==1.7.1"
 pytest-cov = "==2.5.1"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 urwid==2.0.1
 zulip==0.5.9
-pytest==3.4.2
+pytest==3.10.1
 pytest-cov==2.5.1
 pytest-pep8==1.0.6
 pytest-mock==1.7.1

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ def long_description():
 
 
 testing_deps = [
-    'pytest==3.4.2',
+    'pytest==3.10.1',
     'pytest-cov==2.5.1',
     'pytest-mock==1.7.1',
     'pytest-pep8==1.0.6',


### PR DESCRIPTION
Other than upgrading to a later pytest version, this commit also
resolves an issue with Travis, avoiding a need to specify an upgraded
attr package explicitly since this pytest depends on a later version.

Note that this can cause two warnings to be output by pytest re `inspect` being used in a deprecated way inside `urwid`, but I'm not sure there's much we can do here for now.

@amanagr @sumanthvrao The latter issue is causing failures in PRs right now, hence the high priority.