### PR TITLE
Type annotations: Improve keypress and mouse_event signatures

### DIFF
--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -145,6 +145,7 @@ class View(urwid.WidgetWrap):
         if visible:
             self.body.focus_position = 2
 
+    # FIXME: The type of size should be urwid_Size; this needs checking
     def keypress(self, size: Tuple[int, int], key: str) -> str:
         self.model.new_user_input = True
         if self.controller.editor_mode:

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -146,7 +146,7 @@ class View(urwid.WidgetWrap):
             self.body.focus_position = 2
 
     # FIXME: The type of size should be urwid_Size; this needs checking
-    def keypress(self, size: Tuple[int, int], key: str) -> str:
+    def keypress(self, size: Tuple[int, int], key: str) -> Optional[str]:
         self.model.new_user_input = True
         if self.controller.editor_mode:
             return self.controller.editor.keypress((size[1],), key)

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -646,8 +646,8 @@ class MessageBox(urwid.Pile):
         # is designed to take focus.
         return True
 
-    def mouse_event(self, size: urwid_Size, event: Any, button: Any,
-                    col: int, row: int, focus: int) -> Union[bool, Any]:
+    def mouse_event(self, size: urwid_Size, event: str, button: int,
+                    col: int, row: int, focus: bool) -> bool:
         if event == 'mouse press':
             if button == 1:
                 self.keypress(size, 'enter')

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -129,7 +129,7 @@ class WriteBox(urwid.Pile):
         except IndexError:
             return None
 
-    def keypress(self, size: urwid_Size, key: str) -> str:
+    def keypress(self, size: urwid_Size, key: str) -> Optional[str]:
         if is_command_key('SEND_MESSAGE', key):
             if self.msg_edit_id:
                 if not self.to_write_box:
@@ -666,7 +666,7 @@ class MessageBox(urwid.Pile):
 
         return super().mouse_event(size, event, button, col, row, focus)
 
-    def keypress(self, size: urwid_Size, key: str) -> str:
+    def keypress(self, size: urwid_Size, key: str) -> Optional[str]:
         if is_command_key('ENTER', key):
             if self.message['type'] == 'private':
                 self.model.controller.view.write_box.private_box_view(
@@ -790,7 +790,7 @@ class SearchBox(urwid.Pile):
             blcorner=u'─', rline=u'', bline=u'─', brcorner=u'─')
         return [self.search_bar, self.recipient_bar]
 
-    def keypress(self, size: urwid_Size, key: str) -> str:
+    def keypress(self, size: urwid_Size, key: str) -> Optional[str]:
         if is_command_key('GO_BACK', key):
             self.text_box.set_edit_text("")
             self.controller.editor_mode = False
@@ -821,7 +821,7 @@ class PanelSearchBox(urwid.Edit):
         urwid.connect_signal(self, 'change', update_function)
         super().__init__(edit_text=self.search_text)
 
-    def keypress(self, size: urwid_Size, key: str) -> str:
+    def keypress(self, size: urwid_Size, key: str) -> Optional[str]:
         if is_command_key('ENTER', key):
             self.panel_view.view.controller.editor_mode = False
             self.panel_view.set_focus("body")

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -15,6 +15,7 @@ from zulipterminal.config.keys import is_command_key, keys_for_command
 from zulipterminal.helper import (
     Message, match_groups, match_stream, match_user,
 )
+from zulipterminal.urwid_types import urwid_Size
 
 
 class WriteBox(urwid.Pile):
@@ -128,7 +129,7 @@ class WriteBox(urwid.Pile):
         except IndexError:
             return None
 
-    def keypress(self, size: Tuple[int, int], key: str) -> str:
+    def keypress(self, size: urwid_Size, key: str) -> str:
         if is_command_key('SEND_MESSAGE', key):
             if self.msg_edit_id:
                 if not self.to_write_box:
@@ -645,7 +646,7 @@ class MessageBox(urwid.Pile):
         # is designed to take focus.
         return True
 
-    def mouse_event(self, size: Tuple[int, int], event: Any, button: Any,
+    def mouse_event(self, size: urwid_Size, event: Any, button: Any,
                     col: int, row: int, focus: int) -> Union[bool, Any]:
         if event == 'mouse press':
             if button == 1:
@@ -665,7 +666,7 @@ class MessageBox(urwid.Pile):
 
         return super().mouse_event(size, event, button, col, row, focus)
 
-    def keypress(self, size: Tuple[int, int], key: str) -> str:
+    def keypress(self, size: urwid_Size, key: str) -> str:
         if is_command_key('ENTER', key):
             if self.message['type'] == 'private':
                 self.model.controller.view.write_box.private_box_view(
@@ -789,7 +790,7 @@ class SearchBox(urwid.Pile):
             blcorner=u'─', rline=u'', bline=u'─', brcorner=u'─')
         return [self.search_bar, self.recipient_bar]
 
-    def keypress(self, size: Tuple[int, int], key: str) -> str:
+    def keypress(self, size: urwid_Size, key: str) -> str:
         if is_command_key('GO_BACK', key):
             self.text_box.set_edit_text("")
             self.controller.editor_mode = False
@@ -820,7 +821,7 @@ class PanelSearchBox(urwid.Edit):
         urwid.connect_signal(self, 'change', update_function)
         super().__init__(edit_text=self.search_text)
 
-    def keypress(self, size: Tuple[int, int], key: str) -> str:
+    def keypress(self, size: urwid_Size, key: str) -> str:
         if is_command_key('ENTER', key):
             self.panel_view.view.controller.editor_mode = False
             self.panel_view.set_focus("body")

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -78,7 +78,7 @@ class TopButton(urwid.Button):
         self.controller.view.body.focus_col = 1
         self.show_function(self)
 
-    def keypress(self, size: urwid_Size, key: str) -> str:
+    def keypress(self, size: urwid_Size, key: str) -> Optional[str]:
         if is_command_key('ENTER', key):
             self.activate(key)
         return super().keypress(size, key)
@@ -169,7 +169,7 @@ class StreamButton(TopButton):
             # All messages in this stream are read.
             self.update_count(0)
 
-    def keypress(self, size: urwid_Size, key: str) -> str:
+    def keypress(self, size: urwid_Size, key: str) -> Optional[str]:
         if is_command_key('TOGGLE_TOPIC', key):
             topic_view = self.view.left_panel.topics_view(self)
             self.view.left_panel.is_in_topic_view = True

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -3,6 +3,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 import urwid
 
 from zulipterminal.config.keys import is_command_key, keys_for_command
+from zulipterminal.urwid_types import urwid_Size
 
 
 class MenuButton(urwid.Button):
@@ -77,7 +78,7 @@ class TopButton(urwid.Button):
         self.controller.view.body.focus_col = 1
         self.show_function(self)
 
-    def keypress(self, size: Tuple[int, int], key: str) -> str:
+    def keypress(self, size: urwid_Size, key: str) -> str:
         if is_command_key('ENTER', key):
             self.activate(key)
         return super().keypress(size, key)
@@ -168,7 +169,7 @@ class StreamButton(TopButton):
             # All messages in this stream are read.
             self.update_count(0)
 
-    def keypress(self, size: Tuple[int, int], key: str) -> str:
+    def keypress(self, size: urwid_Size, key: str) -> str:
         if is_command_key('TOGGLE_TOPIC', key):
             topic_view = self.view.left_panel.topics_view(self)
             self.view.left_panel.is_in_topic_view = True

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -142,7 +142,7 @@ class MessageView(urwid.ListBox):
                 return True
         return super().mouse_event(size, event, button, col, row, focus)
 
-    def keypress(self, size: urwid_Size, key: str) -> str:
+    def keypress(self, size: urwid_Size, key: str) -> Optional[str]:
         if is_command_key('NEXT_MESSAGE', key) and not self.new_loading:
             try:
                 position = self.log.next_position(self.focus_position)
@@ -290,7 +290,7 @@ class StreamsView(urwid.Frame):
                 return True
         return super().mouse_event(size, event, button, col, row, focus)
 
-    def keypress(self, size: urwid_Size, key: str) -> str:
+    def keypress(self, size: urwid_Size, key: str) -> Optional[str]:
         if is_command_key('SEARCH_STREAMS', key):
             self.set_focus('header')
             return key
@@ -377,7 +377,7 @@ class TopicsView(urwid.Frame):
                 return True
         return super().mouse_event(size, event, button, col, row, focus)
 
-    def keypress(self, size: urwid_Size, key: str) -> str:
+    def keypress(self, size: urwid_Size, key: str) -> Optional[str]:
         if is_command_key('TOGGLE_TOPIC', key):
             # Exit topic view
             self.view.left_panel.contents[1] = (
@@ -461,7 +461,7 @@ class MiddleColumnView(urwid.Frame):
             return pm
         return None
 
-    def keypress(self, size: urwid_Size, key: str) -> str:
+    def keypress(self, size: urwid_Size, key: str) -> Optional[str]:
         if is_command_key('GO_BACK', key):
             self.header.keypress(size, 'esc')
             self.footer.keypress(size, 'esc')
@@ -611,7 +611,7 @@ class RightColumnView(urwid.Frame):
             self.view.user_w = user_w
         return user_w
 
-    def keypress(self, size: urwid_Size, key: str) -> str:
+    def keypress(self, size: urwid_Size, key: str) -> Optional[str]:
         if is_command_key('SEARCH_PEOPLE', key):
             self.allow_update_user_list = False
             self.set_focus('header')
@@ -735,7 +735,7 @@ class LeftColumnView(urwid.Pile):
             )
         return w
 
-    def keypress(self, size: urwid_Size, key: str) -> str:
+    def keypress(self, size: urwid_Size, key: str) -> Optional[str]:
         if (is_command_key('SEARCH_STREAMS', key) or
                 is_command_key('SEARCH_TOPICS', key)):
             self.focus_position = 1

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -132,7 +132,7 @@ class MessageView(urwid.ListBox):
         self.new_loading = False
 
     def mouse_event(self, size: urwid_Size, event: str, button: int, col: int,
-                    row: int, focus: Any) -> Any:
+                    row: int, focus: bool) -> bool:
         if event == 'mouse press':
             if button == 4:
                 self.keypress(size, 'up')
@@ -280,7 +280,7 @@ class StreamsView(urwid.Frame):
             self.view.controller.update_screen()
 
     def mouse_event(self, size: urwid_Size, event: str, button: int, col: int,
-                    row: int, focus: Any) -> Any:
+                    row: int, focus: bool) -> bool:
         if event == 'mouse press':
             if button == 4:
                 self.keypress(size, 'up')
@@ -367,7 +367,7 @@ class TopicsView(urwid.Frame):
             self.list_box.set_focus(0)
 
     def mouse_event(self, size: urwid_Size, event: str, button: int, col: int,
-                    row: int, focus: Any) -> Any:
+                    row: int, focus: bool) -> bool:
         if event == 'mouse press':
             if button == 4:
                 self.keypress(size, 'up')
@@ -406,7 +406,7 @@ class UsersView(urwid.ListBox):
         super().__init__(self.log)
 
     def mouse_event(self, size: urwid_Size, event: str, button: int, col: int,
-                    row: int, focus: Any) -> Any:
+                    row: int, focus: bool) -> bool:
         if event == 'mouse press':
             if button == 4:
                 for _ in range(5):

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -15,6 +15,7 @@ from zulipterminal.ui_tools.buttons import (
     UnreadPMButton, UserButton,
 )
 from zulipterminal.ui_tools.utils import create_msg_box_list
+from zulipterminal.urwid_types import urwid_Size
 
 
 class ModListWalker(urwid.SimpleFocusListWalker):
@@ -130,7 +131,7 @@ class MessageView(urwid.ListBox):
         self.model.controller.update_screen()
         self.new_loading = False
 
-    def mouse_event(self, size: Any, event: str, button: int, col: int,
+    def mouse_event(self, size: urwid_Size, event: str, button: int, col: int,
                     row: int, focus: Any) -> Any:
         if event == 'mouse press':
             if button == 4:
@@ -141,7 +142,7 @@ class MessageView(urwid.ListBox):
                 return True
         return super().mouse_event(size, event, button, col, row, focus)
 
-    def keypress(self, size: Tuple[int, int], key: str) -> str:
+    def keypress(self, size: urwid_Size, key: str) -> str:
         if is_command_key('NEXT_MESSAGE', key) and not self.new_loading:
             try:
                 position = self.log.next_position(self.focus_position)
@@ -278,7 +279,7 @@ class StreamsView(urwid.Frame):
             self.log.extend(streams_display)
             self.view.controller.update_screen()
 
-    def mouse_event(self, size: Any, event: str, button: int, col: int,
+    def mouse_event(self, size: urwid_Size, event: str, button: int, col: int,
                     row: int, focus: Any) -> Any:
         if event == 'mouse press':
             if button == 4:
@@ -289,7 +290,7 @@ class StreamsView(urwid.Frame):
                 return True
         return super().mouse_event(size, event, button, col, row, focus)
 
-    def keypress(self, size: Tuple[int, int], key: str) -> str:
+    def keypress(self, size: urwid_Size, key: str) -> str:
         if is_command_key('SEARCH_STREAMS', key):
             self.set_focus('header')
             return key
@@ -365,7 +366,7 @@ class TopicsView(urwid.Frame):
         if sender_id == self.view.model.user_id:
             self.list_box.set_focus(0)
 
-    def mouse_event(self, size: Any, event: str, button: int, col: int,
+    def mouse_event(self, size: urwid_Size, event: str, button: int, col: int,
                     row: int, focus: Any) -> Any:
         if event == 'mouse press':
             if button == 4:
@@ -376,7 +377,7 @@ class TopicsView(urwid.Frame):
                 return True
         return super().mouse_event(size, event, button, col, row, focus)
 
-    def keypress(self, size: Tuple[int, int], key: str) -> str:
+    def keypress(self, size: urwid_Size, key: str) -> str:
         if is_command_key('TOGGLE_TOPIC', key):
             # Exit topic view
             self.view.left_panel.contents[1] = (
@@ -404,7 +405,7 @@ class UsersView(urwid.ListBox):
         self.log = urwid.SimpleFocusListWalker(users_btn_list)
         super().__init__(self.log)
 
-    def mouse_event(self, size: Any, event: str, button: int, col: int,
+    def mouse_event(self, size: urwid_Size, event: str, button: int, col: int,
                     row: int, focus: Any) -> Any:
         if event == 'mouse press':
             if button == 4:
@@ -460,7 +461,7 @@ class MiddleColumnView(urwid.Frame):
             return pm
         return None
 
-    def keypress(self, size: Tuple[int, int], key: str) -> str:
+    def keypress(self, size: urwid_Size, key: str) -> str:
         if is_command_key('GO_BACK', key):
             self.header.keypress(size, 'esc')
             self.footer.keypress(size, 'esc')
@@ -610,7 +611,7 @@ class RightColumnView(urwid.Frame):
             self.view.user_w = user_w
         return user_w
 
-    def keypress(self, size: Tuple[int, int], key: str) -> str:
+    def keypress(self, size: urwid_Size, key: str) -> str:
         if is_command_key('SEARCH_PEOPLE', key):
             self.allow_update_user_list = False
             self.set_focus('header')
@@ -734,7 +735,7 @@ class LeftColumnView(urwid.Pile):
             )
         return w
 
-    def keypress(self, size: Tuple[int, int], key: str) -> str:
+    def keypress(self, size: urwid_Size, key: str) -> str:
         if (is_command_key('SEARCH_STREAMS', key) or
                 is_command_key('SEARCH_TOPICS', key)):
             self.focus_position = 1
@@ -786,7 +787,7 @@ class HelpView(urwid.ListBox):
 
         super().__init__(self.log)
 
-    def keypress(self, size: Tuple[int, int], key: str) -> str:
+    def keypress(self, size: urwid_Size, key: str) -> str:
         if is_command_key('GO_BACK', key) or is_command_key('HELP', key):
             self.controller.exit_popup()
         return super().keypress(size, key)
@@ -822,7 +823,7 @@ class PopUpConfirmationView(urwid.Overlay):
     def exit_popup_no(self, args: Any) -> None:
         self.controller.exit_popup()
 
-    def keypress(self, size: Tuple[int, int], key: str) -> str:
+    def keypress(self, size: urwid_Size, key: str) -> str:
         if is_command_key('GO_BACK', key):
             self.controller.exit_popup()
         return super().keypress(size, key)
@@ -886,7 +887,7 @@ class MsgInfoView(urwid.ListBox):
 
         super().__init__(self.log)
 
-    def keypress(self, size: Tuple[int, int], key: str) -> str:
+    def keypress(self, size: urwid_Size, key: str) -> str:
         if is_command_key('GO_BACK', key) or is_command_key('MSG_INFO', key):
             self.controller.exit_popup()
         return super().keypress(size, key)

--- a/zulipterminal/urwid_types.py
+++ b/zulipterminal/urwid_types.py
@@ -1,0 +1,4 @@
+from typing import Tuple, Union
+
+
+urwid_Size = Union[Tuple[()], Tuple[int], Tuple[int, int]]


### PR DESCRIPTION
This PR attempts to improve the consistency of these methods, based on their types as defined in urwid.

Currently this defines `urwid_Size` rather loosely, but I wanted to set some kind of standard so that when we make additions then contributors can compare to the existing code and see this. The type alias can always be changed later if we want to.

@amanagr The `FIXME` in `ui.py` is the issue I was referring to you a while back.