### PR TITLE
README/helper: Support notification sound for OSX.

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,21 @@ set-executionpolicy remotesigned
 Install-Module -Name BurntToast
 ```
 
+#### OSX
+
+No additional package is required to enable notifications in OS X. However to have a notification sound, set the following variable (based on your type of shell). The sound value (here Ping) can be any one of the `.aiff` files found at `/System/Library/Sounds` or `~/Library/Sounds`.
+
+*Bash*
+```
+echo 'export ZT_NOTIFICATION_SOUND=Ping' >> ~/.bash_profile
+source ~/.bash_profile
+```
+*ZSH*
+```
+echo 'export ZT_NOTIFICATION_SOUND=Ping' >> ~/.zshenv
+source ~/.zshenv
+```
+
 ## Hot Keys
 ### General
 | Command                                               | Key Combination                               |

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -528,7 +528,8 @@ def notify(title: str, html_text: str) -> None:
     elif MACOS:  # NOTE Tested and should work!
         command_list = shlex.split(
             "osascript -e "
-            "'display notification \"\'{}\'\" with title \"\'{}\'\"'"
+            "'display notification \"\'{}\'\" with title \"\'{}\'\" "
+            " sound name \"ZT_NOTIFICATION_SOUND\"'"
             .format(quoted_text, quoted_title)
         )
         expected_length = 3


### PR DESCRIPTION
The `osascript` command takes in the notification sound as an
extra parameter and without it doesn't have a default sound.
We set an env variable here to tell zt to play a
sound when it receives a notification.

README has been updated to describe the changes needed to
set the env variable.