### PR TITLE
tests: Add command keys for exit popup keypress tests.

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1170,8 +1170,9 @@ class TestHelpMenu:
         self.help_view.keypress(size, key)
         assert not self.controller.exit_popup.called
 
-    @pytest.mark.parametrize('key', keys_for_command("GO_BACK"))
-    def test_keypress_GO_BACK(self, key):
+    @pytest.mark.parametrize('key', {*keys_for_command('GO_BACK'),
+                                     *keys_for_command('HELP')})
+    def test_keypress_exit_popup(self, key):
         size = (200, 20)
         self.help_view.keypress(size, key)
         assert self.controller.exit_popup.called
@@ -1256,8 +1257,9 @@ class TestMsgInfoView:
         self.msg_info_view.keypress(size, key)
         assert not self.controller.exit_popup.called
 
-    @pytest.mark.parametrize('key', keys_for_command("GO_BACK"))
-    def test_keypress_GO_BACK(self, key):
+    @pytest.mark.parametrize('key', {*keys_for_command('GO_BACK'),
+                                     *keys_for_command('MSG_INFO')})
+    def test_keypress_exit_popup(self, key):
         size = (200, 20)
         self.msg_info_view.keypress(size, key)
         assert self.controller.exit_popup.called

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1235,6 +1235,13 @@ class TestStreamInfoView:
         mocker.patch(VIEWS + ".urwid.SimpleFocusListWalker", return_value=[])
         self.stream_info_view = StreamInfoView(self.controller, '', '', '')
 
+    @pytest.mark.parametrize('key', {*keys_for_command('GO_BACK'),
+                                     *keys_for_command('STREAM_DESC')})
+    def test_keypress_exit_popup(self, key):
+        size = (200, 20)
+        self.stream_info_view.keypress(size, key)
+        assert self.controller.exit_popup.called
+
     def test_keypress_navigation(self, mocker,
                                  navigation_key_expected_key_pair):
         key, expected_key = navigation_key_expected_key_pair


### PR DESCRIPTION
This brings minor changes to exit popup keypress tests (previously 'GO_BACK' tests).
* The first and the second commit are renaming refactors to improve consistency (more on this is in the respective commit description).
* The third commit adds command keys to exit popup keypress tests (see #561).
* The fourth commit adds exit popup keypress test for `StreamInfoView`.

Fixes #561.