### PR TITLE
Migrate mouse_event(s) to use keys_for_command.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -798,3 +798,21 @@ def mouse_event_navigation_key_expected_key_pair(request):
     The expected key is the one which is passed to the super `keypress` calls.
     """
     return request.param
+
+
+@pytest.fixture(params=[
+        (key, button)
+        for keys, button in [
+            (keys_for_command('GO_UP'), 4),
+            (keys_for_command('GO_DOWN'), 5),
+        ]
+        for key in keys
+    ],
+    ids=lambda param: 'scroll_wheel_' + ('up' if param[1] == 4 else 'down')
+                      + '-key:{}-button:{}'.format(*param)
+)
+def mouse_scroll_key_button_pair(request):
+    """
+    Fixture to generate key and their respective button pair.
+    """
+    return request.param

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -779,3 +779,22 @@ def navigation_key_expected_key_pair(request):
     The expected key is the one which is passed to the super `keypress` calls.
     """
     return request.param
+
+
+@pytest.fixture(params=[
+        (key, expected_key)
+        for keys, expected_key in [
+            (keys_for_command('GO_UP'), 'up'),
+            (keys_for_command('GO_DOWN'), 'down'),
+        ]
+        for key in keys
+    ],
+    ids=lambda param: 'key:{}-expected_key:{}'.format(*param)
+)
+def mouse_event_navigation_key_expected_key_pair(request):
+    """
+    Fixture to generate pairs of navigation keys with their respective
+    expected key.
+    The expected key is the one which is passed to the super `keypress` calls.
+    """
+    return request.param

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -443,19 +443,20 @@ class TestStreamsView:
                 ] == expected_log
         self.view.controller.update_screen.assert_called_once_with()
 
-    def test_mouse_event(self, mocker, stream_view):
-        mocker.patch.object(stream_view, 'keypress')
+    @pytest.mark.parametrize('button, key', [
+            (4, 'up'),
+            (5, 'down'),
+        ],
+        ids=['scroll_wheel_up', 'scroll_wheel_down']
+    )
+    def test_mouse_event(self, mocker, stream_view, button, key):
         size = (200, 20)
         col = 1
         row = 1
         focus = "WIDGET"
-        # Left click
-        stream_view.mouse_event(size, "mouse press", 4, col, row, focus)
-        stream_view.keypress.assert_called_once_with(size, "up")
-
-        # Right click
-        stream_view.mouse_event(size, "mouse press", 5, col, row, focus)
-        stream_view.keypress.assert_called_with(size, "down")
+        mocker.patch.object(stream_view, 'keypress')
+        stream_view.mouse_event(size, 'mouse press', button, col, row, focus)
+        stream_view.keypress.assert_called_once_with(size, key)
 
     @pytest.mark.parametrize('key', keys_for_command('SEARCH_STREAMS'))
     def test_keypress_SEARCH_STREAMS(self, mocker, stream_view, key):
@@ -674,19 +675,20 @@ class TestUsersView:
         mocker.patch(VIEWS + ".urwid.SimpleFocusListWalker", return_value=[])
         return UsersView("USER_BTN_LIST")
 
-    def test_mouse_event(self, mocker, user_view):
-        mocker.patch.object(user_view, 'keypress')
+    @pytest.mark.parametrize('button, key', [
+            (4, 'up'),
+            (5, 'down'),
+        ],
+        ids=['scroll_wheel_up', 'scroll_wheel_down']
+    )
+    def test_mouse_event(self, mocker, user_view, button, key):
         size = (200, 20)
         col = 1
         row = 1
         focus = "WIDGET"
-        # Left click
-        user_view.mouse_event(size, "mouse press", 4, col, row, focus)
-        user_view.keypress.assert_called_with(size, "up")
-
-        # Right click
-        user_view.mouse_event(size, "mouse press", 5, col, row, focus)
-        user_view.keypress.assert_called_with(size, "down")
+        mocker.patch.object(user_view, 'keypress')
+        user_view.mouse_event(size, 'mouse press', button, col, row, focus)
+        user_view.keypress.assert_called_with(size, key)
 
     @pytest.mark.parametrize('event, button', [
             ('mouse release', 0),

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -443,6 +443,14 @@ class TestStreamsView:
                 ] == expected_log
         self.view.controller.update_screen.assert_called_once_with()
 
+    def test_keypress_navigation(self, mocker, stream_view,
+                                 mouse_event_navigation_key_expected_key_pair):
+        key, expected_key = mouse_event_navigation_key_expected_key_pair
+        size = (200, 20)
+        super_keypress = mocker.patch(VIEWS + '.urwid.Frame.keypress')
+        stream_view.keypress(size, key)
+        super_keypress.assert_called_once_with(size, expected_key)
+
     @pytest.mark.parametrize('button, key', [
             (4, 'up'),
             (5, 'down'),
@@ -667,6 +675,14 @@ class TestTopicsView:
         assert new_focus == previous_focus
         assert previous_focus_topic_name == new_focus_topic_name
 
+    def test_keypress_navigation(self, mocker, topic_view,
+                                 mouse_event_navigation_key_expected_key_pair):
+        key, expected_key = mouse_event_navigation_key_expected_key_pair
+        size = (200, 20)
+        super_keypress = mocker.patch(VIEWS + '.urwid.Frame.keypress')
+        topic_view.keypress(size, key)
+        super_keypress.assert_called_once_with(size, expected_key)
+
 
 class TestUsersView:
 
@@ -674,6 +690,14 @@ class TestUsersView:
     def user_view(self, mocker):
         mocker.patch(VIEWS + ".urwid.SimpleFocusListWalker", return_value=[])
         return UsersView("USER_BTN_LIST")
+
+    def test_keypress_navigation(self, mocker, user_view,
+                                 mouse_event_navigation_key_expected_key_pair):
+        key, expected_key = mouse_event_navigation_key_expected_key_pair
+        size = (200, 20)
+        super_keypress = mocker.patch(VIEWS + '.urwid.ListBox.keypress')
+        user_view.keypress(size, key)
+        super_keypress.assert_called_once_with(size, expected_key)
 
     @pytest.mark.parametrize('button, key', [
             (4, 'up'),

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -235,14 +235,13 @@ class TestMessageView:
                                                         num_after=30,
                                                         anchor=0)
 
-    @pytest.mark.parametrize("event, button, keypress", [
-        ("mouse press", 4, "up"),
-        ("mouse press", 5, "down"),
-    ])
-    def test_mouse_event(self, mocker, msg_view, event, button, keypress):
+    def test_mouse_event(self, mocker, msg_view, mouse_scroll_key_button_pair):
+        key, button = mouse_scroll_key_button_pair
+        size = (20, )
+        mocker.patch(VIEWS + '.keys_for_command', return_value=[key])
         mocker.patch.object(msg_view, "keypress")
-        msg_view.mouse_event((20,), event, button, 0, 0, mocker.Mock())
-        msg_view.keypress.assert_called_once_with((20,), keypress)
+        msg_view.mouse_event(size, 'mouse press', button, 0, 0, mocker.Mock())
+        msg_view.keypress.assert_called_once_with(size, key)
 
     @pytest.mark.parametrize('key', keys_for_command('GO_DOWN'))
     def test_keypress_GO_DOWN(self, mocker, msg_view, key):
@@ -451,17 +450,14 @@ class TestStreamsView:
         stream_view.keypress(size, key)
         super_keypress.assert_called_once_with(size, expected_key)
 
-    @pytest.mark.parametrize('button, key', [
-            (4, 'up'),
-            (5, 'down'),
-        ],
-        ids=['scroll_wheel_up', 'scroll_wheel_down']
-    )
-    def test_mouse_event(self, mocker, stream_view, button, key):
+    def test_mouse_event(self, mocker, stream_view,
+                         mouse_scroll_key_button_pair):
+        key, button = mouse_scroll_key_button_pair
         size = (200, 20)
         col = 1
         row = 1
         focus = "WIDGET"
+        mocker.patch(VIEWS + '.keys_for_command', return_value=[key])
         mocker.patch.object(stream_view, 'keypress')
         stream_view.mouse_event(size, 'mouse press', button, col, row, focus)
         stream_view.keypress.assert_called_once_with(size, key)
@@ -683,6 +679,18 @@ class TestTopicsView:
         topic_view.keypress(size, key)
         super_keypress.assert_called_once_with(size, expected_key)
 
+    def test_mouse_event(self, mocker, topic_view,
+                         mouse_scroll_key_button_pair):
+        key, button = mouse_scroll_key_button_pair
+        size = (200, 20)
+        col = 1
+        row = 1
+        focus = mocker.Mock()
+        mocker.patch(VIEWS + '.keys_for_command', return_value=[key])
+        mocker.patch.object(topic_view, 'keypress')
+        topic_view.mouse_event(size, 'mouse press', button, col, row, focus)
+        topic_view.keypress.assert_called_with(size, key)
+
 
 class TestUsersView:
 
@@ -699,17 +707,14 @@ class TestUsersView:
         user_view.keypress(size, key)
         super_keypress.assert_called_once_with(size, expected_key)
 
-    @pytest.mark.parametrize('button, key', [
-            (4, 'up'),
-            (5, 'down'),
-        ],
-        ids=['scroll_wheel_up', 'scroll_wheel_down']
-    )
-    def test_mouse_event(self, mocker, user_view, button, key):
+    def test_mouse_event(self, mocker, user_view,
+                         mouse_scroll_key_button_pair):
+        key, button = mouse_scroll_key_button_pair
         size = (200, 20)
         col = 1
         row = 1
         focus = "WIDGET"
+        mocker.patch(VIEWS + '.keys_for_command', return_value=[key] * 5)
         mocker.patch.object(user_view, 'keypress')
         user_view.mouse_event(size, 'mouse press', button, col, row, focus)
         user_view.keypress.assert_called_with(size, key)

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -5,7 +5,7 @@ from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
 import urwid
 
 from zulipterminal.config.keys import (
-    HELP_CATEGORIES, KEY_BINDINGS, is_command_key,
+    HELP_CATEGORIES, KEY_BINDINGS, is_command_key, keys_for_command,
 )
 from zulipterminal.helper import Message, asynch, match_stream, match_user
 from zulipterminal.ui_tools.boxes import PanelSearchBox
@@ -134,10 +134,10 @@ class MessageView(urwid.ListBox):
                     row: int, focus: bool) -> bool:
         if event == 'mouse press':
             if button == 4:
-                self.keypress(size, 'up')
+                self.keypress(size, keys_for_command('GO_UP').pop())
                 return True
             if button == 5:
-                self.keypress(size, 'down')
+                self.keypress(size, keys_for_command('GO_DOWN').pop())
                 return True
         return super().mouse_event(size, event, button, col, row, focus)
 
@@ -283,10 +283,10 @@ class StreamsView(urwid.Frame):
                     row: int, focus: bool) -> bool:
         if event == 'mouse press':
             if button == 4:
-                self.keypress(size, 'up')
+                self.keypress(size, keys_for_command('GO_UP').pop())
                 return True
             elif button == 5:
-                self.keypress(size, 'down')
+                self.keypress(size, keys_for_command('GO_DOWN').pop())
                 return True
         return super().mouse_event(size, event, button, col, row, focus)
 
@@ -377,10 +377,10 @@ class TopicsView(urwid.Frame):
                     row: int, focus: bool) -> bool:
         if event == 'mouse press':
             if button == 4:
-                self.keypress(size, 'up')
+                self.keypress(size, keys_for_command('GO_UP').pop())
                 return True
             elif button == 5:
-                self.keypress(size, 'down')
+                self.keypress(size, keys_for_command('GO_DOWN').pop())
                 return True
         return super().mouse_event(size, event, button, col, row, focus)
 
@@ -426,11 +426,11 @@ class UsersView(urwid.ListBox):
         if event == 'mouse press':
             if button == 4:
                 for _ in range(5):
-                    self.keypress(size, 'up')
+                    self.keypress(size, keys_for_command('GO_UP').pop())
                 return True
             elif button == 5:
                 for _ in range(5):
-                    self.keypress(size, 'down')
+                    self.keypress(size, keys_for_command('GO_DOWN').pop())
         return super().mouse_event(size, event, button, col, row, focus)
 
     def keypress(self, size: urwid_Size, key: str) -> Optional[str]:

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -302,6 +302,10 @@ class StreamsView(urwid.Frame):
             self.log.set_focus(self.focus_index_before_search)
             self.view.controller.update_screen()
             return key
+        elif is_command_key('GO_UP', key):
+            key = 'up'
+        elif is_command_key('GO_DOWN', key):
+            key = 'down'
         return_value = super().keypress(size, key)
         _, self.focus_index_before_search = self.log.get_focus()
         return return_value
@@ -403,6 +407,10 @@ class TopicsView(urwid.Frame):
             self.log.set_focus(self.focus_index_before_search)
             self.view.controller.update_screen()
             return key
+        elif is_command_key('GO_UP', key):
+            key = 'up'
+        elif is_command_key('GO_DOWN', key):
+            key = 'down'
         return_value = super().keypress(size, key)
         _, self.focus_index_before_search = self.log.get_focus()
         return return_value
@@ -424,6 +432,13 @@ class UsersView(urwid.ListBox):
                 for _ in range(5):
                     self.keypress(size, 'down')
         return super().mouse_event(size, event, button, col, row, focus)
+
+    def keypress(self, size: urwid_Size, key: str) -> Optional[str]:
+        if is_command_key('GO_UP', key):
+            key = 'up'
+        elif is_command_key('GO_DOWN', key):
+            key = 'down'
+        return super().keypress(size, key)
 
 
 class MiddleColumnView(urwid.Frame):


### PR DESCRIPTION
This migrates mouse_event(s) and the associated tests to use `keys_for_command`.
I have split the commit into four commits for making it easier to review.

Fixes #533 partially.