### PR TITLE
Themes: Separate unread count and idle styles

### DIFF
--- a/zulipterminal/config/themes.py
+++ b/zulipterminal/config/themes.py
@@ -165,7 +165,7 @@ THEMES = {
         ('footer',       'white',           'dark red',   'bold'),
         ('starred',      'light red, bold', 'white'),
         ('category',     'dark gray, bold', 'light gray'),
-        ('unread_count', 'yellow',          'dark gray'),
+        ('unread_count', 'dark blue, bold', 'white'),
     ],
     'blue': [
         (None,           'black',           'light blue'),
@@ -194,7 +194,7 @@ THEMES = {
         ('footer',       'white',           'dark red',   'bold'),
         ('starred',      'light red, bold', 'dark blue'),
         ('category',     'light gray, bold', 'light blue'),
-        ('unread_count', 'yellow',          'dark blue'),
+        ('unread_count', 'yellow',          'light blue'),
     ]
 }  # type: Dict[str, ThemeSpec]
 

--- a/zulipterminal/config/themes.py
+++ b/zulipterminal/config/themes.py
@@ -29,6 +29,7 @@ required_styles = {
     'bold',
     'footer',
     'starred',
+    'category',
 }
 
 # Colors used in gruvbox-256

--- a/zulipterminal/config/themes.py
+++ b/zulipterminal/config/themes.py
@@ -30,6 +30,7 @@ required_styles = {
     'footer',
     'starred',
     'category',
+    'unread_count',
 }
 
 # Colors used in gruvbox-256
@@ -77,6 +78,7 @@ THEMES = {
         ('footer',       'white',           'dark red',  'bold'),
         ('starred',      'light red, bold', ''),
         ('category',     'light blue, bold', ''),
+        ('unread_count', 'yellow',          ''),
     ],
     'gruvbox': [
         # default colorscheme on 16 colors, gruvbox colorscheme
@@ -133,6 +135,8 @@ THEMES = {
          None,           LIGHTREDBOLD,      BLACK),
         ('category',     'light blue, bold', 'black',
          None,           LIGHTBLUE,         BLACK),
+        ('unread_count', 'yellow',          'black',
+         None,           YELLOW,            BLACK),
     ],
     'light': [
         (None,           'black',           'white'),
@@ -161,6 +165,7 @@ THEMES = {
         ('footer',       'white',           'dark red',   'bold'),
         ('starred',      'light red, bold', 'white'),
         ('category',     'dark gray, bold', 'light gray'),
+        ('unread_count', 'yellow',          'dark gray'),
     ],
     'blue': [
         (None,           'black',           'light blue'),
@@ -189,6 +194,7 @@ THEMES = {
         ('footer',       'white',           'dark red',   'bold'),
         ('starred',      'light red, bold', 'dark blue'),
         ('category',     'light gray, bold', 'light blue'),
+        ('unread_count', 'yellow',          'dark blue'),
     ]
 }  # type: Dict[str, ThemeSpec]
 

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -67,7 +67,7 @@ class TopButton(urwid.Button):
         self._w = urwid.AttrMap(urwid.SelectableIcon(
             [' ', self.prefix_character, self.post_prefix_spacing,
              '{}{}'.format(caption, num_extra_spaces*' '),
-             ' ', ('idle',  count_text)],
+             ' ', ('unread_count',  count_text)],
             self.width_for_text_and_count+5),  # cursor location
             self.text_color,
             'selected')


### PR DESCRIPTION
This resolves one aspect of #544, by separating out a style for unread counts from that used for idle.

This in turn allows an improvement in the styling of unread count text, which has been a blocker to improving the user-list styling in the light and blue themes.

Given the small code changes, for review purposes I'm more interested in how this looks compared to master for people on different platforms.

I have a followup to improve the blue theme further, both along the same lines as #553 and now including lightening the user list (if we want this).