### PR TITLE
Migrate docs from wiki to /docs

### DIFF
--- a/docs/developer-documentation.md
+++ b/docs/developer-documentation.md
@@ -4,16 +4,17 @@
 
 Zulip Terminal uses [Zulip's API](https://zulipchat.com/api/) to store and retrieve all the information it displays. It has an [MVC structure](https://en.wikipedia.org/wiki/Model%E2%80%93view%E2%80%93controller) overall. Here is a description of some of its files:
 
-| File/Folder                                           | Description                                   |
-| ----------------------------------------------------- | --------------------------------------------- |
-|zulipterminal/                                         | Root Folder - Contains all the source files   |
-|              ui.py                                    | Controls where each component is displayed    |
-|              core.py                                  | Runs the app and controls data flow into View |
-|              model.py                                 | Fetches and stores data retrieved from server |
-|              helper.py                                | Helper functions used at multiple places      |
-|              config.py                                | Stores keybindings along with what they do    |
-|              ui_tools                                 | Has all the UI elements displayed by View     |
-|              cli/run.py                               | Runs the app                                  |
+| Folder                 | File                | Description                                              |
+| ---------------------- | ------------------- | -------------------------------------------------------- |
+| zulipterminal/         |                     | Root Folder - Contains all the source files              |
+|                        | core.py             | Runs the app and controls data flow into View            |
+|                        | helper.py           | Helper functions used at multiple places                 |
+|                        | model.py            | Fetches and stores data retrieved from server            |
+|                        | ui.py               | Controls where each component is displayed               |
+|                        |                     |                                                          |
+| zulipterminal/cli      | run.py              | Runs the app                                             |
+|                        |                     |                                                          |
+| zulipterminal/ui_tools |                     | Has all the UI elements displayed by View                |
 
 Zulip Terminal uses [urwid](http://urwid.org/) to render the UI components in terminal. Urwid is an awesome library through which you can render a decent terminal UI just using python. [Urwid's Tutorial](http://urwid.org/tutorial/index.html) is a great place to start for new contributors.
 

--- a/docs/developer-documentation.md
+++ b/docs/developer-documentation.md
@@ -1,0 +1,192 @@
+**Zulip Terminal** is a light and fast terminal client for [Zulip](https://zulipchat.com). It's written in python and :snake: only.
+
+## Overview
+Zulip Terminal uses [Zulip's API](https://zulipchat.com/api/) to store and retrieve all the information it displays. It has an [MVC structure](https://en.wikipedia.org/wiki/Model%E2%80%93view%E2%80%93controller) overall. Here is a description of some of its files:
+ 
+| File/Folder                                           | Description                                   |
+| ----------------------------------------------------- | --------------------------------------------- |
+|zulipterminal/                                         | Root Folder - Contains all the source files   |
+|              ui.py                                    | Controls where each component is displayed    |
+|              core.py                                  | Runs the app and controls data flow into View |
+|              model.py                                 | Fetches and stores data retrieved from server |
+|              helper.py                                | Helper functions used at multiple places      |
+|              config.py                                | Stores keybindings along with what they do    |
+|              ui_tools                                 | Has all the UI elements displayed by View     |
+|              cli/run.py                               | Runs the app                                  |
+
+Zulip Terminal uses [urwid](http://urwid.org/) to render the UI components in terminal. Urwid is an awesome library through which you can render a decent terminal UI just using python. [Urwid's Tutorial](http://urwid.org/tutorial/index.html) is a great place to start for new contributors.
+
+## Tests
+Tests for zulip-terminal are written using [pytest](https://pytest.org/). You can read the tests in `/tests` folder to learn about writing tests for a new class/function. If you are new to pytest, reading its documentation is definitely recommended.
+
+
+## Tutorial - Adding typing indicator
+This tutorial shows how typing indicator was implemented in the client. The process for adding a new feature to zulip terminal varies greatly depending on the feature. This tutorial is intended to make you familiar with the general process.
+
+Since the typing indicator data for the other user in pm cannot be generated locally, it should be received from the client.
+
+A quick google search for `zulip typing indicator` points to https://zulip.readthedocs.io/en/latest/subsystems/typing-indicators.html. This document explains how typing indicator is implemented on the web client and is useful in understanding how typing indicator works internally.
+
+You can find most of the web features documented in https://zulip.readthedocs.io/en/latest/subsystems and understand how they work internally.
+
+https://chat.zulip.org/api/ shows how to reach the endpoints and what response to expect from the server. There are two parts to this feature.
+
+There are two parts to implementing typing indicator.
+* Receive typing event from server.
+* Send typing event to the server.
+
+We will be implementing the first part. **Receive typing event from server**:
+
+On startup, the app registers for the events on the server which it is willing to handle. To receive updates for `typing` events, we need to add 'typing' to the initially registered events. 
+
+`register_initial_desired_events` in `core.py` is the function responsible for registering the events.
+``` diff
+
+# zulipterminal/core.py
+
+    @async
+    def register_initial_desired_events(self) -> None:
+        event_types = [
+            'message',
+            'update_message',
+            # ...
++           'typing',
+            # ...
+        ]
+        response = self.client.register(event_types=event_types,
+                                        apply_markdown=True)
+```
+
+Now, to see the type of data server is sending we will write the response from the server to a file.
+
+To do so, we temporarily add the following lines to the function `poll_for_events` in `model.py`. The function uses long polling to stay in contact with the server and continuously receives events from the server. 
+
+``` diff
+
+# zulipterminal/model.py
+
+            for event in response['events']:
++               with open('type', 'a') as f:
++                   f.write(str(event) + "\n")
+                last_event_id = max(last_event_id, int(event['id']))
+```
+
+Now, run zulip terminal and open web app from a different account. Start composing a message to your terminal account from the web app and you will start receiving 2 types of events:
+
+**Start**
+```
+{
+  'type': 'typing',
+  'op': 'start',
+  'sender': {
+    'user_id': 4,
+    'email': 'hamlet@zulip.com'
+  },
+  'recipients': [{
+    'user_id': 2,
+    'email': 'ZOE@zulip.com'
+  }, {
+    'user_id': 4,
+    'email': 'hamlet@zulip.com'
+  }, {
+    'user_id': 5,
+    'email': 'iago@zulip.com'
+  }],
+  'id': 0
+}
+```
+
+
+**Stop**
+```
+{
+  'type': 'typing',
+  'op': 'stop',
+  'sender': {
+    'user_id': 4,
+    'email': 'hamlet@zulip.com'
+  },
+  'recipients': [{
+    'user_id': 2,
+    'email': 'ZOE@zulip.com'
+  }, {
+    'user_id': 4,
+    'email': 'hamlet@zulip.com'
+  }, {
+    'user_id': 5,
+    'email': 'iago@zulip.com'
+  }],
+  'id': 1
+}
+```
+
+You can view these events in the `type` file in your `zulip-terminal` home directory.
+
+Now to display if user is typing in the view, we need to check few things:
+* The `op` is `start`.
+* User is narrowed into PM with a user.
+* The `user_id` of the person is present in the narrowed PM recipients.
+
+If all the above conditions are satisfied we can successfully update the footer to display `X is typing` until we receive
+a `stop` event for typing.
+
+To check for the above conditions, we create a function in `ui.py`:
+```python
+
+    def handle_typing_event(self, event: Dict['str', Any]) -> None:
+        # If the user is in pm narrow with the person typing
+        if len(self.model.narrow) == 1 and\
+                self.model.narrow[0][0] == 'pm_with' and\
+                event['sender']['email'] in self.model.narrow[0][1].split(','):
+            if event['op'] == 'start':
+                user = self.model.user_dict[event['sender']['email']]
+                self._w.footer.set_text([
+                    ' ',
+                    ('code', user['full_name']),
+                    ' is typing...'
+                ])
+                self.controller.update_screen()
+            elif event['op'] == 'stop':
+                self._w.footer.set_text(self.get_random_help())
+                self.controller.update_screen()
+```
+If the conditions are satisfied, we display `x is typing` if the `op` is `start` and display help message if the `op` is `stop`.
+
+There are two parts to updating a widget in urwid:
+* Changing the widget
+* Updating the screen
+
+This line of code,
+```python
+self._w.footer.set_text([
+                    ' ',
+                    ('code', user['full_name']),
+                    ' is typing...'
+                ])
+```
+changes the footer text, and this
+```python
+self.controller.update_screen()
+```
+updates the screen to display the changes. This fully implements the typing feature. 
+
+### Writing tests
+Now, we update the tests for `register_initial_desired_events` by adding `typing`
+to the event types.
+```diff
+# tests/core/test_core.py
+
+        event_types = [
+            'message',
+            'update_message',
+            'reaction',
++           'typing',
+        ]
+        controller.client.register.assert_called_once_with(
+                                   event_types=event_types,
+                                   apply_markdown=True)
+```
+
+`test_handle_typing_event` in `test_ui.py` implements testing for `handle_typing_event`. Please read it to understand how to write tests for a new function in zulip terminal.
+
+Thanks for reading the tutorial. See you on the other side now, i.e, pull request side. :smiley: 

--- a/docs/developer-documentation.md
+++ b/docs/developer-documentation.md
@@ -6,15 +6,22 @@ Zulip Terminal uses [Zulip's API](https://zulipchat.com/api/) to store and retri
 
 | Folder                 | File                | Description                                              |
 | ---------------------- | ------------------- | -------------------------------------------------------- |
-| zulipterminal/         |                     | Root Folder - Contains all the source files              |
-|                        | core.py             | Runs the app and controls data flow into View            |
+| zulipterminal/         | core.py             | Sets up the model, view and runs the application         |
 |                        | helper.py           | Helper functions used at multiple places                 |
 |                        | model.py            | Fetches and stores data retrieved from server            |
 |                        | ui.py               | Controls where each component is displayed               |
+|                        | version.py          | Keeps track of the latest releases PyPI version          |
 |                        |                     |                                                          |
-| zulipterminal/cli      | run.py              | Runs the app                                             |
+| zulipterminal/cli      | run.py              | Marks the entry point into the application               |
 |                        |                     |                                                          |
-| zulipterminal/ui_tools |                     | Has all the UI elements displayed by View                |
+| zulipterminal/config   | keys.py             | Stores keybindings and their helper functions            |
+|                        | themes.py           | Stores different themes and their colour mappings        |
+|                        |                     |                                                          |
+| zulipterminal/ui_tools | boxes.py            | UI boxes such as WriteBox, MessageBox and SearchBox      |
+|                        | buttons.py          | UI buttons such as Stream, PM, Topic, Home, Starred, etc |
+|                        | tables.py           | Helper functions which render tables in the UI           |
+|                        | utils.py            | MessageBox for every message displayed is created here   |
+|                        | views.py            | UI views such as Streams, Messages, Topics, Help, etc    |
 
 Zulip Terminal uses [urwid](http://urwid.org/) to render the UI components in terminal. Urwid is an awesome library through which you can render a decent terminal UI just using python. [Urwid's Tutorial](http://urwid.org/tutorial/index.html) is a great place to start for new contributors.
 

--- a/docs/developer-documentation.md
+++ b/docs/developer-documentation.md
@@ -51,39 +51,32 @@ We will be implementing the first part. **Receive typing event from server**:
 
 On startup, the app registers for the events on the server which it is willing to handle. To receive updates for `typing` events, we need to add 'typing' to the initially registered events.
 
-`register_initial_desired_events` in `core.py` is the function responsible for registering the events.
-``` diff
+The `self.event_actions` in `model.py` is the data structure responsible for containing all the events which we are about to register with the server.
+Add the `typing` entry there with the handler function (defined later).
 
-# zulipterminal/core.py
+``` diff python
+# zulipterminal/model.py
 
-    @async
-    def register_initial_desired_events(self) -> None:
-        event_types = [
-            'message',
-            'update_message',
-            # ...
-+           'typing',
-            # ...
-        ]
-        response = self.client.register(event_types=event_types,
-                                        apply_markdown=True)
+    self.event_actions = OrderedDict([
+        # ...
++       ('typing', self._handle_typing_event),
+        # ...
+    ])  # type: OrderedDict[str, Callable[[Event], None]]
 ```
 
-Now, to see the type of data server is sending we will write the response from the server to a file.
+This is necessary, as in the `_register_desired_events` in `model.py` we use `self.client.register` to register the desired event. This function is provided to us by the Zulip API. For more details, refer https://zulipchat.com/api/register-queue.
 
-To do so, we temporarily add the following lines to the function `poll_for_events` in `model.py`. The function uses long polling to stay in contact with the server and continuously receives events from the server.
+Now, to see the type of data server is sending we will write the response from the server to a file. To do so, we temporarily add the following line to the function `poll_for_events` in `model.py`. The function uses long polling to stay in contact with the server and continuously receive events from the server.
 
 ``` diff
-
 # zulipterminal/model.py
 
             for event in response['events']:
-+               with open('type', 'a') as f:
-+                   f.write(str(event) + "\n")
-                last_event_id = max(last_event_id, int(event['id']))
++             print(event, flush=True)
+              last_event_id = max(last_event_id, int(event['id']))
 ```
 
-Now, run zulip terminal and open web app from a different account. Start composing a message to your terminal account from the web app and you will start receiving 2 types of events:
+Now, run zulip terminal and open web app from a different account. Start composing a message to your terminal account (PM) from the web app and you will start receiving 2 types of events:
 
 **Start**
 ```
@@ -108,7 +101,6 @@ Now, run zulip terminal and open web app from a different account. Start composi
 }
 ```
 
-
 **Stop**
 ```
 {
@@ -132,7 +124,7 @@ Now, run zulip terminal and open web app from a different account. Start composi
 }
 ```
 
-You can view these events in the `type` file in your `zulip-terminal` home directory.
+You can view the output of these events in the `debug.log` file in your `zulip-terminal` home directory.
 
 Now to display if user is typing in the view, we need to check few things:
 * The `op` is `start`.
@@ -142,64 +134,78 @@ Now to display if user is typing in the view, we need to check few things:
 If all the above conditions are satisfied we can successfully update the footer to display `X is typing` until we receive
 a `stop` event for typing.
 
-To check for the above conditions, we create a function in `ui.py`:
+To check for the above conditions, we define the callback, a function in `model.py`:
 ```python
 
-    def handle_typing_event(self, event: Dict['str', Any]) -> None:
-        # If the user is in pm narrow with the person typing
-        if len(self.model.narrow) == 1 and\
-                self.model.narrow[0][0] == 'pm_with' and\
-                event['sender']['email'] in self.model.narrow[0][1].split(','):
-            if event['op'] == 'start':
-                user = self.model.user_dict[event['sender']['email']]
-                self._w.footer.set_text([
-                    ' ',
-                    ('code', user['full_name']),
-                    ' is typing...'
-                ])
-                self.controller.update_screen()
-            elif event['op'] == 'stop':
-                self._w.footer.set_text(self.get_random_help())
-                self.controller.update_screen()
+    def _handle_typing_event(self, event: Event) -> None:
+        """
+        Handle typing notifications (in private messages)
+        """
+        if hasattr(self.controller, 'view'):
+            # If the user is in pm narrow with the person typing
+            if len(self.narrow) == 1 and self.narrow[0][0] == 'pm_with' and\
+                    event['sender']['email'] in self.narrow[0][1].split(','):
+                if event['op'] == 'start':
+                    user = self.user_dict[event['sender']['email']]
+                    self.controller.view.set_footer_text([
+                        ' ',
+                        ('code', user['full_name']),
+                        ' is typing...'
+                    ])
+                elif event['op'] == 'stop':
+                    self.controller.view.set_footer_text()
+                else:
+                    raise RuntimeError("Unknown typing event operation")
 ```
-If the conditions are satisfied, we display `x is typing` if the `op` is `start` and display help message if the `op` is `stop`.
+If the conditions are satisfied, we use the `set_footer_text` defined in `ui.py` to display `x is typing` if the `op` is `start` and display help message if the `op` is `stop`.
 
 There are two parts to updating a widget in urwid:
 * Changing the widget
 * Updating the screen
 
-This line of code,
+This line of code inside `view.set_footer_text`,
+
 ```python
-self._w.footer.set_text([
-                    ' ',
-                    ('code', user['full_name']),
-                    ' is typing...'
-                ])
+self._w.footer.set_text(text)
 ```
+
 changes the footer text, and this
+
 ```python
 self.controller.update_screen()
 ```
+
 updates the screen to display the changes. This fully implements the typing feature.
 
 ### Writing tests
 
-Now, we update the tests for `register_initial_desired_events` by adding `typing`
+Now, we update the tests for `test_register_initial_desired_events` by adding `typing`
 to the event types.
+
 ```diff
-# tests/core/test_core.py
+# tests/model/test_model.py
 
         event_types = [
-            'message',
-            'update_message',
-            'reaction',
+            # ...
 +           'typing',
+            # ...
         ]
-        controller.client.register.assert_called_once_with(
-                                   event_types=event_types,
-                                   apply_markdown=True)
 ```
 
-`test_handle_typing_event` in `test_ui.py` implements testing for `handle_typing_event`. Please read it to understand how to write tests for a new function in zulip terminal.
+`test__handle_typing_event` in `test_model.py` implements testing for `_handle_typing_event`. Please read it to understand how to write tests for a new function in zulip terminal.
+
+Lastly, in order for our linters to pass (specifically mypy), make sure you add any fields specific to the `typing` event in the event TypedDict.
+
+``` diff
+# zulipterminal/model.py
+
+Event = TypedDict('Event', {
+    # ...
++   # typing:
++    'sender': Dict[str, Any],  # 'email', ...
++    # typing & reaction:
++    'op': str,
+    # ...
+```
 
 Thanks for reading the tutorial. See you on the other side now, i.e, pull request side. :smiley:

--- a/docs/developer-documentation.md
+++ b/docs/developer-documentation.md
@@ -1,8 +1,9 @@
 **Zulip Terminal** is a light and fast terminal client for [Zulip](https://zulipchat.com). It's written in python and :snake: only.
 
 ## Overview
+
 Zulip Terminal uses [Zulip's API](https://zulipchat.com/api/) to store and retrieve all the information it displays. It has an [MVC structure](https://en.wikipedia.org/wiki/Model%E2%80%93view%E2%80%93controller) overall. Here is a description of some of its files:
- 
+
 | File/Folder                                           | Description                                   |
 | ----------------------------------------------------- | --------------------------------------------- |
 |zulipterminal/                                         | Root Folder - Contains all the source files   |
@@ -16,11 +17,14 @@ Zulip Terminal uses [Zulip's API](https://zulipchat.com/api/) to store and retri
 
 Zulip Terminal uses [urwid](http://urwid.org/) to render the UI components in terminal. Urwid is an awesome library through which you can render a decent terminal UI just using python. [Urwid's Tutorial](http://urwid.org/tutorial/index.html) is a great place to start for new contributors.
 
+
 ## Tests
+
 Tests for zulip-terminal are written using [pytest](https://pytest.org/). You can read the tests in `/tests` folder to learn about writing tests for a new class/function. If you are new to pytest, reading its documentation is definitely recommended.
 
 
 ## Tutorial - Adding typing indicator
+
 This tutorial shows how typing indicator was implemented in the client. The process for adding a new feature to zulip terminal varies greatly depending on the feature. This tutorial is intended to make you familiar with the general process.
 
 Since the typing indicator data for the other user in pm cannot be generated locally, it should be received from the client.
@@ -37,7 +41,7 @@ There are two parts to implementing typing indicator.
 
 We will be implementing the first part. **Receive typing event from server**:
 
-On startup, the app registers for the events on the server which it is willing to handle. To receive updates for `typing` events, we need to add 'typing' to the initially registered events. 
+On startup, the app registers for the events on the server which it is willing to handle. To receive updates for `typing` events, we need to add 'typing' to the initially registered events.
 
 `register_initial_desired_events` in `core.py` is the function responsible for registering the events.
 ``` diff
@@ -59,7 +63,7 @@ On startup, the app registers for the events on the server which it is willing t
 
 Now, to see the type of data server is sending we will write the response from the server to a file.
 
-To do so, we temporarily add the following lines to the function `poll_for_events` in `model.py`. The function uses long polling to stay in contact with the server and continuously receives events from the server. 
+To do so, we temporarily add the following lines to the function `poll_for_events` in `model.py`. The function uses long polling to stay in contact with the server and continuously receives events from the server.
 
 ``` diff
 
@@ -168,9 +172,10 @@ changes the footer text, and this
 ```python
 self.controller.update_screen()
 ```
-updates the screen to display the changes. This fully implements the typing feature. 
+updates the screen to display the changes. This fully implements the typing feature.
 
 ### Writing tests
+
 Now, we update the tests for `register_initial_desired_events` by adding `typing`
 to the event types.
 ```diff
@@ -189,4 +194,4 @@ to the event types.
 
 `test_handle_typing_event` in `test_ui.py` implements testing for `handle_typing_event`. Please read it to understand how to write tests for a new function in zulip terminal.
 
-Thanks for reading the tutorial. See you on the other side now, i.e, pull request side. :smiley: 
+Thanks for reading the tutorial. See you on the other side now, i.e, pull request side. :smiley:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -11,10 +11,10 @@ I would like you to try out a few of our keyboard shortcuts and send a couple me
 ![An image of working Zulip Terminal](https://camo.githubusercontent.com/d4efe459c212e64ae7c841e5dda288a14837bf1e/68747470733a2f2f64726976652e676f6f676c652e636f6d2f75633f6578706f72743d766965772669643d31746163325053535f47625177587a34476e7a66636f5f68696e5776464f327a61)
 Zulip Terminal is divided into three columns/divisions.
 **The left column** shows list of all the streams you are subscribed to and some buttons for viewing different types of messages.
-**The middle column** displays all the messages in the current narrow. 
+**The middle column** displays all the messages in the current narrow.
 **The right column** shows all the active(green)/idle(yellow)/offline(white) users.
 
-Now that you know what you are looking at, how about checking out some of our features using [keyboard shortcuts](https://github.com/zulip/zulip-terminal#hot-keys)... 
+Now that you know what you are looking at, how about checking out some of our features using [keyboard shortcuts](https://github.com/zulip/zulip-terminal#hot-keys)...
 
 ### Narrowing to a stream
 Narrowing to a stream implies you have set middle column to show messages present in that stream. Let's try narrowing to [# test here](https://chat.zulip.org/#narrow/stream/7-test-here) from zulip terminal. Press <kbd>q</kbd> to focus on  the stream search box in the left column. Type `test here`

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,20 @@
+Hi, are you new to [Zulip](https://github.com/zulip/zulip)? If so, we recommend trying out our [web-client](https://chat.zulip.org) first to understand the concept of [streams/topics/PMs](https://zulipchat.com/help/about-streams-and-topics) in the world of Zulip. Just sending a message or two in [#test here](https://chat.zulip.org/#narrow/stream/7-test-here) stream should help you get started.
+
+Now let's help you get started with using zulip terminal. First, go ahead and complete the [installation](https://github.com/zulip/zulip-terminal#installation--running). If you encountered any issues, we have common issues and their solutions listed [here](https://github.com/zulip/zulip-terminal#troubleshooting-common-issues).
+
+If you encountered any issues above or have any queries, feel free to ask for help at [#zulip-terminal](https://chat.zulip.org/#narrow/stream/206-zulip-terminal) or support@zulipchat.com.
+
+## Tutorial
+I would like you to try out a few of our keyboard shortcuts and send a couple message to help you get familiar with zulip terminal.
+
+#### What do you see?
+![An image of working Zulip Terminal](https://camo.githubusercontent.com/d4efe459c212e64ae7c841e5dda288a14837bf1e/68747470733a2f2f64726976652e676f6f676c652e636f6d2f75633f6578706f72743d766965772669643d31746163325053535f47625177587a34476e7a66636f5f68696e5776464f327a61)
+Zulip Terminal is divided into three columns/divisions.
+**The left column** shows list of all the streams you are subscribed to and some buttons for viewing different types of messages.
+**The middle column** displays all the messages in the current narrow. 
+**The right column** shows all the active(green)/idle(yellow)/offline(white) users.
+
+Now that you know what you are looking at, how about checking out some of our features using [keyboard shortcuts](https://github.com/zulip/zulip-terminal#hot-keys)... 
+
+### Narrowing to a stream
+Narrowing to a stream implies you have set middle column to show messages present in that stream. Let's try narrowing to [# test here](https://chat.zulip.org/#narrow/stream/7-test-here) from zulip terminal. Press <kbd>q</kbd> to focus on  the stream search box in the left column. Type `test here`

--- a/docs/making-a-new-release.md
+++ b/docs/making-a-new-release.md
@@ -1,0 +1,19 @@
+The thrilling process of making a new release has (sadly) been automated. Worry not, we still have a few things to check and a few steps to follow!
+To install the required dependencies for making a release, in the venv activated zulip-terminal directory, run:
+```
+pip install twine wheel
+```
+As much as we would love to hurry and make the final release, it's always better to check if the release works as we want it to. So let's start by making a release to the [Test PyPI](https://test.pypi.org/project/zulip-term/):
+```
+python setup.py upload
+```
+Now install the zulip-term in a new terminal tab via:
+```
+pip install -i https://test.pypi.org/simple/ zulip-term
+```
+If everything looks good then you are ready to push the release to the main PyPI:
+```
+python setup.py upload --final-release=True
+```
+This will automatically set the tags to the commit and push them upstream.
+Congrats! You just made a new zulip-term release. Don't forget to make a new release announcement on czo! :tada:


### PR DESCRIPTION
This PR mainly brings about the migration and some changes in the docs.

* The first commit does a straight migration from wiki (using wiki clone) to the /docs folder. The files have been renamed.
* The second and third commit focus on improving dev-documentation. The tutorial we had was pretty outdated and hence the changes update it.
* The last commit improves wording in the getting started docs.

The making-a-new-release doc has not been covered yet.