### PR TITLE
keys: readme: update help text for auto-completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ source ~/.zshenv
 | ----------------------------------------------------- | --------------------------------------------- |
 | Toggle focus box in compose box                       | <kbd>tab</kbd>                                |
 | Send a message                                        | <kbd>Alt Enter</kbd> / <kbd>Ctrl d</kbd>      |
-| Autocomplete @mentions and #stream_names              | <kbd>Ctrl</kbd> + <kbd>f</kbd>                |
+| Autocomplete @mentions, #stream_names and :emoji:     | <kbd>Ctrl</kbd> + <kbd>f</kbd>                |
 | Cycle through autocomplete suggestions in reverse     | <kbd>Ctrl</kbd> + <kbd>r</kbd>                |
 | Jump to the beginning of line                         | <kbd>Ctrl</kbd> + <kbd>A</kbd>                |
 | Jump backward one character                           | <kbd>Ctrl</kbd> + <kbd>B</kbd> / <kbd>←</kbd> |

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -106,7 +106,7 @@ KEY_BINDINGS = OrderedDict([
     }),
     ('AUTOCOMPLETE', {
         'keys': {'ctrl f'},
-        'help_text': 'Autocomplete @mentions and #stream_names',
+        'help_text': 'Autocomplete @mentions, #stream_names and :emoji:',
         'key_category': 'msg_compose',
     }),
     ('AUTOCOMPLETE_REVERSE', {


### PR DESCRIPTION
Zulip terminal now supports auto-completion for emoji, but help text did not reflect such feature. Updated keys.py and readme. Resolves #604 