### PR TITLE
Don't corrupt screen if notifying fails; indicate to user once instead

### DIFF
--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -15,7 +15,7 @@ from zulipterminal.model import Model
 from zulipterminal.ui import Screen, View
 from zulipterminal.ui_tools.utils import create_msg_box_list
 from zulipterminal.ui_tools.views import (
-    HelpView, MsgInfoView, PopUpConfirmationView, StreamInfoView,
+    HelpView, MsgInfoView, NoticeView, PopUpConfirmationView, StreamInfoView,
 )
 from zulipterminal.version import ZT_VERSION
 
@@ -120,6 +120,9 @@ class Controller:
     def show_stream_info(self, color: str, name: str, desc: str) -> None:
         show_stream_view = StreamInfoView(self, color, name, desc)
         self.show_pop_up(show_stream_view, "# {}".format(name))
+
+    def popup_with_message(self, text: str, width: int, height: int) -> None:
+        self.show_pop_up(NoticeView(self, text, width, height), "NOTICE")
 
     def search_messages(self, text: str) -> None:
         # Search for a text in messages

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -505,8 +505,7 @@ def canonicalize_color(color: str) -> str:
         raise ValueError('Unknown format for color "{}"'.format(color))
 
 
-@asynch
-def notify(title: str, html_text: str) -> None:
+def notify(title: str, html_text: str) -> str:
     document = lxml.html.document_fromstring(html_text)
     text = document.text_content()
     quoted_text = shlex.quote(text)
@@ -542,5 +541,10 @@ def notify(title: str, html_text: str) -> None:
         # NOTE: We assert this in tests, but this signals unexpected breakage
         assert len(command_list) == expected_length
 
-        res = subprocess.run(command_list, stdout=subprocess.DEVNULL,
-                             stderr=subprocess.STDOUT)
+        try:
+            subprocess.run(command_list, stdout=subprocess.DEVNULL,
+                           stderr=subprocess.DEVNULL)
+        except FileNotFoundError:
+            # This likely means the notification command could not be found
+            return command_list[0]
+    return ""

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -67,7 +67,7 @@ UnreadCounts = TypedDict('UnreadCounts', {
 })
 
 
-def asynch(func: Any) -> Any:
+def asynch(func: Callable[..., None]) -> Callable[..., None]:
     """
     Decorator for executing a function in a separate :class:`threading.Thread`.
     """

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -791,6 +791,21 @@ class PopUpView(urwid.ListBox):
         return super().keypress(size, key)
 
 
+class NoticeView(PopUpView):
+    def __init__(self, controller: Any,
+                 notice_text: str,
+                 width: int,
+                 height: int) -> None:
+        self.width = width
+        self.height = height
+        widgets = [
+            urwid.Divider(),
+            urwid.Padding(urwid.Text(notice_text), left=1, right=1),
+            urwid.Divider(),
+        ]
+        super().__init__(controller, widgets, 'GO_BACK')
+
+
 class HelpView(PopUpView):
     def __init__(self, controller: Any) -> None:
         widths = [(len(binding['help_text']) + 4,


### PR DESCRIPTION
Previously if notifications were enabled, but we cannot find the notification executable, then a traceback appears over the UI - I only noticed this since I copied a zuliprc file to another machine where the notification commands weren't available.

This small commit fixes this by wrapping the subprocess.run in a try/except block and logging FileNotFoundError exceptions, currently to `debug.log`.

**NOTE** This fixes the issue as it stands, but could spam the debug file and not be very obvious. I've noted some alternatives in the comments; we could merge this now to avoid the messed-up UI and work on the method in another issue/PR, or decide how best to approach this.