### PR TITLE
Add support for navigation using keys 'j' and 'k' in help popup menu.

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1101,6 +1101,23 @@ class TestHelpMenu:
         self.help_view.keypress(size, key)
         assert self.controller.exit_popup.called
 
+    @pytest.mark.parametrize('key, expected_key', [
+        (key, expected_key)
+        for keys, expected_key in [
+            (keys_for_command('GO_UP'), 'up'),
+            (keys_for_command('GO_DOWN'), 'down'),
+            (keys_for_command('SCROLL_UP'), 'page up'),
+            (keys_for_command('SCROLL_DOWN'), 'page down'),
+            (keys_for_command('GO_TO_BOTTOM'), 'end'),
+        ]
+        for key in keys
+    ])
+    def test_keypress_navigation(self, mocker, key, expected_key):
+        size = (200, 20)
+        super_view = mocker.patch(VIEWS + '.urwid.ListBox.keypress')
+        self.help_view.keypress(size, key)
+        super_view.assert_called_once_with(size, expected_key)
+
 
 class TestPopUpConfirmationView:
     @pytest.fixture

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -24,14 +24,14 @@ KEY_BINDINGS = OrderedDict([
         'excluded_from_random_tips': False,
         'key_category': 'general',
     }),
-    ('PREVIOUS_MESSAGE', {
+    ('GO_UP', {
         'keys': {'k', 'up'},
-        'help_text': 'Previous message',
+        'help_text': 'Go up/Previous message',
         'key_category': 'navigation',
     }),
-    ('NEXT_MESSAGE', {
+    ('GO_DOWN', {
         'keys': {'j', 'down'},
-        'help_text': 'Next message',
+        'help_text': 'Go down/Next message',
         'key_category': 'navigation',
     }),
     ('GO_LEFT', {
@@ -44,19 +44,19 @@ KEY_BINDINGS = OrderedDict([
         'help_text': 'Go right',
         'key_category': 'navigation',
     }),
-    ('SCROLL_TO_TOP', {
+    ('SCROLL_UP', {
         'keys': {'K', 'page up'},
-        'help_text': 'Scroll to top',
+        'help_text': 'Scroll up',
         'key_category': 'navigation',
     }),
-    ('SCROLL_TO_BOTTOM', {
+    ('SCROLL_DOWN', {
         'keys': {'J', 'page down'},
-        'help_text': 'Scroll to bottom',
+        'help_text': 'Scroll down',
         'key_category': 'navigation',
     }),
-    ('END_MESSAGE', {
+    ('GO_TO_BOTTOM', {
         'keys': {'G', 'end'},
-        'help_text': 'Go to last message in view',
+        'help_text': 'Go to bottom/last message in view',
         'key_category': 'navigation',
     }),
     ('REPLY_MESSAGE', {

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -196,19 +196,19 @@ class View(urwid.WidgetWrap):
         # replace alternate keys with arrow/functional keys
         # This is needed for navigating in widgets
         # other than message_view.
-        elif is_command_key('PREVIOUS_MESSAGE', key):
+        elif is_command_key('GO_UP', key):
             key = 'up'
-        elif is_command_key('NEXT_MESSAGE', key):
+        elif is_command_key('GO_DOWN', key):
             key = 'down'
         elif is_command_key('GO_LEFT', key):
             key = 'left'
         elif is_command_key('GO_RIGHT', key):
             key = 'right'
-        elif is_command_key('SCROLL_TO_TOP', key):
+        elif is_command_key('SCROLL_UP', key):
             key = 'page up'
-        elif is_command_key('SCROLL_TO_BOTTOM', key):
+        elif is_command_key('SCROLL_DOWN', key):
             key = 'page down'
-        elif is_command_key('END_MESSAGE', key):
+        elif is_command_key('GO_TO_BOTTOM', key):
             key = 'end'
         return super().keypress(size, key)
 

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -143,7 +143,7 @@ class MessageView(urwid.ListBox):
         return super().mouse_event(size, event, button, col, row, focus)
 
     def keypress(self, size: urwid_Size, key: str) -> Optional[str]:
-        if is_command_key('NEXT_MESSAGE', key) and not self.new_loading:
+        if is_command_key('GO_DOWN', key) and not self.new_loading:
             try:
                 position = self.log.next_position(self.focus_position)
                 self.set_focus(position, 'above')
@@ -156,7 +156,7 @@ class MessageView(urwid.ListBox):
                     self.load_new_messages(id)
                 return key
 
-        elif is_command_key('PREVIOUS_MESSAGE', key) and not self.old_loading:
+        elif is_command_key('GO_UP', key) and not self.old_loading:
             try:
                 position = self.log.prev_position(self.focus_position)
                 self.set_focus(position, 'below')
@@ -170,14 +170,14 @@ class MessageView(urwid.ListBox):
                     self.load_old_messages()
                 return key
 
-        elif is_command_key('SCROLL_TO_TOP', key) and not self.old_loading:
+        elif is_command_key('SCROLL_UP', key) and not self.old_loading:
             if self.focus is not None and \
                self.focus_position == 0:
                 return self.keypress(size, 'up')
             else:
                 return super().keypress(size, 'page up')
 
-        elif is_command_key('SCROLL_TO_BOTTOM', key) and not self.old_loading:
+        elif is_command_key('SCROLL_DOWN', key) and not self.old_loading:
             if self.focus is not None and \
                self.focus_position == len(self.log) - 1:
                 return self.keypress(size, 'down')

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -792,6 +792,16 @@ class HelpView(urwid.ListBox):
     def keypress(self, size: urwid_Size, key: str) -> str:
         if is_command_key('GO_BACK', key) or is_command_key('HELP', key):
             self.controller.exit_popup()
+        elif is_command_key('GO_UP', key):
+            key = 'up'
+        elif is_command_key('GO_DOWN', key):
+            key = 'down'
+        elif is_command_key('SCROLL_UP', key):
+            key = 'page up'
+        elif is_command_key('SCROLL_DOWN', key):
+            key = 'page down'
+        elif is_command_key('GO_TO_BOTTOM', key):
+            key = 'end'
         return super().keypress(size, key)
 
 


### PR DESCRIPTION
@neiljp, I have added two separate commits.
- The former updates labels and descriptions for 'up/k' and 'down/j' keys. 
- The latter adds support for navigation using 'j' and 'k' keys in the help menu. I have also removed the redundant 'up/down scrolls' text from the menu's title.

Fixes #517.