### PR TITLE
setup: Minor adjustments (remove license, adjust some text).

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,13 +52,12 @@ dev_helper_deps = [
 setup(
     name='zulip-term',
     version=ZT_VERSION,
-    description='A terminal-based interface to zulip chat',
+    description='A terminal-based interface to Zulip chat',
     long_description=long_description(),
     long_description_content_type='text/markdown',
     url='https://github.com/zulip/zulip-terminal',
-    author='Zulip',
+    author='Zulip Open Source Project',
     author_email='zulip-devel@googlegroups.com',
-    license='MIT',
     classifiers=[
         'Development Status :: 4 - Beta',
 


### PR DESCRIPTION
Following discussion around [this conversation](https://chat.zulip.org/#narrow/stream/127-integrations/topic/PyPI.20release/near/853887), this inspired the following suggested changes in this commit:
* The license is set in the trove classifiers already, and matches the
  LICENSE file, so is not needed as a separate setup key.
* Zulip is typically capitalized, so use Zulip rather than zulip in
  description.
* Use 'Zulip Open Source Project' as the author, like other Zulip PyPI
  packages.