### PR TITLE
docker: Add dockerfile for building images from latest code (upstream).

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ url = "https://pypi.python.org/simple"
 name = "pypi"
 
 [packages]
-urwid = "~=2.1.1"
+urwid = "~=2.1.2"
 zulip = ">=0.7.0"
 urwid-readline = ">=0.11"
 beautifulsoup4 = ">=4.9.0"

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -8,8 +8,8 @@ RUN addgroup -S zulipgr \
 USER zulip
 WORKDIR /home/zulip
 
-RUN set -ex; python3 -m venv zulip-terminal-venv \
-    && source zulip-terminal-venv/bin/activate \
+RUN set -ex; python3 -m venv zt_venv \
+    && source zt_venv/bin/activate \
     && pip3 --disable-pip-version-check install zulip-term \
     && rm -rf /home/zulip/.cache
 
@@ -23,5 +23,5 @@ RUN addgroup -S zulipgr \
 COPY --from=builder --chown=zulip:zulipgr /home/zulip /home/zulip
 USER zulip
 WORKDIR /home/zulip
-ENTRYPOINT ["/home/zulip/zulip-terminal-venv/bin/zulip-term"]
+ENTRYPOINT ["/home/zulip/zt_venv/bin/zulip-term"]
 CMD ["--config-file", "/.zulip/zuliprc"]

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -1,23 +1,24 @@
 FROM python:3.7-alpine AS builder
 
 RUN addgroup -S zulipgr \
-&& adduser -S zulip -G zulipgr \
-&& apk add --no-cache ca-certificates gcc musl-dev libffi-dev openssl-dev libxml2-dev libxslt-dev
-
+    && adduser -S zulip -G zulipgr \
+    && apk add --no-cache ca-certificates gcc musl-dev \
+                          libffi-dev openssl-dev libxml2-dev \
+                          libxslt-dev
 USER zulip
 WORKDIR /home/zulip
 
 RUN set -ex; python3 -m venv zulip-terminal-venv \
-&& source zulip-terminal-venv/bin/activate \
-&& pip3 --disable-pip-version-check install zulip-term \
-&& rm -rf /home/zulip/.cache
+    && source zulip-terminal-venv/bin/activate \
+    && pip3 --disable-pip-version-check install zulip-term \
+    && rm -rf /home/zulip/.cache
 
 FROM python:3.7-alpine
 
 RUN addgroup -S zulipgr \
-&& adduser -S zulip -G zulipgr \
-&& apk add --no-cache ca-certificates libffi openssl libxml2 libxslt \
-&& rm -rf /var/cache/apk/*
+    && adduser -S zulip -G zulipgr \
+    && apk add --no-cache ca-certificates libffi openssl libxml2 libxslt \
+    && rm -rf /var/cache/apk/*
 
 COPY --from=builder --chown=zulip:zulipgr /home/zulip /home/zulip
 USER zulip

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -2,15 +2,23 @@ FROM python:3.7-alpine AS builder
 
 RUN addgroup -S zulipgr \
     && adduser -S zulip -G zulipgr \
-    && apk add --no-cache ca-certificates gcc musl-dev \
+    && apk add --no-cache git ca-certificates gcc musl-dev \
                           libffi-dev openssl-dev libxml2-dev \
                           libxslt-dev
 USER zulip
 WORKDIR /home/zulip
 
+ARG SOURCE=pypi
+ARG GIT_URL=https://github.com/zulip/zulip-terminal.git@master
+
 RUN set -ex; python3 -m venv zt_venv \
     && source zt_venv/bin/activate \
-    && pip3 --disable-pip-version-check install zulip-term \
+    && if [ "$SOURCE" = "pypi" ] ; \
+        then pip3 --disable-pip-version-check install zulip-term ; \
+       fi\
+    && if [ "$SOURCE" = "git" ] ; \
+        then pip3 --disable-pip-version-check install git+$GIT_URL; \
+       fi \
     && rm -rf /home/zulip/.cache
 
 FROM python:3.7-alpine

--- a/docker/Dockerfile.buster
+++ b/docker/Dockerfile.buster
@@ -4,8 +4,8 @@ RUN useradd --user-group --create-home zulip
 USER zulip
 WORKDIR /home/zulip
 
-RUN set -ex; python3 -m venv zulip-terminal-venv \
-    && . zulip-terminal-venv/bin/activate \
+RUN set -ex; python3 -m venv zt_venv \
+    && . zt_venv/bin/activate \
     && pip3 --disable-pip-version-check install zulip-term \
     && rm -rf /home/zulip/.cache
 
@@ -15,5 +15,5 @@ RUN useradd --user-group --create-home zulip
 COPY --from=builder --chown=zulip:zulip /home/zulip /home/zulip
 USER zulip
 WORKDIR /home/zulip
-ENTRYPOINT ["/home/zulip/zulip-terminal-venv/bin/zulip-term"]
+ENTRYPOINT ["/home/zulip/zt_venv/bin/zulip-term"]
 CMD ["--config-file", "/.zulip/zuliprc"]

--- a/docker/Dockerfile.buster
+++ b/docker/Dockerfile.buster
@@ -5,9 +5,9 @@ USER zulip
 WORKDIR /home/zulip
 
 RUN set -ex; python3 -m venv zulip-terminal-venv \
-&& . zulip-terminal-venv/bin/activate \
-&& pip3 --disable-pip-version-check install zulip-term \
-&& rm -rf /home/zulip/.cache
+    && . zulip-terminal-venv/bin/activate \
+    && pip3 --disable-pip-version-check install zulip-term \
+    && rm -rf /home/zulip/.cache
 
 FROM python:3.7-slim-buster
 

--- a/docker/Dockerfile.buster
+++ b/docker/Dockerfile.buster
@@ -4,9 +4,17 @@ RUN useradd --user-group --create-home zulip
 USER zulip
 WORKDIR /home/zulip
 
+ARG SOURCE=pypi
+ARG GIT_URL=https://github.com/zulip/zulip-terminal.git@master
+
 RUN set -ex; python3 -m venv zt_venv \
     && . zt_venv/bin/activate \
-    && pip3 --disable-pip-version-check install zulip-term \
+    && if [ "$SOURCE" = "pypi" ] ; \
+        then pip3 --disable-pip-version-check install zulip-term ; \
+       fi\
+    && if [ "$SOURCE" = "git" ] ; \
+        then pip3 --disable-pip-version-check install git+$GIT_URL; \
+       fi \
     && rm -rf /home/zulip/.cache
 
 FROM python:3.7-slim-buster

--- a/docker/README.md
+++ b/docker/README.md
@@ -6,6 +6,8 @@ We assume users have Docker correctly installed on their computer if they wish t
 
 # Running Zulip Terminal with Docker
 
+## Quick Start
+
 To run `zulip-terminal` with docker, take the following steps:
 
 ```sh
@@ -14,6 +16,8 @@ git clone --depth=1 git@github.com:zulip/zulip-terminal.git
 cd zulip-terminal/docker
 
 # Build the docker image with your preferred Dockerfile, here based on Alpine
+
+# To build the image with the latest release from PyPI.
 docker build -t zulip-terminal:latest -f Dockerfile.alpine .
 
 # Run zulip-terminal image and setup your zulip for the first time
@@ -22,6 +26,17 @@ mkdir $HOME/.zulip
 docker run -it -v $HOME/.zulip:/.zulip zulip-terminal:latest
 ```
 
+## Advanced Setup
+
+Images built using the `docker build` command above, implicitly use `SOURCE=pypi` to run the [latest pypi release of Zulip-Terminal](https://pypi.org/project/zulip-term/). If you wish to use the latest code available in development (master) branch of the zulip-terminal repository then `SOURCE=git` can be passed as a build argument.
+
+```sh
+# To build docker image with the latest code in the master branch
+docker build -t zulip-terminal:latest -f Dockerfile.alpine . --build-arg SOURCE=git
+
+# In case you want to build the image with code from another branch, use GIT_URL to pass the appropriate remote and branch names
+docker build -t zulip-terminal:latest -f Dockerfile.alpine . --build-arg SOURCE=git --build-arg GIT_URL=https://github.com/zulip/zulip-terminal.git@master
+```
+
 You can swap `Dockerfile.alpine` for `Dockerfile.buster` if you prefer running inside image based on Debian instead of Alpine. The main advantage of Alpine is a better use of resources. The final Alpine docker image has a size of 150MB while the Debian image takes 221MB of disk space.
 
-**NOTE**: The current Dockerfiles contain instructions to use the `zulip-terminal` version published to PyPI and source code in the repository is not used.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-urwid~=2.1.1
+urwid~=2.1.2
 zulip>=0.7.0
 typing_extensions>=3.7
 

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ setup(
     },
     tests_require=testing_deps,
     install_requires=[
-        'urwid~=2.1.1',
+        'urwid~=2.1.2',
         'zulip>=0.7.0',
         'urwid_readline>=0.11',
         'beautifulsoup4>=4.9.0',


### PR DESCRIPTION
The current docker files in docker/Dockerfile.* build images by pulling
our releases from pypi. This commit introduces the 2 docker files at
docker/dev.Dockerfile.* which build images by using the latest code from
master, merged upstream.

README updated to reflect the new change.