### PR TITLE
Add in-line emoji styling to match reaction styling

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1294,11 +1294,11 @@ class TestMessageBox:
         ('<div class="message_inline_image">'
          '<a href="x"><img src="x"></a></div>', []),
         ('<div class="message_inline_ref">blah</div>', []),
-        ('<span class="emoji">:smile:</span>', [':smile:']),
+        ('<span class="emoji">:smile:</span>', [('emoji', ':smile:')]),
         ('<div class="inline-preview-twitter"',
             ['[TWITTER PREVIEW NOT RENDERED]']),
-        ('<img class="emoji" title="zulip"/>', [':zulip:']),
-        ('<img class="emoji" title="github"/>', [':github:']),
+        ('<img class="emoji" title="zulip"/>', [('emoji', ':zulip:')]),
+        ('<img class="emoji" title="github"/>', [('emoji', ':github:')]),
     ], ids=[
         'empty', 'p', 'user-mention', 'group-mention', 'code', 'codehilite',
         'strong', 'em', 'blockquote',

--- a/zulipterminal/config/themes.py
+++ b/zulipterminal/config/themes.py
@@ -21,6 +21,7 @@ required_styles = {
     'bar',
     'help',
     'emoji',
+    'reaction',
     'span',
     'link',
     'blockquote',
@@ -44,6 +45,8 @@ LIGHTGREEN = 'h142'  # bright_green
 LIGHTRED = 'h167'  # bright_red
 LIGHTREDBOLD = '%s, bold' % LIGHTRED
 GRAY = 'h244'  # gray_244
+LIGHTMAGENTA = 'h132'  # neutral_purple
+LIGHTMAGENTABOLD = '%s, bold' % LIGHTMAGENTA
 
 THEMES = {
     'default': [
@@ -64,6 +67,7 @@ THEMES = {
         ('bar',          'white',           'dark gray'),
         ('help',         'white',           'dark gray'),
         ('emoji',        'light magenta',   ''),
+        ('reaction',     'light magenta, bold', ''),
         ('span',         'light red, bold', ''),
         ('link',         'light blue',      ''),
         ('blockquote',   'brown',           ''),
@@ -109,7 +113,9 @@ THEMES = {
         ('help',         'black',           'dark gray',
          None,           BLACK,             GRAY),
         ('emoji',        'light magenta',   'black',
-         None,           'light magenta',   BLACK),
+         None,           LIGHTMAGENTA,   BLACK),
+        ('reaction',     'light magenta, bold', 'black',
+         None,           LIGHTMAGENTABOLD,   BLACK),
         ('span',         'light red, bold', 'black',
          None,           LIGHTREDBOLD,      BLACK),
         ('link',         'light blue',      'black',
@@ -145,6 +151,7 @@ THEMES = {
         ('bar',          'white',           'dark gray'),
         ('help',         'white',           'dark gray'),
         ('emoji',        'light magenta',   'light gray'),
+        ('reaction',     'light magenta, bold',   ''),
         ('span',         'light red, bold', 'light gray'),
         ('link',         'dark blue',       'light gray'),
         ('blockquote',   'brown',           'dark gray'),
@@ -172,6 +179,7 @@ THEMES = {
         ('bar',          'white',           'dark blue'),
         ('help',         'white',           'dark gray'),
         ('emoji',        'dark magenta',   'light blue'),
+        ('reaction',     'dark magenta, bold', ''),
         ('span',         'light red, bold', 'light blue'),
         ('link',         'dark blue',       'light gray'),
         ('blockquote',   'brown',           'dark blue'),

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -364,7 +364,7 @@ class MessageBox(urwid.Pile):
                 ['{} {} '.format(r, custom_reacts[r]) for r in custom_reacts])
             return urwid.Padding(
                 urwid.Text(([
-                    ('emoji', emoji.demojize(emojis + custom_emojis))
+                    ('reaction', emoji.demojize(emojis + custom_emojis))
                 ])), align='left', width=('relative', 90), left=25,
                 min_width=50)
         except Exception:
@@ -412,7 +412,7 @@ class MessageBox(urwid.Pile):
                     element.attrs.get('class', []) == ['emoji']):
                 # CUSTOM EMOJIS AND ZULIP_EXTRA_EMOJI
                 emoji_name = element.attrs.get('title', [])
-                markup.append(":"+emoji_name+":")
+                markup.append(('emoji', ":"+emoji_name+":"))
             elif element.name in unrendered_tags:
                 # UNRENDERED SIMPLE TAGS
                 text = unrendered_tags[element.name]
@@ -424,7 +424,7 @@ class MessageBox(urwid.Pile):
             elif (element.name == 'span' and element.attrs and
                   'emoji' in element.attrs.get('class', [])):
                 # EMOJI
-                markup.append(element.text)
+                markup.append(('emoji', element.text))
             elif (element.name == 'span' and element.attrs and
                   ('katex-display' in element.attrs.get('class', []) or
                    'katex' in element.attrs.get('class', []))):


### PR DESCRIPTION
Emojis in messages are styled to match the styling of reactions. Reactions are additionally made bold to better differentiate between them.

Before:
![before](https://user-images.githubusercontent.com/21107799/66712584-3c21e680-edbc-11e9-84df-adb527e2ea63.png)

After:
![after](https://user-images.githubusercontent.com/21107799/66712597-77bcb080-edbc-11e9-9f68-2756a1a37be1.png)
