### PR TITLE
Migrate from pycodestyle to flake8 in CI & locally

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,9 @@ matrix:
       install: pip3 install .[linting]
       script: ./tools/run-mypy
     - python: 3.7
-      name: "Linting - PEP8 (pycodestyle)"
+      name: "Linting - PEP8 & more (flake8)"
       install: pip3 install .[linting]
-      script: pycodestyle
+      script: flake8
     - python: 3.5
       name: "Linting - import order (isort)"
       install: pip3 install .[linting]

--- a/Pipfile
+++ b/Pipfile
@@ -15,7 +15,7 @@ mypy_extensions = ">=0.4"
 pytest = "==5.3.5"
 pytest-mock = "==1.7.1"
 pytest-cov = "==2.5.1"
-pycodestyle = "==2.5.0"
+flake8 = "==3.7.9"
 zipp = "==1.0.0"  # To support Python 3.5
 pudb = "==2017.1.4"
 snakeviz = "==0.4.2"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ zulip==0.6.3
 pytest==5.3.5
 pytest-cov==2.5.1
 pytest-mock==1.7.1
-pycodestyle==2.5.0
+flake8==3.7.9
 pudb==2017.1.4
 snakeviz==0.4.2
 gitlint==0.10.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,11 +23,27 @@ atomic=True
 # This ensures compatibility with pytest-pep8
 lines_after_imports=2
 
-# This is a first step from using the old pep8 plugin to pytest
-# We could use something else in future, like a combination linter
-# (flake8, pylint, zulint)
-[pycodestyle]
-ignore=E121,E123,E126,E226,E24,E704,W503,W504,E117,E252
+# flake8 takes a little more time than pycodestyle, but finds more things
+# (we could also look at pylint, zulint, etc.)
+[flake8]
+ignore=
+  # E121 - continuation line under-indented for hanging indent
+  E121,
+  # E123 - closing bracket does not match indentation of opening bracket's line
+  E123,
+  # E126 - continuation line over-indented for hanging indent
+  E126,
+  # E226 - Missing whitespace around arithmetic - FIXME possibly change this
+  E226,
+  # W504 - line break after binary operator - we have this currently, vs W503
+  W504,
+  # E241 - Multiple spaces after ',' - breaks layouts like themes.py
+  E241,
+  # E252 - Spaces in parameters, a style deliberately avoided
+  E252,
+  # F841 - assigned to but never used - FIXME: indicates potential issues
+  F841,
+exclude=.git,__pycache__,build,dist,tools
 
 [mypy]
 python_version = 3.6

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ testing_deps = [
 linting_deps = [
     'isort==4.3.21',
     'mypy==0.770',
-    'pycodestyle==2.5.0',
+    'flake8==3.7.9',
 ]
 
 dev_helper_deps = [

--- a/tests/config/test_keys.py
+++ b/tests/config/test_keys.py
@@ -1,3 +1,5 @@
+from typing import Dict
+
 import pytest
 
 from zulipterminal.config import keys
@@ -82,7 +84,7 @@ def test_commands_for_random_tips(mocker):
             'help_text': 'delta',
             'excluded_from_random_tips': True,
             },
-    }  # type: Dict[str, KeyBinding]
+    }  # type: Dict[str, keys.KeyBinding]
     mocker.patch.dict(keys.KEY_BINDINGS, new_key_bindings, clear=True)
     result = keys.commands_for_random_tips()
     assert len(result) == 2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,9 +7,7 @@ import pytest
 from zulipterminal.config.keys import keys_for_command
 from zulipterminal.helper import initial_index as helper_initial_index
 from zulipterminal.ui_tools.boxes import MessageBox
-from zulipterminal.ui_tools.buttons import (
-    StreamButton, TopicButton, UserButton,
-)
+from zulipterminal.ui_tools.buttons import StreamButton, UserButton
 
 
 @pytest.fixture(autouse=True)

--- a/tests/helper/test_helper.py
+++ b/tests/helper/test_helper.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 import pytest
 
 import zulipterminal.helper

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -1,5 +1,4 @@
 import json
-from platform import platform
 from typing import Any
 
 import pytest

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1,5 +1,6 @@
 import datetime
 from collections import OrderedDict, defaultdict
+from typing import Any, Dict
 
 import pytest
 from bs4 import BeautifulSoup

--- a/tools/lint-all
+++ b/tools/lint-all
@@ -7,7 +7,7 @@ import sys
 tools = {
     'Import order (isort)': './tools/run-isort-check',
     'Type consistency (mypy)': './tools/run-mypy',
-    'PEP8 (pycodestyle)': 'pycodestyle',
+    'PEP8 & more (flake8)': 'flake8',
 }
 
 for tool_name, command in tools.items():

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from typing import Dict, List, Set
+from typing import List, Set
 
 from mypy_extensions import TypedDict
 

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -11,7 +11,7 @@ import zulip
 
 from zulipterminal.config.themes import ThemeSpec
 from zulipterminal.helper import Message, asynch
-from zulipterminal.model import Model, ServerConnectionFailure
+from zulipterminal.model import Model
 from zulipterminal.ui import Screen, View
 from zulipterminal.ui_tools.utils import create_msg_box_list
 from zulipterminal.ui_tools.views import (

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -9,8 +9,7 @@ from itertools import chain, combinations
 from re import ASCII, match
 from threading import Thread
 from typing import (
-    Any, Callable, DefaultDict, Dict, FrozenSet, Iterable, List, Optional, Set,
-    Tuple, Union,
+    Any, Callable, Dict, FrozenSet, Iterable, List, Set, Tuple, Union,
 )
 
 import lxml.html

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -2,7 +2,6 @@ import json
 import time
 from collections import OrderedDict, defaultdict
 from concurrent.futures import Future, ThreadPoolExecutor, wait
-from threading import Thread
 from typing import (
     Any, Callable, DefaultDict, Dict, FrozenSet, Iterable, List, Optional, Set,
     Tuple, Union,

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -1,4 +1,3 @@
-import platform
 import random
 import re
 import time
@@ -7,7 +6,6 @@ from typing import Any, Dict, List, Optional, Tuple
 import urwid
 
 from zulipterminal.config.keys import commands_for_random_tips, is_command_key
-from zulipterminal.config.themes import THEMES
 from zulipterminal.helper import WSL, asynch
 from zulipterminal.ui_tools.boxes import SearchBox, WriteBox
 from zulipterminal.ui_tools.views import (

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -1,7 +1,7 @@
 import random
 import re
 import time
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, List, Optional, Tuple
 
 import urwid
 

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -8,7 +8,7 @@ from urllib.parse import urljoin, urlparse
 
 import urwid
 from bs4 import BeautifulSoup
-from bs4.element import NavigableString, Tag
+from bs4.element import NavigableString
 from urwid_readline import ReadlineEdit
 
 from zulipterminal import emoji_names

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1,6 +1,6 @@
 import threading
 import time
-from collections import OrderedDict, defaultdict
+from collections import OrderedDict
 from typing import Any, Callable, List, Optional, Tuple
 
 import urwid


### PR DESCRIPTION
Flake8 covers a lot more coding errors than pycodestyle, including finding unused imports - just as one example. This PR translates the dev and CI environments to use flake8. No documentation should need to be updated, as long as people are just using `tools/lint-all` rather than raw pycodestyle.

The 'barebones' flake8 takes ~6s to run locally for me right now, compared to the ~3s for pycodestyle, but combined with mypy and isort, this isn't as big a proportional change.

This PR removes default installation of pycodestyle (it is installed via flake8, though). We could keep it around as an intentional developer tool, but then we'd need to keep the settings synchronized.

flake8 also has various plugins, which we could investigate further if we go ahead with this.