### PR TITLE
Show tutorial at startup

### DIFF
--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -2,6 +2,7 @@ from platform import platform
 from typing import Any
 
 import pytest
+from urwid import Filler
 
 from zulipterminal.core import Controller
 from zulipterminal.version import ZT_VERSION
@@ -201,6 +202,18 @@ class TestController:
         widgets = controller.model.msg_view.extend.call_args_list[0][0][0]
         msg_ids = {widget.original_widget.message['id'] for widget in widgets}
         assert msg_ids == id_list
+
+    def test_set_loading_view(self, controller):
+        controller.set_loading_view()
+        assert isinstance(controller.loading_view, Filler)
+
+    def test_show_main_view(self, mocker, controller):
+        controller.loop = mocker.Mock()
+        controller.update_screen = mocker.Mock()
+
+        controller.show_main_view()
+        assert controller.loop.widget == controller.view
+        controller.update_screen.assert_called_once_with()
 
     def test_main(self, mocker, controller):
         ret_mock = mocker.Mock()

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -12,9 +12,9 @@ from zulipterminal.ui_tools.buttons import (
     StreamButton, TopButton, TopicButton, UserButton,
 )
 from zulipterminal.ui_tools.views import (
-    HelpView, LeftColumnView, MessageView, MiddleColumnView, ModListWalker,
-    MsgInfoView, PopUpConfirmationView, PopUpView, RightColumnView,
-    StreamInfoView, StreamsView, TopicsView, UsersView,
+    HelpView, LeftColumnView, LoadingView, MessageView, MiddleColumnView,
+    ModListWalker, MsgInfoView, PopUpConfirmationView, PopUpView,
+    RightColumnView, StreamInfoView, StreamsView, TopicsView, UsersView,
 )
 
 
@@ -2225,3 +2225,14 @@ class TestTopicButton:
             mark_muted.assert_called_once_with()
         else:
             mark_muted.assert_not_called()
+
+
+class TestLoadingView:
+    @pytest.fixture
+    def loading_view(self, mocker):
+        self.text = "Random Text"
+        loading_view = LoadingView(self.text)
+        return loading_view
+
+    def test_init(self, loading_view):
+        assert loading_view.text == self.text

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -2231,8 +2231,16 @@ class TestLoadingView:
     @pytest.fixture
     def loading_view(self, mocker):
         self.text = "Random Text"
-        loading_view = LoadingView(self.text)
+        self.controller = mocker.Mock()
+        self.align = "left"
+        loading_view = LoadingView(self.controller,
+                                   self.text, self.align)
         return loading_view
 
     def test_init(self, loading_view):
         assert loading_view.text == self.text
+
+    @pytest.mark.parametrize('key', ['enter'])
+    def test_keypress_enter(self, loading_view, key):
+        loading_view.keypress((20, 20), key)
+        loading_view.controller.show_main_view.assert_called_once_with()

--- a/zulipterminal/config/tutorial.py
+++ b/zulipterminal/config/tutorial.py
@@ -1,0 +1,18 @@
+# Tutorial to display at start
+TUTORIAL = [
+    ('active', 'Welcome to Zulip!\n'),
+    '\nPlease go through this tutorial to understand the \n'
+    'basic workflow of zulip-terminal.',
+    ('unread', '\nMoving around\n'),
+    '- You can use arrow keys or `j`/`k`/`l`/`m` keys to move around and'
+    '`esc` to go back or move out of narrow.',
+    ('unread', '\nFor Reading\n'),
+    '- Use the left sidebar (or the `n` key) to review messages '
+    'thread-by-thread.\n',
+    '- Use the End key to mark all messages in the current view as read.',
+    ('unread', '\nFor Writing\n'),
+    '- To reply to a message or use `r` or `Enter`.\n',
+    '- You can type your message in the bottom big box and send it using'
+    ' `ctrl d` or alt enter.\n'
+    '- To compose a new stream message press `c`\n',
+]

--- a/zulipterminal/config/tutorial.py
+++ b/zulipterminal/config/tutorial.py
@@ -14,5 +14,6 @@ TUTORIAL = [
     '- To reply to a message or use `r` or `Enter`.\n',
     '- You can type your message in the bottom big box and send it using'
     ' `ctrl d` or alt enter.\n'
-    '- To compose a new stream message press `c`\n',
+    '- To compose a new stream message press `c`\n\n\n',
+    'Press `Enter` to continue',
 ]

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -897,3 +897,9 @@ class MsgInfoView(PopUpView):
              for index, (field, data) in enumerate(msg_info.items())]
 
         super().__init__(controller, msg_info_content, 'MSG_INFO')
+
+
+class LoadingView(urwid.Text):
+
+    def selectable(self) -> bool:
+        return True

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -6,7 +6,7 @@ from typing import Any, Callable, List, Optional, Tuple
 import urwid
 
 from zulipterminal.config.keys import (
-    HELP_CATEGORIES, KEY_BINDINGS, is_command_key,
+    HELP_CATEGORIES, KEY_BINDINGS, is_command_key, keys_for_command,
 )
 from zulipterminal.helper import Message, asynch, match_user
 from zulipterminal.ui_tools.boxes import PanelSearchBox
@@ -900,6 +900,15 @@ class MsgInfoView(PopUpView):
 
 
 class LoadingView(urwid.Text):
+    def __init__(self, controller: Any, text: List[object],
+                 align: str) -> None:
+        self.controller = controller
+        super().__init__(text, align)
 
     def selectable(self) -> bool:
         return True
+
+    def keypress(self, size: Tuple[int, int], key: str) -> str:
+        if key == keys_for_command('ENTER').pop():
+            self.controller.show_main_view()
+        return key


### PR DESCRIPTION
Currently this is a v1 implementation of @amanagr's #457 
Follow-ups:

- [ ] Add option to skip tutorial at next startup
- [ ]  Add options to modify config values.
- [ ]  Modify config options on the fly
- [ ]  Replace current loading text with LoadingView