### PR TITLE
Indicate message year, when it is not the current year

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1593,7 +1593,9 @@ class TestMessageBox:
         (['alice', ' ', ' ', 'DAYDATETIME'], {'sender_full_name': 'bob'}),
         ([' ', ' ', ' ', 'DAYDATETIME'], {'timestamp': 1532103779}),
         (['alice', ' ', ' ', 'DAYDATETIME'], {'timestamp': 0}),
-    ], ids=['author_different', 'earlier_message', 'much_earlier_message'])
+    ], ids=['show_author_as_authors_different',
+            'merge_messages_as_only_slightly_earlier_message',
+            'dont_merge_messages_as_much_earlier_message'])
     def test_main_view_content_header_without_header(self, mocker, message,
                                                      expected_header,
                                                      current_year,

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1611,9 +1611,9 @@ class TestMessageBox:
         all_to_vary = dict(to_vary_in_last_message, **stars['last'])
         last_msg = dict(message, **all_to_vary)
         msg_box = MessageBox(this_msg, self.model, last_msg)
-        expected_header[1] = '*' if starred_msg == 'this' else ' '
-        expected_header[2] = '2018 -' if current_year > 2018 else ' '
-        expected_header[3] = msg_box._time_for_message(message)
+        expected_header[1] = '2018 -' if current_year > 2018 else ' '
+        expected_header[2] = msg_box._time_for_message(message)
+        expected_header[3] = '*' if starred_msg == 'this' else ' '
 
         view_components = msg_box.main_view()
         assert len(view_components) == 2

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from time import ctime, time
-from datetime import datetime
+from datetime import datetime, date
 from sys import platform
 from typing import Any, Dict, List, Tuple, Union, Optional
 from urllib.parse import urlparse, urljoin
@@ -519,8 +519,9 @@ class MessageBox(urwid.Pile):
 
         if any_differences:  # Construct content_header, if needed
             TextType = Dict[str, Tuple[Optional[str], str]]
-            text = {key: (None, ' ')
-                    for key in ('author', 'star', 'time')}  # type: TextType
+            text_keys = ('author', 'star', 'time', 'prev_year')
+            text = {key: (None, ' ') for key in text_keys}  # type: TextType
+
             if any(different[key] for key in ('recipients', 'author', '24h')):
                 text['author'] = ('name', message['this']['author'])
             if message['this']['is_starred']:
@@ -528,10 +529,15 @@ class MessageBox(urwid.Pile):
             if any(different[key]
                    for key in ('recipients', 'author', 'timestamp')):
                 text['time'] = ('time', message['this']['time'])
+                this_year = date.today().year
+                msg_year = message['this']['datetime'].year
+                if this_year != msg_year:
+                    text['prev_year'] = ('time', '{} -'.format(msg_year))
 
             content_header = urwid.Columns([
                 ('weight', 10, urwid.Text(text['author'])),
                 (1, urwid.Text(text['star'], align='right')),
+                (6, urwid.Text(text['prev_year'], align='right')),
                 (16, urwid.Text(text['time'], align='right')),
                 ], dividechars=1)
         else:

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -536,9 +536,9 @@ class MessageBox(urwid.Pile):
 
             content_header = urwid.Columns([
                 ('weight', 10, urwid.Text(text['author'])),
-                (1, urwid.Text(text['star'], align='right')),
                 (6, urwid.Text(text['prev_year'], align='right')),
                 (16, urwid.Text(text['time'], align='right')),
+                (1, urwid.Text(text['star'], align='right')),
                 ], dividechars=1)
         else:
             content_header = None


### PR DESCRIPTION
This is a fix for #470, has tests, and works functionally for me. Feedback welcome.

I propose that the extension ideas in #470 are placed into other issues, for things such as any styling improvements and potentially dynamic date changes as with the webapp.