### PR TITLE
run: themes: transparent background is now optional (#513)

### DIFF
--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -61,7 +61,8 @@ def test_main_help(capsys, options):
         '--config-file CONFIG_FILE, -c CONFIG_FILE',
         '--autohide',
         '--no-autohide',
-        '-v, --version'
+        '-v, --version',
+        '--transparent'
     }
     optional_argument_lines = {line[2:] for line in lines
                                if len(line) > 2 and line[2] == '-'}

--- a/tests/config/test_themes.py
+++ b/tests/config/test_themes.py
@@ -1,7 +1,8 @@
 import pytest
 
 from zulipterminal.config.themes import (
-    THEMES, all_themes, complete_and_incomplete_themes, required_styles,
+    THEMES, all_themes, complete_and_incomplete_themes,
+    required_styles, get_transparent_theme_variant,
 )
 
 
@@ -34,3 +35,72 @@ def test_complete_and_incomplete_themes():
     result = (sorted(list(expected_complete_themes)),
               sorted(list(set(THEMES)-expected_complete_themes)))
     assert result == complete_and_incomplete_themes()
+    
+    
+def test_get_transparent_theme_variant():
+    theme = [       
+        (None,           'white', 'black'),
+        ('selected',     'white', 'blue'),
+        ('msg_selected', 'white', 'black'),
+        ('header',       'white', '', ''),
+        ('custom',       'white', 'blue', 'underline'),
+        ('content',      'white', 'black', 'standout'),
+        ('name',         'white'),
+        ('unread',       'white', ''),
+        ('active',       'white', 'black'),
+        ('idle',         'white', 'black'),
+        ('offline',      'white', 'black'),
+        ('inactive',     'white', 'black'),
+        ('title',        'white', 'black'),
+        ('time',         'white', 'black'),
+        ('bar',          'white', 'blue'),
+        ('help',         'white', 'gray'),
+        ('emoji',        'white', 'black'),
+        ('reaction',     'white', 'black'),
+        ('span',         'white', 'black'),
+        ('link',         'white', 'black'),
+        ('blockquote',   'white', 'black'),
+        ('code',         'white', 'white'),
+        ('bold',         'white', 'black'),
+        ('footer',       'white', 'green'),
+        ('starred',      'white', 'black'),
+        ('category',     'white', ''),
+    ]
+    expected_results = {
+     None : '',
+    'msg_selected' : '',
+    'content' : '',
+    'name' : '',
+    'unread' : '',
+    'active' : '',
+    'idle' : '',
+    'offline' : '',
+    'inactive' : '',
+    'title' : '',
+    'time' : '',
+    'emoji' : '',
+    'reaction' : '',
+    'span' : '',
+    'link' : '',
+    'blockquote' : '',
+    'bold' : '',
+    'starred' : '',
+    'selected' : 'blue',
+    'header' : '',
+    'custom' : 'blue',
+    'bar' : 'blue',
+    'help' : 'gray',
+    'code' : 'white',
+    'category' : '',
+    'footer' : 'green',
+    } 
+    
+    result = get_transparent_theme_variant(theme)
+    assert len(result[6]) == 2
+    assert len(result) == len(expected_results)
+    for r in result:
+        assert(r[1] == 'white')
+        if (len(r) > 2):
+            assert(r[2] == expected_results[r[0]])
+            
+

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -30,8 +30,9 @@ class TestController:
         self.theme = 'default'
         self.autohide = True  # FIXME Add tests for no-autohide
         self.notify_enabled = False
+        self.transparent_background = False
         return Controller(self.config_file, self.theme, self.autohide,
-                          self.notify_enabled)
+                          self.notify_enabled, self.transparent_background)
 
     def test_initialize_controller(self, controller, mocker) -> None:
         self.client.assert_called_once_with(

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -10,7 +10,10 @@ import requests
 from urwid import set_encoding
 
 from zulipterminal.config.themes import (
-    THEMES, all_themes, complete_and_incomplete_themes,
+    THEMES,
+    all_themes, 
+    complete_and_incomplete_themes, 
+    get_transparent_theme_variant
 )
 from zulipterminal.core import Controller
 from zulipterminal.model import ServerConnectionFailure
@@ -73,6 +76,12 @@ def parse_args(argv: List[str]) -> argparse.Namespace:
                         action='store_true',
                         default=False,
                         help='Print zulip-terminal version and exit')
+                        
+    parser.add_argument('--transparent',
+                        dest='transparent',
+                        action='store_true',
+                        default=False,
+                        help='Use transparent (provided by terminal) background.')                        
 
     return parser.parse_args(argv)
 
@@ -185,6 +194,7 @@ def parse_zuliprc(zuliprc_str: str) -> Dict[str, Any]:
         'theme': ('default', NO_CONFIG),
         'autohide': ('no_autohide', NO_CONFIG),
         'notify': ('disabled', NO_CONFIG),
+        'transparent': ('disabled', NO_CONFIG),
     }
 
     if 'zterm' in zuliprc:
@@ -225,6 +235,8 @@ def main(options: Optional[List[str]]=None) -> None:
 
         if args.autohide:
             zterm['autohide'] = (args.autohide, 'on command line')
+        if args.transparent:
+            zterm['transparent'] = ('enabled', 'on command line')
         if args.theme:
             theme_to_use = (args.theme, 'on command line')
         else:
@@ -256,6 +268,7 @@ def main(options: Optional[List[str]]=None) -> None:
         valid_settings = {
             'autohide': ['autohide', 'no_autohide'],
             'notify': ['enabled', 'disabled'],
+            'transparent': ['enabled', 'disabled'],
         }
         boolean_settings = dict()  # type: Dict[str, bool]
         for setting, valid_values in valid_settings.items():
@@ -268,6 +281,7 @@ def main(options: Optional[List[str]]=None) -> None:
                 print("Specify the {} option in zuliprc file.".format(setting))
                 sys.exit(1)
             boolean_settings[setting] = (zterm[setting][0] == valid_values[0])
+                        
         Controller(zuliprc_path,
                    THEMES[theme_to_use[0]],
                    **boolean_settings).main()

--- a/zulipterminal/config/themes.py
+++ b/zulipterminal/config/themes.py
@@ -31,6 +31,30 @@ required_styles = {
     'starred',
 }
 
+# Transparent background may be enabled 
+# (based on config and/or command line) for:
+elements_with_transparent_backgrounds = {
+    None,
+    'msg_selected',
+    'content',
+    'name',
+    'unread',
+    'active',
+    'idle',
+    'offline',
+    'inactive',
+    'title',
+    'time',
+    'emoji',
+    'reaction',
+    'span',
+    'link',
+    'blockquote',
+    'bold',
+    'starred',
+}
+
+
 # Colors used in gruvbox-256
 # See https://github.com/morhetz/gruvbox/blob/master/colors/gruvbox.vim
 BLACK = 'h234'  # dark0_hard
@@ -47,34 +71,34 @@ LIGHTREDBOLD = '%s, bold' % LIGHTRED
 GRAY = 'h244'  # gray_244
 LIGHTMAGENTA = 'h132'  # neutral_purple
 LIGHTMAGENTABOLD = '%s, bold' % LIGHTMAGENTA
-
+        
 THEMES = {
     'default': [
-        (None,           'white',           ''),
+        (None,           'white',           'black'),
         ('selected',     'white',           'dark blue'),
-        ('msg_selected', 'light green',     ''),
+        ('msg_selected', 'light green',     'black'),
         ('header',       'dark cyan',       'dark blue', 'bold'),
         ('custom',       'white',           'dark blue', 'underline'),
-        ('content',      'white',           '',          'standout'),
-        ('name',         'yellow, bold',    ''),
-        ('unread',       'light blue',      ''),
-        ('active',       'light green',     ''),
-        ('idle',         'yellow',          ''),
-        ('offline',      'white',           ''),
-        ('inactive',     'white',           ''),
-        ('title',        'white, bold',     ''),
-        ('time',         'light blue',      ''),
+        ('content',      'white',           'black', 'standout'),
+        ('name',         'yellow, bold',    'black'),
+        ('unread',       'light blue',      'black'),
+        ('active',       'light green',     'black'),
+        ('idle',         'yellow',          'black'),
+        ('offline',      'white',           'black'),
+        ('inactive',     'white',           'black'),
+        ('title',        'white, bold',     'black'),
+        ('time',         'light blue',      'black'),
         ('bar',          'white',           'dark gray'),
         ('help',         'white',           'dark gray'),
-        ('emoji',        'light magenta',   ''),
-        ('reaction',     'light magenta, bold', ''),
-        ('span',         'light red, bold', ''),
-        ('link',         'light blue',      ''),
-        ('blockquote',   'brown',           ''),
+        ('emoji',        'light magenta',   'black'),
+        ('reaction',     'light magenta, bold', 'black'),
+        ('span',         'light red, bold', 'black'),
+        ('link',         'light blue',      'black'),
+        ('blockquote',   'brown',           'black'),
         ('code',         'black',           'white'),
-        ('bold',         'white, bold',     ''),
+        ('bold',         'white, bold',     'black'),
         ('footer',       'white',           'dark red',  'bold'),
-        ('starred',      'light red, bold', ''),
+        ('starred',      'light red, bold', 'black'),
         ('category',     'light blue, bold', ''),
     ],
     'gruvbox': [
@@ -201,3 +225,12 @@ def complete_and_incomplete_themes() -> Tuple[List[str], List[str]]:
                 if set(s[0] for s in styles).issuperset(required_styles)}
     incomplete = list(set(THEMES) - complete)
     return sorted(list(complete)), sorted(incomplete)
+    
+def get_transparent_theme_variant(theme: ThemeSpec) -> ThemeSpec:
+    result = []
+    for element in theme:
+        if element[0] in elements_with_transparent_backgrounds and len(element) > 2:
+            result.append(element[:2] + ('',) + element[3:])
+        else:
+            result.append(element)
+    return result

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -9,7 +9,7 @@ from typing import Any, List, Optional
 import urwid
 import zulip
 
-from zulipterminal.config.themes import ThemeSpec
+from zulipterminal.config.themes import ThemeSpec, get_transparent_theme_variant
 from zulipterminal.helper import Message, asynch
 from zulipterminal.model import GetMessagesArgs, Model, ServerConnectionFailure
 from zulipterminal.ui import Screen, View
@@ -19,7 +19,6 @@ from zulipterminal.ui_tools.views import (
 )
 from zulipterminal.version import ZT_VERSION
 
-
 class Controller:
     """
     A class responsible for setting up the model and view and running
@@ -27,7 +26,9 @@ class Controller:
     """
 
     def __init__(self, config_file: str, theme: ThemeSpec,
-                 autohide: bool, notify: bool) -> None:
+                 autohide: bool, notify: bool, transparent: bool) -> None:
+        if transparent:
+            theme = get_transparent_theme_variant(theme)
         self.theme = theme
         self.autohide = autohide
         self.notify_enabled = notify


### PR DESCRIPTION
Default background is not transparent anymore.
Add --transparent flag and analogous option in config file which
may be used to set background's color based on terminal.

Fixes #513.