### PR TITLE
Type Annotations: Use Message type alias consistently

### DIFF
--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -10,7 +10,7 @@ import urwid
 import zulip
 
 from zulipterminal.config.themes import ThemeSpec
-from zulipterminal.helper import asynch
+from zulipterminal.helper import Message, asynch
 from zulipterminal.model import GetMessagesArgs, Model, ServerConnectionFailure
 from zulipterminal.ui import Screen, View
 from zulipterminal.ui_tools.utils import create_msg_box_list
@@ -111,7 +111,7 @@ class Controller:
         help_view = HelpView(self)
         self.show_pop_up(help_view, "Help Menu (up/down scrolls)")
 
-    def show_msg_info(self, msg: Any) -> None:
+    def show_msg_info(self, msg: Message) -> None:
         msg_info_view = MsgInfoView(self, msg)
         self.show_pop_up(msg_info_view,
                          "Message Information (up/down scrolls)")

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -177,7 +177,7 @@ def set_count(id_list: List[int], controller: Any, new_count: int) -> None:
     controller.update_screen()
 
 
-def index_messages(messages: List[Any],
+def index_messages(messages: List[Message],
                    model: Any,
                    index: Index) -> Index:
     """

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -244,7 +244,7 @@ class Model:
 
     @asynch
     def react_to_message(self,
-                         message: Dict[str, Any],
+                         message: Message,
                          reaction_to_toggle: str) -> None:
         # FIXME Only support thumbs_up for now
         assert reaction_to_toggle == 'thumbs_up'
@@ -268,7 +268,7 @@ class Model:
             response = self.client.add_reaction(reaction_to_toggle_spec)
 
     @asynch
-    def toggle_message_star_status(self, message: Dict[str, Any]) -> None:
+    def toggle_message_star_status(self, message: Message) -> None:
         base_request = dict(flag='starred', messages=[message['id']])
         if 'starred' in message['flags']:
             request = dict(base_request, op='remove')
@@ -641,7 +641,7 @@ class Model:
                 else:
                     raise RuntimeError("Unknown typing event operation")
 
-    def notify_user(self, message: Dict[str, Any]) -> None:
+    def notify_user(self, message: Message) -> None:
         # Check if notifications are enabled by the user.
         # It is disabled by default.
         if not self.controller.notify_enabled:

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -12,7 +12,9 @@ from bs4.element import NavigableString, Tag
 from urwid_readline import ReadlineEdit
 
 from zulipterminal.config.keys import is_command_key, keys_for_command
-from zulipterminal.helper import match_groups, match_stream, match_user
+from zulipterminal.helper import (
+    Message, match_groups, match_stream, match_user,
+)
 
 
 class WriteBox(urwid.Pile):
@@ -180,7 +182,8 @@ class WriteBox(urwid.Pile):
 
 
 class MessageBox(urwid.Pile):
-    def __init__(self, message: Dict[str, Any], model: Any,
+    # type of last_message is Optional[Message], but needs refactoring
+    def __init__(self, message: Message, model: Any,
                  last_message: Any) -> None:
         self.model = model
         self.message = message
@@ -226,7 +229,7 @@ class MessageBox(urwid.Pile):
 
         super(MessageBox, self).__init__(self.main_view())
 
-    def _time_for_message(self, message: Dict[str, Any]) -> str:
+    def _time_for_message(self, message: Message) -> str:
         return ctime(message['timestamp'])[:-8]
 
     def need_recipient_header(self) -> bool:

--- a/zulipterminal/ui_tools/utils.py
+++ b/zulipterminal/ui_tools/utils.py
@@ -1,14 +1,15 @@
-from typing import Any, Dict, Iterable, List, Union
+from typing import Any, Iterable, List, Optional, Union
 
 import urwid
 
+from zulipterminal.helper import Message
 from zulipterminal.ui_tools.boxes import MessageBox
 
 
 def create_msg_box_list(model: Any, messages: Union[None, Iterable[Any]]=None,
                         *,
                         focus_msg_id: Union[None, int]=None,
-                        last_message: Union[None, Any]=None) -> List[Any]:
+                        last_message: Optional[Message]=None) -> List[Any]:
     """
     MessageBox for every message displayed is created here.
     """
@@ -50,7 +51,7 @@ def create_msg_box_list(model: Any, messages: Union[None, Iterable[Any]]=None,
     return w_list
 
 
-def is_muted(msg: Dict[Any, Any], model: Any) -> bool:
+def is_muted(msg: Message, model: Any) -> bool:
     # PMs cannot be muted
     if msg['type'] == 'private':
         return False
@@ -64,7 +65,7 @@ def is_muted(msg: Dict[Any, Any], model: Any) -> bool:
     return False
 
 
-def is_unsubscribed_message(msg: Dict[Any, Any], model: Any) -> bool:
+def is_unsubscribed_message(msg: Message, model: Any) -> bool:
     if msg['type'] == 'private':
         return False
     if msg['stream_id'] not in model.stream_dict:

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -8,7 +8,7 @@ import urwid
 from zulipterminal.config.keys import (
     HELP_CATEGORIES, KEY_BINDINGS, is_command_key,
 )
-from zulipterminal.helper import asynch, match_user
+from zulipterminal.helper import Message, asynch, match_user
 from zulipterminal.ui_tools.boxes import PanelSearchBox
 from zulipterminal.ui_tools.buttons import (
     HomeButton, PMButton, StarredButton, StreamButton, TopicButton,
@@ -852,7 +852,7 @@ class StreamInfoView(urwid.ListBox):
 
 
 class MsgInfoView(urwid.ListBox):
-    def __init__(self, controller: Any, msg: Any) -> None:
+    def __init__(self, controller: Any, msg: Message) -> None:
         self.controller = controller
         self.msg = msg
 


### PR DESCRIPTION
This expands use of the existing `Message` type alias for message data.

In some cases, this replaces broad `Any` typing, and in others is a more explicit (but equivalent) substitute for `Dict[str, Any]`, which is the current type of `Message`.

This exposes one case where we cannot make this substitution without refactoring, so I've added a note.