### PR TITLE
themes/run: Rename themes & add compatibility aliases.

### DIFF
--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -94,7 +94,7 @@ def test_valid_zuliprc_but_no_connection(capsys, mocker, minimal_zuliprc,
     lines = captured.out.strip().split("\n")
     expected_lines = [
         "Loading with:",
-        "   theme 'default' specified with no config.",
+        "   theme 'zt_dark' specified with no config.",
         "   autohide setting 'no_autohide' specified with no config.",
         "\x1b[91m",
         ("Error connecting to Zulip server: {}.\x1b[0m".

--- a/tests/config/test_themes.py
+++ b/tests/config/test_themes.py
@@ -7,7 +7,7 @@ from zulipterminal.config.themes import (
 
 
 expected_complete_themes = {
-    'default', 'gruvbox', 'light', 'blue'
+    'zt_dark', 'gruvbox_dark', 'zt_light', 'zt_blue',
 }
 
 

--- a/zulipterminal/config/themes.py
+++ b/zulipterminal/config/themes.py
@@ -77,8 +77,15 @@ GRAY = 'h244'  # gray_244
 LIGHTMAGENTA = 'h132'  # neutral_purple
 LIGHTMAGENTABOLD = '%s, bold' % LIGHTMAGENTA
 
+THEME_ALIASES = {
+    'default': 'zt_dark',
+    'gruvbox': 'gruvbox_dark',
+    'light': 'zt_light',
+    'blue': 'zt_blue',
+}
+
 THEMES = {
-    'default': [
+    'zt_dark': [
         (None,             'white',                   'black',
          None,             DEF['white'],              DEF['black']),
         ('selected',       'white',                   'dark blue',
@@ -138,7 +145,7 @@ THEMES = {
         ('filter_results', 'white',                   'dark green',
          None,             DEF['white'],              DEF['dark_green']),
     ],
-    'gruvbox': [
+    'gruvbox_dark': [
         # default colorscheme on 16 colors, gruvbox colorscheme
         # on 256 colors
         (None,             'white',           'black',
@@ -200,7 +207,7 @@ THEMES = {
         ('filter_results', 'black',           'light green',
          None,             BLACK,             LIGHTGREEN),
     ],
-    'light': [
+    'zt_light': [
         (None,             'black',           'white'),
         ('selected',       'black',           'light green'),
         ('msg_selected',   'black',           'light green'),
@@ -231,7 +238,7 @@ THEMES = {
         ('table_head',     'black, bold',     'white'),
         ('filter_results', 'white',           'dark green'),
     ],
-    'blue': [
+    'zt_blue': [
         (None,             'black',           'light blue'),
         ('selected',       'black',           'light gray'),
         ('msg_selected',   'black',           'light gray'),
@@ -267,6 +274,10 @@ THEMES = {
 
 def all_themes() -> List[str]:
     return list(THEMES.keys())
+
+
+def aliased_themes() -> Dict[str, str]:
+    return dict(THEME_ALIASES)
 
 
 def complete_and_incomplete_themes() -> Tuple[List[str], List[str]]:


### PR DESCRIPTION
This implements the renaming of themes as discussed in the 'Rename default theme' topic.

Also included is an 'alias' table, to allow the old names to continue working, at least for now.