### PR TITLE
WIP: tests: helper: Add tests for set_count.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -793,6 +793,21 @@ def index_multiple_messages():
             'stream_id': 1003, 'display_recipient': 'stream 10', 'flags': []},
         9: {'id': 9, 'type': 'stream', 'subject': 'Topic 10', 'sender_id': 101,
             'stream_id': 1003, 'display_recipient': 'stream 10', 'flags': []},
+        # pms
+        10: {'id': 10, 'type': 'private', 'sender_id': 200,
+             'display_recipient': [{'id': 202}, {'id': 200}], 'flags': []},
+        11: {'id': 11, 'type': 'private', 'sender_id': 201,
+             'display_recipient': [{'id': 202}, {'id': 201}], 'flags': []},
+        12: {'id': 12, 'type': 'private', 'sender_id': 202,
+             'display_recipient': [{'id': 202}, {'id': 201}], 'flags': []},
+        13: {'id': 13, 'type': 'private', 'sender_id': 200,
+             'display_recipient': [{'id': 202}, {'id': 200}], 'flags': []},
+        14: {'id': 14, 'type': 'private', 'sender_id': 201,
+             'display_recipient': [{'id': 202}, {'id': 201}], 'flags': []},
+        15: {'id': 15, 'type': 'private', 'sender_id': 202,
+             'display_recipient': [{'id': 202}], 'flags': []},
+        16: {'id': 16, 'type': 'private', 'sender_id': 200,
+             'display_recipient': [{'id': 202}, {'id': 200}], 'flags': []},
         }})
 
 # --------------- UI Fixtures -----------------------------------------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ from typing import Any, Dict
 import pytest
 
 from zulipterminal.config.keys import keys_for_command
+from zulipterminal.helper import UnreadCounts
 from zulipterminal.helper import initial_index as helper_initial_index
 from zulipterminal.ui_tools.boxes import MessageBox
 from zulipterminal.ui_tools.buttons import (
@@ -757,6 +758,42 @@ def classified_unread_counts():
             99: 1
         }
     }
+
+
+@pytest.fixture
+def initial_unread_counts():
+    return UnreadCounts(all_msg=0, all_pms=0,
+                        unread_topics=dict(), unread_pms=dict(),
+                        unread_huddles=dict(), streams=dict())
+
+
+@pytest.fixture
+def index_multiple_messages():
+    """
+    Index fixture filled with multiple entries for messages.
+    Private messages have minimal data required to test `set_count`.
+    More can be added if and when required.
+    """
+    return dict(helper_initial_index, **{'messages': {
+        1: {'id': 1, 'type': 'stream', 'subject': 'Topic 1', 'sender_id': 99,
+            'stream_id': 1001, 'display_recipient': 'stream 1', 'flags': []},
+        2: {'id': 2, 'type': 'stream', 'subject': 'Topic 1', 'sender_id': 100,
+            'stream_id': 1001, 'display_recipient': 'stream 1', 'flags': []},
+        3: {'id': 3, 'type': 'stream', 'subject': 'Topic 2', 'sender_id': 98,
+            'stream_id': 1002, 'display_recipient': 'stream 2', 'flags': []},
+        4: {'id': 4, 'type': 'stream', 'subject': 'Topic 3', 'sender_id': 101,
+            'stream_id': 1002, 'display_recipient': 'stream 3', 'flags': []},
+        5: {'id': 5, 'type': 'stream', 'subject': 'Topic 3', 'sender_id': 101,
+            'stream_id': 1002, 'display_recipient': 'stream 3', 'flags': []},
+        6: {'id': 6, 'type': 'stream', 'subject': 'Topic 1', 'sender_id': 101,
+            'stream_id': 1001, 'display_recipient': 'stream 1', 'flags': []},
+        7: {'id': 7, 'type': 'stream', 'subject': 'Topic 1', 'sender_id': 101,
+            'stream_id': 1001, 'display_recipient': 'stream 1', 'flags': []},
+        8: {'id': 8, 'type': 'stream', 'subject': 'Topic 10', 'sender_id': 101,
+            'stream_id': 1003, 'display_recipient': 'stream 10', 'flags': []},
+        9: {'id': 9, 'type': 'stream', 'subject': 'Topic 10', 'sender_id': 101,
+            'stream_id': 1003, 'display_recipient': 'stream 10', 'flags': []},
+        }})
 
 # --------------- UI Fixtures -----------------------------------------
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -808,6 +808,24 @@ def index_multiple_messages():
              'display_recipient': [{'id': 202}], 'flags': []},
         16: {'id': 16, 'type': 'private', 'sender_id': 200,
              'display_recipient': [{'id': 202}, {'id': 200}], 'flags': []},
+        # group-pms
+        17: {'id': 17, 'type': 'private', 'sender_id': 202, 'flags': [],
+             'display_recipient': [{'id': 202}, {'id': 201}, {'id': 200}]},
+        18: {'id': 18, 'type': 'private', 'sender_id': 200, 'flags': [],
+             'display_recipient': [{'id': 202}, {'id': 200}, {'id': 201}]},
+        19: {'id': 19, 'type': 'private', 'sender_id': 201, 'flags': [],
+             'display_recipient': [{'id': 202}, {'id': 201}, {'id': 200}]},
+        20: {'id': 21, 'type': 'private', 'sender_id': 200, 'flags': [],
+             'display_recipient': [{'id': 202}, {'id': 200}, {'id': 201}]},
+        21: {'id': 20, 'type': 'private', 'sender_id': 202, 'flags': [],
+             'display_recipient': [{'id': 202}, {'id': 200}, {'id': 199}]},
+        22: {'id': 20, 'type': 'private', 'sender_id': 202, 'flags': [],
+             'display_recipient': [{'id': 202}, {'id': 200}, {'id': 199}]},
+        23: {'id': 20, 'type': 'private', 'sender_id': 202, 'flags': [],
+             'display_recipient': [{'id': 202}, {'id': 200}, {'id': 199}]},
+        24: {'id': 20, 'type': 'private', 'sender_id': 202, 'flags': [],
+             'display_recipient': [{'id': 202}, {'id': 200}, {'id': 199},
+                                   {'id': 198}]},
         }})
 
 # --------------- UI Fixtures -----------------------------------------

--- a/tests/helper/test_helper.py
+++ b/tests/helper/test_helper.py
@@ -51,6 +51,36 @@ def test_set_count_stream(controller, initial_unread_counts,
     assert controller.model.unread_counts == expected_unread_counts
 
 
+@pytest.mark.parametrize('all_msg, all_pms, unread_pms, user_id', [
+    (4, 3, {200: 2, 201: 1}, 202)
+    ])
+@pytest.mark.parametrize(('new_count, id_list, expected_all_msg,'
+                         'expected_all_pms, expected_unread_pms'), [
+    (-1, [10, 13], 2, 1, {201: 1}),
+    (-1, [10, 13, 11], 1, 0, {}),
+    (-1, [], 4, 3, {200: 2, 201: 1}),
+    (-1, [15], 4, 3, {200: 2, 201: 1}),   # self-pm
+    (1, [16, 10], 6, 5, {200: 4, 201: 1}),
+    (1, [], 4, 3, {200: 2, 201: 1}),
+    ])
+def test_set_count_pms(controller, initial_unread_counts, all_msg,
+                       all_pms, unread_pms, user_id, id_list, new_count,
+                       expected_unread_pms, expected_all_pms,
+                       expected_all_msg):
+    controller.model.user_id = user_id
+    unread_counts = deepcopy(dict(initial_unread_counts,
+                                  **{'all_msg': all_msg, 'all_pms': all_pms,
+                                     'unread_pms': unread_pms}))
+    expected_unread_counts = dict(initial_unread_counts,
+                                  **{'all_msg': expected_all_msg,
+                                     'all_pms': expected_all_pms,
+                                     'unread_pms': expected_unread_pms})
+    controller.model.unread_counts = unread_counts
+
+    set_count(id_list, controller, new_count)
+    assert controller.model.unread_counts == expected_unread_counts
+
+
 def test_index_messages_narrow_all_messages(mocker,
                                             messages_successful_response,
                                             index_all_messages,

--- a/tests/helper/test_helper.py
+++ b/tests/helper/test_helper.py
@@ -81,6 +81,41 @@ def test_set_count_pms(controller, initial_unread_counts, all_msg,
     assert controller.model.unread_counts == expected_unread_counts
 
 
+@pytest.mark.parametrize('all_msg, all_pms, unread_huddles', [
+    (4, 3, {frozenset({202, 200, 201}): 2, frozenset({202, 200, 199, 198}): 1})
+    ])
+@pytest.mark.parametrize(('new_count, id_list, expected_all_msg,'
+                         'expected_all_pms, expected_unread_huddles'), [
+    (-1, [20, 18], 2, 1, {frozenset({202, 200, 199, 198}): 1}),
+    (-1, [20, 18, 24], 1, 0, {}),
+    (-1, [], 4, 3, {frozenset({202, 200, 201}): 2,
+                    frozenset({202, 200, 199, 198}): 1}),
+    (1, [17, 19], 6, 5, {frozenset({202, 200, 201}): 4,
+                         frozenset({202, 200, 199, 198}): 1}),
+    (1, [17, 19, 23], 7, 6, {frozenset({202, 200, 201}): 4,
+                             frozenset({202, 200, 199, 198}): 1,
+                             frozenset({202, 200, 199}): 1}),
+    (1, [], 4, 3, {frozenset({202, 200, 201}): 2,
+                   frozenset({202, 200, 199, 198}): 1}),
+    ])
+def test_set_count_group_pms(initial_unread_counts, all_msg, new_count,
+                             all_pms, unread_huddles, user_id, id_list,
+                             expected_unread_huddles, expected_all_pms,
+                             expected_all_msg, controller):
+    unread_counts = deepcopy(dict(initial_unread_counts,
+                                  **{'all_msg': all_msg, 'all_pms': all_pms,
+                                     'unread_huddles': unread_huddles}))
+    expected_unread_counts = dict(initial_unread_counts,
+                                  **{'all_msg': expected_all_msg,
+                                     'all_pms': expected_all_pms,
+                                     'unread_huddles': expected_unread_huddles
+                                     })
+    controller.model.unread_counts = unread_counts
+
+    set_count(id_list, controller, new_count)
+    assert controller.model.unread_counts == expected_unread_counts
+
+
 def test_index_messages_narrow_all_messages(mocker,
                                             messages_successful_response,
                                             index_all_messages,

--- a/tests/helper/test_helper.py
+++ b/tests/helper/test_helper.py
@@ -186,6 +186,14 @@ def test_set_count_muted_topics(initial_unread_counts, muted_topics,
     assert controller.model.unread_counts == expected_unread_counts
 
 
+@pytest.mark.parametrize('id_list, new_count', [([], 1)])
+def test_set_count_screen_updated(mocker, controller, id_list, new_count):
+    controller.update_screen = mocker.patch(
+            'zulipterminal.core.Controller.update_screen')
+    set_count(id_list, controller, new_count)
+    controller.update_screen.assert_called_once_with()
+
+
 def test_index_messages_narrow_all_messages(mocker,
                                             messages_successful_response,
                                             index_all_messages,

--- a/tests/helper/test_helper.py
+++ b/tests/helper/test_helper.py
@@ -152,6 +152,40 @@ def test_set_count_muted_streams(initial_unread_counts, muted_streams,
     assert controller.model.unread_counts == expected_unread_counts
 
 
+@pytest.mark.parametrize('all_msg, unread_topics', [
+    (6, {(1001, 'Topic 1'): 3, (1002, 'Topic 3'): 1, (1003, 'Topic 10'): 2}),
+    ])
+@pytest.mark.parametrize(
+    'new_count, expected_unread_topics, id_list, muted_topics,\
+            expected_all_msg', [
+     (1, {(1001, 'Topic 1'): 4, (1002, 'Topic 3'): 1,
+          (1003, 'Topic 10'): 4}, [7, 8, 9], [['stream 1', 'Topic 1'],
+                                              ['stream 10', 'Topic 10']], 6),
+     (1, {(1001, 'Topic 1'): 4, (1002, 'Topic 3'): 2, (1003, 'Topic 10'): 4},
+      [7, 8, 9, 4], [['stream 1', 'Topic 1'], ['stream 10', 'Topic 10']], 7),
+     (-1, {(1001, 'Topic 1'): 2, (1002, 'Topic 3'): 1,
+           (1003, 'Topic 10'): 2}, [2], [['stream 1', 'Topic 1']], 6),
+     (-1, {(1001, 'Topic 1'): 2, (1003, 'Topic 10'): 2}, [2, 4],
+      [['stream 1', 'Topic 1']], 5),
+     ])
+def test_set_count_muted_topics(initial_unread_counts, muted_topics,
+                                unread_topics, all_msg, id_list, new_count,
+                                expected_unread_topics, expected_all_msg,
+                                controller):
+    # all_msg does not change for muted topics.
+    controller.model.muted_topics = muted_topics
+    unread_counts = deepcopy(dict(initial_unread_counts,
+                                  **{'all_msg': all_msg,
+                                     'unread_topics': unread_topics}))
+    expected_unread_counts = dict(initial_unread_counts,
+                                  **{'all_msg': expected_all_msg,
+                                     'unread_topics': expected_unread_topics})
+    controller.model.unread_counts = unread_counts
+
+    set_count(id_list, controller, new_count)
+    assert controller.model.unread_counts == expected_unread_counts
+
+
 def test_index_messages_narrow_all_messages(mocker,
                                             messages_successful_response,
                                             index_all_messages,


### PR DESCRIPTION
- [x] Test streams
- [x] Test pms
- [x] Test self-pms
- [x] Test group pms
- [x] ~~Test messages sent by user~~ ( `set_count` not called)
- [x] Test muted streams
- [x] Test muted topics
- [ ] ~~Test topics whose view is open~~ ( UI test, fix in different PR )
- [x] Test screen updated
- [ ] Test mentions