### PR TITLE
Fixed Focus in Search Stream

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -415,6 +415,8 @@ class TestStreamsView:
         ('FOO', ['FOO', 'FOOBAR', 'foo']),
         ('test', ['test here']),
         ('here', ['test here']),
+        ('', ['FOO', 'FOOBAR', 'foo', 'fan',
+            'boo', 'BOO', 'bar', 'test here'])
     ])
     def test_update_streams(self, mocker, stream_view, new_text, expected_log):
         stream_names = [

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -278,6 +278,7 @@ class StreamsView(urwid.Frame):
             ]
             self.log.clear()
             self.log.extend(streams_display)
+            self.log.set_focus(0)
             self.view.controller.update_screen()
 
     def mouse_event(self, size: urwid_Size, event: str, button: int, col: int,


### PR DESCRIPTION
- Stream maintains order when text is removed after entering in the search stream

- Added pytest test case for the same