### PR TITLE
Refactor & improve narrowing logic

### DIFF
--- a/tests/ui/test_utils.py
+++ b/tests/ui/test_utils.py
@@ -164,5 +164,6 @@ def test_create_msg_box_list(mocker, narrow, messages, focus_msg_id,
     mocker.patch('zulipterminal.ui_tools.utils.is_muted', return_value=muted)
     mocker.patch('zulipterminal.ui_tools.utils.is_unsubscribed_message',
                  return_value=unsubscribed)
-    return_value = create_msg_box_list(model, messages, focus_msg_id)
+    return_value = create_msg_box_list(model, messages,
+                                       focus_msg_id=focus_msg_id)
     assert len(return_value) == len_w_list

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -164,7 +164,7 @@ class Controller:
 
         if hasattr(button, 'message'):
             w_list = create_msg_box_list(
-                self.model, msg_id_list, button.message['id'])
+                self.model, msg_id_list, focus_msg_id=button.message['id'])
         else:
             w_list = create_msg_box_list(self.model, msg_id_list)
 
@@ -191,7 +191,7 @@ class Controller:
 
         if hasattr(button, 'message'):
             w_list = create_msg_box_list(
-                self.model, msg_id_list, button.message['id'])
+                self.model, msg_id_list, focus_msg_id=button.message['id'])
         else:
             w_list = create_msg_box_list(self.model, msg_id_list)
 
@@ -220,7 +220,7 @@ class Controller:
 
         if hasattr(button, 'message'):
             w_list = create_msg_box_list(
-                self.model, msg_id_list, button.message['id'])
+                self.model, msg_id_list, focus_msg_id=button.message['id'])
         else:
             w_list = create_msg_box_list(self.model, msg_id_list)
 
@@ -236,7 +236,7 @@ class Controller:
 
         if hasattr(button, 'message'):
             w_list = create_msg_box_list(
-                self.model, msg_id_list, button.message['id'])
+                self.model, msg_id_list, focus_msg_id=button.message['id'])
         else:
             w_list = create_msg_box_list(self.model, msg_id_list)
 

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -148,6 +148,11 @@ class Controller:
         if already_narrowed:
             return
 
+        if hasattr(button, 'message'):
+            anchor = button.message['id']
+        else:
+            anchor = None
+
         self.model.found_newest = False
         # store the steam id in the model (required for get_message_ids...)
         self.model.stream_id = button.stream_id
@@ -155,18 +160,14 @@ class Controller:
 
         # if no messages are found get more messages
         if len(msg_id_list) == 0:
-            get_msg_opts = dict(num_before=30, num_after=10,
-                                anchor=None)  # type: GetMessagesArgs
-            if hasattr(button, 'message'):
-                get_msg_opts['anchor'] = button.message['id']
-            self.model.get_messages(**get_msg_opts)
+            self.model.get_messages(num_before=30,
+                                    num_after=10,
+                                    anchor=anchor)
             msg_id_list = self.model.get_message_ids_in_current_narrow()
 
-        if hasattr(button, 'message'):
-            w_list = create_msg_box_list(
-                self.model, msg_id_list, focus_msg_id=button.message['id'])
-        else:
-            w_list = create_msg_box_list(self.model, msg_id_list)
+        w_list = create_msg_box_list(self.model,
+                                     msg_id_list,
+                                     focus_msg_id=anchor)
 
         self._finalize_show(w_list)
 
@@ -176,32 +177,35 @@ class Controller:
         if already_narrowed:
             return
 
+        if hasattr(button, 'message'):
+            anchor = button.message['id']
+        else:
+            anchor = None
+
         self.model.found_newest = False
         # store the steam id in the model (required for get_message_ids...)
         self.model.stream_id = button.stream_id
         msg_id_list = self.model.get_message_ids_in_current_narrow()
 
         if len(msg_id_list) == 0:
-            get_msg_opts = dict(num_before=30, num_after=10,
-                                anchor=None)  # type: GetMessagesArgs
-            if hasattr(button, 'message'):
-                get_msg_opts['anchor'] = button.message['id']
-            self.model.get_messages(**get_msg_opts)
+            self.model.get_messages(num_before=30,
+                                    num_after=10,
+                                    anchor=anchor)
             msg_id_list = self.model.get_message_ids_in_current_narrow()
 
-        if hasattr(button, 'message'):
-            w_list = create_msg_box_list(
-                self.model, msg_id_list, focus_msg_id=button.message['id'])
-        else:
-            w_list = create_msg_box_list(self.model, msg_id_list)
+        w_list = create_msg_box_list(self.model,
+                                     msg_id_list,
+                                     focus_msg_id=anchor)
 
         self._finalize_show(w_list)
 
     def narrow_to_user(self, button: Any) -> None:
         if hasattr(button, 'message'):
             user_emails = button.recipients_emails
+            anchor = button.message['id']
         else:
             user_emails = button.email
+            anchor = None
 
         already_narrowed = self.model.set_narrow(pm_with=user_emails)
         if already_narrowed:
@@ -211,18 +215,14 @@ class Controller:
         msg_id_list = self.model.get_message_ids_in_current_narrow()
 
         if len(msg_id_list) == 0:
-            get_msg_opts = dict(num_before=30, num_after=10,
-                                anchor=None)  # type: GetMessagesArgs
-            if hasattr(button, 'message'):
-                get_msg_opts['anchor'] = button.message['id']
-            self.model.get_messages(**get_msg_opts)
+            self.model.get_messages(num_before=30,
+                                    num_after=10,
+                                    anchor=anchor)
             msg_id_list = self.model.get_message_ids_in_current_narrow()
 
-        if hasattr(button, 'message'):
-            w_list = create_msg_box_list(
-                self.model, msg_id_list, focus_msg_id=button.message['id'])
-        else:
-            w_list = create_msg_box_list(self.model, msg_id_list)
+        w_list = create_msg_box_list(self.model,
+                                     msg_id_list,
+                                     focus_msg_id=anchor)
 
         self._finalize_show(w_list)
 
@@ -231,14 +231,14 @@ class Controller:
         if already_narrowed:
             return
 
+        anchor = None
+
         self.model.found_newest = False
         msg_id_list = self.model.get_message_ids_in_current_narrow()
 
-        if hasattr(button, 'message'):
-            w_list = create_msg_box_list(
-                self.model, msg_id_list, focus_msg_id=button.message['id'])
-        else:
-            w_list = create_msg_box_list(self.model, msg_id_list)
+        w_list = create_msg_box_list(self.model,
+                                     msg_id_list,
+                                     focus_msg_id=anchor)
 
         self._finalize_show(w_list)
 
@@ -247,14 +247,20 @@ class Controller:
         if already_narrowed:
             return
 
+        anchor = None
+
         self.model.found_newest = False
         msg_id_list = self.model.get_message_ids_in_current_narrow()
 
         if len(msg_id_list) == 0:
-            self.model.get_messages(num_before=30, num_after=10, anchor=None)
+            self.model.get_messages(num_before=30,
+                                    num_after=10,
+                                    anchor=anchor)
             msg_id_list = self.model.get_message_ids_in_current_narrow()
 
-        w_list = create_msg_box_list(self.model, msg_id_list)
+        w_list = create_msg_box_list(self.model,
+                                     msg_id_list,
+                                     focus_msg_id=anchor)
 
         self._finalize_show(w_list)
 
@@ -263,14 +269,20 @@ class Controller:
         if already_narrowed:
             return
 
+        anchor = None
+
         self.model.found_newest = False
         msg_id_list = self.model.get_message_ids_in_current_narrow()
 
         if len(msg_id_list) == 0:
-            self.model.get_messages(num_before=30, num_after=10, anchor=None)
+            self.model.get_messages(num_before=30,
+                                    num_after=10,
+                                    anchor=anchor)
             msg_id_list = self.model.get_message_ids_in_current_narrow()
 
-        w_list = create_msg_box_list(self.model, msg_id_list)
+        w_list = create_msg_box_list(self.model,
+                                     msg_id_list,
+                                     focus_msg_id=anchor)
 
         self._finalize_show(w_list)
 

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -204,15 +204,27 @@ class Controller:
                         pm_with=user_emails)
 
     def show_all_messages(self, button: Any) -> None:
+        if hasattr(button, 'message'):
+            anchor = button.message['id']
+        else:
+            anchor = None
+
         self._narrow_to(button,
-                        anchor=None)
+                        anchor=anchor)
 
     def show_all_pm(self, button: Any) -> None:
+        if hasattr(button, 'message'):
+            anchor = button.message['id']
+        else:
+            anchor = None
+
         self._narrow_to(button,
-                        anchor=None,
+                        anchor=anchor,
                         pms=True)
 
     def show_all_starred(self, button: Any) -> None:
+        # NOTE: Should we ensure we maintain anchor focus here?
+        # (it seems to work fine without)
         self._narrow_to(button,
                         anchor=None,
                         starred=True)

--- a/zulipterminal/ui_tools/utils.py
+++ b/zulipterminal/ui_tools/utils.py
@@ -6,6 +6,7 @@ from zulipterminal.ui_tools.boxes import MessageBox
 
 
 def create_msg_box_list(model: Any, messages: Union[None, Iterable[Any]]=None,
+                        *,
                         focus_msg_id: Union[None, int]=None,
                         last_message: Union[None, Any]=None) -> List[Any]:
     """


### PR DESCRIPTION
This is a more straightforward version of #449, splitting things up to make the main refactoring and some of the implicit changes more obvious.

This version also provides a parameter to the extracted method to specify the `anchor` for the narrow, which clarifies when message focus is retained on changing narrow (if possible).

The last commit then extends the message focus retention to all-messages and all-PMs narrowing; this is a specific change in behavior, but with this refactored version it should be more obvious what is happening.

NOTE: I've not changed the behavior for starred messages, as it didn't seem to be an issue - but we should investigate this.

NOTE: I may extract the `stream_id` setting into the model, but I think this is clean enough to merge now.