### PR TITLE
Improve support for different color depths (16, 1)

### DIFF
--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -61,7 +61,8 @@ def test_main_help(capsys, options):
         '--config-file CONFIG_FILE, -c CONFIG_FILE',
         '--autohide',
         '--no-autohide',
-        '-v, --version'
+        '-v, --version',
+        '--color-depth'
     }
     optional_argument_lines = {line[2:] for line in lines
                                if len(line) > 2 and line[2] == '-'}

--- a/tests/config/test_themes.py
+++ b/tests/config/test_themes.py
@@ -2,6 +2,7 @@ import pytest
 
 from zulipterminal.config.themes import (
     THEMES, all_themes, complete_and_incomplete_themes, required_styles,
+    theme_with_monochrome_added,
 )
 
 
@@ -34,3 +35,25 @@ def test_complete_and_incomplete_themes():
     result = (sorted(list(expected_complete_themes)),
               sorted(list(set(THEMES)-expected_complete_themes)))
     assert result == complete_and_incomplete_themes()
+
+
+@pytest.mark.parametrize('theme, expected_new_theme, req_styles', [
+    ([('a', 'another')], [], {}),
+    ([('a', 'another')], [('a', 'another')], {'a': ''}),
+    ([('a', 'fg', 'bg')], [('a', 'fg', 'bg', 'x')], {'a': 'x'}),
+    ([('a', 'fg', 'bg', 'bold')], [('a', 'fg', 'bg', 'x')], {'a': 'x'}),
+    ([('a', 'fg', 'bg', 'bold', 'h1', 'h2')],
+     [('a', 'fg', 'bg', 'x', 'h1', 'h2')],
+     {'a': 'x'}),
+], ids=[
+    'incomplete_theme',
+    'one_to_one',
+    '16_color_add_mono',
+    '16_color_mono_overwrite',
+    '256_color',
+])
+def test_theme_with_monochrome_added(mocker,
+                                     theme, expected_new_theme, req_styles):
+    mocker.patch.dict('zulipterminal.config.themes.required_styles',
+                      req_styles)
+    assert theme_with_monochrome_added(theme) == expected_new_theme

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -30,7 +30,7 @@ class TestController:
         self.theme = 'default'
         self.autohide = True  # FIXME Add tests for no-autohide
         self.notify_enabled = False
-        return Controller(self.config_file, self.theme, self.autohide,
+        return Controller(self.config_file, self.theme, 256, self.autohide,
                           self.notify_enabled)
 
     def test_initialize_controller(self, controller, mocker) -> None:

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -48,6 +48,9 @@ def parse_args(argv: List[str]) -> argparse.Namespace:
                              organization.(e.g. ~/zuliprc)')
     parser.add_argument('--theme', '-t',
                         help='choose color theme. (e.g. blue, light)')
+    parser.add_argument('--color-depth',
+                        choices=['1', '16', '256'], default=256,
+                        help="Force the color depth (default 256).")
     # debug mode
     parser.add_argument("-d",
                         "--debug",
@@ -270,6 +273,7 @@ def main(options: Optional[List[str]]=None) -> None:
             boolean_settings[setting] = (zterm[setting][0] == valid_values[0])
         Controller(zuliprc_path,
                    THEMES[theme_to_use[0]],
+                   int(args.color_depth),
                    **boolean_settings).main()
     except ServerConnectionFailure as e:
         print(in_color('red',

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -11,6 +11,7 @@ from urwid import set_encoding
 
 from zulipterminal.config.themes import (
     THEMES, all_themes, complete_and_incomplete_themes,
+    theme_with_monochrome_added,
 )
 from zulipterminal.core import Controller
 from zulipterminal.model import ServerConnectionFailure
@@ -271,8 +272,15 @@ def main(options: Optional[List[str]]=None) -> None:
                 print("Specify the {} option in zuliprc file.".format(setting))
                 sys.exit(1)
             boolean_settings[setting] = (zterm[setting][0] == valid_values[0])
+
+        color_depth = int(args.color_depth)
+        if color_depth == 1:
+            theme_data = theme_with_monochrome_added(THEMES[theme_to_use[0]])
+        else:
+            theme_data = THEMES[theme_to_use[0]]
+
         Controller(zuliprc_path,
-                   THEMES[theme_to_use[0]],
+                   theme_data,
                    int(args.color_depth),
                    **boolean_settings).main()
     except ServerConnectionFailure as e:

--- a/zulipterminal/config/themes.py
+++ b/zulipterminal/config/themes.py
@@ -3,34 +3,38 @@ from typing import Dict, List, Optional, Tuple
 
 ThemeSpec = List[Tuple[Optional[str], ...]]
 
-required_styles = {
-    None,
-    'selected',
-    'msg_selected',
-    'header',
-    'custom',
-    'name',
-    'unread',
-    'user_active',
-    'user_idle',
-    'user_offline',
-    'user_inactive',
-    'title',
-    'time',
-    'bar',
-    'popup_contrast',
-    'msg_emoji',
-    'reaction',
-    'msg_mention',
-    'msg_link',
-    'msg_quote',
-    'msg_code',
-    'msg_bold',
-    'footer',
-    'starred',
-    'popup_category',
-    'unread_count',
-    'filter_results',
+# The keys in required_styles specify what styles are necessary for a theme to
+# be complete, while the values are those used to style each element in
+# monochrome (1-bit) mode - independently of the specified theme
+
+required_styles = {  # style-name: monochrome-bit-depth-style
+    None: '',
+    'selected': 'standout',
+    'msg_selected': 'standout',
+    'header': 'bold',
+    'custom': 'standout',
+    'name': '',
+    'unread': 'strikethrough',
+    'user_active': 'bold',
+    'user_idle': '',
+    'user_offline': '',
+    'user_inactive': '',
+    'title': 'standout',
+    'time': '',
+    'bar': 'standout',
+    'popup_contrast': 'standout',
+    'msg_emoji': 'bold',
+    'reaction': 'bold',
+    'msg_mention': 'bold',
+    'msg_link': '',
+    'msg_quote': 'underline',
+    'msg_code': 'bold',
+    'msg_bold': 'bold',
+    'footer': 'standout',
+    'starred': 'bold',
+    'popup_category': 'bold',
+    'unread_count': '',
+    'filter_results': 'bold',
 }
 
 # Colors used in gruvbox-256
@@ -55,8 +59,8 @@ THEMES = {
         (None,             'white',           ''),
         ('selected',       'white',           'dark blue'),
         ('msg_selected',   'white',           'dark blue'),
-        ('header',         'dark cyan',       'dark blue', 'bold'),
-        ('custom',         'white',           'dark blue', 'underline'),
+        ('header',         'dark cyan',       'dark blue'),
+        ('custom',         'white',           'dark blue'),
         ('name',           'yellow, bold',    ''),
         ('unread',         'dark blue',       ''),
         ('user_active',    'light green',     ''),
@@ -74,7 +78,7 @@ THEMES = {
         ('msg_quote',      'brown',           ''),
         ('msg_code',       'black',           'white'),
         ('msg_bold',       'white, bold',     ''),
-        ('footer',         'white',           'dark red',  'bold'),
+        ('footer',         'white',           'dark red'),
         ('starred',        'light red, bold', ''),
         ('popup_category', 'light blue, bold', ''),
         ('unread_count',   'yellow',          ''),
@@ -91,9 +95,9 @@ THEMES = {
         ('msg_selected',   'black',           'white',
          None,             BLACK,             WHITE),
         ('header',         'dark cyan',       'dark blue',
-         'bold',           'dark cyan',       DARKBLUE),
+         None,             'dark cyan',       DARKBLUE),
         ('custom',         'white',           'dark blue',
-         'underline',      WHITE,             DARKBLUE),
+         None,             WHITE,             DARKBLUE),
         ('name',           'yellow, bold',    'black',
          None,             YELLOWBOLD,        BLACK),
         ('unread',         'light magenta',   'black',
@@ -129,7 +133,7 @@ THEMES = {
         ('msg_bold',       'white, bold',     'black',
          None,             WHITEBOLD,         BLACK),
         ('footer',         'white',           'dark red',
-         'bold',           WHITE,             DARKRED),
+         None,             WHITE,             DARKRED),
         ('starred',        'light red, bold', 'black',
          None,             LIGHTREDBOLD,      BLACK),
         ('popup_category', 'light blue, bold', 'black',
@@ -145,9 +149,9 @@ THEMES = {
         (None,             'black',           'white'),
         ('selected',       'black',           'light green'),
         ('msg_selected',   'black',           'light green'),
-        ('header',         'white',           'dark blue',  'bold'),
-        ('custom',         'white',           'dark blue',  'underline'),
-        ('name',           'dark green',      'white', 'bold'),
+        ('header',         'white',           'dark blue'),
+        ('custom',         'white',           'dark blue'),
+        ('name',           'dark green',      'white'),
         ('unread',         'dark gray',       'light gray'),
         ('user_active',    'dark green',      'white'),
         ('user_idle',      'dark blue',       'white'),
@@ -164,7 +168,7 @@ THEMES = {
         ('msg_quote',      'black',           'brown'),
         ('msg_code',       'black',           'light gray'),
         ('msg_bold',       'white, bold',     'dark gray'),
-        ('footer',         'white',           'dark red',   'bold'),
+        ('footer',         'white',           'dark red'),
         ('starred',        'light red, bold', 'white'),
         ('popup_category', 'dark gray, bold', 'light gray'),
         ('unread_count',   'dark blue, bold', 'white'),
@@ -175,9 +179,9 @@ THEMES = {
         (None,             'black',           'light blue'),
         ('selected',       'black',           'light gray'),
         ('msg_selected',   'black',           'light gray'),
-        ('header',         'black',           'dark blue',  'bold'),
-        ('custom',         'white',           'dark blue',  'underline'),
-        ('name',           'dark red',        'light blue', 'bold'),
+        ('header',         'black',           'dark blue'),
+        ('custom',         'white',           'dark blue'),
+        ('name',           'dark red',        'light blue'),
         ('unread',         'light gray',      'light blue'),
         ('user_active',    'light green, bold', 'light blue'),
         ('user_idle',      'dark gray',       'light blue'),
@@ -194,7 +198,7 @@ THEMES = {
         ('msg_quote',      'brown',           'dark blue'),
         ('msg_code',       'dark blue',       'white'),
         ('msg_bold',       'white, bold',     'dark blue'),
-        ('footer',         'white',           'dark red',   'bold'),
+        ('footer',         'white',           'dark red'),
         ('starred',        'light red, bold', 'light blue'),
         ('popup_category', 'light gray, bold', 'light blue'),
         ('unread_count',   'yellow',          'light blue'),
@@ -213,3 +217,22 @@ def complete_and_incomplete_themes() -> Tuple[List[str], List[str]]:
                 if set(s[0] for s in styles).issuperset(required_styles)}
     incomplete = list(set(THEMES) - complete)
     return sorted(list(complete)), sorted(incomplete)
+
+
+def theme_with_monochrome_added(theme: ThemeSpec) -> ThemeSpec:
+    updated_theme = []
+    for style in theme:
+        style_name = style[0]
+        if style_name not in required_styles:  # incomplete theme
+            continue
+        mono_style = required_styles[style_name]
+        if len(style) > 4:     # 256 colors+
+            new_style = style[:3] + (mono_style,) + style[4:]
+        elif len(style) == 4:  # 16 colors + mono (overwrite mono)
+            new_style = style[:3] + (mono_style,)
+        elif len(style) == 3:  # 16 colors only
+            new_style = style[:3] + (mono_style,)
+        else:                  # 1-to-1 mapping (same as other style)
+            new_style = style
+        updated_theme.append(new_style)
+    return updated_theme

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -27,8 +27,10 @@ class Controller:
     """
 
     def __init__(self, config_file: str, theme: ThemeSpec,
+                 color_depth: int,
                  autohide: bool, notify: bool) -> None:
         self.theme = theme
+        self.color_depth = color_depth
         self.autohide = autohide
         self.notify_enabled = notify
         self.editor_mode = False  # type: bool
@@ -262,7 +264,7 @@ class Controller:
 
     def main(self) -> None:
         screen = Screen()
-        screen.set_terminal_properties(colors=256)
+        screen.set_terminal_properties(colors=self.color_depth)
         self.loop = urwid.MainLoop(self.view,
                                    self.theme,
                                    screen=screen)


### PR DESCRIPTION
Currently we just run with 256 colors and assume the user system supports that.

This is reasonable to a great degree, but urwid supports palettes from 1 (monochrome), 16, and others too. The first commit in this PR enables specifying color depths of 16 or 256 on the command line, defaulting to 256, which may help with reproducing color rendering issues. The subsequent commit is a minor change which makes the 256-bit stream colors be rendered with a color; I'm open to dropping this commit as we could do something different.

The last three commits extend the first commit to allow running in monochrome, add reasonable defaults in the default theme, and finally overwrite the monochrome settings in all themes at run-time. I can't imagine we'll actually want monochrome themes, which is why I made the final change, and these commits could be squashed/dropped and combined with other work to just have empty values in the monochrome settings in themes if this looks good. I was using it just now :+1: