### PR TITLE
Improve link rendering

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -32,6 +32,8 @@ TOPBUTTON = "zulipterminal.ui_tools.buttons.TopButton"
 STREAMBUTTON = "zulipterminal.ui_tools.buttons.StreamButton"
 MESSAGEBOX = "zulipterminal.ui_tools.boxes.MessageBox"
 
+SERVER_URL = "https://chat.zulip.zulip"
+
 
 class TestModListWalker:
     @pytest.fixture
@@ -1247,7 +1249,7 @@ class TestMessageBox:
         ('<a href="foo">foo</a>', [('link', 'foo')]),
         ('<a href="foo">bar</a>', [('link', '[bar](foo)')]),
         ('<a href="/user_uploads/blah"',
-            [('link', '[](SOME_BASE_URL/user_uploads/blah)')]),
+            [('link', '[]({}/user_uploads/blah)'.format(SERVER_URL))]),
         ('<li>Something', ['  * ', '', 'Something']),
         ('<li>Something<li>else',  # NOTE Real items are newline-separated?
             ['  * ', '', 'Something', '  * ', '', 'else']),
@@ -1289,7 +1291,7 @@ class TestMessageBox:
                 'color': '#bd6',
             },
         }
-        self.model.server_url = "SOME_BASE_URL"
+        self.model.server_url = SERVER_URL
         # NOTE Absence of previous (last) message should not affect markup
         msg_box = MessageBox(message, self.model, None)
 

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1246,10 +1246,12 @@ class TestMessageBox:
         ('<blockquote>stuff', [('blockquote', ['', 'stuff'])]),
         ('<div class="message_embed">',
             ['[EMBEDDED CONTENT NOT RENDERED]']),  # FIXME Unsupported
-        ('<a href="foo">foo</a>', [('link', 'foo')]),
-        ('<a href="foo">bar</a>', [('link', '[bar](foo)')]),
+        ('<a href="http://foo">http://foo</a>', [('link', 'http://foo')]),
+        ('<a href="http://foo">bar</a>', [('link', '[bar](http://foo)')]),
         ('<a href="/user_uploads/blah"',
             [('link', '[]({}/user_uploads/blah)'.format(SERVER_URL))]),
+        ('<a href="/api"',
+            [('link', '[]({}/api)'.format(SERVER_URL))]),
         ('<li>Something', ['  * ', '', 'Something']),
         ('<li>Something<li>else',  # NOTE Real items are newline-separated?
             ['  * ', '', 'Something', '  * ', '', 'else']),
@@ -1274,8 +1276,10 @@ class TestMessageBox:
     ], ids=[
         'empty', 'p', 'user-mention', 'group-mention', 'code', 'codehilite',
         'strong', 'em', 'blockquote',
-        'embedded_content', 'link_sametext', 'link_differenttext',
-        'link_userupload', 'listitem', 'listitems',
+        'embedded_content',
+        'link_sametext', 'link_differenttext',
+        'link_userupload', 'link_api',
+        'listitem', 'listitems',
         'br', 'br2', 'hr', 'hr2', 'img', 'img2', 'table', 'math', 'math2',
         'ul', 'strikethrough_del', 'inline_image', 'inline_ref',
         'emoji', 'preview-twitter', 'zulip_extra_emoji', 'custom_emoji'

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1262,9 +1262,8 @@ class TestMessageBox:
         ('<ul><li>text</li></ul>', ['', '  * ', '', 'text']),
         ('<del>text</del>', ['', 'text']),  # FIXME Strikethrough
         ('<div class="message_inline_image">'
-         '<a href="x"><img src="x"></a></div>', ['', 'x']),
-        ('<div class="message_inline_ref">blah</div>',
-            ['[MESSAGE INLINE REF NOT RENDERED]']),
+         '<a href="x"><img src="x"></a></div>', []),
+        ('<div class="message_inline_ref">blah</div>', []),
         ('<span class="emoji">:smile:</span>', [':smile:']),
         ('<div class="inline-preview-twitter"',
             ['[TWITTER PREVIEW NOT RENDERED]']),

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1244,7 +1244,7 @@ class TestMessageBox:
         ('<blockquote>stuff', [('blockquote', ['', 'stuff'])]),
         ('<div class="message_embed">',
             ['[EMBEDDED CONTENT NOT RENDERED]']),  # FIXME Unsupported
-        ('<a href="foo">foo</a>', ['foo']),  # FIXME? Render with link style?
+        ('<a href="foo">foo</a>', [('link', 'foo')]),
         ('<a href="foo">bar</a>', [('link', '[bar](foo)')]),
         ('<a href="/user_uploads/blah"',
             [('link', '[](SOME_BASE_URL/user_uploads/blah)')]),

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1254,6 +1254,9 @@ class TestMessageBox:
             [('link', '[]({}/user_uploads/blah)'.format(SERVER_URL))]),
         ('<a href="/api"',
             [('link', '[]({}/api)'.format(SERVER_URL))]),
+        ('<a href="some/relative_url">{}/some/relative_url</a>'
+         .format(SERVER_URL),
+            [('link', '{}/some/relative_url'.format(SERVER_URL))]),
         ('<li>Something', ['  * ', '', 'Something']),
         ('<li>Something<li>else',  # NOTE Real items are newline-separated?
             ['  * ', '', 'Something', '  * ', '', 'else']),
@@ -1280,7 +1283,7 @@ class TestMessageBox:
         'strong', 'em', 'blockquote',
         'embedded_content',
         'link_sametext', 'link_sameimage', 'link_differenttext',
-        'link_userupload', 'link_api',
+        'link_userupload', 'link_api', 'link_serverrelative_same',
         'listitem', 'listitems',
         'br', 'br2', 'hr', 'hr2', 'img', 'img2', 'table', 'math', 'math2',
         'ul', 'strikethrough_del', 'inline_image', 'inline_ref',

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1247,6 +1247,8 @@ class TestMessageBox:
         ('<div class="message_embed">',
             ['[EMBEDDED CONTENT NOT RENDERED]']),  # FIXME Unsupported
         ('<a href="http://foo">http://foo</a>', [('link', 'http://foo')]),
+        ('<a href="http://foo/bar.png">http://foo/bar.png</a>',
+            [('link', 'http://foo/bar.png')]),
         ('<a href="http://foo">bar</a>', [('link', '[bar](http://foo)')]),
         ('<a href="/user_uploads/blah"',
             [('link', '[]({}/user_uploads/blah)'.format(SERVER_URL))]),
@@ -1277,7 +1279,7 @@ class TestMessageBox:
         'empty', 'p', 'user-mention', 'group-mention', 'code', 'codehilite',
         'strong', 'em', 'blockquote',
         'embedded_content',
-        'link_sametext', 'link_differenttext',
+        'link_sametext', 'link_sameimage', 'link_differenttext',
         'link_userupload', 'link_api',
         'listitem', 'listitems',
         'br', 'br2', 'hr', 'hr2', 'img', 'img2', 'table', 'math', 'math2',

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -436,16 +436,18 @@ class MessageBox(urwid.Pile):
                 # LINKS
                 link = element.attrs['href']
                 text = element.img['src'] if element.img else element.text
+
+                parsed_link = urlparse(link)
+                if not parsed_link.scheme:  # => relative link
+                    # Prepend org url to convert it to an absolute link
+                    link = urljoin(self.model.server_url, link)
+
                 if link == text:
                     # If the link and text are same
                     # usually the case when user just pastes
                     # a link then just display the link
                     markup.append(('link', text))
                 else:
-                    parsed_link = urlparse(link)
-                    if not parsed_link.scheme:  # => relative link
-                        # Prepend org url to convert it to an absolute link
-                        link = urljoin(self.model.server_url, link)
                     markup.append(
                         ('link', '[' + text + ']' + '(' + link + ')'))
             elif element.name == 'blockquote':

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -3,6 +3,7 @@ from time import ctime, time
 from datetime import datetime
 from sys import platform
 from typing import Any, Dict, List, Tuple, Union, Optional
+from urllib.parse import urlparse, urljoin
 
 import emoji
 import urwid
@@ -441,10 +442,10 @@ class MessageBox(urwid.Pile):
                     # a link then just display the link
                     markup.append(('link', text))
                 else:
-                    if link.startswith('/user_uploads/'):
-                        # Append org url to before user_uploads to convert it
-                        # into a link.
-                        link = self.model.server_url + link
+                    parsed_link = urlparse(link)
+                    if not parsed_link.scheme:  # => relative link
+                        # Prepend org url to convert it to an absolute link
+                        link = urljoin(self.model.server_url, link)
                     markup.append(
                         ('link', '[' + text + ']' + '(' + link + ')'))
             elif element.name == 'blockquote':

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -439,7 +439,7 @@ class MessageBox(urwid.Pile):
                     # If the link and text are same
                     # usually the case when user just pastes
                     # a link then just display the link
-                    markup.append(text)
+                    markup.append(('link', text))
                 else:
                     if link.startswith('/user_uploads/'):
                         # Append org url to before user_uploads to convert it

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -383,7 +383,8 @@ class MessageBox(urwid.Pile):
             # TODO: Support embedded content & twitter preview?
             'message_embed': 'EMBEDDED CONTENT',
             'inline-preview-twitter': 'TWITTER PREVIEW',
-            'message_inline_ref': 'MESSAGE INLINE REF',
+            'message_inline_ref': '',  # Duplicate of other content
+            'message_inline_image': '',  # Duplicate of other content
         }
         unrendered_template = '[{} NOT RENDERED]'
         for element in soup:


### PR DESCRIPTION
This fixes a few outstanding issues in link rendering:
* Don't render extra copies of images/refs provided by the server
* Render simplified links (where text & link match) in the link style
* Improve handling of relative links, by using `urlparse` and `urljoin` to determine them & prepend the server URL
* Ensure that if we get a relative link which matches the actual text, we also simplify that rendering (the server simplifies the URL; we want to ensure the full link+text is simplified)

Tests are updated & added.