### PR TITLE
Improve typeahead suggestion and search for streams

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -409,23 +409,29 @@ class TestStreamsView:
         self.stream_search_box.assert_called_once_with(
             stream_view, 'SEARCH_STREAMS', stream_view.update_streams)
 
-    @pytest.mark.parametrize('new_text, expected_log', [
-        ('f', ['fan', 'FOO', 'foo', 'FOOBAR']),
-        ('a', ['bar', 'fan', 'FOOBAR']),
-        ('bar', ['bar', 'FOOBAR']),
-        ('foo', ['FOO', 'foo', 'FOOBAR']),
-        ('FOO', ['FOO', 'foo', 'FOOBAR']),
-        ('test', ['test here']),
-        ('here', ['test here']),
+    @pytest.mark.parametrize('new_text, expected_log, to_pin', [
+        ('f', ['fan', 'FOO', 'foo', 'FOOBAR'], []),
+        ('bar', ['bar'], []),
+        ('foo', ['FOO', 'foo', 'FOOBAR'], []),
+        ('FOO', ['FOO', 'foo', 'FOOBAR'], []),
+        ('test', ['test here'], []),
+        ('here', ['test here'], []),
+        ('test here', ['test here'], []),
+        # With 'foo' pinned.
+        ('f', ['foo', 'fan', 'FOO', 'FOOBAR'], [['foo'], ]),
+        ('FOO', ['foo', 'FOO', 'FOOBAR'], [['foo'], ]),
     ])
-    def test_update_streams(self, mocker, stream_view, new_text, expected_log):
+    def test_update_streams(self, mocker, stream_view, new_text, expected_log,
+                            to_pin):
         stream_names = [
             'FOO', 'FOOBAR', 'foo', 'fan',
             'boo', 'BOO', 'bar', 'test here',
         ]
         stream_names.sort(key=lambda stream_name: stream_name.lower())
+        self.view.pinned_streams = to_pin
+        stream_names.sort(key=lambda stream_name: stream_name in [
+            stream[0] for stream in to_pin], reverse=True)
         self.view.controller.editor_mode = True
-        new_text = new_text
         search_box = "SEARCH_BOX"
         stream_view.streams_btn_list = [
             mocker.Mock(stream_name=stream_name)

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -410,11 +410,11 @@ class TestStreamsView:
             stream_view, 'SEARCH_STREAMS', stream_view.update_streams)
 
     @pytest.mark.parametrize('new_text, expected_log', [
-        ('f', ['FOO', 'FOOBAR', 'foo', 'fan']),
-        ('a', ['FOOBAR', 'fan', 'bar']),
-        ('bar', ['FOOBAR', 'bar']),
-        ('foo', ['FOO', 'FOOBAR', 'foo']),
-        ('FOO', ['FOO', 'FOOBAR', 'foo']),
+        ('f', ['fan', 'FOO', 'foo', 'FOOBAR']),
+        ('a', ['bar', 'fan', 'FOOBAR']),
+        ('bar', ['bar', 'FOOBAR']),
+        ('foo', ['FOO', 'foo', 'FOOBAR']),
+        ('FOO', ['FOO', 'foo', 'FOOBAR']),
         ('test', ['test here']),
         ('here', ['test here']),
     ])
@@ -423,6 +423,7 @@ class TestStreamsView:
             'FOO', 'FOOBAR', 'foo', 'fan',
             'boo', 'BOO', 'bar', 'test here',
         ]
+        stream_names.sort(key=lambda stream_name: stream_name.lower())
         self.view.controller.editor_mode = True
         new_text = new_text
         search_box = "SEARCH_BOX"

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -22,9 +22,9 @@ class TestWriteBox:
             groups['name'] for groups in user_groups_fixture]
 
         write_box.view.pinned_streams = []
-        write_box.view.unpinned_streams = [
+        write_box.view.unpinned_streams = sorted([
             [stream['name']] for stream in
-            streams_fixture]
+            streams_fixture], key=lambda stream: stream[0].lower())
 
         mocker.patch('zulipterminal.ui_tools.boxes.emoji_names',
                      EMOJI_NAMES=emojis_fixture)
@@ -103,14 +103,14 @@ class TestWriteBox:
     @pytest.mark.parametrize('text, state, required_typeahead', [
         ('#Stream', 0, '#**Stream 1**'),
         ('#Stream', 1, '#**Stream 2**'),
-        ('#S', 0, '#**Some general stream**'),
-        ('#S', 1, '#**Secret stream**'),
+        ('#S', 0, '#**Secret stream**'),
+        ('#S', 1, '#**Some general stream**'),
         ('#S', 2, '#**Stream 1**'),
         ('#S', 3, '#**Stream 2**'),
         ('#S', -1, '#**Stream 2**'),
         ('#S', -2, '#**Stream 1**'),
-        ('#S', -3, '#**Secret stream**'),
-        ('#S', -4, '#**Some general stream**'),
+        ('#S', -3, '#**Some general stream**'),
+        ('#S', -4, '#**Secret stream**'),
         ('#S', -5, None),
         ('#So', 0, '#**Some general stream**'),
         ('#So', 1, None),

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -129,10 +129,10 @@ class WriteBox(urwid.Pile):
 
     def autocomplete_streams(self, text: str) -> List[str]:
         streams_list = self.view.pinned_streams + self.view.unpinned_streams
-        stream_typeahead = ['#**{}**'.format(stream[0])
-                            for stream in streams_list
-                            if match_stream(stream, text[1:])]
-        return stream_typeahead
+        stream_typeahead = [('#**{}**'.format(stream[0]), stream[0])
+                            for stream in streams_list]
+        return match_stream(stream_typeahead, text[1:],
+                            self.view.pinned_streams)
 
     def autocomplete_emojis(self, text: str) -> List[str]:
         emoji_list = emoji_names.EMOJI_NAMES

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -8,7 +8,7 @@ import urwid
 from zulipterminal.config.keys import (
     HELP_CATEGORIES, KEY_BINDINGS, is_command_key,
 )
-from zulipterminal.helper import Message, asynch, match_user
+from zulipterminal.helper import Message, asynch, match_stream, match_user
 from zulipterminal.ui_tools.boxes import PanelSearchBox
 from zulipterminal.ui_tools.buttons import (
     HomeButton, MentionedButton, PMButton, StarredButton, StreamButton,
@@ -270,12 +270,12 @@ class StreamsView(urwid.Frame):
         # wait for any previously started search to finish to avoid
         # displaying wrong stream list.
         with self.search_lock:
-            new_text = new_text.lower()
-            streams_display = [
-                stream
+            stream_buttons = [
+                (stream, stream.stream_name)
                 for stream in self.streams_btn_list.copy()
-                if new_text in stream.stream_name.lower()
             ]
+            streams_display = match_stream(stream_buttons, new_text,
+                                           self.view.pinned_streams)
             self.log.clear()
             self.log.extend(streams_display)
             self.view.controller.update_screen()


### PR DESCRIPTION
@neiljp This is a follow up to https://github.com/zulip/zulip-terminal/pull/510#pullrequestreview-363060680. 

The previous implementation only did a `startswith` lookup which caused it to miss out on the suggestions that were expected. I have fixed that with a substring lookup. I have also amended the test cases as now the suggestions are being given in an sorted (non-decreasing) order.