### PR TITLE
Be consistent with import statements by linting/formatting using isort

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,9 @@ cache:
 matrix:
   include:
     - python: 3.5
-      name: "CPython 3.5 pytest (default linux)"
+      name: "CPython 3.5 pytest & isort linting (default linux)"
+      # Note that running isort on the lowest version should ensure changes are compatible
+      env: RUN_ISORT_CHECK=yes
     - python: 3.6
       name: "CPython 3.6 pytest & mypy type-checking (default linux)"
       env: RUN_MYPY=yes
@@ -30,6 +32,7 @@ install:
 script:
   - pipenv run pytest
   - if [[ "$RUN_MYPY" == "yes" ]]; then pipenv run pip install -r requirements.txt && pipenv run ./tools/run-mypy; fi
+  - if [[ "$RUN_ISORT_CHECK" == "yes" ]]; then pipenv run pip install -r requirements.txt && pipenv run ./tools/run-isort-check; fi
 after_success:
   - pip install codecov
   - codecov

--- a/Pipfile
+++ b/Pipfile
@@ -21,3 +21,4 @@ zipp = "==1.0.0"  # To support Python 3.5
 pudb = "==2017.1.4"
 snakeviz = "==0.4.2"
 gitlint = "==0.10.0"
+isort = "==4.3.21"

--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ Once you have a development environment set up, you might find the following use
 | Run all tests (including linter) | `pytest` | `pipenv run pytest` |
 | Build test coverage report | `pytest --cov-report html:cov_html --cov=./` | `pipenv run pytest --cov-report html:cov_html --cov=./` |
 | Check type annotations | `./tools/run-mypy` | `pipenv run ./tools/run-mypy` |
+| Check isort compliance | `./tools/run-isort-check` | `pipenv run ./tools/run-isort-check` |
 
 #### GitLint (optional)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ pudb==2017.1.4
 snakeviz==0.4.2
 gitlint==0.10.0
 mypy==0.740
+isort==4.3.21
 emoji==0.5.0
 urwid_readline==0.10
 beautifulsoup4==4.6.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,19 @@
 [tool:pytest]
 addopts = --pep8 -rxXs --cov=zulipterminal
 
+[tool:isort]
+# For compatibility with 'black', we'd want this to be 3
+multi_line_output=5
+include_trailing_comma=True
+force_grid_wrap=0
+use_parentheses=True
+# For compatibility with 'black' we'd want to set this consistently
+line_length=79
+# We run this in Travis on the lowest python version, and this should keep valid syntax
+atomic=True
+# This ensures compatibility with pytest-pep8
+lines_after_imports=2
+
 [mypy]
 python_version = 3.6
 mypy_path = mypy_stubs

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,10 @@
+import codecs
 import os
 import sys
-import codecs
-from setuptools import setup, find_packages
+
+from setuptools import find_packages, setup
 from setuptools.command.test import test as TestCommand
+
 from zulipterminal.version import ZT_VERSION
 
 

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ dev_helper_deps = [
     'pudb==2017.1.4',
     'snakeviz==0.4.2',
     'gitlint>=0.10',
+    'isort==4.3.21',
 ]
 
 setup(

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -1,5 +1,6 @@
 import pytest
-from zulipterminal.cli.run import main, in_color, THEMES, get_login_id
+
+from zulipterminal.cli.run import THEMES, get_login_id, in_color, main
 from zulipterminal.model import ServerConnectionFailure
 from zulipterminal.version import ZT_VERSION
 

--- a/tests/config/test_keys.py
+++ b/tests/config/test_keys.py
@@ -2,6 +2,7 @@ import pytest
 
 from zulipterminal.config import keys
 
+
 AVAILABLE_COMMANDS = list(keys.KEY_BINDINGS.keys())
 
 USED_KEYS = {key

--- a/tests/config/test_themes.py
+++ b/tests/config/test_themes.py
@@ -1,8 +1,9 @@
 import pytest
 
 from zulipterminal.config.themes import (
-    THEMES, required_styles, all_themes, complete_and_incomplete_themes
+    THEMES, all_themes, complete_and_incomplete_themes, required_styles,
 )
+
 
 expected_complete_themes = {
     'default', 'gruvbox', 'light', 'blue'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,13 +4,11 @@ from typing import Any, Dict
 
 import pytest
 
+from zulipterminal.helper import initial_index as helper_initial_index
 from zulipterminal.ui_tools.boxes import MessageBox
 from zulipterminal.ui_tools.buttons import (
-    StreamButton,
-    UserButton,
-    TopicButton,
+    StreamButton, TopicButton, UserButton,
 )
-from zulipterminal.helper import initial_index as helper_initial_index
 
 
 @pytest.fixture(autouse=True)

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -6,6 +6,7 @@ import pytest
 from zulipterminal.core import Controller
 from zulipterminal.version import ZT_VERSION
 
+
 CORE = "zulipterminal.core"
 
 

--- a/tests/helper/test_helper.py
+++ b/tests/helper/test_helper.py
@@ -1,13 +1,11 @@
+from typing import Any
+
 import pytest
 
 from zulipterminal.helper import (
-    index_messages,
+    canonicalize_color, classify_unread_counts, index_messages, notify,
     powerset,
-    classify_unread_counts,
-    canonicalize_color,
-    notify,
 )
-from typing import Any
 
 
 def test_index_messages_narrow_all_messages(mocker,

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -4,8 +4,8 @@ from typing import Any
 
 import pytest
 
-from zulipterminal.model import Model, ServerConnectionFailure
 from zulipterminal.helper import initial_index, powerset
+from zulipterminal.model import Model, ServerConnectionFailure
 
 
 class TestModel:

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1,32 +1,22 @@
-import pytest
 import datetime
-from collections import defaultdict, OrderedDict
-from bs4 import BeautifulSoup
+from collections import OrderedDict, defaultdict
 
-from zulipterminal.ui_tools.views import (
-    MessageView,
-    MiddleColumnView,
-    StreamsView,
-    TopicsView,
-    UsersView,
-    RightColumnView,
-    LeftColumnView,
-    HelpView,
-    ModListWalker,
-    PopUpConfirmationView,
-    MsgInfoView,
-)
-from zulipterminal.ui_tools.boxes import MessageBox
-from zulipterminal.ui_tools.buttons import (
-    TopButton,
-    StreamButton,
-    UserButton,
-    TopicButton,
-)
+import pytest
+from bs4 import BeautifulSoup
+from urwid import AttrWrap, Columns, Padding, Text
+
 from zulipterminal.config.keys import keys_for_command
 from zulipterminal.helper import powerset
+from zulipterminal.ui_tools.boxes import MessageBox
+from zulipterminal.ui_tools.buttons import (
+    StreamButton, TopButton, TopicButton, UserButton,
+)
+from zulipterminal.ui_tools.views import (
+    HelpView, LeftColumnView, MessageView, MiddleColumnView, ModListWalker,
+    MsgInfoView, PopUpConfirmationView, RightColumnView, StreamsView,
+    TopicsView, UsersView,
+)
 
-from urwid import AttrWrap, Columns, Padding, Text
 
 VIEWS = "zulipterminal.ui_tools.views"
 TOPBUTTON = "zulipterminal.ui_tools.buttons.TopButton"

--- a/tests/ui/test_utils.py
+++ b/tests/ui/test_utils.py
@@ -1,5 +1,6 @@
 import pytest
-from zulipterminal.ui_tools.utils import is_muted, create_msg_box_list
+
+from zulipterminal.ui_tools.utils import create_msg_box_list, is_muted
 
 
 @pytest.mark.parametrize('msg, narrow, muted_streams, muted_topics,\

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -2,6 +2,7 @@ import pytest
 
 from zulipterminal.ui_tools.boxes import WriteBox
 
+
 WRITEBOX = "zulipterminal.ui_tools.boxes.WriteBox"
 
 

--- a/tools/gitlint-extra-rules.py
+++ b/tools/gitlint-extra-rules.py
@@ -1,8 +1,8 @@
-import gitlint
-from gitlint.rules import CommitRule, RuleViolation
-from gitlint.options import ListOption
+from typing import Any, List, Optional
 
-from typing import List, Any, Optional
+import gitlint
+from gitlint.options import ListOption
+from gitlint.rules import CommitRule, RuleViolation
 
 
 class EndsWithDot(CommitRule):

--- a/tools/lister.py
+++ b/tools/lister.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 
-import os
-import sys
-import subprocess
-import re
-from collections import defaultdict
 import argparse
+import os
+import re
+import subprocess
+import sys
+from collections import defaultdict
+
 from six.moves import filter
 
 

--- a/tools/run-isort-check
+++ b/tools/run-isort-check
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+
+import subprocess
+import sys
+
+cmds = ["isort"]
+
+result = subprocess.call(cmds + ["--check-only", "--diff"])
+
+if result == 0:
+    print("All files have imports sorted according to rules.")
+else:
+    print("Some files are not sorted according to rules.")
+    print("You might try '{}' to automatically fix all files.".format(" ".join(cmds)))
+    print("Alternatively try 'isort <somefiles>' to just fix specific files.")
+
+sys.exit(result)

--- a/tools/run-isort-check
+++ b/tools/run-isort-check
@@ -3,6 +3,7 @@
 import subprocess
 import sys
 
+
 cmds = ["isort"]
 
 result = subprocess.call(cmds + ["--check-only", "--diff"])

--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
 
-import os
-import sys
 import argparse
+import os
 import subprocess
-import lister
-from typing import cast, Dict, List
+import sys
 from pathlib import PurePath
+from typing import Dict, List, cast
+
+import lister
+
 
 EXCLUDE_FILES = ['tools/fetch-pull-request', 'tools/fetch-rebase-pull-request']
 

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -1,20 +1,21 @@
 import argparse
 import configparser
-import traceback
-import sys
 import logging
-import requests
-from typing import Dict, Any, List, Optional, Tuple
+import sys
+import traceback
 from os import path, remove
+from typing import Any, Dict, List, Optional, Tuple
 
+import requests
 from urwid import set_encoding
 
+from zulipterminal.config.themes import (
+    THEMES, all_themes, complete_and_incomplete_themes,
+)
 from zulipterminal.core import Controller
 from zulipterminal.model import ServerConnectionFailure
-from zulipterminal.config.themes import (
-    THEMES, all_themes, complete_and_incomplete_themes
-)
 from zulipterminal.version import ZT_VERSION
+
 
 LOG_FILENAME = 'zulip-terminal-tracebacks.log'
 logging.basicConfig(filename=LOG_FILENAME, level=logging.DEBUG)

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -1,6 +1,8 @@
-from typing import Set, Dict, List
 from collections import OrderedDict
+from typing import Dict, List, Set
+
 from mypy_extensions import TypedDict
+
 
 KeyBinding = TypedDict('KeyBinding', {
     'keys': Set[str],

--- a/zulipterminal/config/themes.py
+++ b/zulipterminal/config/themes.py
@@ -1,4 +1,5 @@
-from typing import Dict, List, Tuple, Optional
+from typing import Dict, List, Optional, Tuple
+
 
 ThemeSpec = List[Tuple[Optional[str], ...]]
 

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -1,22 +1,23 @@
-from platform import platform
-from typing import Any, List
 import os
+import signal
 import sys
 import time
-import signal
 from functools import partial
+from platform import platform
+from typing import Any, List
 
 import urwid
 import zulip
 
-from zulipterminal.version import ZT_VERSION
-from zulipterminal.helper import asynch
-from zulipterminal.model import Model, GetMessagesArgs, ServerConnectionFailure
-from zulipterminal.ui import View, Screen
-from zulipterminal.ui_tools.utils import create_msg_box_list
-from zulipterminal.ui_tools.views import HelpView, MsgInfoView
 from zulipterminal.config.themes import ThemeSpec
-from zulipterminal.ui_tools.views import PopUpConfirmationView
+from zulipterminal.helper import asynch
+from zulipterminal.model import GetMessagesArgs, Model, ServerConnectionFailure
+from zulipterminal.ui import Screen, View
+from zulipterminal.ui_tools.utils import create_msg_box_list
+from zulipterminal.ui_tools.views import (
+    HelpView, MsgInfoView, PopUpConfirmationView,
+)
+from zulipterminal.version import ZT_VERSION
 
 
 class Controller:

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -1,20 +1,21 @@
-import time
-from collections import defaultdict
-from itertools import chain, combinations
-from functools import wraps
-from re import match, ASCII
-from threading import Thread
-from typing import (
-    Any, Dict, List, Set, Tuple, Optional, DefaultDict, FrozenSet, Union,
-    Iterable, Callable, FrozenSet
-)
-from mypy_extensions import TypedDict
-
 import os
 import platform
-import subprocess
 import shlex
+import subprocess
+import time
+from collections import defaultdict
+from functools import wraps
+from itertools import chain, combinations
+from re import ASCII, match
+from threading import Thread
+from typing import (
+    Any, Callable, DefaultDict, Dict, FrozenSet, Iterable, List, Optional, Set,
+    Tuple, Union,
+)
+
 import lxml.html
+from mypy_extensions import TypedDict
+
 
 MACOS = platform.system() == "Darwin"
 LINUX = platform.system() == "Linux"

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1,29 +1,23 @@
 import json
-from urllib.parse import urlparse
-from threading import Thread
-from concurrent.futures import ThreadPoolExecutor, wait, Future
 import time
 from collections import OrderedDict
-
+from concurrent.futures import Future, ThreadPoolExecutor, wait
+from threading import Thread
 from typing import (
-        Any, Dict, List, FrozenSet, Set, Union, Optional, Tuple, Callable,
-        Iterable
+    Any, Callable, Dict, FrozenSet, Iterable, List, Optional, Set, Tuple,
+    Union,
 )
-from mypy_extensions import TypedDict
+from urllib.parse import urlparse
 
 import zulip
+from mypy_extensions import TypedDict
 
 from zulipterminal.helper import (
-    asynch,
-    classify_unread_counts,
-    canonicalize_color,
-    index_messages,
-    set_count,
-    initial_index,
-    Message,
-    notify,
+    Message, asynch, canonicalize_color, classify_unread_counts,
+    index_messages, initial_index, notify, set_count,
 )
 from zulipterminal.ui_tools.utils import create_msg_box_list
+
 
 GetMessagesArgs = TypedDict('GetMessagesArgs', {
      'num_before': int,

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -1,22 +1,17 @@
 import platform
-import re
-from typing import Any, Tuple, List, Dict, Optional
 import random
+import re
 import time
+from typing import Any, Dict, List, Optional, Tuple
 
 import urwid
 
-from zulipterminal.config.keys import (
-    is_command_key,
-    commands_for_random_tips
-)
-from zulipterminal.helper import asynch
+from zulipterminal.config.keys import commands_for_random_tips, is_command_key
 from zulipterminal.config.themes import THEMES
-from zulipterminal.ui_tools.boxes import WriteBox, SearchBox
+from zulipterminal.helper import asynch
+from zulipterminal.ui_tools.boxes import SearchBox, WriteBox
 from zulipterminal.ui_tools.views import (
-    RightColumnView,
-    MiddleColumnView,
-    LeftColumnView,
+    LeftColumnView, MiddleColumnView, RightColumnView,
 )
 
 

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -1,18 +1,18 @@
 from collections import defaultdict
-from time import ctime, time
-from datetime import datetime, date
+from datetime import date, datetime
 from sys import platform
-from typing import Any, Dict, List, Tuple, Union, Optional
-from urllib.parse import urlparse, urljoin
+from time import ctime, time
+from typing import Any, Dict, List, Optional, Tuple, Union
+from urllib.parse import urljoin, urlparse
 
 import emoji
 import urwid
-from urwid_readline import ReadlineEdit
 from bs4 import BeautifulSoup
 from bs4.element import NavigableString, Tag
+from urwid_readline import ReadlineEdit
 
 from zulipterminal.config.keys import is_command_key, keys_for_command
-from zulipterminal.helper import match_user, match_stream, match_groups
+from zulipterminal.helper import match_groups, match_stream, match_user
 
 
 class WriteBox(urwid.Pile):

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Tuple, Callable, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import urwid
 

--- a/zulipterminal/ui_tools/utils.py
+++ b/zulipterminal/ui_tools/utils.py
@@ -1,4 +1,4 @@
-from typing import Any, Iterable, List, Union, Dict
+from typing import Any, Dict, Iterable, List, Union
 
 import urwid
 

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1,26 +1,20 @@
-from collections import defaultdict, OrderedDict
-from typing import Any, List, Tuple, Optional, Callable
 import threading
-import urwid
 import time
+from collections import OrderedDict, defaultdict
+from typing import Any, Callable, List, Optional, Tuple
+
+import urwid
 
 from zulipterminal.config.keys import (
-    KEY_BINDINGS,
-    is_command_key,
-    HELP_CATEGORIES
+    HELP_CATEGORIES, KEY_BINDINGS, is_command_key,
 )
 from zulipterminal.helper import asynch, match_user
+from zulipterminal.ui_tools.boxes import PanelSearchBox
 from zulipterminal.ui_tools.buttons import (
-    TopicButton,
-    UnreadPMButton,
-    UserButton,
-    HomeButton,
-    PMButton,
-    StarredButton,
-    StreamButton,
+    HomeButton, PMButton, StarredButton, StreamButton, TopicButton,
+    UnreadPMButton, UserButton,
 )
 from zulipterminal.ui_tools.utils import create_msg_box_list
-from zulipterminal.ui_tools.boxes import PanelSearchBox
 
 
 class ModListWalker(urwid.SimpleFocusListWalker):


### PR DESCRIPTION
This looks like a reasonable linting and auto-formatting approach, which generally has less of a one-size-fits-all approach, leaves our imports looking broadly as they currently do - yet automatically standardizing them :+1:

I know this has been discussed on the server repo; we have slightly different formatting (historically, at least).

It will be interesting to see if the soon-to-be-released v5 of isort has some exciting new features.

@SGeetansh We discussed this, so would be interested to know what you think.