### PR TITLE
Refactor autocomplete methods

### DIFF
--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -23,86 +23,73 @@ class TestWriteBox:
         assert write_box.view == self.view
         assert write_box.msg_edit_id is None
 
-    @pytest.mark.parametrize('text, prefix_string, state', [
-        ('@Boo', '@', 0),
-        ('@Boo', '@', 1),
-        ('@_Boo', '@_', 0),
-        ('@_Boo', '@_', 1),
-        ('Plain Text', '', 0),
-        ('Plain Text', '', 1),
+    @pytest.mark.parametrize('text, state', [
+        ('Plain Text', 0),
+        ('Plain Text', 1),
     ])
-    def test_generic_autocomplete(self, mocker, write_box, text,
-                                  prefix_string, state):
-        autocomplete_mentions = mocker.patch(WRITEBOX+'.autocomplete_mentions')
+    def test_generic_autocomplete_no_prefix(self, mocker, write_box, text,
+                                            state):
         return_val = write_box.generic_autocomplete(text, state)
-        if prefix_string == '':
-            assert return_val == text
-        else:
-            autocomplete_mentions.assert_called_once_with(text, state,
-                                                          prefix_string)
+        assert return_val == text
 
-    @pytest.mark.parametrize('text, state, prefix_string,\
-                              required_typeahead', [
-        ('@Human', 0, '@', '@**Human Myself**'),
-        ('@Human', 1, '@', '@**Human 1**'),
-        ('@Human', 2, '@', '@**Human 2**'),
-        ('@Human', -1, '@', '@**Human 2**'),
-        ('@Human', -2, '@', '@**Human 1**'),
-        ('@Human', -3, '@', '@**Human Myself**'),
-        ('@Human', -4, '@', None),
-        ('@_Human', 0, '@_', '@_**Human Myself**'),
-        ('@_Human', 1, '@_', '@_**Human 1**'),
-        ('@_Human', 2, '@_', '@_**Human 2**'),
-        ('@H', 1, '@', '@**Human 1**'),
-        ('@Hu', 1, '@', '@**Human 1**'),
-        ('@Hum', 1, '@', '@**Human 1**'),
-        ('@Huma', 1, '@', '@**Human 1**'),
-        ('@Human', 1, '@', '@**Human 1**'),
-        ('@Human 1', 0, '@', '@**Human 1**'),
-        ('@_H', 1, '@_', '@_**Human 1**'),
-        ('@_Hu', 1, '@_', '@_**Human 1**'),
-        ('@_Hum', 1, '@_', '@_**Human 1**'),
-        ('@_Huma', 1, '@_', '@_**Human 1**'),
-        ('@_Human', 1, '@_', '@_**Human 1**'),
-        ('@_Human 1', 0, '@_', '@_**Human 1**'),
-        ('@Group', 0, '@', '@*Group 1*'),
-        ('@Group', 1, '@', '@*Group 2*'),
-        ('@G', 0, '@', '@*Group 1*'),
-        ('@Gr', 0, '@', '@*Group 1*'),
-        ('@Gro', 0, '@', '@*Group 1*'),
-        ('@Grou', 0, '@', '@*Group 1*'),
-        ('@G', 1, '@', '@*Group 2*'),
-        ('@Gr', 1, '@', '@*Group 2*'),
-        ('@Gro', 1, '@', '@*Group 2*'),
-        ('@Grou', 1, '@', '@*Group 2*'),
-        ('No match', 1, '', None),
-        ('No match', -1, '', None),
+    @pytest.mark.parametrize('text, state, required_typeahead', [
+        ('@Human', 0, '@**Human Myself**'),
+        ('@Human', 1, '@**Human 1**'),
+        ('@Human', 2, '@**Human 2**'),
+        ('@Human', -1, '@**Human 2**'),
+        ('@Human', -2, '@**Human 1**'),
+        ('@Human', -3, '@**Human Myself**'),
+        ('@Human', -4, None),
+        ('@_Human', 0, '@_**Human Myself**'),
+        ('@_Human', 1, '@_**Human 1**'),
+        ('@_Human', 2, '@_**Human 2**'),
+        ('@H', 1, '@**Human 1**'),
+        ('@Hu', 1, '@**Human 1**'),
+        ('@Hum', 1, '@**Human 1**'),
+        ('@Huma', 1, '@**Human 1**'),
+        ('@Human', 1, '@**Human 1**'),
+        ('@Human 1', 0, '@**Human 1**'),
+        ('@_H', 1, '@_**Human 1**'),
+        ('@_Hu', 1, '@_**Human 1**'),
+        ('@_Hum', 1, '@_**Human 1**'),
+        ('@_Huma', 1, '@_**Human 1**'),
+        ('@_Human', 1, '@_**Human 1**'),
+        ('@_Human 1', 0, '@_**Human 1**'),
+        ('@Group', 0, '@*Group 1*'),
+        ('@Group', 1, '@*Group 2*'),
+        ('@G', 0, '@*Group 1*'),
+        ('@Gr', 0, '@*Group 1*'),
+        ('@Gro', 0, '@*Group 1*'),
+        ('@Grou', 0, '@*Group 1*'),
+        ('@G', 1, '@*Group 2*'),
+        ('@Gr', 1, '@*Group 2*'),
+        ('@Gro', 1, '@*Group 2*'),
+        ('@Grou', 1, '@*Group 2*'),
         # Expected sequence of autocompletes from '@'
-        ('@', 0, '@', '@*Group 1*'),
-        ('@', 1, '@', '@*Group 2*'),
-        ('@', 2, '@', '@*Group 3*'),
-        ('@', 3, '@', '@*Group 4*'),
-        ('@', 4, '@', '@**Human Myself**'),
-        ('@', 5, '@', '@**Human 1**'),
-        ('@', 6, '@', '@**Human 2**'),
-        ('@', 7, '@', None),  # Reached last match
-        ('@', 8, '@', None),  # Beyond end
+        ('@', 0, '@*Group 1*'),
+        ('@', 1, '@*Group 2*'),
+        ('@', 2, '@*Group 3*'),
+        ('@', 3, '@*Group 4*'),
+        ('@', 4, '@**Human Myself**'),
+        ('@', 5, '@**Human 1**'),
+        ('@', 6, '@**Human 2**'),
+        ('@', 7, None),  # Reached last match
+        ('@', 8, None),  # Beyond end
         # Expected sequence of autocompletes from '@_'
-        ('@_', 0, '@_', '@_**Human Myself**'),  # NOTE: No silent group mention
-        ('@_', 1, '@_', '@_**Human 1**'),
-        ('@_', 2, '@_', '@_**Human 2**'),
-        ('@_', 3, '@_', None),  # Reached last match
-        ('@_', 4, '@_', None),  # Beyond end
-        ('@_', -1, '@_', '@_**Human 2**'),
+        ('@_', 0, '@_**Human Myself**'),  # NOTE: No silent group mention
+        ('@_', 1, '@_**Human 1**'),
+        ('@_', 2, '@_**Human 2**'),
+        ('@_', 3, None),  # Reached last match
+        ('@_', 4, None),  # Beyond end
+        ('@_', -1, '@_**Human 2**'),
     ])
-    def test_autocomplete_mentions(self, write_box, users_fixture,
-                                   text, state, prefix_string,
-                                   required_typeahead, user_groups_fixture):
+    def test_generic_autocomplete_mentions(self, write_box, users_fixture,
+                                           text, state, required_typeahead,
+                                           user_groups_fixture):
         write_box.view.users = users_fixture
         write_box.model.user_group_names = [
             groups['name'] for groups in user_groups_fixture]
-        typeahead_string = write_box.autocomplete_mentions(
-            text, state, prefix_string)
+        typeahead_string = write_box.generic_autocomplete(text, state)
         assert typeahead_string == required_typeahead
 
     @pytest.mark.parametrize('text, state, required_typeahead', [
@@ -124,18 +111,16 @@ class TestWriteBox:
         ('#St', 0, '#**Stream 1**'),
         ('#St', 1, '#**Stream 2**'),
         ('#Stream 1', 0, '#**Stream 1**'),
-        ('No match', 0, None),
-        ('No match', -1, None)
     ])
-    def test_autocomplete_streams(self, write_box, streams_fixture,
-                                  text, state, required_typeahead):
+    def test_generic_autocomplete_streams(self, write_box, streams_fixture,
+                                          text, state, required_typeahead):
         write_box.view.pinned_streams = [
             [stream['name']] for stream in
             streams_fixture[:len(streams_fixture)//2]]
         write_box.view.unpinned_streams = [
             [stream['name']] for stream in
             streams_fixture[len(streams_fixture)//2:]]
-        typeahead_string = write_box.autocomplete_streams(text, state)
+        typeahead_string = write_box.generic_autocomplete(text, state)
         assert typeahead_string == required_typeahead
 
     @pytest.mark.parametrize('text, state, required_typeahead', [
@@ -153,13 +138,12 @@ class TestWriteBox:
         (':', 1, ':joker:'),
         (':', -2, ':smiley:'),
         (':', -1, ':smirk:'),
-        ('no match', 0, None),
         (':nomatch', 0, None),
         (':nomatch', -1, None),
         ])
-    def test_autocomplete_emojis(self, write_box, emojis_fixture, mocker,
-                                 text, state, required_typeahead):
+    def test_generic_autocomplete_emojis(self, write_box, emojis_fixture, text,
+                                         mocker, state, required_typeahead):
         emoji_names = mocker.patch('zulipterminal.ui_tools.boxes.emoji_names')
         emoji_names.EMOJI_NAMES = emojis_fixture
-        typeahead_string = write_box.autocomplete_emojis(text, state)
+        typeahead_string = write_box.generic_autocomplete(text, state)
         assert typeahead_string == required_typeahead

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -1,5 +1,6 @@
 import pytest
 
+import zulipterminal.emoji_names
 from zulipterminal.ui_tools.boxes import WriteBox
 
 
@@ -156,8 +157,9 @@ class TestWriteBox:
         (':nomatch', 0, None),
         (':nomatch', -1, None),
         ])
-    def test_autocomplete_emojis(self, write_box, emojis_fixture,
+    def test_autocomplete_emojis(self, write_box, emojis_fixture, mocker,
                                  text, state, required_typeahead):
-        typeahead_string = write_box.autocomplete_emojis(text,
-                                                         state, emojis_fixture)
+        emoji_names = mocker.patch('zulipterminal.ui_tools.boxes.emoji_names')
+        emoji_names.EMOJI_NAMES = emojis_fixture
+        typeahead_string = write_box.autocomplete_emojis(text, state)
         assert typeahead_string == required_typeahead

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -461,7 +461,7 @@ def match_stream(stream: Any, text: str) -> bool:
     return False
 
 
-def match_groups(group_name: str, text: str) -> bool:
+def match_group(group_name: str, text: str) -> bool:
     """
     True if any group name matches with `text` (case insensitive),
     False otherwise.

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -11,8 +11,8 @@ from bs4 import BeautifulSoup
 from bs4.element import NavigableString, Tag
 from urwid_readline import ReadlineEdit
 
+from zulipterminal import emoji_names
 from zulipterminal.config.keys import is_command_key, keys_for_command
-from zulipterminal.emoji_names import EMOJI_NAMES
 from zulipterminal.helper import (
     Message, match_emoji, match_groups, match_stream, match_user,
 )
@@ -134,9 +134,8 @@ class WriteBox(urwid.Pile):
         except (IndexError, TypeError):
             return None
 
-    def autocomplete_emojis(self, text: str, state: int,
-                            emoji_list: List[str] = EMOJI_NAMES
-                            ) -> Optional[str]:
+    def autocomplete_emojis(self, text: str, state: int) -> Optional[str]:
+        emoji_list = emoji_names.EMOJI_NAMES
         emoji_typeahead = [':{}:'.format(emoji)
                            for emoji in emoji_list
                            if match_emoji(emoji, text[1:])]

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -14,7 +14,7 @@ from urwid_readline import ReadlineEdit
 from zulipterminal import emoji_names
 from zulipterminal.config.keys import is_command_key, keys_for_command
 from zulipterminal.helper import (
-    Message, match_emoji, match_groups, match_stream, match_user,
+    Message, match_emoji, match_group, match_stream, match_user,
 )
 from zulipterminal.urwid_types import urwid_Size
 
@@ -117,7 +117,7 @@ class WriteBox(urwid.Pile):
         # and group mentions.
         group_typeahead = ['@*{}*'.format(group_name)
                            for group_name in self.model.user_group_names
-                           if match_groups(group_name, text[1:])]
+                           if match_group(group_name, text[1:])]
 
         users_list = self.view.users
         user_typeahead = [prefix_string+'**{}**'.format(user['full_name'])


### PR DESCRIPTION
As per the new changes, adding the footer text for typeaheads will now cause changes only in the `generic_autocomplete` method. This should decrease a lot of redundancy faced in #540 