### PR TITLE
boxes: Merge date/time and optional prev-year fields to improve styling.

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1629,9 +1629,9 @@ class TestMessageBox:
     @pytest.mark.parametrize('starred_msg', ['this', 'last', 'neither'],
                              ids=['this_starred', 'last_starred', 'no_stars'])
     @pytest.mark.parametrize('expected_header, to_vary_in_last_message', [
-        (['alice', ' ', ' ', 'DAYDATETIME'], {'sender_full_name': 'bob'}),
-        ([' ', ' ', ' ', 'DAYDATETIME'], {'timestamp': 1532103779}),
-        (['alice', ' ', ' ', 'DAYDATETIME'], {'timestamp': 0}),
+        (['alice', ' ', 'DAYDATETIME'], {'sender_full_name': 'bob'}),
+        ([' ', ' ', 'DAYDATETIME'], {'timestamp': 1532103779}),
+        (['alice', ' ', 'DAYDATETIME'], {'timestamp': 0}),
     ], ids=['show_author_as_authors_different',
             'merge_messages_as_only_slightly_earlier_message',
             'dont_merge_messages_as_much_earlier_message'])
@@ -1650,11 +1650,13 @@ class TestMessageBox:
         all_to_vary = dict(to_vary_in_last_message, **stars['last'])
         last_msg = dict(message, **all_to_vary)
         msg_box = MessageBox(this_msg, self.model, last_msg)
-        expected_header[1] = '2018 -' if current_year > 2018 else ' '
-        expected_header[2] = msg_box._time_for_message(message)
-        expected_header[3] = '*' if starred_msg == 'this' else ' '
+        expected_header[1] = msg_box._time_for_message(message)
+        if current_year > 2018:
+            expected_header[1] = '2018 - ' + expected_header[1]
+        expected_header[2] = '*' if starred_msg == 'this' else ' '
 
         view_components = msg_box.main_view()
+
         assert len(view_components) == 2
         assert isinstance(view_components[0], Columns)
         assert ([w.text for w in view_components[0].widget_list] ==

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -527,7 +527,7 @@ class MessageBox(urwid.Pile):
 
         if any_differences:  # Construct content_header, if needed
             TextType = Dict[str, Tuple[Optional[str], str]]
-            text_keys = ('author', 'star', 'time', 'prev_year')
+            text_keys = ('author', 'star', 'time')
             text = {key: (None, ' ') for key in text_keys}  # type: TextType
 
             if any(different[key] for key in ('recipients', 'author', '24h')):
@@ -536,16 +536,19 @@ class MessageBox(urwid.Pile):
                 text['star'] = ('starred', "*")
             if any(different[key]
                    for key in ('recipients', 'author', 'timestamp')):
-                text['time'] = ('time', message['this']['time'])
                 this_year = date.today().year
                 msg_year = message['this']['datetime'].year
                 if this_year != msg_year:
-                    text['prev_year'] = ('time', '{} -'.format(msg_year))
+                    text['time'] = (
+                        'time',
+                        '{} - {}'.format(msg_year, message['this']['time'])
+                    )
+                else:
+                    text['time'] = ('time', message['this']['time'])
 
             content_header = urwid.Columns([
                 ('weight', 10, urwid.Text(text['author'])),
-                (6, urwid.Text(text['prev_year'], align='right')),
-                (16, urwid.Text(text['time'], align='right')),
+                (23, urwid.Text(text['time'], align='right')),
                 (1, urwid.Text(text['star'], align='right')),
                 ], dividechars=1)
         else:


### PR DESCRIPTION
While not visible in the default theme, in the light theme the two parts of the
date are separated by a gap, due to how the optional year feature was
added as an extra column. By merging the columns and explicitly adding
spaces this now displays more cleanly and appears as one block of text.

Tests amended.