### PR TITLE
refactor: tests: Eliminate hard-coded size variables from keypress tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -875,3 +875,20 @@ def navigation_key_expected_key_pair(request):
     The expected key is the one which is passed to the super `keypress` calls.
     """
     return request.param
+
+
+@pytest.fixture
+def widget_size():
+    """
+    Returns widget size for any widget.
+    """
+    def _widget_size(widget):
+        widget_type, *_ = widget.sizing()
+        if widget_type == 'box':
+            return (200, 20)
+        elif widget_type == 'flow':
+            return (20, )
+        else:
+            None
+
+    return _widget_size

--- a/tests/ui/test_ui.py
+++ b/tests/ui/test_ui.py
@@ -220,8 +220,6 @@ class TestView:
         view.body = mocker.Mock()
         view.user_search = mocker.Mock()
         size = widget_size(view)
-        assert size != (20,), 'Incorrect size used for a Box widget'
-        assert size == (200, 20)
 
         super_keypress = mocker.patch("zulipterminal.ui.urwid.WidgetWrap"
                                       ".keypress")
@@ -238,8 +236,6 @@ class TestView:
         view.body.focus_col = None
         view.controller.is_in_editor_mode = lambda: False
         size = widget_size(view)
-        assert size != (20,), 'Incorrect size used for a Box widget'
-        assert size == (200, 20)
         view.model.controller.show_all_mentions = mocker.Mock()
 
         view.keypress(size, key)
@@ -260,8 +256,6 @@ class TestView:
         view.left_panel = mocker.Mock()
         view.right_panel = mocker.Mock()
         size = widget_size(view)
-        assert size != (20,), 'Incorrect size used for a Box widget'
-        assert size == (200, 20)
 
         super_view = mocker.patch("zulipterminal.ui.urwid.WidgetWrap.keypress")
         view.controller.is_in_editor_mode = lambda: False
@@ -291,8 +285,6 @@ class TestView:
         view.left_panel.is_in_topic_view = False
         view.right_panel = mocker.Mock()
         size = widget_size(view)
-        assert size != (20,), 'Incorrect size used for a Box widget'
-        assert size == (200, 20)
 
         super_view = mocker.patch("zulipterminal.ui.urwid.WidgetWrap.keypress")
         view.controller.is_in_editor_mode = lambda: False
@@ -318,8 +310,6 @@ class TestView:
 
         view.controller.is_in_editor_mode = lambda: True
         size = widget_size(view)
-        assert size != (130, 28), 'Different box size value'
-        assert size == (200, 20)
 
         view.keypress(size, key)
 

--- a/tests/ui/test_ui.py
+++ b/tests/ui/test_ui.py
@@ -16,6 +16,9 @@ class TestView:
     @pytest.fixture
     def view(self, mocker):
         main_window = mocker.patch('zulipterminal.ui.View.main_window')
+        # View is an urwid.Frame instance, a Box widget.
+        mocker.patch('zulipterminal.ui.View.sizing',
+                     return_value=frozenset({'box'}))
         return View(self.controller)
 
     def test_init(self, mocker):
@@ -210,13 +213,15 @@ class TestView:
         else:
             view.body.options.assert_not_called()
 
-    def test_keypress_normal_mode_navigation(self, view, mocker,
+    def test_keypress_normal_mode_navigation(self, view, mocker, widget_size,
                                              navigation_key_expected_key_pair):
         key, expected_key = navigation_key_expected_key_pair
         view.users_view = mocker.Mock()
         view.body = mocker.Mock()
         view.user_search = mocker.Mock()
-        size = (20,)
+        size = widget_size(view)
+        assert size != (20,), 'Incorrect size used for a Box widget'
+        assert size == (200, 20)
 
         super_keypress = mocker.patch("zulipterminal.ui.urwid.WidgetWrap"
                                       ".keypress")
@@ -228,11 +233,13 @@ class TestView:
         super_keypress.assert_called_once_with(size, expected_key)
 
     @pytest.mark.parametrize('key', keys_for_command('ALL_MENTIONS'))
-    def test_keypress_ALL_MENTIONS(self, view, mocker, key):
+    def test_keypress_ALL_MENTIONS(self, view, mocker, key, widget_size):
         view.body = mocker.Mock()
         view.body.focus_col = None
         view.controller.is_in_editor_mode = lambda: False
-        size = (20,)
+        size = widget_size(view)
+        assert size != (20,), 'Incorrect size used for a Box widget'
+        assert size == (200, 20)
         view.model.controller.show_all_mentions = mocker.Mock()
 
         view.keypress(size, key)
@@ -243,7 +250,8 @@ class TestView:
     @pytest.mark.parametrize('key', keys_for_command('SEARCH_PEOPLE'))
     @pytest.mark.parametrize('autohide', [True, False], ids=[
         'autohide', 'no_autohide'])
-    def test_keypress_autohide_users(self, view, mocker, autohide, key):
+    def test_keypress_autohide_users(self, view, mocker, autohide, key,
+                                     widget_size):
         view.users_view = mocker.Mock()
         view.body = mocker.Mock()
         view.controller.autohide = autohide
@@ -251,7 +259,9 @@ class TestView:
         view.user_search = mocker.Mock()
         view.left_panel = mocker.Mock()
         view.right_panel = mocker.Mock()
-        size = (20,)
+        size = widget_size(view)
+        assert size != (20,), 'Incorrect size used for a Box widget'
+        assert size == (200, 20)
 
         super_view = mocker.patch("zulipterminal.ui.urwid.WidgetWrap.keypress")
         view.controller.is_in_editor_mode = lambda: False
@@ -269,7 +279,8 @@ class TestView:
     @pytest.mark.parametrize('key', keys_for_command('SEARCH_STREAMS'))
     @pytest.mark.parametrize('autohide', [True, False], ids=[
         'autohide', 'no_autohide'])
-    def test_keypress_autohide_streams(self, view, mocker, autohide, key):
+    def test_keypress_autohide_streams(self, view, mocker, autohide, key,
+                                       widget_size):
         view.stream_w = mocker.Mock()
         view.left_col_w = mocker.Mock()
         view.stream_w.stream_search_box = mocker.Mock()
@@ -279,7 +290,9 @@ class TestView:
         view.left_panel = mocker.Mock()
         view.left_panel.is_in_topic_view = False
         view.right_panel = mocker.Mock()
-        size = (20,)
+        size = widget_size(view)
+        assert size != (20,), 'Incorrect size used for a Box widget'
+        assert size == (200, 20)
 
         super_view = mocker.patch("zulipterminal.ui.urwid.WidgetWrap.keypress")
         view.controller.is_in_editor_mode = lambda: False

--- a/tests/ui/test_ui.py
+++ b/tests/ui/test_ui.py
@@ -309,7 +309,7 @@ class TestView:
          .assert_called_once_with(view.stream_w.stream_search_box))
 
     @pytest.mark.parametrize('key', keys_for_command('SEARCH_PEOPLE'))
-    def test_keypress_edit_mode(self, view, mocker, key):
+    def test_keypress_edit_mode(self, view, mocker, key, widget_size):
         view.users_view = mocker.Mock()
         view.body = mocker.Mock()
         view.user_search = mocker.Mock()
@@ -317,9 +317,11 @@ class TestView:
         super_view = mocker.patch("zulipterminal.ui.urwid.WidgetWrap.keypress")
 
         view.controller.is_in_editor_mode = lambda: True
-        size = (130, 28)
+        size = widget_size(view)
+        assert size != (130, 28), 'Different box size value'
+        assert size == (200, 20)
 
         view.keypress(size, key)
 
         (view.controller.current_editor().keypress
-         .assert_called_once_with((28,), key))
+         .assert_called_once_with((size[1], ), key))

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1491,8 +1491,10 @@ class TestPopUpConfirmationView:
         assert self.controller.exit_popup.called
 
     @pytest.mark.parametrize('key', keys_for_command('GO_BACK'))
-    def test_exit_popup_GO_BACK(self, mocker, popup_view, key):
-        size = (20, 20)
+    def test_exit_popup_GO_BACK(self, mocker, popup_view, key, widget_size):
+        size = widget_size(popup_view)
+        assert size != (20, 20), 'Different box size value'
+        assert size == (200, 20)
         popup_view.keypress(size, key)
         self.callback.assert_not_called()
         assert self.controller.exit_popup.called

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -2257,15 +2257,16 @@ class TestMessageBox:
             'topic_edit_only_after_time_limit',
             'editing_not_allowed',
             'all_conditions_met'])
-    def test_keypress_EDIT_MESSAGE(self, mocker, message_fixture,
+    def test_keypress_EDIT_MESSAGE(self, mocker, message_fixture, widget_size,
                                    expect_editing_to_succeed,
                                    to_vary_in_each_message,
                                    realm_editing_allowed,
                                    msg_body_edit_enabled,
                                    key):
         varied_message = dict(message_fixture, **to_vary_in_each_message)
-        size = (20,)
         msg_box = MessageBox(varied_message, self.model, message_fixture)
+        size = widget_size(msg_box)
+        assert size in [(200, 20), (20, )], 'Box/Flow widget'
         msg_box.model.user_id = 1
         msg_box.model.initial_data = {
             'realm_allow_message_editing': realm_editing_allowed,
@@ -2497,9 +2498,10 @@ class TestMessageBox:
         'key', keys_for_command('ENTER'),
         ids=lambda param: 'left_click-key:{}'.format(param)
     )
-    def test_mouse_event_left_click(self, mocker, msg_box, key,
+    def test_mouse_event_left_click(self, mocker, msg_box, key, widget_size,
                                     compose_box_is_open):
-        size = (20, )
+        size = widget_size(msg_box)
+        assert size in [(200, 20), (20, )], 'Box/Flow widget'
         col = 1
         row = 1
         focus = mocker.Mock()

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -509,9 +509,10 @@ class TestStreamsView:
                 ] == expected_log
         self.view.controller.update_screen.assert_called_once_with()
 
-    def test_mouse_event(self, mocker, stream_view):
+    def test_mouse_event(self, mocker, stream_view, widget_size):
         mocker.patch.object(stream_view, 'keypress')
-        size = (200, 20)
+        size = widget_size(stream_view)
+        assert size == (200, 20)
         col = 1
         row = 1
         focus = "WIDGET"
@@ -661,8 +662,10 @@ class TestTopicsView:
         set_focus_valign.assert_called_once_with('bottom')
 
     @pytest.mark.parametrize('key', keys_for_command('TOGGLE_TOPIC'))
-    def test_keypress_EXIT_TOGGLE_TOPIC(self, mocker, topic_view, key):
-        size = (200, 20)
+    def test_keypress_EXIT_TOGGLE_TOPIC(self, mocker, topic_view, key,
+                                        widget_size):
+        size = widget_size(topic_view)
+        assert size == (200, 20)
         mocker.patch(VIEWS + '.urwid.Frame.keypress')
         topic_view.view.left_panel = mocker.Mock()
         topic_view.view.left_panel.contents = [mocker.Mock(), mocker.Mock()]
@@ -671,8 +674,9 @@ class TestTopicsView:
             options.assert_called_once_with(height_type="weight"))
 
     @pytest.mark.parametrize('key', keys_for_command('GO_RIGHT'))
-    def test_keypress_GO_RIGHT(self, mocker, topic_view, key):
-        size = (200, 20)
+    def test_keypress_GO_RIGHT(self, mocker, topic_view, key, widget_size):
+        size = widget_size(topic_view)
+        assert size == (200, 20)
         mocker.patch(VIEWS + '.urwid.Frame.keypress')
         topic_view.view.body.focus_col = None
         topic_view.keypress(size, key)
@@ -680,16 +684,19 @@ class TestTopicsView:
         topic_view.view.show_left_panel.assert_called_once_with(visible=False)
 
     @pytest.mark.parametrize('key', keys_for_command('SEARCH_TOPICS'))
-    def test_keypress_SEARCH_TOPICS(self, mocker, topic_view, key):
-        size = (200, 20)
+    def test_keypress_SEARCH_TOPICS(self, mocker, topic_view, key,
+                                    widget_size):
+        size = widget_size(topic_view)
+        assert size == (200, 20)
         mocker.patch(VIEWS + '.TopicsView.set_focus')
         topic_view.keypress(size, key)
         topic_view.set_focus.assert_called_once_with('header')
         topic_view.header_list.set_focus.assert_called_once_with(2)
 
     @pytest.mark.parametrize('key', keys_for_command('GO_BACK'))
-    def test_keypress_GO_BACK(self, mocker, topic_view, key):
-        size = (200, 20)
+    def test_keypress_GO_BACK(self, mocker, topic_view, key, widget_size):
+        size = widget_size(topic_view)
+        assert size == (200, 20)
         mocker.patch(VIEWS + '.TopicsView.set_focus')
         mocker.patch.object(topic_view.topic_search_box, 'reset_search_text')
         topic_view.keypress(size, key)
@@ -743,9 +750,10 @@ class TestUsersView:
         controller = mocker.Mock()
         return UsersView(controller, "USER_BTN_LIST")
 
-    def test_mouse_event(self, mocker, user_view):
+    def test_mouse_event(self, mocker, user_view, widget_size):
         mocker.patch.object(user_view, 'keypress')
-        size = (200, 20)
+        size = widget_size(user_view)
+        assert size == (200, 20)
         col = 1
         row = 1
         focus = "WIDGET"
@@ -786,8 +794,9 @@ class TestUsersView:
             'invalid_event_button_combination',
         ]
     )
-    def test_mouse_event_invalid(self, user_view, event, button):
-        size = (200, 20)
+    def test_mouse_event_invalid(self, user_view, event, button, widget_size):
+        size = widget_size(user_view)
+        assert size == (200, 20)
         col = 1
         row = 1
         focus = 'WIDGET'
@@ -1267,23 +1276,26 @@ class TestPopUpView:
         self.super_init.assert_called_once_with(self.pop_up_view.log)
 
     @pytest.mark.parametrize('key', keys_for_command('GO_BACK'))
-    def test_keypress_GO_BACK(self, key):
-        size = (200, 20)
+    def test_keypress_GO_BACK(self, key, widget_size):
+        size = widget_size(self.pop_up_view)
+        assert size == (200, 20)
         self.pop_up_view.keypress(size, key)
         assert self.controller.exit_popup.called
 
-    def test_keypress_command_key(self, mocker):
-        size = (200, 20)
+    def test_keypress_command_key(self, mocker, widget_size):
+        size = widget_size(self.pop_up_view)
+        assert size == (200, 20)
         mocker.patch(VIEWS + '.is_command_key', side_effect=(
             lambda command, key: command == self.command
         ))
         self.pop_up_view.keypress(size, 'cmd_key')
         assert self.controller.exit_popup.called
 
-    def test_keypress_navigation(self, mocker,
+    def test_keypress_navigation(self, mocker, widget_size,
                                  navigation_key_expected_key_pair):
         key, expected_key = navigation_key_expected_key_pair
-        size = (200, 20)
+        size = widget_size(self.pop_up_view)
+        assert size == (200, 20)
         # Patch `is_command_key` to not raise an 'Invalid Command' exception
         # when its parameters are (self.command, key) as there is no
         # self.command='COMMAND' command in keys.py.
@@ -1305,23 +1317,26 @@ class TestHelpMenu:
         mocker.patch(VIEWS + ".urwid.SimpleFocusListWalker", return_value=[])
         self.help_view = HelpView(self.controller, 'Help Menu')
 
-    def test_keypress_any_key(self):
+    def test_keypress_any_key(self, widget_size):
         key = "a"
-        size = (200, 20)
+        size = widget_size(self.help_view)
+        assert size == (200, 20)
         self.help_view.keypress(size, key)
         assert not self.controller.exit_popup.called
 
     @pytest.mark.parametrize('key', {*keys_for_command('GO_BACK'),
                                      *keys_for_command('HELP')})
-    def test_keypress_exit_popup(self, key):
-        size = (200, 20)
+    def test_keypress_exit_popup(self, key, widget_size):
+        size = widget_size(self.help_view)
+        assert size == (200, 20)
         self.help_view.keypress(size, key)
         assert self.controller.exit_popup.called
 
-    def test_keypress_navigation(self, mocker,
+    def test_keypress_navigation(self, mocker, widget_size,
                                  navigation_key_expected_key_pair):
         key, expected_key = navigation_key_expected_key_pair
-        size = (200, 20)
+        size = widget_size(self.help_view)
+        assert size == (200, 20)
         super_keypress = mocker.patch(VIEWS + '.urwid.ListBox.keypress')
         self.help_view.keypress(size, key)
         super_keypress.assert_called_once_with(size, expected_key)
@@ -1342,21 +1357,24 @@ class TestAboutView:
 
     @pytest.mark.parametrize('key', {*keys_for_command('GO_BACK'),
                                      *keys_for_command('ABOUT')})
-    def test_keypress_exit_popup(self, key):
-        size = (200, 20)
+    def test_keypress_exit_popup(self, key, widget_size):
+        size = widget_size(self.about_view)
+        assert size == (200, 20)
         self.about_view.keypress(size, key)
         assert self.controller.exit_popup.called
 
-    def test_keypress_exit_popup_invalid_key(self):
+    def test_keypress_exit_popup_invalid_key(self, widget_size):
         key = 'a'
-        size = (200, 20)
+        size = widget_size(self.about_view)
+        assert size == (200, 20)
         self.about_view.keypress(size, key)
         assert not self.controller.exit_popup.called
 
-    def test_keypress_navigation(self, mocker,
+    def test_keypress_navigation(self, mocker, widget_size,
                                  navigation_key_expected_key_pair):
         key, expected_key = navigation_key_expected_key_pair
-        size = (200, 20)
+        size = widget_size(self.about_view)
+        assert size == (200, 20)
         super_keypress = mocker.patch(VIEWS + '.urwid.ListBox.keypress')
         self.about_view.keypress(size, key)
         super_keypress.assert_called_once_with(size, expected_key)
@@ -1461,15 +1479,17 @@ class TestStreamInfoView:
 
     @pytest.mark.parametrize('key', {*keys_for_command('GO_BACK'),
                                      *keys_for_command('STREAM_DESC')})
-    def test_keypress_exit_popup(self, key):
-        size = (200, 20)
+    def test_keypress_exit_popup(self, key, widget_size):
+        size = widget_size(self.stream_info_view)
+        assert size == (200, 20)
         self.stream_info_view.keypress(size, key)
         assert self.controller.exit_popup.called
 
-    def test_keypress_navigation(self, mocker,
+    def test_keypress_navigation(self, mocker, widget_size,
                                  navigation_key_expected_key_pair):
         key, expected_key = navigation_key_expected_key_pair
-        size = (200, 20)
+        size = widget_size(self.stream_info_view)
+        assert size == (200, 20)
         super_keypress = mocker.patch(VIEWS + '.urwid.ListBox.keypress')
         self.stream_info_view.keypress(size, key)
         super_keypress.assert_called_once_with(size, expected_key)
@@ -1514,9 +1534,10 @@ class TestMsgInfoView:
                                          'Message Information', OrderedDict(),
                                          list())
 
-    def test_keypress_any_key(self):
+    def test_keypress_any_key(self, widget_size):
         key = "a"
-        size = (200, 20)
+        size = widget_size(self.msg_info_view)
+        assert size == (200, 20)
         self.msg_info_view.keypress(size, key)
         assert not self.controller.exit_popup.called
 
@@ -1533,10 +1554,9 @@ class TestMsgInfoView:
             'group_pm_message_id',
         ]
     )
-    def test_keypress_edit_history(self, message_fixture, key,
+    def test_keypress_edit_history(self, message_fixture, key, widget_size,
                                    realm_allow_edit_history,
                                    edited_message_id):
-        size = (200, 20)
         self.controller.model.index = {
             'edited_messages': set([edited_message_id]),
         }
@@ -1547,6 +1567,8 @@ class TestMsgInfoView:
                                     title='Message Information',
                                     message_links=OrderedDict(),
                                     time_mentions=list())
+        size = widget_size(msg_info_view)
+        assert size == (200, 20)
 
         msg_info_view.keypress(size, key)
 
@@ -1561,8 +1583,9 @@ class TestMsgInfoView:
 
     @pytest.mark.parametrize('key', {*keys_for_command('GO_BACK'),
                                      *keys_for_command('MSG_INFO')})
-    def test_keypress_exit_popup(self, key):
-        size = (200, 20)
+    def test_keypress_exit_popup(self, key, widget_size):
+        size = widget_size(self.msg_info_view)
+        assert size == (200, 20)
         self.msg_info_view.keypress(size, key)
         assert self.controller.exit_popup.called
 
@@ -1619,10 +1642,11 @@ class TestMsgInfoView:
         expected_height = 9
         assert self.msg_info_view.height == expected_height
 
-    def test_keypress_navigation(self, mocker,
+    def test_keypress_navigation(self, mocker, widget_size,
                                  navigation_key_expected_key_pair):
         key, expected_key = navigation_key_expected_key_pair
-        size = (200, 20)
+        size = widget_size(self.msg_info_view)
+        assert size == (200, 20)
         super_keypress = mocker.patch(VIEWS + '.urwid.ListBox.keypress')
         self.msg_info_view.keypress(size, key)
         super_keypress.assert_called_once_with(size, expected_key)
@@ -2640,8 +2664,10 @@ class TestStreamButton:
             options.assert_called_once_with(height_type="weight"))
 
     @pytest.mark.parametrize('key', keys_for_command('TOGGLE_MUTE_STREAM'))
-    def test_keypress_TOGGLE_MUTE_STREAM(self, mocker, stream_button, key):
-        size = (20,)
+    def test_keypress_TOGGLE_MUTE_STREAM(self, mocker, stream_button, key,
+                                         widget_size):
+        size = widget_size(stream_button)
+        assert size == (20,)
         pop_up = mocker.patch(
             'zulipterminal.core.Controller.stream_muting_confirmation_popup')
         stream_button.keypress(size, key)
@@ -2705,7 +2731,7 @@ class TestUserButton:
     @pytest.mark.parametrize('enter_key', keys_for_command('ENTER'))
     def test_activate_called_once_on_keypress(
         self,
-        mocker, enter_key,
+        mocker, enter_key, widget_size,
         caption="some user", width=30, email='some_email', user_id=5,
     ):
         user = {
@@ -2713,7 +2739,6 @@ class TestUserButton:
             'user_id': user_id,
             'full_name': caption,
         }  # type: Dict[str, Any]
-        size = (20,)
         activate = mocker.patch(BUTTONS + ".UserButton.activate")
         user_button = UserButton(user,
                                  controller=mocker.Mock(),
@@ -2721,6 +2746,8 @@ class TestUserButton:
                                  width=width,
                                  color=mocker.Mock(),
                                  count=mocker.Mock())
+        size = widget_size(user_button)
+        assert size == (20,)
 
         user_button.keypress(size, enter_key)
 

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -260,16 +260,12 @@ class TestMessageView:
                          widget_size):
         mocker.patch.object(msg_view, "keypress")
         size = widget_size(msg_view)
-        assert size != (20,), 'Incorrect size used for a Box widget'
-        assert size == (200, 20)
         msg_view.mouse_event(size, event, button, 0, 0, mocker.Mock())
         msg_view.keypress.assert_called_once_with(size, keypress)
 
     @pytest.mark.parametrize('key', keys_for_command('GO_DOWN'))
     def test_keypress_GO_DOWN(self, mocker, msg_view, key, widget_size):
         size = widget_size(msg_view)
-        assert size != (20,), 'Incorrect size used for a Box widget'
-        assert size == (200, 20)
         msg_view.new_loading = False
         mocker.patch(VIEWS + ".MessageView.focus_position", return_value=0)
         mocker.patch(VIEWS + ".MessageView.set_focus_valign")
@@ -284,8 +280,6 @@ class TestMessageView:
     def test_keypress_GO_DOWN_exception(self, mocker, msg_view, key,
                                         widget_size):
         size = widget_size(msg_view)
-        assert size != (20,), 'Incorrect size used for a Box widget'
-        assert size == (200, 20)
         msg_view.new_loading = False
         mocker.patch(VIEWS + ".MessageView.focus_position", return_value=0)
         mocker.patch(VIEWS + ".MessageView.set_focus_valign")
@@ -307,8 +301,6 @@ class TestMessageView:
     @pytest.mark.parametrize('key', keys_for_command('GO_UP'))
     def test_keypress_GO_UP(self, mocker, msg_view, key, widget_size):
         size = widget_size(msg_view)
-        assert size != (20,), 'Incorrect size used for a Box widget'
-        assert size == (200, 20)
         mocker.patch(VIEWS + ".MessageView.focus_position", return_value=0)
         mocker.patch(VIEWS + ".MessageView.set_focus_valign")
         msg_view.old_loading = False
@@ -323,8 +315,6 @@ class TestMessageView:
     def test_keypress_GO_UP_exception(self, mocker, msg_view, key,
                                       widget_size):
         size = widget_size(msg_view)
-        assert size != (20,), 'Incorrect size used for a Box widget'
-        assert size == (200, 20)
         mocker.patch(VIEWS + ".MessageView.focus_position", return_value=0)
         mocker.patch(VIEWS + ".MessageView.set_focus_valign")
         msg_view.old_loading = False
@@ -526,7 +516,6 @@ class TestStreamsView:
     def test_mouse_event(self, mocker, stream_view, widget_size):
         mocker.patch.object(stream_view, 'keypress')
         size = widget_size(stream_view)
-        assert size == (200, 20)
         col = 1
         row = 1
         focus = "WIDGET"
@@ -542,8 +531,6 @@ class TestStreamsView:
     def test_keypress_SEARCH_STREAMS(self, mocker, stream_view, key,
                                      widget_size):
         size = widget_size(stream_view)
-        assert size != (20,), 'Incorrect size used for a Box widget'
-        assert size == (200, 20)
         mocker.patch.object(stream_view, 'set_focus')
         stream_view.keypress(size, key)
         stream_view.set_focus.assert_called_once_with("header")
@@ -551,8 +538,6 @@ class TestStreamsView:
     @pytest.mark.parametrize('key', keys_for_command('GO_BACK'))
     def test_keypress_GO_BACK(self, mocker, stream_view, key, widget_size):
         size = widget_size(stream_view)
-        assert size != (20,), 'Incorrect size used for a Box widget'
-        assert size == (200, 20)
         mocker.patch.object(stream_view, 'set_focus')
         mocker.patch.object(stream_view.stream_search_box, 'reset_search_text')
         stream_view.keypress(size, key)
@@ -586,8 +571,6 @@ class TestStreamsView:
 
         # Toggle Stream Search
         size = widget_size(stream_view)
-        assert size != (20,), 'Incorrect size used for a Box widget'
-        assert size == (200, 20)
         stream_view.keypress(size, search_streams_key)
 
         # Exit Stream Search
@@ -686,7 +669,6 @@ class TestTopicsView:
     def test_keypress_EXIT_TOGGLE_TOPIC(self, mocker, topic_view, key,
                                         widget_size):
         size = widget_size(topic_view)
-        assert size == (200, 20)
         mocker.patch(VIEWS + '.urwid.Frame.keypress')
         topic_view.view.left_panel = mocker.Mock()
         topic_view.view.left_panel.contents = [mocker.Mock(), mocker.Mock()]
@@ -697,7 +679,6 @@ class TestTopicsView:
     @pytest.mark.parametrize('key', keys_for_command('GO_RIGHT'))
     def test_keypress_GO_RIGHT(self, mocker, topic_view, key, widget_size):
         size = widget_size(topic_view)
-        assert size == (200, 20)
         mocker.patch(VIEWS + '.urwid.Frame.keypress')
         topic_view.view.body.focus_col = None
         topic_view.keypress(size, key)
@@ -708,7 +689,6 @@ class TestTopicsView:
     def test_keypress_SEARCH_TOPICS(self, mocker, topic_view, key,
                                     widget_size):
         size = widget_size(topic_view)
-        assert size == (200, 20)
         mocker.patch(VIEWS + '.TopicsView.set_focus')
         topic_view.keypress(size, key)
         topic_view.set_focus.assert_called_once_with('header')
@@ -717,7 +697,6 @@ class TestTopicsView:
     @pytest.mark.parametrize('key', keys_for_command('GO_BACK'))
     def test_keypress_GO_BACK(self, mocker, topic_view, key, widget_size):
         size = widget_size(topic_view)
-        assert size == (200, 20)
         mocker.patch(VIEWS + '.TopicsView.set_focus')
         mocker.patch.object(topic_view.topic_search_box, 'reset_search_text')
         topic_view.keypress(size, key)
@@ -751,8 +730,6 @@ class TestTopicsView:
 
         # Toggle Search
         size = widget_size(topic_view)
-        assert size != (20,), 'Incorrect size used for a Box widget'
-        assert size == (200, 20)
         topic_view.keypress(size, search_topics_key)
 
         # Exit Search
@@ -776,7 +753,6 @@ class TestUsersView:
     def test_mouse_event(self, mocker, user_view, widget_size):
         mocker.patch.object(user_view, 'keypress')
         size = widget_size(user_view)
-        assert size == (200, 20)
         col = 1
         row = 1
         focus = "WIDGET"
@@ -796,8 +772,6 @@ class TestUsersView:
                 compose_box_is_open
         )
         size = widget_size(user_view)
-        assert size != (20, ), 'Incorrect size used for a Box widget'
-        assert size == (200, 20)
         focus = mocker.Mock()
 
         user_view.mouse_event(size, 'mouse press', 1, 1, 1, focus)
@@ -821,7 +795,6 @@ class TestUsersView:
     )
     def test_mouse_event_invalid(self, user_view, event, button, widget_size):
         size = widget_size(user_view)
-        assert size == (200, 20)
         col = 1
         row = 1
         focus = 'WIDGET'
@@ -911,8 +884,6 @@ class TestMiddleColumnView:
     @pytest.mark.parametrize('key', keys_for_command('GO_BACK'))
     def test_keypress_GO_BACK(self, mid_col_view, mocker, key, widget_size):
         size = widget_size(mid_col_view)
-        assert size != (20,), 'Incorrect size used for a Box widget'
-        assert size == (200, 20)
         mocker.patch(VIEWS + '.MiddleColumnView.header')
         mocker.patch(VIEWS + '.MiddleColumnView.footer')
         mocker.patch(VIEWS + '.MiddleColumnView.set_focus')
@@ -928,8 +899,6 @@ class TestMiddleColumnView:
     def test_keypress_focus_header(self, mid_col_view, mocker, key,
                                    widget_size):
         size = widget_size(mid_col_view)
-        assert size != (20,), 'Incorrect size used for a Box widget'
-        assert size == (200, 20)
         mid_col_view.focus_part = 'header'
         mid_col_view.keypress(size, key)
         self.super_keypress.assert_called_once_with(size, key)
@@ -938,8 +907,6 @@ class TestMiddleColumnView:
     def test_keypress_SEARCH_MESSAGES(self, mid_col_view, mocker, key,
                                       widget_size):
         size = widget_size(mid_col_view)
-        assert size != (20,), 'Incorrect size used for a Box widget'
-        assert size == (200, 20)
         mocker.patch(VIEWS + '.MiddleColumnView.focus_position')
         mocker.patch(VIEWS + '.MiddleColumnView.set_focus')
 
@@ -955,8 +922,6 @@ class TestMiddleColumnView:
     def test_keypress_REPLY_MESSAGE(self, mid_col_view, mocker, widget_size,
                                     reply_message_key, enter_key):
         size = widget_size(mid_col_view)
-        assert size != (20,), 'Incorrect size used for a Box widget'
-        assert size == (200, 20)
         mocker.patch(VIEWS + '.MiddleColumnView.body')
         mocker.patch(VIEWS + '.MiddleColumnView.footer')
         mocker.patch(VIEWS + '.MiddleColumnView.focus_position')
@@ -972,8 +937,6 @@ class TestMiddleColumnView:
     def test_keypress_STREAM_MESSAGE(self, mid_col_view, mocker, key,
                                      widget_size):
         size = widget_size(mid_col_view)
-        assert size != (20,), 'Incorrect size used for a Box widget'
-        assert size == (200, 20)
         mocker.patch(VIEWS + '.MiddleColumnView.body')
         mocker.patch(VIEWS + '.MiddleColumnView.footer')
         mocker.patch(VIEWS + '.MiddleColumnView.focus_position')
@@ -989,8 +952,6 @@ class TestMiddleColumnView:
     def test_keypress_REPLY_AUTHOR(self, mid_col_view, mocker, key,
                                    widget_size):
         size = widget_size(mid_col_view)
-        assert size != (20,), 'Incorrect size used for a Box widget'
-        assert size == (200, 20)
         mocker.patch(VIEWS + '.MiddleColumnView.body')
         mocker.patch(VIEWS + '.MiddleColumnView.footer')
         mocker.patch(VIEWS + '.MiddleColumnView.focus_position')
@@ -1007,8 +968,6 @@ class TestMiddleColumnView:
                                                widget_size,
                                                key):
         size = widget_size(mid_col_view)
-        assert size != (20,), 'Incorrect size used for a Box widget'
-        assert size == (200, 20)
         mocker.patch(VIEWS + '.MiddleColumnView.focus_position')
         topic_btn = mocker.patch(VIEWS + '.TopicButton')
         mocker.patch(VIEWS + '.MiddleColumnView.get_next_unread_topic',
@@ -1026,8 +985,6 @@ class TestMiddleColumnView:
                                                   widget_size,
                                                   key):
         size = widget_size(mid_col_view)
-        assert size != (20,), 'Incorrect size used for a Box widget'
-        assert size == (200, 20)
         mocker.patch(VIEWS + '.MiddleColumnView.focus_position')
         topic_btn = mocker.patch(VIEWS + '.TopicButton')
         mocker.patch(VIEWS + '.MiddleColumnView.get_next_unread_topic',
@@ -1040,8 +997,6 @@ class TestMiddleColumnView:
     def test_keypress_NEXT_UNREAD_PM_stream(self, mid_col_view, mocker, key,
                                             widget_size):
         size = widget_size(mid_col_view)
-        assert size != (20,), 'Incorrect size used for a Box widget'
-        assert size == (200, 20)
         mocker.patch(VIEWS + '.MiddleColumnView.focus_position')
         pm_btn = mocker.patch(VIEWS + '.UnreadPMButton')
         mocker.patch(VIEWS + '.MiddleColumnView.get_next_unread_pm',
@@ -1058,8 +1013,6 @@ class TestMiddleColumnView:
     def test_keypress_NEXT_UNREAD_PM_no_pm(self, mid_col_view, mocker, key,
                                            widget_size):
         size = widget_size(mid_col_view)
-        assert size != (20,), 'Incorrect size used for a Box widget'
-        assert size == (200, 20)
         mocker.patch(VIEWS + '.MiddleColumnView.focus_position')
         pm_btn = mocker.patch(VIEWS + '.UnreadPMButton')
         mocker.patch(VIEWS + '.MiddleColumnView.get_next_unread_pm',
@@ -1072,8 +1025,6 @@ class TestMiddleColumnView:
     def test_keypress_PRIVATE_MESSAGE(self, mid_col_view, mocker, key,
                                       widget_size):
         size = widget_size(mid_col_view)
-        assert size != (20,), 'Incorrect size used for a Box widget'
-        assert size == (200, 20)
         mocker.patch(VIEWS + '.MiddleColumnView.focus_position')
         pm_btn = mocker.patch(VIEWS + '.UnreadPMButton')
         mocker.patch(VIEWS + '.MiddleColumnView.get_next_unread_pm',
@@ -1192,8 +1143,6 @@ class TestRightColumnView:
     def test_keypress_SEARCH_PEOPLE(self, right_col_view, mocker, key,
                                     widget_size):
         size = widget_size(right_col_view)
-        assert size != (20,), 'Incorrect size used for a Box widget'
-        assert size == (200, 20)
         mocker.patch(VIEWS + ".RightColumnView.set_focus")
         right_col_view.keypress(size, key)
         right_col_view.set_focus.assert_called_once_with('header')
@@ -1201,8 +1150,6 @@ class TestRightColumnView:
     @pytest.mark.parametrize('key', keys_for_command('GO_BACK'))
     def test_keypress_GO_BACK(self, right_col_view, mocker, key, widget_size):
         size = widget_size(right_col_view)
-        assert size != (20,), 'Incorrect size used for a Box widget'
-        assert size == (200, 20)
         mocker.patch(VIEWS + ".UsersView")
         mocker.patch(VIEWS + ".RightColumnView.set_focus")
         mocker.patch(VIEWS + ".RightColumnView.set_body")
@@ -1339,13 +1286,11 @@ class TestPopUpView:
     @pytest.mark.parametrize('key', keys_for_command('GO_BACK'))
     def test_keypress_GO_BACK(self, key, widget_size):
         size = widget_size(self.pop_up_view)
-        assert size == (200, 20)
         self.pop_up_view.keypress(size, key)
         assert self.controller.exit_popup.called
 
     def test_keypress_command_key(self, mocker, widget_size):
         size = widget_size(self.pop_up_view)
-        assert size == (200, 20)
         mocker.patch(VIEWS + '.is_command_key', side_effect=(
             lambda command, key: command == self.command
         ))
@@ -1356,7 +1301,6 @@ class TestPopUpView:
                                  navigation_key_expected_key_pair):
         key, expected_key = navigation_key_expected_key_pair
         size = widget_size(self.pop_up_view)
-        assert size == (200, 20)
         # Patch `is_command_key` to not raise an 'Invalid Command' exception
         # when its parameters are (self.command, key) as there is no
         # self.command='COMMAND' command in keys.py.
@@ -1381,7 +1325,6 @@ class TestHelpMenu:
     def test_keypress_any_key(self, widget_size):
         key = "a"
         size = widget_size(self.help_view)
-        assert size == (200, 20)
         self.help_view.keypress(size, key)
         assert not self.controller.exit_popup.called
 
@@ -1389,7 +1332,6 @@ class TestHelpMenu:
                                      *keys_for_command('HELP')})
     def test_keypress_exit_popup(self, key, widget_size):
         size = widget_size(self.help_view)
-        assert size == (200, 20)
         self.help_view.keypress(size, key)
         assert self.controller.exit_popup.called
 
@@ -1397,7 +1339,6 @@ class TestHelpMenu:
                                  navigation_key_expected_key_pair):
         key, expected_key = navigation_key_expected_key_pair
         size = widget_size(self.help_view)
-        assert size == (200, 20)
         super_keypress = mocker.patch(VIEWS + '.urwid.ListBox.keypress')
         self.help_view.keypress(size, key)
         super_keypress.assert_called_once_with(size, expected_key)
@@ -1420,14 +1361,12 @@ class TestAboutView:
                                      *keys_for_command('ABOUT')})
     def test_keypress_exit_popup(self, key, widget_size):
         size = widget_size(self.about_view)
-        assert size == (200, 20)
         self.about_view.keypress(size, key)
         assert self.controller.exit_popup.called
 
     def test_keypress_exit_popup_invalid_key(self, widget_size):
         key = 'a'
         size = widget_size(self.about_view)
-        assert size == (200, 20)
         self.about_view.keypress(size, key)
         assert not self.controller.exit_popup.called
 
@@ -1435,7 +1374,6 @@ class TestAboutView:
                                  navigation_key_expected_key_pair):
         key, expected_key = navigation_key_expected_key_pair
         size = widget_size(self.about_view)
-        assert size == (200, 20)
         super_keypress = mocker.patch(VIEWS + '.urwid.ListBox.keypress')
         self.about_view.keypress(size, key)
         super_keypress.assert_called_once_with(size, expected_key)
@@ -1493,8 +1431,6 @@ class TestPopUpConfirmationView:
     @pytest.mark.parametrize('key', keys_for_command('GO_BACK'))
     def test_exit_popup_GO_BACK(self, mocker, popup_view, key, widget_size):
         size = widget_size(popup_view)
-        assert size != (20, 20), 'Different box size value'
-        assert size == (200, 20)
         popup_view.keypress(size, key)
         self.callback.assert_not_called()
         assert self.controller.exit_popup.called
@@ -1519,8 +1455,6 @@ class TestEditModeView:
                               index_in_widgets, mode, key):
         radio_button = edit_mode_view.widgets[index_in_widgets]
         size = widget_size(radio_button)
-        assert size != (20, 20), 'Incorrect size for a Flow widget'
-        assert size == (20,)
 
         radio_button.keypress(size, key)
 
@@ -1546,7 +1480,6 @@ class TestStreamInfoView:
                                      *keys_for_command('STREAM_DESC')})
     def test_keypress_exit_popup(self, key, widget_size):
         size = widget_size(self.stream_info_view)
-        assert size == (200, 20)
         self.stream_info_view.keypress(size, key)
         assert self.controller.exit_popup.called
 
@@ -1554,7 +1487,6 @@ class TestStreamInfoView:
                                  navigation_key_expected_key_pair):
         key, expected_key = navigation_key_expected_key_pair
         size = widget_size(self.stream_info_view)
-        assert size == (200, 20)
         super_keypress = mocker.patch(VIEWS + '.urwid.ListBox.keypress')
         self.stream_info_view.keypress(size, key)
         super_keypress.assert_called_once_with(size, expected_key)
@@ -1565,8 +1497,6 @@ class TestStreamInfoView:
         toggle_mute_status = self.controller.model.toggle_stream_muted_status
         stream_id = self.stream_info_view.stream_id
         size = widget_size(mute_checkbox)
-        assert size != (20, 20), 'Incorrect size for a Flow widget'
-        assert size == (20,)
 
         mute_checkbox.keypress(size, key)
 
@@ -1578,8 +1508,6 @@ class TestStreamInfoView:
         toggle_pin_status = self.controller.model.toggle_stream_pinned_status
         stream_id = self.stream_info_view.stream_id
         size = widget_size(pin_checkbox)
-        assert size != (20, 20), 'Incorrect size for a Flow widget'
-        assert size == (20,)
 
         pin_checkbox.keypress(size, key)
 
@@ -1606,7 +1534,6 @@ class TestMsgInfoView:
     def test_keypress_any_key(self, widget_size):
         key = "a"
         size = widget_size(self.msg_info_view)
-        assert size == (200, 20)
         self.msg_info_view.keypress(size, key)
         assert not self.controller.exit_popup.called
 
@@ -1637,7 +1564,6 @@ class TestMsgInfoView:
                                     message_links=OrderedDict(),
                                     time_mentions=list())
         size = widget_size(msg_info_view)
-        assert size == (200, 20)
 
         msg_info_view.keypress(size, key)
 
@@ -1654,7 +1580,6 @@ class TestMsgInfoView:
                                      *keys_for_command('MSG_INFO')})
     def test_keypress_exit_popup(self, key, widget_size):
         size = widget_size(self.msg_info_view)
-        assert size == (200, 20)
         self.msg_info_view.keypress(size, key)
         assert self.controller.exit_popup.called
 
@@ -1715,7 +1640,6 @@ class TestMsgInfoView:
                                  navigation_key_expected_key_pair):
         key, expected_key = navigation_key_expected_key_pair
         size = widget_size(self.msg_info_view)
-        assert size == (200, 20)
         super_keypress = mocker.patch(VIEWS + '.urwid.ListBox.keypress')
         self.msg_info_view.keypress(size, key)
         super_keypress.assert_called_once_with(size, expected_key)
@@ -2335,7 +2259,6 @@ class TestMessageBox:
         varied_message = dict(message_fixture, **to_vary_in_each_message)
         msg_box = MessageBox(varied_message, self.model, message_fixture)
         size = widget_size(msg_box)
-        assert size in [(200, 20), (20, )], 'Box/Flow widget'
         msg_box.model.user_id = 1
         msg_box.model.initial_data = {
             'realm_allow_message_editing': realm_editing_allowed,
@@ -2570,7 +2493,6 @@ class TestMessageBox:
     def test_mouse_event_left_click(self, mocker, msg_box, key, widget_size,
                                     compose_box_is_open):
         size = widget_size(msg_box)
-        assert size in [(200, 20), (20, )], 'Box/Flow widget'
         col = 1
         row = 1
         focus = mocker.Mock()
@@ -2726,8 +2648,6 @@ class TestStreamButton:
     def test_keypress_ENTER_TOGGLE_TOPIC(self, mocker, stream_button, key,
                                          widget_size):
         size = widget_size(stream_button)
-        assert size != (200, 20), 'Incorrect size for a Flow widget'
-        assert size == (20, )
         stream_button.view.left_panel = mocker.Mock()
         stream_button.view.left_panel.is_in_topic_view = None
         stream_button.view.left_panel.contents = [mocker.Mock(), mocker.Mock()]
@@ -2741,7 +2661,6 @@ class TestStreamButton:
     def test_keypress_TOGGLE_MUTE_STREAM(self, mocker, stream_button, key,
                                          widget_size):
         size = widget_size(stream_button)
-        assert size == (20,)
         pop_up = mocker.patch(
             'zulipterminal.core.Controller.stream_muting_confirmation_popup')
         stream_button.keypress(size, key)
@@ -2821,7 +2740,6 @@ class TestUserButton:
                                  color=mocker.Mock(),
                                  count=mocker.Mock())
         size = widget_size(user_button)
-        assert size == (20,)
 
         user_button.keypress(size, enter_key)
 

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -256,14 +256,20 @@ class TestMessageView:
         ("mouse press", 4, "up"),
         ("mouse press", 5, "down"),
     ])
-    def test_mouse_event(self, mocker, msg_view, event, button, keypress):
+    def test_mouse_event(self, mocker, msg_view, event, button, keypress,
+                         widget_size):
         mocker.patch.object(msg_view, "keypress")
-        msg_view.mouse_event((20,), event, button, 0, 0, mocker.Mock())
-        msg_view.keypress.assert_called_once_with((20,), keypress)
+        size = widget_size(msg_view)
+        assert size != (20,), 'Incorrect size used for a Box widget'
+        assert size == (200, 20)
+        msg_view.mouse_event(size, event, button, 0, 0, mocker.Mock())
+        msg_view.keypress.assert_called_once_with(size, keypress)
 
     @pytest.mark.parametrize('key', keys_for_command('GO_DOWN'))
-    def test_keypress_GO_DOWN(self, mocker, msg_view, key):
-        size = (20,)
+    def test_keypress_GO_DOWN(self, mocker, msg_view, key, widget_size):
+        size = widget_size(msg_view)
+        assert size != (20,), 'Incorrect size used for a Box widget'
+        assert size == (200, 20)
         msg_view.new_loading = False
         mocker.patch(VIEWS + ".MessageView.focus_position", return_value=0)
         mocker.patch(VIEWS + ".MessageView.set_focus_valign")
@@ -275,8 +281,11 @@ class TestMessageView:
         msg_view.set_focus_valign.assert_called_once_with('middle')
 
     @pytest.mark.parametrize('key', keys_for_command('GO_DOWN'))
-    def test_keypress_GO_DOWN_exception(self, mocker, msg_view, key):
-        size = (20,)
+    def test_keypress_GO_DOWN_exception(self, mocker, msg_view, key,
+                                        widget_size):
+        size = widget_size(msg_view)
+        assert size != (20,), 'Incorrect size used for a Box widget'
+        assert size == (200, 20)
         msg_view.new_loading = False
         mocker.patch(VIEWS + ".MessageView.focus_position", return_value=0)
         mocker.patch(VIEWS + ".MessageView.set_focus_valign")
@@ -296,8 +305,10 @@ class TestMessageView:
         assert return_value == key
 
     @pytest.mark.parametrize('key', keys_for_command('GO_UP'))
-    def test_keypress_GO_UP(self, mocker, msg_view, key):
-        size = (20,)
+    def test_keypress_GO_UP(self, mocker, msg_view, key, widget_size):
+        size = widget_size(msg_view)
+        assert size != (20,), 'Incorrect size used for a Box widget'
+        assert size == (200, 20)
         mocker.patch(VIEWS + ".MessageView.focus_position", return_value=0)
         mocker.patch(VIEWS + ".MessageView.set_focus_valign")
         msg_view.old_loading = False
@@ -309,8 +320,11 @@ class TestMessageView:
         msg_view.set_focus_valign.assert_called_once_with('middle')
 
     @pytest.mark.parametrize('key', keys_for_command('GO_UP'))
-    def test_keypress_GO_UP_exception(self, mocker, msg_view, key):
-        size = (20,)
+    def test_keypress_GO_UP_exception(self, mocker, msg_view, key,
+                                      widget_size):
+        size = widget_size(msg_view)
+        assert size != (20,), 'Incorrect size used for a Box widget'
+        assert size == (200, 20)
         mocker.patch(VIEWS + ".MessageView.focus_position", return_value=0)
         mocker.patch(VIEWS + ".MessageView.set_focus_valign")
         msg_view.old_loading = False
@@ -525,15 +539,20 @@ class TestStreamsView:
         stream_view.keypress.assert_called_with(size, "down")
 
     @pytest.mark.parametrize('key', keys_for_command('SEARCH_STREAMS'))
-    def test_keypress_SEARCH_STREAMS(self, mocker, stream_view, key):
-        size = (20,)
+    def test_keypress_SEARCH_STREAMS(self, mocker, stream_view, key,
+                                     widget_size):
+        size = widget_size(stream_view)
+        assert size != (20,), 'Incorrect size used for a Box widget'
+        assert size == (200, 20)
         mocker.patch.object(stream_view, 'set_focus')
         stream_view.keypress(size, key)
         stream_view.set_focus.assert_called_once_with("header")
 
     @pytest.mark.parametrize('key', keys_for_command('GO_BACK'))
-    def test_keypress_GO_BACK(self, mocker, stream_view, key):
-        size = (20,)
+    def test_keypress_GO_BACK(self, mocker, stream_view, key, widget_size):
+        size = widget_size(stream_view)
+        assert size != (20,), 'Incorrect size used for a Box widget'
+        assert size == (200, 20)
         mocker.patch.object(stream_view, 'set_focus')
         mocker.patch.object(stream_view.stream_search_box, 'reset_search_text')
         stream_view.keypress(size, key)
@@ -550,6 +569,7 @@ class TestStreamsView:
         (4, 'BOO'),
     ])
     def test_return_to_focus_after_search(self, mocker, stream_view,
+                                          widget_size,
                                           current_focus, stream,
                                           search_streams_key, go_back_key):
         # Initialize log
@@ -565,11 +585,12 @@ class TestStreamsView:
         previous_focus_stream_name = stream
 
         # Toggle Stream Search
-        size = (20,)
+        size = widget_size(stream_view)
+        assert size != (20,), 'Incorrect size used for a Box widget'
+        assert size == (200, 20)
         stream_view.keypress(size, search_streams_key)
 
         # Exit Stream Search
-        size = (20,)
         stream_view.keypress(size, go_back_key)
 
         # Obtain new stream focus
@@ -713,6 +734,7 @@ class TestTopicsView:
         (4, 'BOO'),
     ])
     def test_return_to_focus_after_search(self, mocker, topic_view,
+                                          widget_size,
                                           current_focus, topic,
                                           search_topics_key, go_back_key):
         # Initialize log
@@ -728,11 +750,12 @@ class TestTopicsView:
         previous_focus_topic_name = topic
 
         # Toggle Search
-        size = (20,)
+        size = widget_size(topic_view)
+        assert size != (20,), 'Incorrect size used for a Box widget'
+        assert size == (200, 20)
         topic_view.keypress(size, search_topics_key)
 
         # Exit Search
-        size = (20,)
         topic_view.keypress(size, go_back_key)
 
         # Obtain new focus
@@ -765,14 +788,16 @@ class TestUsersView:
         user_view.mouse_event(size, "mouse press", 5, col, row, focus)
         user_view.keypress.assert_called_with(size, "down")
 
-    def test_mouse_event_left_click(self, mocker, user_view,
+    def test_mouse_event_left_click(self, mocker, user_view, widget_size,
                                     compose_box_is_open):
         super_mouse_event = mocker.patch(
                         'zulipterminal.ui.urwid.ListBox.mouse_event')
         user_view.controller.is_in_editor_mode.return_value = (
                 compose_box_is_open
         )
-        size = (20, )
+        size = widget_size(user_view)
+        assert size != (20, ), 'Incorrect size used for a Box widget'
+        assert size == (200, 20)
         focus = mocker.Mock()
 
         user_view.mouse_event(size, 'mouse press', 1, 1, 1, focus)
@@ -884,8 +909,10 @@ class TestMiddleColumnView:
         assert mid_col_view.last_unread_pm is None
 
     @pytest.mark.parametrize('key', keys_for_command('GO_BACK'))
-    def test_keypress_GO_BACK(self, mid_col_view, mocker, key):
-        size = (20,)
+    def test_keypress_GO_BACK(self, mid_col_view, mocker, key, widget_size):
+        size = widget_size(mid_col_view)
+        assert size != (20,), 'Incorrect size used for a Box widget'
+        assert size == (200, 20)
         mocker.patch(VIEWS + '.MiddleColumnView.header')
         mocker.patch(VIEWS + '.MiddleColumnView.footer')
         mocker.patch(VIEWS + '.MiddleColumnView.set_focus')
@@ -898,15 +925,21 @@ class TestMiddleColumnView:
         self.super_keypress.assert_called_once_with(size, key)
 
     @pytest.mark.parametrize('key', keys_for_command('SEARCH_MESSAGES'))
-    def test_keypress_focus_header(self, mid_col_view, mocker, key):
-        size = (20,)
+    def test_keypress_focus_header(self, mid_col_view, mocker, key,
+                                   widget_size):
+        size = widget_size(mid_col_view)
+        assert size != (20,), 'Incorrect size used for a Box widget'
+        assert size == (200, 20)
         mid_col_view.focus_part = 'header'
         mid_col_view.keypress(size, key)
         self.super_keypress.assert_called_once_with(size, key)
 
     @pytest.mark.parametrize('key', keys_for_command('SEARCH_MESSAGES'))
-    def test_keypress_SEARCH_MESSAGES(self, mid_col_view, mocker, key):
-        size = (20,)
+    def test_keypress_SEARCH_MESSAGES(self, mid_col_view, mocker, key,
+                                      widget_size):
+        size = widget_size(mid_col_view)
+        assert size != (20,), 'Incorrect size used for a Box widget'
+        assert size == (200, 20)
         mocker.patch(VIEWS + '.MiddleColumnView.focus_position')
         mocker.patch(VIEWS + '.MiddleColumnView.set_focus')
 
@@ -919,9 +952,11 @@ class TestMiddleColumnView:
     @pytest.mark.parametrize('enter_key', keys_for_command('ENTER'))
     @pytest.mark.parametrize('reply_message_key',
                              keys_for_command('REPLY_MESSAGE'))
-    def test_keypress_REPLY_MESSAGE(self, mid_col_view, mocker,
+    def test_keypress_REPLY_MESSAGE(self, mid_col_view, mocker, widget_size,
                                     reply_message_key, enter_key):
-        size = (20,)
+        size = widget_size(mid_col_view)
+        assert size != (20,), 'Incorrect size used for a Box widget'
+        assert size == (200, 20)
         mocker.patch(VIEWS + '.MiddleColumnView.body')
         mocker.patch(VIEWS + '.MiddleColumnView.footer')
         mocker.patch(VIEWS + '.MiddleColumnView.focus_position')
@@ -934,8 +969,11 @@ class TestMiddleColumnView:
         assert mid_col_view.footer.focus_position == 1
 
     @pytest.mark.parametrize('key', keys_for_command('STREAM_MESSAGE'))
-    def test_keypress_STREAM_MESSAGE(self, mid_col_view, mocker, key):
-        size = (20,)
+    def test_keypress_STREAM_MESSAGE(self, mid_col_view, mocker, key,
+                                     widget_size):
+        size = widget_size(mid_col_view)
+        assert size != (20,), 'Incorrect size used for a Box widget'
+        assert size == (200, 20)
         mocker.patch(VIEWS + '.MiddleColumnView.body')
         mocker.patch(VIEWS + '.MiddleColumnView.footer')
         mocker.patch(VIEWS + '.MiddleColumnView.focus_position')
@@ -948,8 +986,11 @@ class TestMiddleColumnView:
         assert mid_col_view.footer.focus_position == 0
 
     @pytest.mark.parametrize('key', keys_for_command('REPLY_AUTHOR'))
-    def test_keypress_REPLY_AUTHOR(self, mid_col_view, mocker, key):
-        size = (20,)
+    def test_keypress_REPLY_AUTHOR(self, mid_col_view, mocker, key,
+                                   widget_size):
+        size = widget_size(mid_col_view)
+        assert size != (20,), 'Incorrect size used for a Box widget'
+        assert size == (200, 20)
         mocker.patch(VIEWS + '.MiddleColumnView.body')
         mocker.patch(VIEWS + '.MiddleColumnView.footer')
         mocker.patch(VIEWS + '.MiddleColumnView.focus_position')
@@ -963,8 +1004,11 @@ class TestMiddleColumnView:
 
     @pytest.mark.parametrize('key', keys_for_command('NEXT_UNREAD_TOPIC'))
     def test_keypress_NEXT_UNREAD_TOPIC_stream(self, mid_col_view, mocker,
+                                               widget_size,
                                                key):
-        size = (20,)
+        size = widget_size(mid_col_view)
+        assert size != (20,), 'Incorrect size used for a Box widget'
+        assert size == (200, 20)
         mocker.patch(VIEWS + '.MiddleColumnView.focus_position')
         topic_btn = mocker.patch(VIEWS + '.TopicButton')
         mocker.patch(VIEWS + '.MiddleColumnView.get_next_unread_topic',
@@ -979,8 +1023,11 @@ class TestMiddleColumnView:
 
     @pytest.mark.parametrize('key', keys_for_command('NEXT_UNREAD_TOPIC'))
     def test_keypress_NEXT_UNREAD_TOPIC_no_stream(self, mid_col_view, mocker,
+                                                  widget_size,
                                                   key):
-        size = (20,)
+        size = widget_size(mid_col_view)
+        assert size != (20,), 'Incorrect size used for a Box widget'
+        assert size == (200, 20)
         mocker.patch(VIEWS + '.MiddleColumnView.focus_position')
         topic_btn = mocker.patch(VIEWS + '.TopicButton')
         mocker.patch(VIEWS + '.MiddleColumnView.get_next_unread_topic',
@@ -990,8 +1037,11 @@ class TestMiddleColumnView:
         assert return_value == key
 
     @pytest.mark.parametrize('key', keys_for_command('NEXT_UNREAD_PM'))
-    def test_keypress_NEXT_UNREAD_PM_stream(self, mid_col_view, mocker, key):
-        size = (20,)
+    def test_keypress_NEXT_UNREAD_PM_stream(self, mid_col_view, mocker, key,
+                                            widget_size):
+        size = widget_size(mid_col_view)
+        assert size != (20,), 'Incorrect size used for a Box widget'
+        assert size == (200, 20)
         mocker.patch(VIEWS + '.MiddleColumnView.focus_position')
         pm_btn = mocker.patch(VIEWS + '.UnreadPMButton')
         mocker.patch(VIEWS + '.MiddleColumnView.get_next_unread_pm',
@@ -1005,8 +1055,11 @@ class TestMiddleColumnView:
         )
 
     @pytest.mark.parametrize('key', keys_for_command('NEXT_UNREAD_PM'))
-    def test_keypress_NEXT_UNREAD_PM_no_pm(self, mid_col_view, mocker, key):
-        size = (20,)
+    def test_keypress_NEXT_UNREAD_PM_no_pm(self, mid_col_view, mocker, key,
+                                           widget_size):
+        size = widget_size(mid_col_view)
+        assert size != (20,), 'Incorrect size used for a Box widget'
+        assert size == (200, 20)
         mocker.patch(VIEWS + '.MiddleColumnView.focus_position')
         pm_btn = mocker.patch(VIEWS + '.UnreadPMButton')
         mocker.patch(VIEWS + '.MiddleColumnView.get_next_unread_pm',
@@ -1016,8 +1069,11 @@ class TestMiddleColumnView:
         assert return_value == key
 
     @pytest.mark.parametrize('key', keys_for_command('PRIVATE_MESSAGE'))
-    def test_keypress_PRIVATE_MESSAGE(self, mid_col_view, mocker, key):
-        size = (20,)
+    def test_keypress_PRIVATE_MESSAGE(self, mid_col_view, mocker, key,
+                                      widget_size):
+        size = widget_size(mid_col_view)
+        assert size != (20,), 'Incorrect size used for a Box widget'
+        assert size == (200, 20)
         mocker.patch(VIEWS + '.MiddleColumnView.focus_position')
         pm_btn = mocker.patch(VIEWS + '.UnreadPMButton')
         mocker.patch(VIEWS + '.MiddleColumnView.get_next_unread_pm',
@@ -1133,15 +1189,20 @@ class TestRightColumnView:
         assert len(right_col_view.users_btn_list) == users_btn_len
 
     @pytest.mark.parametrize('key', keys_for_command('SEARCH_PEOPLE'))
-    def test_keypress_SEARCH_PEOPLE(self, right_col_view, mocker, key):
-        size = (20,)
+    def test_keypress_SEARCH_PEOPLE(self, right_col_view, mocker, key,
+                                    widget_size):
+        size = widget_size(right_col_view)
+        assert size != (20,), 'Incorrect size used for a Box widget'
+        assert size == (200, 20)
         mocker.patch(VIEWS + ".RightColumnView.set_focus")
         right_col_view.keypress(size, key)
         right_col_view.set_focus.assert_called_once_with('header')
 
     @pytest.mark.parametrize('key', keys_for_command('GO_BACK'))
-    def test_keypress_GO_BACK(self, right_col_view, mocker, key):
-        size = (20,)
+    def test_keypress_GO_BACK(self, right_col_view, mocker, key, widget_size):
+        size = widget_size(right_col_view)
+        assert size != (20,), 'Incorrect size used for a Box widget'
+        assert size == (200, 20)
         mocker.patch(VIEWS + ".UsersView")
         mocker.patch(VIEWS + ".RightColumnView.set_focus")
         mocker.patch(VIEWS + ".RightColumnView.set_body")
@@ -1452,10 +1513,12 @@ class TestEditModeView:
         (2, 'change_all'),
     ])
     @pytest.mark.parametrize('key', keys_for_command('ENTER'))
-    def test_select_edit_mode(self, mocker, edit_mode_view,
+    def test_select_edit_mode(self, mocker, edit_mode_view, widget_size,
                               index_in_widgets, mode, key):
         radio_button = edit_mode_view.widgets[index_in_widgets]
-        size = (20, 20)
+        size = widget_size(radio_button)
+        assert size != (20, 20), 'Incorrect size for a Flow widget'
+        assert size == (20,)
 
         radio_button.keypress(size, key)
 
@@ -1495,22 +1558,26 @@ class TestStreamInfoView:
         super_keypress.assert_called_once_with(size, expected_key)
 
     @pytest.mark.parametrize('key', (*keys_for_command('ENTER'), ' '))
-    def test_checkbox_toggle_mute_stream(self, mocker, key):
+    def test_checkbox_toggle_mute_stream(self, mocker, key, widget_size):
         mute_checkbox = self.stream_info_view.widgets[3]
         toggle_mute_status = self.controller.model.toggle_stream_muted_status
         stream_id = self.stream_info_view.stream_id
-        size = (20, 20)
+        size = widget_size(mute_checkbox)
+        assert size != (20, 20), 'Incorrect size for a Flow widget'
+        assert size == (20,)
 
         mute_checkbox.keypress(size, key)
 
         toggle_mute_status.assert_called_once_with(stream_id)
 
     @pytest.mark.parametrize('key', (*keys_for_command('ENTER'), ' '))
-    def test_checkbox_toggle_pin_stream(self, mocker, key):
+    def test_checkbox_toggle_pin_stream(self, mocker, key, widget_size):
         pin_checkbox = self.stream_info_view.widgets[4]
         toggle_pin_status = self.controller.model.toggle_stream_pinned_status
         stream_id = self.stream_info_view.stream_id
-        size = (20, 20)
+        size = widget_size(pin_checkbox)
+        assert size != (20, 20), 'Incorrect size for a Flow widget'
+        assert size == (20,)
 
         pin_checkbox.keypress(size, key)
 
@@ -2654,8 +2721,11 @@ class TestStreamButton:
         assert text[0] == expected_text
 
     @pytest.mark.parametrize('key', keys_for_command('TOGGLE_TOPIC'))
-    def test_keypress_ENTER_TOGGLE_TOPIC(self, mocker, stream_button, key):
-        size = (200, 20)
+    def test_keypress_ENTER_TOGGLE_TOPIC(self, mocker, stream_button, key,
+                                         widget_size):
+        size = widget_size(stream_button)
+        assert size != (200, 20), 'Incorrect size for a Flow widget'
+        assert size == (20, )
         stream_button.view.left_panel = mocker.Mock()
         stream_button.view.left_panel.is_in_topic_view = None
         stream_button.view.left_panel.contents = [mocker.Mock(), mocker.Mock()]

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -319,13 +319,15 @@ class TestWriteBox:
                          reason="Lacking urwid-readline support")),
     ])
     def test__stream_box_autocomplete_with_spaces(self, mocker, write_box,
+                                                  widget_size,
                                                   text, expected_text):
         write_box.stream_box_view(1000)
         write_box.contents[0][0][0].set_edit_text(text)
         write_box.contents[0][0][0].set_edit_pos(len(text))
         write_box.focus_position = 0
         write_box.contents[0][0].focus_col = 0
-        size = (20,)
+        size = widget_size(write_box)
+        assert size in [(200, 20), (20, )], 'Box/Flow widget'
 
         write_box.keypress(size, keys_for_command('AUTOCOMPLETE').pop())
 
@@ -355,6 +357,7 @@ class TestWriteBox:
                              reason="Lacking urwid-readline support")),
     ])
     def test__topic_box_autocomplete_with_spaces(self, mocker, write_box,
+                                                 widget_size,
                                                  text, expected_text,
                                                  topics):
         write_box.stream_box_view(1000)
@@ -363,7 +366,8 @@ class TestWriteBox:
         write_box.contents[0][0][1].set_edit_pos(len(text))
         write_box.focus_position = 0
         write_box.contents[0][0].focus_col = 1
-        size = (20,)
+        size = widget_size(write_box)
+        assert size in [(200, 20), (20, )], 'Box/Flow widget'
 
         write_box.keypress(size, keys_for_command('AUTOCOMPLETE').pop())
 
@@ -416,6 +420,7 @@ class TestWriteBox:
     def test_keypress_SEND_MESSAGE_no_topic(self, mocker, write_box,
                                             msg_edit_id, topic_entered_by_user,
                                             topic_sent_to_server, key,
+                                            widget_size,
                                             propagate_mode='change_one'):
         write_box.stream_write_box = mocker.Mock()
         write_box.msg_write_box = mocker.Mock(edit_text='')
@@ -423,7 +428,8 @@ class TestWriteBox:
             edit_text=topic_entered_by_user
         )
         write_box.to_write_box = None
-        size = (20,)
+        size = widget_size(write_box)
+        assert size in [(200, 20), (20, )], 'Box/Flow widget'
         write_box.msg_edit_id = msg_edit_id
         write_box.edit_mode_button = mocker.Mock(mode=propagate_mode)
 
@@ -457,12 +463,14 @@ class TestWriteBox:
         ('k', True, False, True),
     ])
     def test_keypress_typeahead_mode_autocomplete_key(self, mocker, write_box,
+                                                      widget_size,
                                                       current_typeahead_mode,
                                                       expected_typeahead_mode,
                                                       expect_footer_was_reset,
                                                       key):
         write_box.is_in_typeahead_mode = current_typeahead_mode
-        size = (20,)
+        size = widget_size(write_box)
+        assert size in [(200, 20), (20, )], 'Box/Flow widget'
 
         write_box.keypress(size, key)
 
@@ -512,6 +520,7 @@ class TestWriteBox:
                                           expected_focus_col, box_type,
                                           msg_body_edit_enabled,
                                           message_being_edited,
+                                          widget_size,
                                           mocker, stream_id=10):
         if box_type == "stream":
             if message_being_edited:
@@ -522,7 +531,8 @@ class TestWriteBox:
                 write_box.stream_box_view(stream_id)
         else:
             write_box.private_box_view()
-        size = (20,)
+        size = widget_size(write_box)
+        assert size in [(200, 20), (20, )], 'Box/Flow widget'
         write_box.focus_position = initial_focus_position
         write_box.msg_body_edit_enabled = msg_body_edit_enabled
         write_box.contents[0][0].focus_col = initial_focus_col

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -327,7 +327,6 @@ class TestWriteBox:
         write_box.focus_position = 0
         write_box.contents[0][0].focus_col = 0
         size = widget_size(write_box)
-        assert size in [(200, 20), (20, )], 'Box/Flow widget'
 
         write_box.keypress(size, keys_for_command('AUTOCOMPLETE').pop())
 
@@ -367,7 +366,6 @@ class TestWriteBox:
         write_box.focus_position = 0
         write_box.contents[0][0].focus_col = 1
         size = widget_size(write_box)
-        assert size in [(200, 20), (20, )], 'Box/Flow widget'
 
         write_box.keypress(size, keys_for_command('AUTOCOMPLETE').pop())
 
@@ -429,7 +427,6 @@ class TestWriteBox:
         )
         write_box.to_write_box = None
         size = widget_size(write_box)
-        assert size in [(200, 20), (20, )], 'Box/Flow widget'
         write_box.msg_edit_id = msg_edit_id
         write_box.edit_mode_button = mocker.Mock(mode=propagate_mode)
 
@@ -470,7 +467,6 @@ class TestWriteBox:
                                                       key):
         write_box.is_in_typeahead_mode = current_typeahead_mode
         size = widget_size(write_box)
-        assert size in [(200, 20), (20, )], 'Box/Flow widget'
 
         write_box.keypress(size, key)
 
@@ -532,7 +528,6 @@ class TestWriteBox:
         else:
             write_box.private_box_view()
         size = widget_size(write_box)
-        assert size in [(200, 20), (20, )], 'Box/Flow widget'
         write_box.focus_position = initial_focus_position
         write_box.msg_body_edit_enabled = msg_body_edit_enabled
         write_box.contents[0][0].focus_col = initial_focus_col
@@ -599,7 +594,6 @@ class TestPanelSearchBox:
     def test_keypress_ENTER(self, panel_search_box, widget_size,
                             enter_key, log, expect_body_focus_set):
         size = widget_size(panel_search_box)
-        assert size == (20, )
         panel_search_box.panel_view.view.controller.is_in_editor_mode = (
             lambda: True
         )
@@ -631,7 +625,6 @@ class TestPanelSearchBox:
     @pytest.mark.parametrize("back_key", keys_for_command("GO_BACK"))
     def test_keypress_GO_BACK(self, panel_search_box, back_key, widget_size):
         size = widget_size(panel_search_box)
-        assert size == (20,)
         panel_search_box.panel_view.view.controller.is_in_editor_mode = (
             lambda: True
         )

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -586,9 +586,10 @@ class TestPanelSearchBox:
         (["SOMETHING"], True)
     ])
     @pytest.mark.parametrize("enter_key", keys_for_command("ENTER"))
-    def test_keypress_ENTER(self, panel_search_box,
+    def test_keypress_ENTER(self, panel_search_box, widget_size,
                             enter_key, log, expect_body_focus_set):
-        size = (20,)
+        size = widget_size(panel_search_box)
+        assert size == (20, )
         panel_search_box.panel_view.view.controller.is_in_editor_mode = (
             lambda: True
         )
@@ -618,8 +619,9 @@ class TestPanelSearchBox:
              .assert_not_called())
 
     @pytest.mark.parametrize("back_key", keys_for_command("GO_BACK"))
-    def test_keypress_GO_BACK(self, panel_search_box, back_key):
-        size = (20,)
+    def test_keypress_GO_BACK(self, panel_search_box, back_key, widget_size):
+        size = widget_size(panel_search_box)
+        assert size == (20,)
         panel_search_box.panel_view.view.controller.is_in_editor_mode = (
             lambda: True
         )

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -42,15 +42,17 @@ class TestEditHistoryView:
         )
 
     @pytest.mark.parametrize('key', keys_for_command('MSG_INFO'))
-    def test_keypress_exit_popup(self, key):
-        size = (200, 20)
+    def test_keypress_exit_popup(self, key, widget_size):
+        size = widget_size(self.edit_history_view)
+        assert size == (200, 20)
 
         self.edit_history_view.keypress(size, key)
 
         assert self.controller.exit_popup.called
 
-    def test_keypress_exit_popup_invalid_key(self):
-        size = (200, 20)
+    def test_keypress_exit_popup_invalid_key(self, widget_size):
+        size = widget_size(self.edit_history_view)
+        assert size == (200, 20)
         key = 'a'
 
         self.edit_history_view.keypress(size, key)
@@ -59,8 +61,9 @@ class TestEditHistoryView:
 
     @pytest.mark.parametrize('key', {*keys_for_command('EDIT_HISTORY'),
                                      *keys_for_command('GO_BACK')})
-    def test_keypress_show_msg_info(self, key):
-        size = (200, 20)
+    def test_keypress_show_msg_info(self, key, widget_size):
+        size = widget_size(self.edit_history_view)
+        assert size == (200, 20)
 
         self.edit_history_view.keypress(size, key)
 
@@ -70,9 +73,10 @@ class TestEditHistoryView:
             time_mentions=list(),
         )
 
-    def test_keypress_navigation(self, mocker,
+    def test_keypress_navigation(self, mocker, widget_size,
                                  navigation_key_expected_key_pair):
-        size = (200, 20)
+        size = widget_size(self.edit_history_view)
+        assert size == (200, 20)
         key, expected_key = navigation_key_expected_key_pair
         super_keypress = mocker.patch(VIEWS + '.urwid.ListBox.keypress')
 

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -44,7 +44,6 @@ class TestEditHistoryView:
     @pytest.mark.parametrize('key', keys_for_command('MSG_INFO'))
     def test_keypress_exit_popup(self, key, widget_size):
         size = widget_size(self.edit_history_view)
-        assert size == (200, 20)
 
         self.edit_history_view.keypress(size, key)
 
@@ -52,7 +51,6 @@ class TestEditHistoryView:
 
     def test_keypress_exit_popup_invalid_key(self, widget_size):
         size = widget_size(self.edit_history_view)
-        assert size == (200, 20)
         key = 'a'
 
         self.edit_history_view.keypress(size, key)
@@ -63,7 +61,6 @@ class TestEditHistoryView:
                                      *keys_for_command('GO_BACK')})
     def test_keypress_show_msg_info(self, key, widget_size):
         size = widget_size(self.edit_history_view)
-        assert size == (200, 20)
 
         self.edit_history_view.keypress(size, key)
 
@@ -76,7 +73,6 @@ class TestEditHistoryView:
     def test_keypress_navigation(self, mocker, widget_size,
                                  navigation_key_expected_key_pair):
         size = widget_size(self.edit_history_view)
-        assert size == (200, 20)
         key, expected_key = navigation_key_expected_key_pair
         super_keypress = mocker.patch(VIEWS + '.urwid.ListBox.keypress')
 


### PR DESCRIPTION
The PR has been updated to use a factory fixture instead. This would help in compacting our tests and also correcting our keypress sizes (see asserts in the code).

Every `Use/Migrate ...` commit adds extra assert statements for sanity-check and every `Remove ...` commit removes those statements along with `size`. These are ordered alternatively, so we could either squash them in pair or let them be as-is.

The prior discussion for this can be found here: https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/Compacting.20tests.