### PR TITLE
cleanup: Results of pyupgrade with --py3-only --keep-percent-format.

### DIFF
--- a/zulipterminal/config/themes.py
+++ b/zulipterminal/config/themes.py
@@ -264,7 +264,7 @@ def all_themes() -> List[str]:
 
 def complete_and_incomplete_themes() -> Tuple[List[str], List[str]]:
     complete = {name for name, styles in THEMES.items()
-                if set(s[0] for s in styles).issuperset(required_styles)}
+                if {s[0] for s in styles}.issuperset(required_styles)}
     incomplete = list(set(THEMES) - complete)
     return sorted(list(complete)), sorted(incomplete)
 

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -50,8 +50,7 @@ class Controller:
 
         def spinning_cursor() -> Any:
             while True:
-                for cursor in '|/-\\':
-                    yield cursor
+                yield from '|/-\\'
 
         spinner = spinning_cursor()
         sys.stdout.write("\033[92mWelcome to Zulip.\033[0m\n")

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -360,9 +360,9 @@ def index_messages(messages: List[Message],
 
             if msg['type'] == 'private':
                 index['private_msg_ids'].add(msg['id'])
-                recipients = frozenset(set(
+                recipients = frozenset({
                     recipient['id'] for recipient in msg['display_recipient']
-                ))
+                })
 
                 if narrow[0][0] == 'pm_with':
                     narrow_emails = ([model.user_dict[email]['user_id']

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -255,10 +255,10 @@ class Model:
         existing_reactions = [
             reaction['emoji_code']
             for reaction in message['reactions']
-            if (('user_id' in reaction['user'] and
-                reaction['user']['user_id'] == self.user_id)) or
-               (('id' in reaction['user'] and
-                reaction['user']['id'] == self.user_id))
+            if ('user_id' in reaction['user'] and
+                reaction['user']['user_id'] == self.user_id) or
+               ('id' in reaction['user'] and
+                reaction['user']['id'] == self.user_id)
         ]
         if reaction_to_toggle_spec['emoji_code'] in existing_reactions:
             response = self.client.remove_reaction(reaction_to_toggle_spec)

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -40,17 +40,17 @@ class View(urwid.WidgetWrap):
     def message_view(self) -> Any:
         self.middle_column = MiddleColumnView(self, self.model, self.write_box,
                                               self.search_box)
-        return urwid.LineBox(self.middle_column, title=u'Messages',
-                             bline=u'', tline=u'━',
-                             trcorner=u'│', tlcorner=u'│')
+        return urwid.LineBox(self.middle_column, title='Messages',
+                             bline='', tline='━',
+                             trcorner='│', tlcorner='│')
 
     def right_column_view(self) -> Any:
         self.users_view = RightColumnView(View.RIGHT_WIDTH, self)
         return urwid.LineBox(
-            self.users_view, title=u"Users",
-            tlcorner=u'━', tline=u'━', lline=u'',
-            trcorner=u'━', blcorner=u'─', rline=u'',
-            bline=u'', brcorner=u''
+            self.users_view, title="Users",
+            tlcorner='━', tline='━', lline='',
+            trcorner='━', blcorner='─', rline='',
+            bline='', brcorner=''
         )
 
     def get_random_help(self) -> List[Any]:

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -43,7 +43,7 @@ class WriteBox(urwid.Pile):
         self.set_editor_mode()
         if email == '' and button is not None:
             email = button.email
-        self.to_write_box = ReadlineEdit(u"To: ", edit_text=email)
+        self.to_write_box = ReadlineEdit("To: ", edit_text=email)
         self.msg_write_box = ReadlineEdit(multiline=True)
         self.msg_write_box.enable_autocomplete(
             func=self.generic_autocomplete,
@@ -51,9 +51,9 @@ class WriteBox(urwid.Pile):
             key_reverse=keys_for_command('AUTOCOMPLETE_REVERSE').pop()
         )
         to_write_box = urwid.LineBox(
-            self.to_write_box, tlcorner=u'─', tline=u'─', lline=u'',
-            trcorner=u'─', blcorner=u'─', rline=u'',
-            bline=u'─', brcorner=u'─'
+            self.to_write_box, tlcorner='─', tline='─', lline='',
+            trcorner='─', blcorner='─', rline='',
+            bline='─', brcorner='─'
         )
         self.contents = [
             (to_write_box, self.options()),
@@ -71,22 +71,22 @@ class WriteBox(urwid.Pile):
             key_reverse=keys_for_command('AUTOCOMPLETE_REVERSE').pop()
         )
         self.stream_write_box = ReadlineEdit(
-            caption=u"Stream:  ",
+            caption="Stream:  ",
             edit_text=caption
         )
-        self.title_write_box = ReadlineEdit(caption=u"Topic:  ",
+        self.title_write_box = ReadlineEdit(caption="Topic:  ",
                                             edit_text=title)
 
         header_write_box = urwid.Columns([
             urwid.LineBox(
-                self.stream_write_box, tlcorner=u'─', tline=u'─', lline=u'',
-                trcorner=u'┬', blcorner=u'─', rline=u'│',
-                bline=u'─', brcorner=u'┴'
+                self.stream_write_box, tlcorner='─', tline='─', lline='',
+                trcorner='┬', blcorner='─', rline='│',
+                bline='─', brcorner='┴'
             ),
             urwid.LineBox(
-                self.title_write_box, tlcorner=u'─', tline=u'─', lline=u'',
-                trcorner=u'─', blcorner=u'─', rline=u'',
-                bline=u'─', brcorner=u'─'
+                self.title_write_box, tlcorner='─', tline='─', lline='',
+                trcorner='─', blcorner='─', rline='',
+                bline='─', brcorner='─'
             ),
         ])
         write_box = [
@@ -804,9 +804,9 @@ class SearchBox(urwid.Pile):
         ])
         self.msg_narrow = urwid.Text("DONT HIDE")
         self.recipient_bar = urwid.LineBox(
-            self.msg_narrow, title=u"Current message recipients",
-            tline=u'─', lline=u'', trcorner=u'─', tlcorner=u'─',
-            blcorner=u'─', rline=u'', bline=u'─', brcorner=u'─')
+            self.msg_narrow, title="Current message recipients",
+            tline='─', lline='', trcorner='─', tlcorner='─',
+            blcorner='─', rline='', bline='─', brcorner='─')
         return [self.search_bar, self.recipient_bar]
 
     def keypress(self, size: urwid_Size, key: str) -> Optional[str]:

--- a/zulipterminal/ui_tools/tables.py
+++ b/zulipterminal/ui_tools/tables.py
@@ -116,9 +116,9 @@ def render_table(table_element: Any) -> StyledTableData:
         for column in zip(*cells)
     ]
 
-    top_border = row_with_only_border(u'┌', u'─', u'┬', u'┐', column_widths)
-    middle_border = row_with_only_border(u'├', u'─', u'┼', u'┤', column_widths)
-    bottom_border = row_with_only_border(u'└', u'─', u'┴', u'┘', column_widths,
+    top_border = row_with_only_border('┌', '─', '┬', '┐', column_widths)
+    middle_border = row_with_only_border('├', '─', '┼', '┤', column_widths)
+    bottom_border = row_with_only_border('└', '─', '┴', '┘', column_widths,
                                          newline=False)
 
     # Construct the table, row-by-row.
@@ -127,7 +127,7 @@ def render_table(table_element: Any) -> StyledTableData:
     # Add the header/0th row and the borders that surround it to the table.
     table.extend(top_border)
     table.extend(row_with_styled_content(cells.pop(0), column_alignments,
-                                         column_widths, u'│',
+                                         column_widths, '│',
                                          row_style='table_head'))
     table.extend(middle_border)
 
@@ -135,7 +135,7 @@ def render_table(table_element: Any) -> StyledTableData:
     # end.
     for row in cells:
         table.extend(row_with_styled_content(row, column_alignments,
-                                             column_widths, u'│'))
+                                             column_widths, '│'))
     table.extend(bottom_border)
 
     return table

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -257,9 +257,9 @@ class StreamsView(urwid.Frame):
                                                 'SEARCH_STREAMS',
                                                 self.update_streams)
         super().__init__(list_box, header=urwid.LineBox(
-            self.stream_search_box, tlcorner=u'─', tline=u'', lline=u'',
-            trcorner=u'─', blcorner=u'─', rline=u'',
-            bline=u'─', brcorner=u'─'
+            self.stream_search_box, tlcorner='─', tline='', lline='',
+            trcorner='─', blcorner='─', rline='',
+            bline='─', brcorner='─'
         ))
         self.search_lock = threading.Lock()
 
@@ -323,9 +323,9 @@ class TopicsView(urwid.Frame):
                                        urwid.Divider('─'),
                                        self.topic_search_box])
         super().__init__(self.list_box, header=urwid.LineBox(
-            self.header_list, tlcorner=u'─', tline=u'', lline=u'',
-            trcorner=u'─', blcorner=u'─', rline=u'',
-            bline=u'─', brcorner=u'─'
+            self.header_list, tlcorner='─', tline='', lline='',
+            trcorner='─', blcorner='─', rline='',
+            bline='─', brcorner='─'
         ))
         self.search_lock = threading.Lock()
 
@@ -548,9 +548,9 @@ class RightColumnView(urwid.Frame):
                                           self.update_user_list)
         self.view.user_search = self.user_search
         search_box = urwid.LineBox(
-            self.user_search, tlcorner=u'─', tline=u'', lline=u'',
-            trcorner=u'─', blcorner=u'─', rline=u'',
-            bline=u'─', brcorner=u'─'
+            self.user_search, tlcorner='─', tline='', lline='',
+            trcorner='─', blcorner='─', rline='',
+            bline='─', brcorner='─'
             )
         self.allow_update_user_list = True
         self.search_lock = threading.Lock()
@@ -718,9 +718,9 @@ class LeftColumnView(urwid.Pile):
         self.view.stream_w = StreamsView(streams_btn_list, self.view)
         w = urwid.LineBox(
             self.view.stream_w, title="Streams",
-            tlcorner=u'━', tline=u'━', lline=u'',
-            trcorner=u'━', blcorner=u'', rline=u'',
-            bline=u'', brcorner=u'─'
+            tlcorner='━', tline='━', lline='',
+            trcorner='━', blcorner='', rline='',
+            bline='', brcorner='─'
             )
         return w
 
@@ -740,9 +740,9 @@ class LeftColumnView(urwid.Pile):
                                        stream_button)
         w = urwid.LineBox(
             self.view.topic_w, title="Topics",
-            tlcorner=u'━', tline=u'━', lline=u'',
-            trcorner=u'━', blcorner=u'', rline=u'',
-            bline=u'', brcorner=u'─'
+            tlcorner='━', tline='━', lline='',
+            trcorner='━', blcorner='', rline='',
+            bline='', brcorner='─'
             )
         return w
 
@@ -824,8 +824,8 @@ class PopUpConfirmationView(urwid.Overlay):
                  success_callback: Callable[[], bool]):
         self.controller = controller
         self.success_callback = success_callback
-        yes = urwid.Button(u'Yes', self.exit_popup_yes)
-        no = urwid.Button(u'No', self.exit_popup_no)
+        yes = urwid.Button('Yes', self.exit_popup_yes)
+        no = urwid.Button('No', self.exit_popup_no)
         yes._w = urwid.AttrMap(urwid.SelectableIcon(
             'Yes', 4), None, 'selected')
         no._w = urwid.AttrMap(urwid.SelectableIcon(


### PR DESCRIPTION
This tool automatically upgrades some common early python.

Changes made include:
* removal of u prefix from unicode strings
* remove some excessive uses of set() where {...} is sufficient
* use 'yield from' for spinning_cursor
* remove extra parentheses

Fixes #360, at least to a reasonable automated level at this point.