### PR TITLE
Upgrade pytest from 3.10.1 to 5.3.5 (latest).

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -13,7 +13,7 @@ lxml = "==4.2.3"
 mypy_extensions = ">=0.4"
 
 [dev-packages]
-pytest = "==3.10.1"
+pytest = "==5.3.5"
 pytest-pep8 = "==1.0.6"
 pytest-mock = "==1.7.1"
 pytest-cov = "==2.5.1"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 urwid==2.1.0
 zulip==0.6.3
-pytest==3.10.1
+pytest==5.3.5
 pytest-cov==2.5.1
 pytest-pep8==1.0.6
 pytest-mock==1.7.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,17 @@
 [tool:pytest]
+filterwarnings =
+    # distutils: imp module is deprecated in favor of importlib
+    # * python3.5
+    ignore::PendingDeprecationWarning:distutils.*:
+    # * python3.6/3.7/3.8
+    ignore::DeprecationWarning:distutils.*:
+    # bs4: ABCs must be imported from collections.abc, not collections, from python3.9
+    # * python 3.7/3.8
+    ignore::DeprecationWarning:bs4.*:
+markers =
+    # The pep8 plugin works but is quite old; we could use something else
+    # (straight pycodestyle, other linters, or combinations like zulint)
+    pep8: workaround for https://bitbucket.org/pytest-dev/pytest-pep8/issues/23/
 addopts = --pep8 -rxXs --cov=zulipterminal
 
 [mypy]

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ def long_description():
 
 
 testing_deps = [
-    'pytest==3.10.1',
+    'pytest==5.3.5',
     'pytest-cov==2.5.1',
     'pytest-mock==1.7.1',
     'pytest-pep8==1.0.6',


### PR DESCRIPTION
This is a replacement/extension for @amanagr's idea in #455. pytest was partially upgraded in 14c9161 already. Since #455 was opened, 5.3.1 is now available (cf 5.0.1 in #455 ).

Upgrading shows two types of external warnings:
* `urwid` uses some 'inspect' calls which are deprecated (since last upgrade to 3.10.1)
* `pytest-pep8` doesn't set up some kind of 'hook' to register a marker

To avoid confusing users with these warnings about external code, this commit works around
the existing and new issue by adding a `filterwarnings` entry for urwid, and explicitly
mentioning the pep8 `mark`, both in `setup.cfg`.