### PR TITLE
Use bullet character in list & remove newlines.

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1451,8 +1451,12 @@ class TestMessageBox:
          .format(SERVER_URL),
             [('msg_link', '{}/some/relative_url'.format(SERVER_URL))]),
         ('<li>Something', ['  \N{BULLET} ', '', 'Something']),
+        ('<li>\n<p>Something', ['  \N{BULLET} ', '', '', '', 'Something']),
         ('<li>Something<li>else',  # NOTE Real items are newline-separated?
             ['  \N{BULLET} ', '', 'Something', '  \N{BULLET} ', '', 'else']),
+        ('<li>\n<p>Something</p>\n</li><li>else',
+            ['  \N{BULLET} ', '', '', '', 'Something', '',
+             '  \N{BULLET} ', '', 'else']),
         ('<br>', []), ('<br/>', []),
         ('<hr>', ['[RULER NOT RENDERED]']),
         ('<hr/>', ['[RULER NOT RENDERED]']),
@@ -1514,6 +1518,8 @@ class TestMessageBox:
         ('<span class="katex-display">some-math</span>', ['some-math']),
         ('<span class="katex">some-math</span>', ['some-math']),
         ('<ul><li>text</li></ul>', ['', '  \N{BULLET} ', '', 'text']),
+        ('<ul>\n<li>text</li>\n</ul>',
+            ['', '', '  \N{BULLET} ', '', 'text', '']),
         ('<del>text</del>', ['', 'text']),  # FIXME Strikethrough
         ('<div class="message_inline_image">'
          '<a href="x"><img src="x"></a></div>', []),
@@ -1529,7 +1535,7 @@ class TestMessageBox:
         'embedded_content',
         'link_sametext', 'link_sameimage', 'link_differenttext',
         'link_userupload', 'link_api', 'link_serverrelative_same',
-        'listitem', 'listitems',
+        'li', 'li_with_li_p_newline', 'two_li', 'two_li_with_li_p_newlines',
         'br', 'br2', 'hr', 'hr2', 'img', 'img2',
         'table_default',
         'table_with_left_and_right_alignments',
@@ -1537,7 +1543,8 @@ class TestMessageBox:
         'table_with_single_column',
         'table_with_the_bare_minimum',
         'math', 'math2',
-        'ul', 'strikethrough_del', 'inline_image', 'inline_ref',
+        'ul', 'ul_with_ul_li_newlines',
+        'strikethrough_del', 'inline_image', 'inline_ref',
         'emoji', 'preview-twitter', 'zulip_extra_emoji', 'custom_emoji'
     ])
     def test_soup2markup(self, content, markup):

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1450,9 +1450,9 @@ class TestMessageBox:
         ('<a href="some/relative_url">{}/some/relative_url</a>'
          .format(SERVER_URL),
             [('msg_link', '{}/some/relative_url'.format(SERVER_URL))]),
-        ('<li>Something', ['  * ', '', 'Something']),
+        ('<li>Something', ['  \N{BULLET} ', '', 'Something']),
         ('<li>Something<li>else',  # NOTE Real items are newline-separated?
-            ['  * ', '', 'Something', '  * ', '', 'else']),
+            ['  \N{BULLET} ', '', 'Something', '  \N{BULLET} ', '', 'else']),
         ('<br>', []), ('<br/>', []),
         ('<hr>', ['[RULER NOT RENDERED]']),
         ('<hr/>', ['[RULER NOT RENDERED]']),
@@ -1513,7 +1513,7 @@ class TestMessageBox:
          ]),
         ('<span class="katex-display">some-math</span>', ['some-math']),
         ('<span class="katex">some-math</span>', ['some-math']),
-        ('<ul><li>text</li></ul>', ['', '  * ', '', 'text']),
+        ('<ul><li>text</li></ul>', ['', '  \N{BULLET} ', '', 'text']),
         ('<del>text</del>', ['', 'text']),  # FIXME Strikethrough
         ('<div class="message_inline_image">'
          '<a href="x"><img src="x"></a></div>', []),

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -441,8 +441,8 @@ class MessageBox(urwid.Pile):
                 text = unrendered_tags[element.name]
                 if text:
                     markup.append(unrendered_template.format(text))
-            elif element.name in ('p', 'ul', 'del'):
-                # PARAGRAPH, LISTS, STRIKE-THROUGH
+            elif element.name in ('p', 'del'):
+                # PARAGRAPH, STRIKE-THROUGH
                 markup.extend(self.soup2markup(element))
             elif (element.name == 'span' and element.attrs
                   and 'emoji' in element.attrs.get('class', [])):
@@ -495,10 +495,19 @@ class MessageBox(urwid.Pile):
             elif element.name in ('strong', 'em'):
                 # BOLD & ITALIC
                 markup.append(('msg_bold', element.text))
+            elif element.name == 'ul':
+                # LISTS (UL)
+                for index in [0, -1]:
+                    if element.contents[index] == '\n':
+                        element.contents[index].replace_with('')
+                markup.extend(self.soup2markup(element))
             elif element.name == 'li':
-                # LISTS
+                # LIST ITEMS (LI)
                 # TODO: Support nested lists
                 markup.append('  \N{BULLET} ')
+                for index in [0, -1]:
+                    if element.contents[index] == '\n':
+                        element.contents[index].replace_with('')
                 markup.extend(self.soup2markup(element))
             elif element.name == 'table':
                 markup.extend(render_table(element))

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -498,7 +498,7 @@ class MessageBox(urwid.Pile):
             elif element.name == 'li':
                 # LISTS
                 # TODO: Support nested lists
-                markup.append('  * ')
+                markup.append('  \N{BULLET} ')
                 markup.extend(self.soup2markup(element))
             elif element.name == 'table':
                 markup.extend(render_table(element))


### PR DESCRIPTION
This change:
* makes it clearer when markdown text is recognized as bullets
* saves space by removing extra lines that are in the html

Tests amended.

New tests added for changed code, to ensure newlines removed:
* between ul and li elements
* between li and p elements
---
To see a good example of the reduction in newlines this makes, have a look at:
* simple bulleted elements in eg. #**test here**
* the bash++ topic in #**learning** (there were extra newlines *after* a bullet, before text)

A side by side comparison makes the difference very obvious.

The bullet characters make it clearer when a bullet is used, since `* foo` previously appeared like a bullet, but wasn't always recognized by the markdown parser eg. depending on indent, so wasn't always obviously rendered differently.

Note that the bullet symbol doesn't cause rendering issues for me, and is already used in the user list, so should be good to use.