### PR TITLE
Displays '(You)' after current user on rightColumn

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -966,7 +966,8 @@ class TestRightColumnView:
                 view=self.view,
                 width=width,
                 color=self.view.users[0]['status'],
-                count=1
+                count=1,
+                is_current_user=False
             )
         users_view.assert_called_once_with(right_col_view.users_btn_list)
         assert len(right_col_view.users_btn_list) == users_btn_len

--- a/zulipterminal/config/themes.py
+++ b/zulipterminal/config/themes.py
@@ -29,6 +29,7 @@ required_styles = {
     'bold',
     'footer',
     'starred',
+    'current_user_indicator',
 }
 
 # Colors used in gruvbox-256
@@ -76,6 +77,7 @@ THEMES = {
         ('footer',       'white',           'dark red',  'bold'),
         ('starred',      'light red, bold', ''),
         ('category',     'light blue, bold', ''),
+        ('current_user_indicator', 'white',  ''),
     ],
     'gruvbox': [
         # default colorscheme on 16 colors, gruvbox colorscheme
@@ -132,6 +134,8 @@ THEMES = {
          None,           LIGHTREDBOLD,      BLACK),
         ('category',     'light blue, bold', 'black',
          None,           LIGHTBLUE,         BLACK),
+        ('current_user_indicator',  'white', 'black',
+         None,           WHITE,             BLACK),
     ],
     'light': [
         (None,           'black',           'white'),
@@ -160,6 +164,7 @@ THEMES = {
         ('footer',       'white',           'dark red',   'bold'),
         ('starred',      'light red, bold', 'dark gray'),
         ('category',     'dark gray, bold', 'light gray'),
+        ('current_user_indicator', 'white', 'dark gray'),
     ],
     'blue': [
         (None,           'black',           'light blue'),
@@ -188,6 +193,7 @@ THEMES = {
         ('footer',       'white',           'dark red',   'bold'),
         ('starred',      'light red, bold', 'dark blue'),
         ('category',     'light gray, bold', 'light blue'),
+        ('current_user_indicator',  'white', 'dark blue'),
     ]
 }  # type: Dict[str, ThemeSpec]
 

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -603,7 +603,10 @@ class RightColumnView(urwid.Frame):
                     view=self.view,
                     width=self.width,
                     color=user['status'],
-                    count=unread_count
+                    count=unread_count,
+                    is_current_user=(
+                        self.view.model.user_id == user['user_id']
+                    )
                 )
             )
         user_w = UsersView(users_btn_list)


### PR DESCRIPTION
The PR prepends a "(You)" indicating that the user is the current user. I've chosen to prepend the indicator to avoid the issues faced in #468, where the indicator fell to the next line. 

![Screenshot from 2020-03-05 09-48-08](https://user-images.githubusercontent.com/8143634/75947477-879d7400-5ec6-11ea-9c3b-b5b49be29429.png)

This is how it looks on my terminal.