### PR TITLE
Upgrade zulip to 0.6.1, avoiding uncaught SSLError

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,7 @@ name = "pypi"
 
 [packages]
 urwid = "==2.0.1"
-zulip = "==0.5.9"
+zulip = "==0.6.1"
 emoji = "==0.5.0"
 urwid-readline = "==0.10"
 beautifulsoup4 = "==4.6.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 urwid==2.0.1
-zulip==0.5.9
+zulip==0.6.1
 pytest==3.10.1
 pytest-cov==2.5.1
 pytest-pep8==1.0.6

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ setup(
     tests_require=testing_deps,
     install_requires=[
         'urwid==2.0.1',
-        'zulip==0.5.9',
+        'zulip==0.6.1',
         'emoji==0.5.0',
         'urwid_readline==0.10',
         'beautifulsoup4==4.6.0',


### PR DESCRIPTION
The new zulip library version allows catching of `ZulipError` in an
additional case, removing some cases where a requests exception was
thrown directly into zulip-terminal.

This avoids an uncaught exception, in cases such as being connected to a
network but not routed, such as if not signed in to a wifi router.