### PR TITLE
views: Reset search box text when 'esc' is pressed.

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -458,8 +458,10 @@ class TestStreamsView:
     def test_keypress_GO_BACK(self, mocker, stream_view, key):
         size = (20,)
         mocker.patch.object(stream_view, 'set_focus')
+        mocker.patch.object(stream_view.stream_search_box, 'reset_search_text')
         stream_view.keypress(size, key)
         stream_view.set_focus.assert_called_once_with("body")
+        assert stream_view.stream_search_box.reset_search_text.called
         assert stream_view.log == self.streams_btn_list
 
     @pytest.mark.parametrize('search_streams_key',
@@ -613,8 +615,10 @@ class TestTopicsView:
     def test_keypress_GO_BACK(self, mocker, topic_view, key):
         size = (200, 20)
         mocker.patch(VIEWS + '.TopicsView.set_focus')
+        mocker.patch.object(topic_view.topic_search_box, 'reset_search_text')
         topic_view.keypress(size, key)
         topic_view.set_focus.assert_called_once_with("body")
+        assert topic_view.topic_search_box.reset_search_text.called
         assert topic_view.log == self.topics_btn_list
 
 
@@ -989,12 +993,14 @@ class TestRightColumnView:
         mocker.patch(VIEWS + ".UsersView")
         mocker.patch(VIEWS + ".RightColumnView.set_focus")
         mocker.patch(VIEWS + ".RightColumnView.set_body")
+        mocker.patch.object(right_col_view.user_search, 'reset_search_text')
         right_col_view.users_btn_list = []
 
         right_col_view.keypress(size, key)
 
         right_col_view.set_body.assert_called_once_with(right_col_view.body)
         right_col_view.set_focus.assert_called_once_with('body')
+        assert right_col_view.user_search.reset_search_text.called
 
 
 class TestLeftColumnView:

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -825,6 +825,9 @@ class PanelSearchBox(urwid.Edit):
         urwid.connect_signal(self, 'change', update_function)
         super().__init__(edit_text=self.search_text)
 
+    def reset_search_text(self) -> None:
+        self.set_edit_text(self.search_text)
+
     def keypress(self, size: urwid_Size, key: str) -> Optional[str]:
         if is_command_key('ENTER', key):
             self.panel_view.view.controller.editor_mode = False

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -296,6 +296,7 @@ class StreamsView(urwid.Frame):
             self.set_focus('header')
             return key
         elif is_command_key('GO_BACK', key):
+            self.stream_search_box.reset_search_text()
             self.log.clear()
             self.log.extend(self.streams_btn_list)
             self.set_focus('body')
@@ -394,6 +395,7 @@ class TopicsView(urwid.Frame):
             self.header_list.set_focus(2)
             return key
         elif is_command_key('GO_BACK', key):
+            self.topic_search_box.reset_search_text()
             self.log.clear()
             self.log.extend(self.topics_btn_list)
             self.set_focus('body')
@@ -619,6 +621,7 @@ class RightColumnView(urwid.Frame):
             self.set_focus('header')
             return key
         elif is_command_key('GO_BACK', key):
+            self.user_search.reset_search_text()
             self.allow_update_user_list = True
             self.body = UsersView(self.users_btn_list)
             self.set_body(self.body)


### PR DESCRIPTION
This resets search box text whenever the user presses `esc` key to clear the search. The text is replaced with its appropriate search text along with the key required to trigger the search and amends the tests.

@neiljp It was not working as expected for topics as well. I have added a patch for that.

GIF: 
[![asciicast](https://asciinema.org/a/309148.svg)](https://asciinema.org/a/309148)

Fixes #536.