### PR TITLE
Refactoring focusing on tidying/migrating msg_list & msg_view

### DIFF
--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -74,7 +74,6 @@ class TestController:
                               stream_button, index_stream) -> None:
         controller.model.narrow = []
         controller.model.index = index_stream
-        controller.model.msg_view = mocker.patch('urwid.SimpleFocusListWalker')
         controller.model.msg_list = mocker.patch('urwid.ListBox')
         controller.model.stream_dict = {
             205: {
@@ -87,9 +86,10 @@ class TestController:
         assert controller.model.stream_id == stream_button.stream_id
         assert controller.model.narrow == [['stream',
                                             stream_button.stream_name]]
-        controller.model.msg_view.clear.assert_called_once_with()
+        controller.model.msg_list.log.clear.assert_called_once_with()
 
-        widget = controller.model.msg_view.extend.call_args_list[0][0][0][0]
+        widget = (controller.model.msg_list.log
+                  .extend.call_args_list[0][0][0][0])
         stream_id = stream_button.stream_id
         id_list = index_stream['stream_msg_ids_by_stream_id'][stream_id]
         assert {widget.original_widget.message['id']} == id_list
@@ -100,7 +100,6 @@ class TestController:
                            ['topic', msg_box.topic_name]]
         controller.model.narrow = []
         controller.model.index = index_topic
-        controller.model.msg_view = mocker.patch('urwid.SimpleFocusListWalker')
         controller.model.msg_list = mocker.patch('urwid.ListBox')
         controller.model.stream_dict = {
             205: {
@@ -112,9 +111,10 @@ class TestController:
         controller.narrow_to_topic(msg_box)
         assert controller.model.stream_id == msg_box.stream_id
         assert controller.model.narrow == expected_narrow
-        controller.model.msg_view.clear.assert_called_once_with()
+        controller.model.msg_list.log.clear.assert_called_once_with()
 
-        widget = controller.model.msg_view.extend.call_args_list[0][0][0][0]
+        widget = (controller.model.msg_list.log
+                  .extend.call_args_list[0][0][0][0])
         stream_id, topic_name = msg_box.stream_id, msg_box.topic_name
         id_list = index_topic['topic_msg_ids'][stream_id][topic_name]
         assert {widget.original_widget.message['id']} == id_list
@@ -122,7 +122,6 @@ class TestController:
     def test_narrow_to_user(self, mocker, controller, user_button, index_user):
         controller.model.narrow = []
         controller.model.index = index_user
-        controller.model.msg_view = mocker.patch('urwid.SimpleFocusListWalker')
         controller.model.msg_list = mocker.patch('urwid.ListBox')
         controller.model.user_id = 5140
         controller.model.user_email = "some@email"
@@ -133,17 +132,17 @@ class TestController:
         }
         controller.narrow_to_user(user_button)
         assert controller.model.narrow == [["pm_with", user_button.email]]
-        controller.model.msg_view.clear.assert_called_once_with()
+        controller.model.msg_list.log.clear.assert_called_once_with()
         recipients = frozenset([controller.model.user_id, user_button.user_id])
         assert controller.model.recipients == recipients
-        widget = controller.model.msg_view.extend.call_args_list[0][0][0][0]
+        widget = (controller.model.msg_list.log
+                  .extend.call_args_list[0][0][0][0])
         id_list = index_user['private_msg_ids_by_user_ids'][recipients]
         assert {widget.original_widget.message['id']} == id_list
 
     def test_show_all_messages(self, mocker, controller, index_all_messages):
         controller.model.narrow = [['stream', 'PTEST']]
         controller.model.index = index_all_messages
-        controller.model.msg_view = mocker.patch('urwid.SimpleFocusListWalker')
         controller.model.msg_list = mocker.patch('urwid.ListBox')
         controller.model.user_email = "some@email"
         controller.model.stream_dict = {
@@ -157,9 +156,9 @@ class TestController:
         controller.show_all_messages('')
 
         assert controller.model.narrow == []
-        controller.model.msg_view.clear.assert_called_once_with()
+        controller.model.msg_list.log.clear.assert_called_once_with()
 
-        widgets = controller.model.msg_view.extend.call_args_list[0][0][0]
+        widgets = controller.model.msg_list.log.extend.call_args_list[0][0][0]
         id_list = index_all_messages['all_msg_ids']
         msg_ids = {widget.original_widget.message['id'] for widget in widgets}
         assert msg_ids == id_list
@@ -167,16 +166,15 @@ class TestController:
     def test_show_all_pm(self, mocker, controller, index_user):
         controller.model.narrow = []
         controller.model.index = index_user
-        controller.model.msg_view = mocker.patch('urwid.SimpleFocusListWalker')
         controller.model.msg_list = mocker.patch('urwid.ListBox')
         controller.model.user_email = "some@email"
 
         controller.show_all_pm('')
 
         assert controller.model.narrow == [['is', 'private']]
-        controller.model.msg_view.clear.assert_called_once_with()
+        controller.model.msg_list.log.clear.assert_called_once_with()
 
-        widgets = controller.model.msg_view.extend.call_args_list[0][0][0]
+        widgets = controller.model.msg_list.log.extend.call_args_list[0][0][0]
         id_list = index_user['private_msg_ids']
         msg_ids = {widget.original_widget.message['id'] for widget in widgets}
         assert msg_ids == id_list
@@ -192,16 +190,15 @@ class TestController:
                 'color': '#ffffff',
             }
         }
-        controller.model.msg_view = mocker.patch('urwid.SimpleFocusListWalker')
         controller.model.msg_list = mocker.patch('urwid.ListBox')
 
         controller.show_all_starred('')
 
         assert controller.model.narrow == [['is', 'starred']]
-        controller.model.msg_view.clear.assert_called_once_with()
+        controller.model.msg_list.log.clear.assert_called_once_with()
 
         id_list = index_all_starred['starred_msg_ids']
-        widgets = controller.model.msg_view.extend.call_args_list[0][0][0]
+        widgets = controller.model.msg_list.log.extend.call_args_list[0][0][0]
         msg_ids = {widget.original_widget.message['id'] for widget in widgets}
         assert msg_ids == id_list
 
@@ -216,16 +213,15 @@ class TestController:
                 'color': '#ffffff',
             }
         }
-        controller.model.msg_view = mocker.patch('urwid.SimpleFocusListWalker')
         controller.model.msg_list = mocker.patch('urwid.ListBox')
 
         controller.show_all_mentions('')
 
         assert controller.model.narrow == [['is', 'mentioned']]
-        controller.model.msg_view.clear.assert_called_once_with()
+        controller.model.msg_list.log.clear.assert_called_once_with()
 
         id_list = index_all_mentions['mentioned_msg_ids']
-        widgets = controller.model.msg_view.extend.call_args_list[0][0][0]
+        widgets = controller.model.msg_list.log.extend.call_args_list[0][0][0]
         msg_ids = {widget.original_widget.message['id'] for widget in widgets}
         assert msg_ids == id_list
 
@@ -285,7 +281,7 @@ class TestController:
             'zulipterminal.model.Model.get_message_ids_in_current_narrow',
             return_value=msg_ids)
         controller.model.index = {'search': {500}}  # Any initial search index
-        controller.model.msg_view = []
+        controller.model.msg_list = mocker.patch('urwid.ListBox')
         controller.model.narrow = initial_narrow
 
         def set_msg_ids(*args, **kwargs):

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -30,8 +30,10 @@ class TestController:
         self.theme = 'default'
         self.autohide = True  # FIXME Add tests for no-autohide
         self.notify_enabled = False
-        return Controller(self.config_file, self.theme, 256, self.autohide,
-                          self.notify_enabled)
+        result = Controller(self.config_file, self.theme, 256, self.autohide,
+                            self.notify_enabled)
+        result.view.msg_list = mocker.Mock()  # set in View.__init__
+        return result
 
     def test_initialize_controller(self, controller, mocker) -> None:
         self.client.assert_called_once_with(
@@ -74,7 +76,7 @@ class TestController:
                               stream_button, index_stream) -> None:
         controller.model.narrow = []
         controller.model.index = index_stream
-        controller.model.msg_list = mocker.patch('urwid.ListBox')
+        controller.view.msg_list = mocker.patch('urwid.ListBox')
         controller.model.stream_dict = {
             205: {
                 'color': '#ffffff',
@@ -82,13 +84,15 @@ class TestController:
         }
         controller.model.muted_streams = []
         controller.model.muted_topics = []
+
         controller.narrow_to_stream(stream_button)
+
         assert controller.model.stream_id == stream_button.stream_id
         assert controller.model.narrow == [['stream',
                                             stream_button.stream_name]]
-        controller.model.msg_list.log.clear.assert_called_once_with()
+        controller.view.msg_list.log.clear.assert_called_once_with()
 
-        widget = (controller.model.msg_list.log
+        widget = (controller.view.msg_list.log
                   .extend.call_args_list[0][0][0][0])
         stream_id = stream_button.stream_id
         id_list = index_stream['stream_msg_ids_by_stream_id'][stream_id]
@@ -100,7 +104,7 @@ class TestController:
                            ['topic', msg_box.topic_name]]
         controller.model.narrow = []
         controller.model.index = index_topic
-        controller.model.msg_list = mocker.patch('urwid.ListBox')
+        controller.view.msg_list = mocker.patch('urwid.ListBox')
         controller.model.stream_dict = {
             205: {
                 'color': '#ffffff',
@@ -111,9 +115,9 @@ class TestController:
         controller.narrow_to_topic(msg_box)
         assert controller.model.stream_id == msg_box.stream_id
         assert controller.model.narrow == expected_narrow
-        controller.model.msg_list.log.clear.assert_called_once_with()
+        controller.view.msg_list.log.clear.assert_called_once_with()
 
-        widget = (controller.model.msg_list.log
+        widget = (controller.view.msg_list.log
                   .extend.call_args_list[0][0][0][0])
         stream_id, topic_name = msg_box.stream_id, msg_box.topic_name
         id_list = index_topic['topic_msg_ids'][stream_id][topic_name]
@@ -122,7 +126,7 @@ class TestController:
     def test_narrow_to_user(self, mocker, controller, user_button, index_user):
         controller.model.narrow = []
         controller.model.index = index_user
-        controller.model.msg_list = mocker.patch('urwid.ListBox')
+        controller.view.msg_list = mocker.patch('urwid.ListBox')
         controller.model.user_id = 5140
         controller.model.user_email = "some@email"
         controller.model.user_dict = {
@@ -132,10 +136,10 @@ class TestController:
         }
         controller.narrow_to_user(user_button)
         assert controller.model.narrow == [["pm_with", user_button.email]]
-        controller.model.msg_list.log.clear.assert_called_once_with()
+        controller.view.msg_list.log.clear.assert_called_once_with()
         recipients = frozenset([controller.model.user_id, user_button.user_id])
         assert controller.model.recipients == recipients
-        widget = (controller.model.msg_list.log
+        widget = (controller.view.msg_list.log
                   .extend.call_args_list[0][0][0][0])
         id_list = index_user['private_msg_ids_by_user_ids'][recipients]
         assert {widget.original_widget.message['id']} == id_list
@@ -143,7 +147,7 @@ class TestController:
     def test_show_all_messages(self, mocker, controller, index_all_messages):
         controller.model.narrow = [['stream', 'PTEST']]
         controller.model.index = index_all_messages
-        controller.model.msg_list = mocker.patch('urwid.ListBox')
+        controller.view.msg_list = mocker.patch('urwid.ListBox')
         controller.model.user_email = "some@email"
         controller.model.stream_dict = {
             205: {
@@ -156,9 +160,9 @@ class TestController:
         controller.show_all_messages('')
 
         assert controller.model.narrow == []
-        controller.model.msg_list.log.clear.assert_called_once_with()
+        controller.view.msg_list.log.clear.assert_called_once_with()
 
-        widgets = controller.model.msg_list.log.extend.call_args_list[0][0][0]
+        widgets = controller.view.msg_list.log.extend.call_args_list[0][0][0]
         id_list = index_all_messages['all_msg_ids']
         msg_ids = {widget.original_widget.message['id'] for widget in widgets}
         assert msg_ids == id_list
@@ -166,15 +170,15 @@ class TestController:
     def test_show_all_pm(self, mocker, controller, index_user):
         controller.model.narrow = []
         controller.model.index = index_user
-        controller.model.msg_list = mocker.patch('urwid.ListBox')
+        controller.view.msg_list = mocker.patch('urwid.ListBox')
         controller.model.user_email = "some@email"
 
         controller.show_all_pm('')
 
         assert controller.model.narrow == [['is', 'private']]
-        controller.model.msg_list.log.clear.assert_called_once_with()
+        controller.view.msg_list.log.clear.assert_called_once_with()
 
-        widgets = controller.model.msg_list.log.extend.call_args_list[0][0][0]
+        widgets = controller.view.msg_list.log.extend.call_args_list[0][0][0]
         id_list = index_user['private_msg_ids']
         msg_ids = {widget.original_widget.message['id'] for widget in widgets}
         assert msg_ids == id_list
@@ -190,15 +194,15 @@ class TestController:
                 'color': '#ffffff',
             }
         }
-        controller.model.msg_list = mocker.patch('urwid.ListBox')
+        controller.view.msg_list = mocker.patch('urwid.ListBox')
 
         controller.show_all_starred('')
 
         assert controller.model.narrow == [['is', 'starred']]
-        controller.model.msg_list.log.clear.assert_called_once_with()
+        controller.view.msg_list.log.clear.assert_called_once_with()
 
         id_list = index_all_starred['starred_msg_ids']
-        widgets = controller.model.msg_list.log.extend.call_args_list[0][0][0]
+        widgets = controller.view.msg_list.log.extend.call_args_list[0][0][0]
         msg_ids = {widget.original_widget.message['id'] for widget in widgets}
         assert msg_ids == id_list
 
@@ -213,15 +217,15 @@ class TestController:
                 'color': '#ffffff',
             }
         }
-        controller.model.msg_list = mocker.patch('urwid.ListBox')
+        controller.view.msg_list = mocker.patch('urwid.ListBox')
 
         controller.show_all_mentions('')
 
         assert controller.model.narrow == [['is', 'mentioned']]
-        controller.model.msg_list.log.clear.assert_called_once_with()
+        controller.view.msg_list.log.clear.assert_called_once_with()
 
         id_list = index_all_mentions['mentioned_msg_ids']
-        widgets = controller.model.msg_list.log.extend.call_args_list[0][0][0]
+        widgets = controller.view.msg_list.log.extend.call_args_list[0][0][0]
         msg_ids = {widget.original_widget.message['id'] for widget in widgets}
         assert msg_ids == id_list
 
@@ -281,7 +285,7 @@ class TestController:
             'zulipterminal.model.Model.get_message_ids_in_current_narrow',
             return_value=msg_ids)
         controller.model.index = {'search': {500}}  # Any initial search index
-        controller.model.msg_list = mocker.patch('urwid.ListBox')
+        controller.view.msg_list = mocker.patch('urwid.ListBox')
         controller.model.narrow = initial_narrow
 
         def set_msg_ids(*args, **kwargs):

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -32,7 +32,7 @@ class TestController:
         self.notify_enabled = False
         result = Controller(self.config_file, self.theme, 256, self.autohide,
                             self.notify_enabled)
-        result.view.msg_list = mocker.Mock()  # set in View.__init__
+        result.view.message_view = mocker.Mock()  # set in View.__init__
         return result
 
     def test_initialize_controller(self, controller, mocker) -> None:
@@ -76,7 +76,7 @@ class TestController:
                               stream_button, index_stream) -> None:
         controller.model.narrow = []
         controller.model.index = index_stream
-        controller.view.msg_list = mocker.patch('urwid.ListBox')
+        controller.view.message_view = mocker.patch('urwid.ListBox')
         controller.model.stream_dict = {
             205: {
                 'color': '#ffffff',
@@ -90,9 +90,9 @@ class TestController:
         assert controller.model.stream_id == stream_button.stream_id
         assert controller.model.narrow == [['stream',
                                             stream_button.stream_name]]
-        controller.view.msg_list.log.clear.assert_called_once_with()
+        controller.view.message_view.log.clear.assert_called_once_with()
 
-        widget = (controller.view.msg_list.log
+        widget = (controller.view.message_view.log
                   .extend.call_args_list[0][0][0][0])
         stream_id = stream_button.stream_id
         id_list = index_stream['stream_msg_ids_by_stream_id'][stream_id]
@@ -104,7 +104,7 @@ class TestController:
                            ['topic', msg_box.topic_name]]
         controller.model.narrow = []
         controller.model.index = index_topic
-        controller.view.msg_list = mocker.patch('urwid.ListBox')
+        controller.view.message_view = mocker.patch('urwid.ListBox')
         controller.model.stream_dict = {
             205: {
                 'color': '#ffffff',
@@ -115,9 +115,9 @@ class TestController:
         controller.narrow_to_topic(msg_box)
         assert controller.model.stream_id == msg_box.stream_id
         assert controller.model.narrow == expected_narrow
-        controller.view.msg_list.log.clear.assert_called_once_with()
+        controller.view.message_view.log.clear.assert_called_once_with()
 
-        widget = (controller.view.msg_list.log
+        widget = (controller.view.message_view.log
                   .extend.call_args_list[0][0][0][0])
         stream_id, topic_name = msg_box.stream_id, msg_box.topic_name
         id_list = index_topic['topic_msg_ids'][stream_id][topic_name]
@@ -126,7 +126,7 @@ class TestController:
     def test_narrow_to_user(self, mocker, controller, user_button, index_user):
         controller.model.narrow = []
         controller.model.index = index_user
-        controller.view.msg_list = mocker.patch('urwid.ListBox')
+        controller.view.message_view = mocker.patch('urwid.ListBox')
         controller.model.user_id = 5140
         controller.model.user_email = "some@email"
         controller.model.user_dict = {
@@ -136,10 +136,10 @@ class TestController:
         }
         controller.narrow_to_user(user_button)
         assert controller.model.narrow == [["pm_with", user_button.email]]
-        controller.view.msg_list.log.clear.assert_called_once_with()
+        controller.view.message_view.log.clear.assert_called_once_with()
         recipients = frozenset([controller.model.user_id, user_button.user_id])
         assert controller.model.recipients == recipients
-        widget = (controller.view.msg_list.log
+        widget = (controller.view.message_view.log
                   .extend.call_args_list[0][0][0][0])
         id_list = index_user['private_msg_ids_by_user_ids'][recipients]
         assert {widget.original_widget.message['id']} == id_list
@@ -147,7 +147,7 @@ class TestController:
     def test_show_all_messages(self, mocker, controller, index_all_messages):
         controller.model.narrow = [['stream', 'PTEST']]
         controller.model.index = index_all_messages
-        controller.view.msg_list = mocker.patch('urwid.ListBox')
+        controller.view.message_view = mocker.patch('urwid.ListBox')
         controller.model.user_email = "some@email"
         controller.model.stream_dict = {
             205: {
@@ -160,9 +160,10 @@ class TestController:
         controller.show_all_messages('')
 
         assert controller.model.narrow == []
-        controller.view.msg_list.log.clear.assert_called_once_with()
+        controller.view.message_view.log.clear.assert_called_once_with()
 
-        widgets = controller.view.msg_list.log.extend.call_args_list[0][0][0]
+        widgets = (controller.view.message_view.log.extend
+                   .call_args_list[0][0][0])
         id_list = index_all_messages['all_msg_ids']
         msg_ids = {widget.original_widget.message['id'] for widget in widgets}
         assert msg_ids == id_list
@@ -170,15 +171,16 @@ class TestController:
     def test_show_all_pm(self, mocker, controller, index_user):
         controller.model.narrow = []
         controller.model.index = index_user
-        controller.view.msg_list = mocker.patch('urwid.ListBox')
+        controller.view.message_view = mocker.patch('urwid.ListBox')
         controller.model.user_email = "some@email"
 
         controller.show_all_pm('')
 
         assert controller.model.narrow == [['is', 'private']]
-        controller.view.msg_list.log.clear.assert_called_once_with()
+        controller.view.message_view.log.clear.assert_called_once_with()
 
-        widgets = controller.view.msg_list.log.extend.call_args_list[0][0][0]
+        widgets = (controller.view.message_view.log.extend
+                   .call_args_list[0][0][0])
         id_list = index_user['private_msg_ids']
         msg_ids = {widget.original_widget.message['id'] for widget in widgets}
         assert msg_ids == id_list
@@ -194,15 +196,16 @@ class TestController:
                 'color': '#ffffff',
             }
         }
-        controller.view.msg_list = mocker.patch('urwid.ListBox')
+        controller.view.message_view = mocker.patch('urwid.ListBox')
 
         controller.show_all_starred('')
 
         assert controller.model.narrow == [['is', 'starred']]
-        controller.view.msg_list.log.clear.assert_called_once_with()
+        controller.view.message_view.log.clear.assert_called_once_with()
 
         id_list = index_all_starred['starred_msg_ids']
-        widgets = controller.view.msg_list.log.extend.call_args_list[0][0][0]
+        widgets = (controller.view.message_view.log.extend
+                   .call_args_list[0][0][0])
         msg_ids = {widget.original_widget.message['id'] for widget in widgets}
         assert msg_ids == id_list
 
@@ -217,15 +220,16 @@ class TestController:
                 'color': '#ffffff',
             }
         }
-        controller.view.msg_list = mocker.patch('urwid.ListBox')
+        controller.view.message_view = mocker.patch('urwid.ListBox')
 
         controller.show_all_mentions('')
 
         assert controller.model.narrow == [['is', 'mentioned']]
-        controller.view.msg_list.log.clear.assert_called_once_with()
+        controller.view.message_view.log.clear.assert_called_once_with()
 
         id_list = index_all_mentions['mentioned_msg_ids']
-        widgets = controller.view.msg_list.log.extend.call_args_list[0][0][0]
+        widgets = (controller.view.message_view.log.extend
+                   .call_args_list[0][0][0])
         msg_ids = {widget.original_widget.message['id'] for widget in widgets}
         assert msg_ids == id_list
 
@@ -285,7 +289,7 @@ class TestController:
             'zulipterminal.model.Model.get_message_ids_in_current_narrow',
             return_value=msg_ids)
         controller.model.index = {'search': {500}}  # Any initial search index
-        controller.view.msg_list = mocker.patch('urwid.ListBox')
+        controller.view.message_view = mocker.patch('urwid.ListBox')
         controller.model.narrow = initial_narrow
 
         def set_msg_ids(*args, **kwargs):

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -581,7 +581,7 @@ class TestModel:
             {'flag': 'read', 'messages': [1, 2], 'op': 'add'},
         )
 
-    def test_mark_message_ids_as_read_empty_msg_list(self, model) -> None:
+    def test_mark_message_ids_as_read_empty_message_view(self, model) -> None:
         assert model.mark_message_ids_as_read([]) is None
 
     def test__update_initial_data(self, model, initial_data):
@@ -655,7 +655,7 @@ class TestModel:
         mocker.patch('zulipterminal.model.Model._update_topic_index')
         index_msg = mocker.patch('zulipterminal.model.index_messages',
                                  return_value={})
-        self.controller.view.msg_list = mocker.Mock(log=[])
+        self.controller.view.message_view = mocker.Mock(log=[])
         create_msg_box_list = mocker.patch('zulipterminal.model.'
                                            'create_msg_box_list',
                                            return_value=["msg_w"])
@@ -664,7 +664,7 @@ class TestModel:
 
         model._handle_message_event(event)
 
-        assert len(self.controller.view.msg_list.log) == 1  # Added "msg_w"
+        assert len(self.controller.view.message_view.log) == 1  # Added "msg_w"
         model.notify_user.assert_called_once_with(event['message'])
         (create_msg_box_list.
          assert_called_once_with(model, [message_fixture['id']],
@@ -676,7 +676,7 @@ class TestModel:
         mocker.patch('zulipterminal.model.Model._update_topic_index')
         index_msg = mocker.patch('zulipterminal.model.index_messages',
                                  return_value={})
-        self.controller.view.msg_list = mocker.Mock(log=[mocker.Mock()])
+        self.controller.view.message_view = mocker.Mock(log=[mocker.Mock()])
         create_msg_box_list = mocker.patch('zulipterminal.model.'
                                            'create_msg_box_list',
                                            return_value=["msg_w"])
@@ -685,10 +685,10 @@ class TestModel:
 
         model._handle_message_event(event)
 
-        assert len(self.controller.view.msg_list.log) == 2  # Added "msg_w"
+        assert len(self.controller.view.message_view.log) == 2  # Added "msg_w"
         model.notify_user.assert_called_once_with(event['message'])
         # NOTE: So we expect the first element *was* the last_message parameter
-        expected_last_msg = (self.controller.view.msg_list.log[0]
+        expected_last_msg = (self.controller.view.message_view.log[0]
                              .original_widget.message)
         (create_msg_box_list.
          assert_called_once_with(model, [message_fixture['id']],
@@ -700,7 +700,7 @@ class TestModel:
         mocker.patch('zulipterminal.model.Model._update_topic_index')
         index_msg = mocker.patch('zulipterminal.model.index_messages',
                                  return_value={})
-        self.controller.view.msg_list = mocker.Mock(log=[mocker.Mock()])
+        self.controller.view.message_view = mocker.Mock(log=[mocker.Mock()])
         create_msg_box_list = mocker.patch('zulipterminal.model.'
                                            'create_msg_box_list',
                                            return_value=["msg_w"])
@@ -715,7 +715,7 @@ class TestModel:
 
         # Test event without flags
         model.notify_user.assert_called_once_with(event['message'])
-        self.controller.view.msg_list.log = [mocker.Mock()]
+        self.controller.view.message_view.log = [mocker.Mock()]
         event = {'message': message_fixture, 'flags': []}
         model._handle_message_event(event)
         # set count called since the message is unread.
@@ -768,7 +768,7 @@ class TestModel:
                                            'create_msg_box_list',
                                            return_value=["msg_w"])
         set_count = mocker.patch('zulipterminal.model.set_count')
-        self.controller.view.msg_list = mocker.Mock(log=[])
+        self.controller.view.message_view = mocker.Mock(log=[])
         model.notify_user = mocker.Mock()
         model.narrow = narrow
         model.recipients = recipients
@@ -778,14 +778,14 @@ class TestModel:
 
         model._handle_message_event(event)
 
-        assert self.controller.view.msg_list.log == log
+        assert self.controller.view.message_view.log == log
         set_count.assert_called_once_with([response['id']], self.controller, 1)
 
         model._have_last_message[repr(narrow)] = False
         model.notify_user.assert_called_once_with(response)
         model._handle_message_event(event)
         # LOG REMAINS THE SAME IF UPDATE IS FALSE
-        assert self.controller.view.msg_list.log == log
+        assert self.controller.view.message_view.log == log
 
     @pytest.mark.parametrize(['topic_name', 'topic_order_intial',
                               'topic_order_final'], [
@@ -1018,7 +1018,9 @@ class TestModel:
         msg_w.original_widget.message = {'id': msg_id, 'subject': subject}
         model.narrow = narrow
         other_msg_w.original_widget.message = {'id': 2}
-        self.controller.view.msg_list = mocker.Mock(log=[msg_w, other_msg_w])
+        self.controller.view.message_view = (
+            mocker.Mock(log=[msg_w, other_msg_w])
+        )
         # New msg widget generated after updating index.
         new_msg_w = mocker.Mock()
         cmbl = mocker.patch('zulipterminal.model.create_msg_box_list',
@@ -1029,7 +1031,7 @@ class TestModel:
         # If there are 2 msgs and first one is updated, next one is updated too
         if new_log_len == 2:
             other_msg_w = new_msg_w
-        assert (self.controller.view.msg_list.log
+        assert (self.controller.view.message_view.log
                 == [new_msg_w, other_msg_w][-new_log_len:])
         assert model.controller.update_screen.called
 
@@ -1049,7 +1051,7 @@ class TestModel:
         other_msg_w = mocker.Mock()
         msg_w.original_widget.message = {'id': msg_id, 'subject': subject}
         model.narrow = narrow
-        self.controller.view.msg_list = mocker.Mock(log=[msg_w])
+        self.controller.view.message_view = mocker.Mock(log=[msg_w])
         # New msg widget generated after updating index.
         new_msg_w = mocker.Mock()
         cmbl = mocker.patch('zulipterminal.model.create_msg_box_list',
@@ -1102,8 +1104,8 @@ class TestModel:
         model.index = index
         mock_msg = mocker.Mock()
         another_msg = mocker.Mock()
-        self.controller.view.msg_list = mocker.Mock()
-        self.controller.view.msg_list.log = [mock_msg, another_msg]
+        self.controller.view.message_view = mocker.Mock()
+        self.controller.view.message_view.log = [mock_msg, another_msg]
         mock_msg.original_widget.message = index['messages'][1]
         another_msg.original_widget.message = index['messages'][2]
         mocker.patch('zulipterminal.model.create_msg_box_list',
@@ -1162,7 +1164,7 @@ class TestModel:
         model.index = index
         mock_msg = mocker.Mock()
         another_msg = mocker.Mock()
-        self.controller.view.msg_list = (
+        self.controller.view.message_view = (
             mocker.Mock(log=[mock_msg, another_msg])
         )
         mock_msg.original_widget.message = index['messages'][1]

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -41,7 +41,6 @@ class TestModel:
     def test_init(self, model, initial_data, user_profile):
         assert hasattr(model, 'controller')
         assert hasattr(model, 'client')
-        assert model.msg_view is None
         assert model.msg_list is None
         assert model.narrow == []
         assert model._have_last_message == {}

--- a/tests/ui/test_ui.py
+++ b/tests/ui/test_ui.py
@@ -35,10 +35,10 @@ class TestView:
         return_value = view.left_column_view()
         assert return_value == left_view(view)
 
-    def test_message_view(self, view, mocker):
+    def test_middle_column_view(self, view, mocker):
         middle_view = mocker.patch('zulipterminal.ui.MiddleColumnView')
         line_box = mocker.patch('zulipterminal.ui.urwid.LineBox')
-        return_value = view.message_view()
+        return_value = view.middle_column_view()
         middle_view.assert_called_once_with(view, view.model,
                                             view.write_box, view.search_box)
         assert view.middle_column == middle_view()
@@ -115,7 +115,7 @@ class TestView:
         # NOTE: Use monkeypatch not patch, as view doesn't exist until later
         def just_set_msg_list(self):
             self.msg_list = mocker.Mock(read_message=lambda: None)
-        monkeypatch.setattr(View, 'message_view', just_set_msg_list)
+        monkeypatch.setattr(View, 'middle_column_view', just_set_msg_list)
 
         right = mocker.patch('zulipterminal.ui.View.right_column_view')
         col = mocker.patch("zulipterminal.ui.urwid.Columns")

--- a/tests/ui/test_ui.py
+++ b/tests/ui/test_ui.py
@@ -25,7 +25,7 @@ class TestView:
         assert view.model == self.model
         assert view.pinned_streams == self.model.pinned_streams
         assert view.unpinned_streams == self.model.unpinned_streams
-        assert view.msg_list is None
+        assert view.message_view is None
         self.write_box.assert_called_once_with(view)
         self.search_box.assert_called_once_with(self.controller)
         main_window.assert_called_once_with()
@@ -113,9 +113,9 @@ class TestView:
         left = mocker.patch('zulipterminal.ui.View.left_column_view')
 
         # NOTE: Use monkeypatch not patch, as view doesn't exist until later
-        def just_set_msg_list(self):
-            self.msg_list = mocker.Mock(read_message=lambda: None)
-        monkeypatch.setattr(View, 'middle_column_view', just_set_msg_list)
+        def just_set_message_view(self):
+            self.message_view = mocker.Mock(read_message=lambda: None)
+        monkeypatch.setattr(View, 'middle_column_view', just_set_message_view)
 
         right = mocker.patch('zulipterminal.ui.View.right_column_view')
         col = mocker.patch("zulipterminal.ui.urwid.Columns")
@@ -151,7 +151,7 @@ class TestView:
                 (0, right()),
                 ], focus_column=0),
             mocker.call()._contents.set_focus_changed_callback(
-                view.msg_list.read_message),
+                view.message_view.read_message),
             mocker.call([
                 title_divider(),
                 (title_length, text()),

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -70,6 +70,7 @@ class TestMessageView:
     @pytest.fixture(autouse=True)
     def mock_external_classes(self, mocker):
         self.model = mocker.MagicMock()
+        self.view = mocker.Mock()
         self.urwid = mocker.patch(VIEWS + ".urwid")
 
     @pytest.fixture
@@ -77,7 +78,7 @@ class TestMessageView:
         mocker.patch(VIEWS + ".MessageView.main_view", return_value=[msg_box])
         mocker.patch(VIEWS + ".MessageView.read_message")
         mocker.patch(VIEWS + ".MessageView.set_focus")
-        msg_view = MessageView(self.model)
+        msg_view = MessageView(self.model, self.view)
         msg_view.log = mocker.Mock()
         msg_view.body = mocker.Mock()
         return msg_view
@@ -99,7 +100,9 @@ class TestMessageView:
         mocker.patch(VIEWS + ".create_msg_box_list",
                      return_value=msg_list)
         self.model.get_focus_in_current_narrow.return_value = narrow_focus_pos
-        msg_view = MessageView(self.model)
+
+        msg_view = MessageView(self.model, self.view)
+
         assert msg_view.focus_msg == focus_msg
 
     @pytest.mark.parametrize('messages_fetched', [
@@ -329,7 +332,7 @@ class TestMessageView:
         self.urwid.SimpleFocusListWalker.return_value = mocker.Mock()
         mocker.patch(VIEWS + ".MessageView.set_focus")
         mocker.patch(VIEWS + ".MessageView.update_search_box_narrow")
-        msg_view = MessageView(self.model)
+        msg_view = MessageView(self.model, self.view)
         msg_view.model.is_search_narrow = lambda: False
         msg_view.log = mocker.Mock()
         msg_view.body = mocker.Mock()
@@ -381,7 +384,7 @@ class TestMessageView:
         mocker.patch(VIEWS + ".MessageView.main_view", return_value=[msg_box])
         mocker.patch(VIEWS + ".MessageView.set_focus")
         mocker.patch(VIEWS + ".MessageView.update_search_box_narrow")
-        msg_view = MessageView(self.model)
+        msg_view = MessageView(self.model, self.view)
         msg_view.model.controller.view = mocker.Mock()
         msg_w = mocker.Mock()
         msg_view.body = mocker.Mock()
@@ -398,7 +401,7 @@ class TestMessageView:
                                                       empty_index, msg_box):
         mocker.patch(VIEWS + ".MessageView.main_view", return_value=[msg_box])
         mocker.patch(VIEWS + ".MessageView.set_focus")
-        msg_view = MessageView(self.model)
+        msg_view = MessageView(self.model, self.view)
         msg_view.model.is_search_narrow = lambda: False
         msg_view.log = [0, 1]
         msg_view.body = mocker.Mock()
@@ -792,7 +795,7 @@ class TestMiddleColumnView:
         assert mid_col_view.last_unread_topic is None
         assert mid_col_view.last_unread_pm is None
         assert mid_col_view.search_box == self.search_box
-        assert self.model.msg_list == "MSG_LIST"
+        assert self.view.msg_list == "MSG_LIST"
         self.super.assert_called_once_with("MSG_LIST", header=self.search_box,
                                            footer=self.write_box)
 

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -795,7 +795,7 @@ class TestMiddleColumnView:
         assert mid_col_view.last_unread_topic is None
         assert mid_col_view.last_unread_pm is None
         assert mid_col_view.search_box == self.search_box
-        assert self.view.msg_list == "MSG_LIST"
+        assert self.view.message_view == "MSG_LIST"
         self.super.assert_called_once_with("MSG_LIST", header=self.search_box,
                                            footer=self.write_box)
 

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -163,11 +163,11 @@ class Controller:
         msg_id_list = self.model.get_message_ids_in_current_narrow()
 
         w_list = create_msg_box_list(self.model, msg_id_list)
-        self.view.msg_list.log.clear()
-        self.view.msg_list.log.extend(w_list)
+        self.view.message_view.log.clear()
+        self.view.message_view.log.extend(w_list)
         focus_position = 0
         if 0 <= focus_position < len(w_list):
-            self.view.msg_list.set_focus(focus_position)
+            self.view.message_view.set_focus(focus_position)
 
     def stream_muting_confirmation_popup(self, button: Any) -> None:
         currently_muted = self.model.is_muted_stream(button.stream_id)
@@ -208,11 +208,11 @@ class Controller:
             focus_position = len(w_list) - 1
         assert not isinstance(focus_position, set)
 
-        self.view.msg_list.log.clear()
+        self.view.message_view.log.clear()
         if 0 <= focus_position < len(w_list):
-            self.view.msg_list.log.extend(w_list, focus_position)
+            self.view.message_view.log.extend(w_list, focus_position)
         else:
-            self.view.msg_list.log.extend(w_list)
+            self.view.message_view.log.extend(w_list)
 
         self.exit_editor_mode()
 

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -163,8 +163,8 @@ class Controller:
         msg_id_list = self.model.get_message_ids_in_current_narrow()
 
         w_list = create_msg_box_list(self.model, msg_id_list)
-        self.model.msg_view.clear()
-        self.model.msg_view.extend(w_list)
+        self.model.msg_list.log.clear()
+        self.model.msg_list.log.extend(w_list)
         focus_position = 0
         if 0 <= focus_position < len(w_list):
             self.model.msg_list.set_focus(focus_position)
@@ -208,11 +208,11 @@ class Controller:
             focus_position = len(w_list) - 1
         assert not isinstance(focus_position, set)
 
-        self.model.msg_view.clear()
+        self.model.msg_list.log.clear()
         if 0 <= focus_position < len(w_list):
-            self.model.msg_view.extend(w_list, focus_position)
+            self.model.msg_list.log.extend(w_list, focus_position)
         else:
-            self.model.msg_view.extend(w_list)
+            self.model.msg_list.log.extend(w_list)
 
         self.exit_editor_mode()
 

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -163,11 +163,11 @@ class Controller:
         msg_id_list = self.model.get_message_ids_in_current_narrow()
 
         w_list = create_msg_box_list(self.model, msg_id_list)
-        self.model.msg_list.log.clear()
-        self.model.msg_list.log.extend(w_list)
+        self.view.msg_list.log.clear()
+        self.view.msg_list.log.extend(w_list)
         focus_position = 0
         if 0 <= focus_position < len(w_list):
-            self.model.msg_list.set_focus(focus_position)
+            self.view.msg_list.set_focus(focus_position)
 
     def stream_muting_confirmation_popup(self, button: Any) -> None:
         currently_muted = self.model.is_muted_stream(button.stream_id)
@@ -208,11 +208,11 @@ class Controller:
             focus_position = len(w_list) - 1
         assert not isinstance(focus_position, set)
 
-        self.model.msg_list.log.clear()
+        self.view.msg_list.log.clear()
         if 0 <= focus_position < len(w_list):
-            self.model.msg_list.log.extend(w_list, focus_position)
+            self.view.msg_list.log.extend(w_list, focus_position)
         else:
-            self.model.msg_list.log.extend(w_list)
+            self.view.msg_list.log.extend(w_list)
 
         self.exit_editor_mode()
 

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -743,7 +743,7 @@ class Model:
 
         if (hasattr(self.controller, 'view')
                 and self._have_last_message[repr(self.narrow)]):
-            msg_log = self.controller.view.msg_list.log
+            msg_log = self.controller.view.message_view.log
             if msg_log:
                 last_message = msg_log[-1].original_widget.message
             else:
@@ -894,17 +894,17 @@ class Model:
         """
         # Update new content in the rendered view
         view = self.controller.view
-        for msg_w in view.msg_list.log:
+        for msg_w in view.message_view.log:
             msg_box = msg_w.original_widget
             if msg_box.message['id'] == msg_id:
                 # Remove the message if it no longer belongs in the current
                 # narrow.
                 if (len(self.narrow) == 2
                         and msg_box.message['subject'] != self.narrow[1][1]):
-                    view.msg_list.log.remove(msg_w)
+                    view.message_view.log.remove(msg_w)
                     # Change narrow if there are no messages left in the
                     # current narrow.
-                    if not view.msg_list.log:
+                    if not view.message_view.log:
                         msg_w_list = create_msg_box_list(
                                         self, [msg_id],
                                         last_message=msg_box.last_message)
@@ -921,17 +921,17 @@ class Model:
                     return
                 else:
                     new_msg_w = msg_w_list[0]
-                    msg_pos = view.msg_list.log.index(msg_w)
-                    view.msg_list.log[msg_pos] = new_msg_w
+                    msg_pos = view.message_view.log.index(msg_w)
+                    view.message_view.log[msg_pos] = new_msg_w
 
                     # If this is not the last message in the view
                     # update the next message's last_message too.
-                    if len(view.msg_list.log) != (msg_pos + 1):
-                        next_msg_w = view.msg_list.log[msg_pos + 1]
+                    if len(view.message_view.log) != (msg_pos + 1):
+                        next_msg_w = view.message_view.log[msg_pos + 1]
                         msg_w_list = create_msg_box_list(
                             self, [next_msg_w.original_widget.message['id']],
                             last_message=new_msg_w.original_widget.message)
-                        view.msg_list.log[msg_pos + 1] = msg_w_list[0]
+                        view.message_view.log[msg_pos + 1] = msg_w_list[0]
                     self.controller.update_screen()
                     return
 

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -66,7 +66,6 @@ class Model:
         self.controller = controller
         self.client = controller.client
 
-        self.msg_view = None  # type: Any
         self.msg_list = None  # type: Any
         self.narrow = []  # type: List[Any]
         self._have_last_message = {}  # type: Dict[str, bool]

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -31,7 +31,7 @@ class View(urwid.WidgetWrap):
         self.write_box = WriteBox(self)
         self.search_box = SearchBox(self.controller)
 
-        self.msg_list = None  # type: Any
+        self.message_view = None  # type: Any
 
         super().__init__(self.main_window())
 
@@ -120,14 +120,14 @@ class View(urwid.WidgetWrap):
             ]
         self.body = urwid.Columns(body, focus_column=0)
 
-        # NOTE: msg_list is None, but middle_column_view is called above and
-        #       sets it.
-        assert self.msg_list is not None
+        # NOTE: message_view is None, but middle_column_view is called above
+        # and sets it.
+        assert self.message_view is not None
         # NOTE: set_focus_changed_callback is actually called before the
         # focus is set, so the message is not read yet, it will be read when
         # the focus is changed again either vertically or horizontally.
         self.body._contents.set_focus_changed_callback(
-            self.msg_list.read_message)
+            self.message_view.read_message)
         div_char = '═'
 
         title_text = " {full_name} ({email}) - {server_name} ({url}) ".format(

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -38,7 +38,7 @@ class View(urwid.WidgetWrap):
     def left_column_view(self) -> Any:
         return LeftColumnView(View.LEFT_WIDTH, self)
 
-    def message_view(self) -> Any:
+    def middle_column_view(self) -> Any:
         self.middle_column = MiddleColumnView(self, self.model, self.write_box,
                                               self.search_box)
         return urwid.LineBox(self.middle_column, title='Messages',
@@ -104,7 +104,7 @@ class View(urwid.WidgetWrap):
 
     def main_window(self) -> Any:
         self.left_panel = self.left_column_view()
-        self.center_panel = self.message_view()
+        self.center_panel = self.middle_column_view()
         self.right_panel = self.right_column_view()
         if self.controller.autohide:
             body = [
@@ -120,7 +120,8 @@ class View(urwid.WidgetWrap):
             ]
         self.body = urwid.Columns(body, focus_column=0)
 
-        # NOTE: msg_list is None, but message_view is called above and sets it.
+        # NOTE: msg_list is None, but middle_column_view is called above and
+        #       sets it.
         assert self.msg_list is not None
         # NOTE: set_focus_changed_callback is actually called before the
         # focus is set, so the message is not read yet, it will be read when

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -30,6 +30,9 @@ class View(urwid.WidgetWrap):
         self.unpinned_streams = self.model.unpinned_streams
         self.write_box = WriteBox(self)
         self.search_box = SearchBox(self.controller)
+
+        self.msg_list = None  # type: Any
+
         super().__init__(self.main_window())
 
     def left_column_view(self) -> Any:
@@ -116,11 +119,14 @@ class View(urwid.WidgetWrap):
                 (View.RIGHT_WIDTH, self.right_panel),
             ]
         self.body = urwid.Columns(body, focus_column=0)
+
+        # NOTE: msg_list is None, but message_view is called above and sets it.
+        assert self.msg_list is not None
         # NOTE: set_focus_changed_callback is actually called before the
         # focus is set, so the message is not read yet, it will be read when
         # the focus is changed again either vertically or horizontally.
         self.body._contents.set_focus_changed_callback(
-            self.model.msg_list.read_message)
+            self.msg_list.read_message)
         div_char = '═'
 
         title_text = " {full_name} ({email}) - {server_name} ({url}) ".format(

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -62,9 +62,6 @@ class MessageView(urwid.ListBox):
         self.focus_msg = 0
         self.log = ModListWalker(self.main_view())
         self.log.read_message = self.read_message
-        # This Function completely controls the messages
-        # shown in the MessageView
-        self.model.msg_view = self.log
 
         super().__init__(self.log)
         self.set_focus(self.focus_msg)

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -56,8 +56,9 @@ class ModListWalker(urwid.SimpleFocusListWalker):
 
 
 class MessageView(urwid.ListBox):
-    def __init__(self, model: Any) -> None:
+    def __init__(self, model: Any, view: Any) -> None:
         self.model = model
+        self.view = view
         # Initialize for reference
         self.focus_msg = 0
         self.log = ModListWalker(self.main_view())
@@ -466,14 +467,14 @@ class UsersView(urwid.ListBox):
 class MiddleColumnView(urwid.Frame):
     def __init__(self, view: Any, model: Any,
                  write_box: Any, search_box: Any) -> None:
-        msg_list = MessageView(model)
+        msg_list = MessageView(model, view)
         self.model = model
         self.controller = model.controller
         self.view = view
         self.last_unread_topic = None
         self.last_unread_pm = None
         self.search_box = search_box
-        model.msg_list = msg_list
+        view.msg_list = msg_list
         super().__init__(msg_list, header=search_box, footer=write_box)
 
     def get_next_unread_topic(self) -> Optional[Tuple[int, str]]:

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -467,15 +467,15 @@ class UsersView(urwid.ListBox):
 class MiddleColumnView(urwid.Frame):
     def __init__(self, view: Any, model: Any,
                  write_box: Any, search_box: Any) -> None:
-        msg_list = MessageView(model, view)
+        message_view = MessageView(model, view)
         self.model = model
         self.controller = model.controller
         self.view = view
         self.last_unread_topic = None
         self.last_unread_pm = None
         self.search_box = search_box
-        view.msg_list = msg_list
-        super().__init__(msg_list, header=search_box, footer=write_box)
+        view.message_view = message_view
+        super().__init__(message_view, header=search_box, footer=write_box)
 
     def get_next_unread_topic(self) -> Optional[Tuple[int, str]]:
         topics = list(self.model.unread_counts['unread_topics'].keys())


### PR DESCRIPTION
The motivation for this PR started as an exploratory migration of the `msg_list` and `msg_view` attributes of the `Model` into a more appropriate location - the `View`. These variables have stuck out each time I look at the model due to their UI focus, and that they're initialized to meaningful values outside of the `Model`. One is used in some model methods, but similarly to `set_count`, these are cases where there are model and view changes, which can be split - and so the UI ones can hopefully be migrated into the `View` after this change.

Some less directly connected refactoring commits are included: the first three are not strictly related, so could be merged separately or first, but should be small or separate to understand and review.

The last 4 commits are the thrust of the PR:
* remove use of `msg_view`, since it is a shorthand for `msg_list.log`
* do the migration of `msg_list` into `View`
* rename the existing `message_view` method in `View`
* rename `msg_list` to `message_view` to improve the accuracy/clarity

This is a large change, but I believe worth the effort!