### PR TITLE
Start to enforce quoting styles using flake8-quotes

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -16,6 +16,7 @@ pytest = "==5.3.5"
 pytest-mock = "==1.7.1"
 pytest-cov = "==2.5.1"
 flake8 = "==3.7.9"
+flake8-quotes = "==3.0.0"
 zipp = "==1.0.0"  # To support Python 3.5
 pudb = "==2017.1.4"
 snakeviz = "==0.4.2"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ pytest==5.3.5
 pytest-cov==2.5.1
 pytest-mock==1.7.1
 flake8==3.7.9
+flake8-quotes==3.0.0
 pudb==2017.1.4
 snakeviz==0.4.2
 gitlint==0.10.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,10 @@ ignore=
   E252,
   # F841 - assigned to but never used - FIXME: indicates potential issues
   F841,
+  # Q000 - inline quotes - FIXME: standardize on " or ' in future?
+  Q000,
+inline-quotes = "
+multiline-quotes = """
 exclude=.git,__pycache__,build,dist,tools
 
 [mypy]

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ linting_deps = [
     'isort==4.3.21',
     'mypy==0.770',
     'flake8==3.7.9',
+    'flake8-quotes==3.0.0',
 ]
 
 dev_helper_deps = [

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -36,9 +36,9 @@ def in_color(color: str, text: str) -> str:
 
 
 def parse_args(argv: List[str]) -> argparse.Namespace:
-    description = '''
+    description = """
         Starts Zulip-Terminal.
-        '''
+        """
     formatter_class = argparse.RawDescriptionHelpFormatter
     parser = argparse.ArgumentParser(description=description,
                                      formatter_class=formatter_class)

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -631,7 +631,7 @@ class MessageBox(urwid.Pile):
         return (None, self.soup2markup(body))
 
     def indent_quoted_content(self, soup: Any, padding_char: str) -> None:
-        '''
+        """
         We indent quoted text by padding them.
         The extent of indentation depends on their level of quoting.
         For example:
@@ -643,7 +643,7 @@ class MessageBox(urwid.Pile):
         </blockquote>       --->        </blockquote>
         <p>Boo</p>                      <p>▒ </p><p>Boo</p>
         </blockquote>                   </blockquote>
-        '''
+        """
         pad_count = 1
         blockquote_list = soup.find_all('blockquote')
         self.bq_len = len(blockquote_list)


### PR DESCRIPTION
This enforces multi-line quoting at this stage, which we have mostly been consistent with already.

Regular quoting is a little less consistent right now, so I've not enabled that check. There is some argument for keeping single quotes for short elements and double for longer, but I favor sticking with one type for regular strings if we can - it makes searching for string (vs variable names) much easier.