### PR TITLE
tests: Migrate keypress tests to use keys_for_command.

### DIFF
--- a/tests/ui/test_ui.py
+++ b/tests/ui/test_ui.py
@@ -217,9 +217,10 @@ class TestView:
         view.model.controller.show_all_mentions.assert_called_once_with(view)
         assert view.body.focus_col == 1
 
+    @pytest.mark.parametrize('key', keys_for_command('SEARCH_PEOPLE'))
     @pytest.mark.parametrize('autohide', [True, False], ids=[
         'autohide', 'no_autohide'])
-    def test_keypress_w(self, view, mocker, autohide):
+    def test_keypress_autohide_users(self, view, mocker, autohide, key):
         view.users_view = mocker.Mock()
         view.body = mocker.Mock()
         view.controller.autohide = autohide
@@ -234,17 +235,17 @@ class TestView:
 
         view.body.focus_position = None
 
-        # Test "w" keypress
-        view.keypress(size, "w")
-        view.users_view.keypress.assert_called_once_with(size, "w")
+        view.keypress(size, key)
+        view.users_view.keypress.assert_called_once_with(size, key)
         assert view.body.focus_position == 2
         view.user_search.set_edit_text.assert_called_once_with("")
         assert view.controller.editor_mode is True
         assert view.controller.editor == view.user_search
 
+    @pytest.mark.parametrize('key', keys_for_command('SEARCH_STREAMS'))
     @pytest.mark.parametrize('autohide', [True, False], ids=[
         'autohide', 'no_autohide'])
-    def test_keypress_q(self, view, mocker, autohide):
+    def test_keypress_autohide_streams(self, view, mocker, autohide, key):
         view.stream_w = mocker.Mock()
         view.left_col_w = mocker.Mock()
         view.stream_w.stream_search_box = mocker.Mock()
@@ -261,10 +262,8 @@ class TestView:
 
         view.body.focus_position = None
 
-        # Test "q" keypress
-        view.keypress(size, "q")
-
-        view.left_panel.keypress.assert_called_once_with(size, "q")
+        view.keypress(size, key)
+        view.left_panel.keypress.assert_called_once_with(size, key)
         assert view.body.focus_position == 0
         view.stream_w.stream_search_box.set_edit_text.\
             assert_called_once_with("")

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -462,13 +462,17 @@ class TestStreamsView:
         stream_view.set_focus.assert_called_once_with("body")
         assert stream_view.log == self.streams_btn_list
 
+    @pytest.mark.parametrize('search_streams_key',
+                             keys_for_command('SEARCH_STREAMS'))
+    @pytest.mark.parametrize('go_back_key', keys_for_command('GO_BACK'))
     @pytest.mark.parametrize('current_focus, stream', [
         (0, 'FOO'),
         (2, 'fan'),
         (4, 'BOO'),
     ])
     def test_return_to_focus_after_search(self, mocker, stream_view,
-                                          current_focus, stream):
+                                          current_focus, stream,
+                                          search_streams_key, go_back_key):
         # Initialize log
         stream_view.streams_btn_list = [
             mocker.Mock(stream_name=stream_name) for stream_name in [
@@ -482,14 +486,12 @@ class TestStreamsView:
         previous_focus_stream_name = stream
 
         # Toggle Stream Search
-        key = "q"
         size = (20,)
-        stream_view.keypress(size, key)
+        stream_view.keypress(size, search_streams_key)
 
         # Exit Stream Search
-        key = "esc"
         size = (20,)
-        stream_view.keypress(size, key)
+        stream_view.keypress(size, go_back_key)
 
         # Obtain new stream focus
         new_focus = stream_view.log.get_focus()[1]

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1679,6 +1679,7 @@ class TestMessageBox:
             assert label[0].text == 'EDITED'
             assert label[1][1] == 7
 
+    @pytest.mark.parametrize('key', keys_for_command('EDIT_MESSAGE'))
     @pytest.mark.parametrize('to_vary_in_each_message, realm_editing_allowed,\
                              expect_editing_to_succeed', [
         ({'sender_id': 2, 'timestamp': 45}, True, False),
@@ -1689,12 +1690,12 @@ class TestMessageBox:
             'time_limit_esceeded',
             'editing_not_allowed',
             'all_conditions_met'])
-    def test_keypress_edit_message(self, mocker, message_fixture,
+    def test_keypress_EDIT_MESSAGE(self, mocker, message_fixture,
                                    expect_editing_to_succeed,
                                    to_vary_in_each_message,
-                                   realm_editing_allowed):
+                                   realm_editing_allowed,
+                                   key):
         varied_message = dict(message_fixture, **to_vary_in_each_message)
-        key = 'e'
         size = (20,)
         msg_box = MessageBox(varied_message, self.model, message_fixture)
         msg_box.model.user_id = 1


### PR DESCRIPTION
This updates keypress tests to use `keys_for_command` to ensure that the tests are future-proof and they work for multiple specified keys. @neiljp

Fixes #469.