### PR TITLE
Improve CI speed & effectiveness

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,24 +19,24 @@ matrix:
       # Note that running isort on the lowest version should ensure changes are compatible
       script: ./tools/run-isort-check
     - python: 3.5
-      name: "Pytest - CPython 3.5 (default linux)"
+      name: "Install & pytest - CPython 3.5 (default linux)"
     - python: 3.6
-      name: "Pytest - CPython 3.6 (default linux)"
+      name: "Install & pytest - CPython 3.6 (default linux)"
     - python: 3.7
-      name: "Pytest - CPython 3.7 (default linux)"
+      name: "Install & pytest - CPython 3.7 (default linux)"
     - python: 3.8
-      name: "Pytest - CPython 3.8 (default linux)"
+      name: "Install & pytest - CPython 3.8 (default linux)"
     - python: pypy3.5
-      name: "Pytest - PyPy 3.5 (default linux)"
+      name: "Install & pytest - PyPy 3.5 (default linux)"
     - os: osx
-      name: "Pytest - Python 3 (OS X; xcode10)"
+      name: "Install & pytest - Python 3 (OS X; xcode10)"
       cache:
       - $HOME/Library/Caches/pip
       osx_image: xcode10
       sudo: required
       language: generic
 install:
-  - pip3 install .[testing]
+  - pip3 install . && pip3 install .[testing]
 script:
   - pytest
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,12 +26,12 @@ matrix:
       sudo: required
       language: generic
 install:
-  - pip3 install .[dev]
+  - pip3 install .[testing]
 script:
   - pytest
-  - if [[ "$RUN_MYPY" == "yes" ]]; then pip3 install -r requirements.txt && ./tools/run-mypy; fi
-  - if [[ "$RUN_ISORT_CHECK" == "yes" ]]; then pip3 install -r requirements.txt && ./tools/run-isort-check; fi
-  - if [[ "$RUN_PYCODESTYLE" == "yes" ]]; then pip3 install -r requirements.txt && pycodestyle; fi
+  - if [[ "$RUN_MYPY" == "yes" ]]; then pip3 install .[linting] && ./tools/run-mypy; fi
+  - if [[ "$RUN_ISORT_CHECK" == "yes" ]]; then pip3 install .[linting] && ./tools/run-isort-check; fi
+  - if [[ "$RUN_PYCODESTYLE" == "yes" ]]; then pip3 install .[linting] && pycodestyle; fi
 after_success:
   - pip3 install codecov
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,25 @@ cache:
   pip: true
 matrix:
   include:
-    - python: 3.5
-      name: "CPython 3.5 pytest & isort linting (default linux)"
-      # Note that running isort on the lowest version should ensure changes are compatible
-      env: RUN_ISORT_CHECK=yes
-    - python: 3.6
-      name: "CPython 3.6 pytest & mypy type-checking (default linux)"
-      env: RUN_MYPY=yes
     - python: 3.7
-      name: "CPython 3.7 pytest & pycodestyle PEP8 linting (default linux)"
-      env: RUN_PYCODESTYLE=yes
+      name: "Linting - type consistency (mypy)"
+      install: pip3 install .[linting]
+      script: ./tools/run-mypy
+    - python: 3.7
+      name: "Linting - PEP8 (pycodestyle)"
+      install: pip3 install .[linting]
+      script: pycodestyle
+    - python: 3.5
+      name: "Linting - import order (isort)"
+      install: pip3 install .[linting]
+      # Note that running isort on the lowest version should ensure changes are compatible
+      script: ./tools/run-isort-check
+    - python: 3.5
+      name: "CPython 3.5 pytest (default linux)"
+    - python: 3.6
+      name: "CPython 3.6 pytest (default linux)"
+    - python: 3.7
+      name: "CPython 3.7 pytest (default linux)"
     - python: 3.8
       name: "CPython 3.8 pytest (default linux)"
     - python: pypy3.5
@@ -29,9 +38,6 @@ install:
   - pip3 install .[testing]
 script:
   - pytest
-  - if [[ "$RUN_MYPY" == "yes" ]]; then pip3 install .[linting] && ./tools/run-mypy; fi
-  - if [[ "$RUN_ISORT_CHECK" == "yes" ]]; then pip3 install .[linting] && ./tools/run-isort-check; fi
-  - if [[ "$RUN_PYCODESTYLE" == "yes" ]]; then pip3 install .[linting] && pycodestyle; fi
 after_success:
   - pip3 install codecov
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,16 +19,17 @@ matrix:
       # Note that running isort on the lowest version should ensure changes are compatible
       script: ./tools/run-isort-check
     - python: 3.5
-      name: "CPython 3.5 pytest (default linux)"
+      name: "Pytest - CPython 3.5 (default linux)"
     - python: 3.6
-      name: "CPython 3.6 pytest (default linux)"
+      name: "Pytest - CPython 3.6 (default linux)"
     - python: 3.7
-      name: "CPython 3.7 pytest (default linux)"
+      name: "Pytest - CPython 3.7 (default linux)"
     - python: 3.8
-      name: "CPython 3.8 pytest (default linux)"
+      name: "Pytest - CPython 3.8 (default linux)"
     - python: pypy3.5
-      name: "PyPy 3.5 pytest (default linux)"
+      name: "Pytest - PyPy 3.5 (default linux)"
     - os: osx
+      name: "Pytest - Python 3 (OS X; xcode10)"
       cache:
       - $HOME/Library/Caches/pip
       osx_image: xcode10

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ git:
   depth: 20
 cache:
   pip: true
-  directories:
-    - $HOME/.cache/pipenv
 matrix:
   include:
     - python: 3.5
@@ -28,13 +26,12 @@ matrix:
       sudo: required
       language: generic
 install:
-  - pip install pipenv==11.10
-  - pipenv install --three --dev Pipfile
+  - pip3 install .[dev]
 script:
-  - pipenv run pytest
-  - if [[ "$RUN_MYPY" == "yes" ]]; then pipenv run pip install -r requirements.txt && pipenv run ./tools/run-mypy; fi
-  - if [[ "$RUN_ISORT_CHECK" == "yes" ]]; then pipenv run pip install -r requirements.txt && pipenv run ./tools/run-isort-check; fi
-  - if [[ "$RUN_PYCODESTYLE" == "yes" ]]; then pipenv run pip install -r requirements.txt && pipenv run pycodestyle; fi
+  - pytest
+  - if [[ "$RUN_MYPY" == "yes" ]]; then pip3 install -r requirements.txt && ./tools/run-mypy; fi
+  - if [[ "$RUN_ISORT_CHECK" == "yes" ]]; then pip3 install -r requirements.txt && ./tools/run-isort-check; fi
+  - if [[ "$RUN_PYCODESTYLE" == "yes" ]]; then pip3 install -r requirements.txt && pycodestyle; fi
 after_success:
-  - pip install codecov
+  - pip3 install codecov
   - codecov

--- a/setup.py
+++ b/setup.py
@@ -34,16 +34,19 @@ testing_deps = [
     'pytest==5.3.5',
     'pytest-cov==2.5.1',
     'pytest-mock==1.7.1',
-    'pycodestyle==2.5.0',
     'zipp==1.0.0',  # To support Python 3.5
 ]
 
-dev_helper_deps = [
+linting_deps = [
+    'isort==4.3.21',
     'mypy==0.740',
+    'pycodestyle==2.5.0',
+]
+
+dev_helper_deps = [
     'pudb==2017.1.4',
     'snakeviz==0.4.2',
     'gitlint>=0.10',
-    'isort==4.3.21',
 ]
 
 setup(
@@ -84,7 +87,9 @@ setup(
         ],
     },
     extras_require={
-        'dev': testing_deps + dev_helper_deps,
+        'dev': testing_deps + linting_deps + dev_helper_deps,
+        'testing': testing_deps,
+        'linting': linting_deps,
     },
     tests_require=testing_deps,
     install_requires=[


### PR DESCRIPTION
* Use `pip3` in travis instead of `pipenv` - this alone reduces runtime significantly
* Split linting and testing dependencies from general 'dev' dependencies in `setup.py`, allowing unnecessary package installation to be avoided in travis
* Now that jobs run faster individually, it's practical to set up linting in separate jobs, making it easier for developers to see what CI aspect failed
* On each platform, first install the package, then install testing packages for running tests; this is a partial fix towards #181.

I merged #502 pretty quickly so that this would be easier to discuss/review. However, I think the increased speed from pip over pipenv makes this a pretty clear improvement.