### PR TITLE
Report reasons for initial connection failure

### DIFF
--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -22,7 +22,8 @@ class TestModel:
 
     @pytest.fixture
     def model(self, mocker, initial_data, user_profile):
-        mocker.patch('zulipterminal.model.Model.get_messages')
+        mocker.patch('zulipterminal.model.Model.get_messages',
+                     return_value='')
         self.client.register.return_value = initial_data
         mocker.patch('zulipterminal.model.Model.get_all_users',
                      return_value=[])
@@ -67,7 +68,8 @@ class TestModel:
         assert model.unread_counts == []
 
     def test_register_initial_desired_events(self, mocker, initial_data):
-        mocker.patch('zulipterminal.model.Model.get_messages')
+        mocker.patch('zulipterminal.model.Model.get_messages',
+                     return_value='')
         mocker.patch('zulipterminal.model.Model.get_all_users')
         mocker.patch('zulipterminal.model.Model.fetch_all_topics')
         self.client.register.return_value = initial_data
@@ -252,10 +254,11 @@ class TestModel:
 
     @pytest.mark.parametrize("response, expected_index, return_value", [
         ({'result': 'success', 'topics': [{'name': 'Foo'}, {'name': 'Boo'}]},
-         {23: ['Foo', 'Boo']}, True),
+         {23: ['Foo', 'Boo']}, ''),
         ({'result': 'success', 'topics': []},
-         {23: []}, True),
-        ({'result': 'failure', 'topics': []}, {23: []}, False)
+         {23: []}, ''),
+        ({'result': 'failure', 'msg': 'Some Error', 'topics': []},
+         {23: []}, 'Some Error')
     ])
     def test_get_topics_in_streams(self, mocker, response, model, return_value,
                                    expected_index) -> None:
@@ -533,7 +536,7 @@ class TestModel:
 
     def test__update_initial_data_raises_exception(self, mocker, initial_data):
         # Initialize Model
-        mocker.patch('zulipterminal.model.Model.get_messages')
+        mocker.patch('zulipterminal.model.Model.get_messages', return_value='')
         mocker.patch('zulipterminal.model.Model.get_all_users',
                      return_value=[])
         mocker.patch('zulipterminal.model.Model.'
@@ -568,7 +571,7 @@ class TestModel:
 
     def test_get_all_users(self, mocker, initial_data, user_list, user_dict,
                            user_id):
-        mocker.patch('zulipterminal.model.Model.get_messages')
+        mocker.patch('zulipterminal.model.Model.get_messages', return_value='')
         self.client.register.return_value = initial_data
         mocker.patch('zulipterminal.model.Model.'
                      '_stream_info_from_subscriptions',


### PR DESCRIPTION
This PR first adjusts the error handling in functions used by `ThreadPool`s in the model, allowing for a reason to be passed back rather than just a boolean. That in turn allows for reporting of why an error has occurred to the user; initially this is simply for the first connection attempt to the server, which can diagnose rather useful situations such as incorrect API keys.

Tests are amended for the refactor, and a test added for the example case of an incorrect API key.