### PR TITLE
run: Rephrase the login screen messages.

### DIFF
--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -92,7 +92,7 @@ def fetch_zuliprc(zuliprc_path: str) -> None:
                       "web browser to log in to Zulip." +
                       "\nIt often looks like one of the following:" +
                       in_color('green', "\n   your-org.zulipchat.com") +
-                      " (Zulip-hosted servers)" +
+                      " (Zulip cloud)" +
                       in_color('green', "\n   zulip.your-org.com") +
                       " (self-hosted servers)" +
                       in_color('green', "\n   chat.zulip.org") +
@@ -109,7 +109,7 @@ def fetch_zuliprc(zuliprc_path: str) -> None:
     res, email = get_api_key(realm_url)
 
     while res.status_code != 200:
-        print(in_color('red', "\nUsername or Password Incorrect!\n"))
+        print(in_color('red', "\nIncorrect Email or Password!\n"))
         res, email = get_api_key(realm_url)
 
     with open(zuliprc_path, 'w') as f:


### PR DESCRIPTION
Issue:
When trying to login to the Zulip terminal, the error message being displayed after entering the wrong email or password is "Username or Password Incorrect!" but the user is never asked for a username. 

Fix:
Rephrasing the error message in `run.py`

Screenshots:

Before:
![Screenshot from 2019-12-29 21-52-09](https://user-images.githubusercontent.com/43616959/71586655-f8c85000-2b40-11ea-9eef-fdf7a0f5c470.png)

After:
![Screenshot from 2019-12-30 20-15-07](https://user-images.githubusercontent.com/43616959/71586692-172e4b80-2b41-11ea-8b28-c130606055dc.png)
