### PR TITLE
Message reactions: Add spacing and refactor

### DIFF
--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -376,18 +376,23 @@ class MessageBox(urwid.Pile):
                     std_reaction_stats[reaction['emoji_code']] += 1
                 else:
                     # Includes realm_emoji and zulip_extra_emoji
-                    custom_reaction_stats[":"+reaction['emoji_name']+":"] += 1
-            dis = [
-                '\\U{:0>8} {} '.format(reaction, count)
+                    custom_reaction_stats[reaction['emoji_name']] += 1
+
+            std_reactions = [
+                '{} {} '.format(
+                    '\\U{:0>8}'.format(reaction)
+                    .encode().decode('unicode-escape'),
+                    count)
                 for reaction, count in std_reaction_stats.items()
             ]
-            emojis = ''.join(e.encode().decode('unicode-escape') for e in dis)
-            custom_emojis = ''.join(
-                ['{} {} '.format(reaction, count)
-                 for reaction, count in custom_reaction_stats.items()])
+            custom_reactions = [
+                ':{}: {} '.format(reaction, count)
+                for reaction, count in custom_reaction_stats.items()
+            ]
+            all_emoji_text = ''.join(std_reactions + custom_reactions)
             return urwid.Padding(
                 urwid.Text(([
-                    ('reaction', emoji.demojize(emojis + custom_emojis))
+                    ('reaction', emoji.demojize(all_emoji_text))
                 ])), align='left', width=('relative', 90), left=25,
                 min_width=50)
         except Exception:

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -377,8 +377,9 @@ class MessageBox(urwid.Pile):
                     # Includes realm_emoji and zulip_extra_emoji
                     custom_reacts[":"+reaction['emoji_name']+":"] += 1
             dis = [
-                '\\U' + '0'*(8-len(emoji)) + emoji + ' ' + str(reacts[emoji]) +
-                ' ' for emoji in reacts]
+                '\\U{:0>8} {} '.format(emoji, reacts[emoji])
+                for emoji in reacts
+            ]
             emojis = ''.join(e.encode().decode('unicode-escape') for e in dis)
             custom_emojis = ''.join(
                 ['{} {} '.format(r, custom_reacts[r]) for r in custom_reacts])

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -377,12 +377,13 @@ class MessageBox(urwid.Pile):
                     # Includes realm_emoji and zulip_extra_emoji
                     custom_reacts[":"+reaction['emoji_name']+":"] += 1
             dis = [
-                '\\U{:0>8} {} '.format(emoji, reacts[emoji])
-                for emoji in reacts
+                '\\U{:0>8} {} '.format(reaction, count)
+                for reaction, count in reacts.items()
             ]
             emojis = ''.join(e.encode().decode('unicode-escape') for e in dis)
             custom_emojis = ''.join(
-                ['{} {} '.format(r, custom_reacts[r]) for r in custom_reacts])
+                ['{} {} '.format(reaction, count)
+                 for reaction, count in custom_reacts.items()])
             return urwid.Padding(
                 urwid.Text(([
                     ('reaction', emoji.demojize(emojis + custom_emojis))

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -379,22 +379,25 @@ class MessageBox(urwid.Pile):
                     custom_reaction_stats[reaction['emoji_name']] += 1
 
             std_reactions = [
-                '{} {} '.format(
+                '{} {}'.format(
                     '\\U{:0>8}'.format(reaction)
                     .encode().decode('unicode-escape'),
                     count)
                 for reaction, count in std_reaction_stats.items()
             ]
             custom_reactions = [
-                ':{}: {} '.format(reaction, count)
+                ':{}: {}'.format(reaction, count)
                 for reaction, count in custom_reaction_stats.items()
             ]
-            all_emoji_text = ''.join(std_reactions + custom_reactions)
+            all_emoji = std_reactions + custom_reactions
+            spaced_emoji = [
+                ('reaction', emoji.demojize(entry)) if entry != ' ' else entry
+                for pair in zip(all_emoji, ' ' * len(all_emoji))
+                for entry in pair
+            ]
             return urwid.Padding(
-                urwid.Text(([
-                    ('reaction', emoji.demojize(all_emoji_text))
-                ])), align='left', width=('relative', 90), left=25,
-                min_width=50)
+                urwid.Text(spaced_emoji),
+                align='left', width=('relative', 90), left=25, min_width=50)
         except Exception:
             return ''
 

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -1,4 +1,5 @@
-from collections import defaultdict
+import typing
+from collections import Counter, defaultdict
 from datetime import date, datetime
 from sys import platform
 from time import ctime, time
@@ -368,22 +369,22 @@ class MessageBox(urwid.Pile):
         if not reactions:
             return ''
         try:
-            reacts = defaultdict(int)  # type: Dict[str, int]
-            custom_reacts = defaultdict(int)  # type: Dict[str, int]
+            std_reaction_stats = Counter()  # type: typing.Counter[str]
+            custom_reaction_stats = Counter()  # type: typing.Counter[str]
             for reaction in reactions:
                 if reaction['reaction_type'] == 'unicode_emoji':
-                    reacts[reaction['emoji_code']] += 1
+                    std_reaction_stats[reaction['emoji_code']] += 1
                 else:
                     # Includes realm_emoji and zulip_extra_emoji
-                    custom_reacts[":"+reaction['emoji_name']+":"] += 1
+                    custom_reaction_stats[":"+reaction['emoji_name']+":"] += 1
             dis = [
                 '\\U{:0>8} {} '.format(reaction, count)
-                for reaction, count in reacts.items()
+                for reaction, count in std_reaction_stats.items()
             ]
             emojis = ''.join(e.encode().decode('unicode-escape') for e in dis)
             custom_emojis = ''.join(
                 ['{} {} '.format(reaction, count)
-                 for reaction, count in custom_reacts.items()])
+                 for reaction, count in custom_reaction_stats.items()])
             return urwid.Padding(
                 urwid.Text(([
                     ('reaction', emoji.demojize(emojis + custom_emojis))


### PR DESCRIPTION
I was diving into this code to look into the `:crossed_fingers:` vs `:fingers_crossed` situation and noticed this code could be cleaner.

This PR is mainly refactoring to make this clearer to read and more pythonic.

However, partly as a result of the refactoring (or vice versa) this PR adds "unstyled spaces" between reactions - this is particularly noticeable for messages such as in **#announce** with lots of reactions (and of different types), and clearly associates the number with the reaction itself (particularly when the message is selected). The other side effect is that there is also no trailing "styled" space.