### PR TITLE
tools: Use pycodestyle in place of outdated pytest-pep8.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,8 @@ matrix:
       name: "CPython 3.6 pytest & mypy type-checking (default linux)"
       env: RUN_MYPY=yes
     - python: 3.7
-      name: "CPython 3.7 pytest (default linux)"
+      name: "CPython 3.7 pytest & pycodestyle PEP8 linting (default linux)"
+      env: RUN_PYCODESTYLE=yes
     - python: 3.8
       name: "CPython 3.8 pytest (default linux)"
     - python: pypy3.5
@@ -33,6 +34,7 @@ script:
   - pipenv run pytest
   - if [[ "$RUN_MYPY" == "yes" ]]; then pipenv run pip install -r requirements.txt && pipenv run ./tools/run-mypy; fi
   - if [[ "$RUN_ISORT_CHECK" == "yes" ]]; then pipenv run pip install -r requirements.txt && pipenv run ./tools/run-isort-check; fi
+  - if [[ "$RUN_PYCODESTYLE" == "yes" ]]; then pipenv run pip install -r requirements.txt && pipenv run pycodestyle; fi
 after_success:
   - pip install codecov
   - codecov

--- a/Pipfile
+++ b/Pipfile
@@ -14,9 +14,9 @@ mypy_extensions = ">=0.4"
 
 [dev-packages]
 pytest = "==5.3.5"
-pytest-pep8 = "==1.0.6"
 pytest-mock = "==1.7.1"
 pytest-cov = "==2.5.1"
+pycodestyle = "==2.5.0"
 zipp = "==1.0.0"  # To support Python 3.5
 pudb = "==2017.1.4"
 snakeviz = "==0.4.2"

--- a/README.md
+++ b/README.md
@@ -289,10 +289,11 @@ Once you have a development environment set up, you might find the following use
 | Run normally | `zulip-term` | `pipenv run zulip-term` |
 | Run in debug mode | `zulip-term -d` | `pipenv run zulip-term -d` |
 | Run with profiling | `zulip-term --profile` | `pipenv run zulip-term --profile` |
-| Run all tests (including linter) | `pytest` | `pipenv run pytest` |
+| Run all tests | `pytest` | `pipenv run pytest` |
 | Build test coverage report | `pytest --cov-report html:cov_html --cov=./` | `pipenv run pytest --cov-report html:cov_html --cov=./` |
 | Check type annotations | `./tools/run-mypy` | `pipenv run ./tools/run-mypy` |
 | Check isort compliance | `./tools/run-isort-check` | `pipenv run ./tools/run-isort-check` |
+| Check PEP8 compliance | `pycodestyle` | `pipenv run pycodestyle` |
 
 #### GitLint (optional)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@ urwid==2.1.0
 zulip==0.6.3
 pytest==5.3.5
 pytest-cov==2.5.1
-pytest-pep8==1.0.6
 pytest-mock==1.7.1
+pycodestyle==2.5.0
 pudb==2017.1.4
 snakeviz==0.4.2
 gitlint==0.10.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,11 +8,7 @@ filterwarnings =
     # bs4: ABCs must be imported from collections.abc, not collections, from python3.9
     # * python 3.7/3.8
     ignore::DeprecationWarning:bs4.*:
-markers =
-    # The pep8 plugin works but is quite old; we could use something else
-    # (straight pycodestyle, other linters, or combinations like zulint)
-    pep8: workaround for https://bitbucket.org/pytest-dev/pytest-pep8/issues/23/
-addopts = --pep8 -rxXs --cov=zulipterminal
+addopts = -rxXs --cov=zulipterminal
 
 [tool:isort]
 # For compatibility with 'black', we'd want this to be 3
@@ -26,6 +22,12 @@ line_length=79
 atomic=True
 # This ensures compatibility with pytest-pep8
 lines_after_imports=2
+
+# This is a first step from using the old pep8 plugin to pytest
+# We could use something else in future, like a combination linter
+# (flake8, pylint, zulint)
+[pycodestyle]
+ignore=E121,E123,E126,E226,E24,E704,W503,W504,E117,E252
 
 [mypy]
 python_version = 3.6

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ testing_deps = [
     'pytest==5.3.5',
     'pytest-cov==2.5.1',
     'pytest-mock==1.7.1',
-    'pytest-pep8==1.0.6',
+    'pycodestyle==2.5.0',
     'zipp==1.0.0',  # To support Python 3.5
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -117,6 +117,7 @@ def logged_on_user():
         'short_name': 'Human',
     }
 
+
 general_stream = {
     'name': 'Some general stream',
     'invite_only': False,
@@ -172,6 +173,7 @@ def streams_fixture():
             'email_address': 'stream{}@example.com'.format(i),
         })
     return deepcopy(streams)
+
 
 stream_msg_template = {
     'id': 537286,

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -309,24 +309,24 @@ class Model:
         return response['result'] == 'success'
 
     def update_private_message(self, msg_id: int, content: str) -> bool:
-            request = {
-                "message_id": msg_id,
-                "content": content,
-            }
-            response = self.client.update_message(request)
-            return response['result'] == 'success'
+        request = {
+            "message_id": msg_id,
+            "content": content,
+        }
+        response = self.client.update_message(request)
+        return response['result'] == 'success'
 
     def update_stream_message(self, topic: str, msg_id: int,
                               content: str) -> bool:
-            request = {
-                "message_id": msg_id,
-                "content": content,
-                # TODO: Add support for "change_later" & "change_all"
-                "propagate_mode": "change_one",
-                "subject": topic,
-            }
-            response = self.client.update_message(request)
-            return response['result'] == 'success'
+        request = {
+            "message_id": msg_id,
+            "content": content,
+            # TODO: Add support for "change_later" & "change_all"
+            "propagate_mode": "change_one",
+            "subject": topic,
+        }
+        response = self.client.update_message(request)
+        return response['result'] == 'success'
 
     def get_messages(self, *,
                      num_after: int, num_before: int,


### PR DESCRIPTION
This is intended to be a step towards updated PEP8 linting, as now
provided by pycodestyle.

Other than moving to a more maintained and current linter (pycodestyle
vs pep8), using a separate linter outside of pytest makes it more obvious which aspects
are failing (tests vs pep8 linting) and reduces the need to run it in
every test run - including each version of python on CI. It also allows
the linter to be run consistently in editors more frequently (if
desired), as it runs fairly rapidly.

Locally this broadly just splits the time taken to run, with pycodestyle
taking ~3s.

* Update dependencies (pytest-pep8 -> pycodestyle)
* Add pycodestyle configuration to setup.cfg
* Remove pytest-pep8 configuration from setup.cfg
* Minimal changes to two files to show consistency
* Explicitly add PEP8 checks to only one CI task in travis
* Update README for different lint commands

Currently this explicitly excludes E252, for spacing around typed
function parameters, which is a newer style. This also excludes a newer
E117 check, which appears flakey.

All other excludes are as per pycodestyle defaults.