### PR TITLE
Improve consistency of selection styles

### DIFF
--- a/zulipterminal/config/themes.py
+++ b/zulipterminal/config/themes.py
@@ -54,7 +54,7 @@ THEMES = {
     'default': [
         (None,           'white',           ''),
         ('selected',     'white',           'dark blue'),
-        ('msg_selected', 'light green',     ''),
+        ('msg_selected', 'white',           'dark blue'),
         ('header',       'dark cyan',       'dark blue', 'bold'),
         ('custom',       'white',           'dark blue', 'underline'),
         ('content',      'white',           '',          'standout'),
@@ -85,10 +85,10 @@ THEMES = {
         # on 256 colors
         (None,           'white',           'black',
          None,           WHITE,             BLACK),
-        ('selected',     'white',           'dark blue',
-         None,           WHITE,             DARKBLUE),
-        ('msg_selected', 'light green',     'black',
-         None,           LIGHTGREEN,        BLACK),
+        ('selected',     'black',           'white',
+         None,           BLACK,             WHITE),
+        ('msg_selected', 'black',           'white',
+         None,           BLACK,             WHITE),
         ('header',       'dark cyan',       'dark blue',
          'bold',         'dark cyan',       DARKBLUE),
         ('custom',       'white',           'dark blue',
@@ -169,7 +169,7 @@ THEMES = {
     ],
     'blue': [
         (None,           'black',           'light blue'),
-        ('selected',     'white',           'dark blue'),
+        ('selected',     'black',           'light gray'),
         ('msg_selected', 'black',           'light gray'),
         ('header',       'black',           'dark blue',  'bold'),
         ('custom',       'white',           'dark blue',  'underline'),


### PR DESCRIPTION
I've noticed this before, but my feeling is that it's confusing when moving between the side panels and the message list, that the selection is different.

I explored matching them in the light theme in 2c211bb, and I think that's an improvement.

This PR updates the blue and default themes, not yet touching the gruvbox theme. I also adjusted the unread style, as that's important to show a clear distinction between unread/active/read.

Any thoughts on this approach in general, and also if you think it's good, of how to approach it in gruvbox, would be great to hear.