### PR TITLE
linting: Switch to check line break before binary operator (W504) & for presence of continuation characters

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -17,6 +17,7 @@ pytest-mock = "==1.7.1"
 pytest-cov = "==2.5.1"
 flake8 = "==3.7.9"
 flake8-quotes = "==3.0.0"
+flake8-continuation = "==1.0.5"
 zipp = "==1.0.0"  # To support Python 3.5
 pudb = "==2017.1.4"
 snakeviz = "==0.4.2"

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ pytest-cov==2.5.1
 pytest-mock==1.7.1
 flake8==3.7.9
 flake8-quotes==3.0.0
+flake8-continuation==1.0.5
 pudb==2017.1.4
 snakeviz==0.4.2
 gitlint==0.10.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,8 +33,8 @@ ignore=
   E123,
   # E126 - continuation line over-indented for hanging indent
   E126,
-  # W504 - line break after binary operator - we have this currently, vs W503
-  W504,
+  # W503 - line break before binary operator - new PEP8 best practice, cf W504
+  W503,
   # E241 - Multiple spaces after ',' - breaks layouts like themes.py
   E241,
   # E252 - Spaces in parameters, a style deliberately avoided

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ linting_deps = [
     'mypy==0.770',
     'flake8==3.7.9',
     'flake8-quotes==3.0.0',
+    'flake8-continuation==1.0.5',
 ]
 
 dev_helper_deps = [

--- a/tests/config/test_keys.py
+++ b/tests/config/test_keys.py
@@ -23,8 +23,8 @@ def invalid_command(request):
 
 
 def test_keys_for_command(valid_command):
-    assert (keys.KEY_BINDINGS[valid_command]['keys'] ==
-            keys.keys_for_command(valid_command))
+    assert (keys.KEY_BINDINGS[valid_command]['keys']
+            == keys.keys_for_command(valid_command))
 
 
 def test_keys_for_command_invalid_command(invalid_command):

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -226,10 +226,10 @@ class TestController:
         controller.loop = mocker.Mock()
 
         controller.stream_muting_confirmation_popup(stream_button)
-        text.assert_called_with(("bold", "Confirm " + action +
-                                 " of stream '" +
-                                 stream_button.stream_name +
-                                 "' ?"), "center")
+        text.assert_called_with(("bold", "Confirm " + action
+                                 + " of stream '"
+                                 + stream_button.stream_name
+                                 + "' ?"), "center")
         pop_up.assert_called_once_with(controller, text(), partial())
 
     @pytest.mark.parametrize('initial_narrow, final_narrow', [

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -532,16 +532,17 @@ class TestModel:
     def test_toggle_stream_muted_status(self, mocker, model,
                                         initial_muted_streams, value):
         model.muted_streams = initial_muted_streams
-        model.client.update_subscription_settings.return_value = \
-            {'result': "success"}
+        model.client.update_subscription_settings.return_value = {
+            'result': "success"
+        }
         model.toggle_stream_muted_status(205)
         request = [{
             'stream_id': 205,
             'property': 'is_muted',
             'value': value
         }]
-        model.client.update_subscription_settings.\
-            assert_called_once_with(request)
+        (model.client.update_subscription_settings
+         .assert_called_once_with(request))
 
     @pytest.mark.parametrize('flags_before, expected_operator', [
         ([], 'add'),
@@ -782,8 +783,8 @@ class TestModel:
         # LOG REMAINS THE SAME IF UPDATE IS FALSE
         assert model.msg_list.log == log
 
-    @pytest.mark.parametrize('topic_name, topic_order_intial,\
-                             topic_order_final', [
+    @pytest.mark.parametrize(['topic_name', 'topic_order_intial',
+                              'topic_order_final'], [
         ('TOPIC3', ['TOPIC2', 'TOPIC3', 'TOPIC1'],
                    ['TOPIC3', 'TOPIC2', 'TOPIC1']),
         ('TOPIC1', ['TOPIC1', 'TOPIC2', 'TOPIC3'],
@@ -804,8 +805,8 @@ class TestModel:
         assert model.index['topics'][86] == topic_order_final
 
     # TODO: Ideally message_fixture would use standardized ids?
-    @pytest.mark.parametrize('user_id, vary_each_msg, \
-                              types_when_notify_called', [
+    @pytest.mark.parametrize(['user_id', 'vary_each_msg',
+                              'types_when_notify_called'], [
         (5140, {}, []),  # message_fixture sender_id is 5140
         (5179, {'flags': ['mentioned']}, ['stream', 'private']),
         (5179, {'flags': ['wildcard_mentioned']}, ['stream', 'private']),

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -1220,8 +1220,8 @@ class TestModel:
                           for changed_id in changed_ids]))
 
         for unchanged_id in (set(indexed_ids) - set(event_message_ids)):
-            assert (model.index['messages'][unchanged_id]['flags'] ==
-                    flags_before)
+            assert (model.index['messages'][unchanged_id]['flags']
+                    == flags_before)
 
         set_count.assert_not_called()
 
@@ -1273,8 +1273,8 @@ class TestModel:
                 model._update_rendered_view.assert_not_called()
 
         for unchanged_id in (set(indexed_ids) - set(event_message_ids)):
-            assert (model.index['messages'][unchanged_id]['flags'] ==
-                    flags_before)
+            assert (model.index['messages'][unchanged_id]['flags']
+                    == flags_before)
 
         if event_op == 'add':
             set_count.assert_called_once_with(list(changed_ids),

--- a/tests/ui/test_ui.py
+++ b/tests/ui/test_ui.py
@@ -106,8 +106,8 @@ class TestView:
         self.model.server_url = server
         self.model.server_name = server_name
 
-        title_length = (len(email) + len(full_name) +
-                        len(server) + len(server_name) + 11)
+        title_length = (len(email) + len(full_name)
+                        + len(server) + len(server_name) + 11)
 
         view = View(self.controller)
 

--- a/tests/ui/test_ui.py
+++ b/tests/ui/test_ui.py
@@ -256,8 +256,8 @@ class TestView:
         view.keypress(size, key)
         view.left_panel.keypress.assert_called_once_with(size, key)
         assert view.body.focus_position == 0
-        view.stream_w.stream_search_box.set_edit_text.\
-            assert_called_once_with("")
+        (view.stream_w.stream_search_box.set_edit_text
+         .assert_called_once_with(""))
         assert view.controller.editor_mode is True
         assert view.controller.editor == view.stream_w.stream_search_box
 

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -559,8 +559,8 @@ class TestTopicsView:
                 ] == expected_log
         self.view.controller.update_screen.assert_called_once_with()
 
-    @pytest.mark.parametrize('topic_name, topic_initial_log,\
-                              topic_final_log', [
+    @pytest.mark.parametrize(['topic_name', 'topic_initial_log',
+                              'topic_final_log'], [
         ('TOPIC3', ['TOPIC2', 'TOPIC3', 'TOPIC1'],
             ['TOPIC3', 'TOPIC2', 'TOPIC1']),
         ('TOPIC1', ['TOPIC1', 'TOPIC2', 'TOPIC3'],
@@ -933,8 +933,8 @@ class TestRightColumnView:
 
         right_col_view.view.controller.update_screen.assert_not_called()
 
-    @pytest.mark.parametrize('search_string, assert_list, \
-                              match_return_value', [
+    @pytest.mark.parametrize(['search_string', 'assert_list',
+                              'match_return_value'], [
         ('U', ["USER1", "USER2"], True),
         ('F', [], False)
     ], ids=[
@@ -1712,8 +1712,8 @@ class TestMessageBox:
         assert isinstance(view_components[1], Columns)
         assert isinstance(view_components[2], Padding)
 
-    @pytest.mark.parametrize('msg_narrow, msg_type, assert_header_bar,\
-                              assert_search_bar', [
+    @pytest.mark.parametrize(['msg_narrow', 'msg_type', 'assert_header_bar',
+                              'assert_search_bar'], [
         ([], 0, 'PTEST ▶ ', 'All messages'),
         ([], 1, 'You and ', 'All messages'),
         ([], 2, 'You and ', 'All messages'),
@@ -1843,8 +1843,9 @@ class TestMessageBox:
             assert label[1][1] == 7
 
     @pytest.mark.parametrize('key', keys_for_command('EDIT_MESSAGE'))
-    @pytest.mark.parametrize('to_vary_in_each_message, realm_editing_allowed,\
-                             expect_editing_to_succeed', [
+    @pytest.mark.parametrize(['to_vary_in_each_message',
+                              'realm_editing_allowed',
+                              'expect_editing_to_succeed'], [
         ({'sender_id': 2, 'timestamp': 45}, True, False),
         ({'sender_id': 1, 'timestamp': 1}, True, False),
         ({'sender_id': 1, 'timestamp': 45}, False, False),
@@ -2134,8 +2135,9 @@ class TestStreamButton:
         mocker.patch(STREAMBUTTON + ".mark_muted")
         controller = mocker.Mock()
         controller.model.muted_streams = {}
-        properties = \
-            [caption, 5, '#ffffff', is_private, 'Some Stream Description']
+        properties = [
+            caption, 5, '#ffffff', is_private, 'Some Stream Description'
+        ]
         view_mock = mocker.Mock()
         view_mock.palette = [(None, 'black', 'white')]
         stream_button = StreamButton(properties,
@@ -2153,8 +2155,8 @@ class TestStreamButton:
         assert len(text[0]) == len(expected_text) == (width - 1)
         assert text[0] == expected_text
 
-    @pytest.mark.parametrize('stream_id, muted_streams, called_value,\
-                             is_action_muting, updated_all_msgs', [
+    @pytest.mark.parametrize(['stream_id', 'muted_streams', 'called_value',
+                              'is_action_muting', 'updated_all_msgs'], [
         (86, set(), 50, False, 400),
         (86, {86, 205}, None, True, 300),
         (205, {14, 99}, 0, False, 350),
@@ -2189,8 +2191,8 @@ class TestStreamButton:
         if called_value is not None:
             stream_button.update_count.assert_called_once_with(called_value)
         if called_value != 0:
-            stream_button.view.home_button.update_count.\
-                assert_called_once_with(updated_all_msgs)
+            (stream_button.view.home_button.update_count
+             .assert_called_once_with(updated_all_msgs))
         assert stream_button.model.unread_counts['all_msg'] == updated_all_msgs
 
     @pytest.mark.parametrize('key', keys_for_command('TOGGLE_TOPIC'))
@@ -2299,8 +2301,8 @@ class TestTopicButton:
         assert topic_button.stream_id == stream_id
         assert topic_button.topic_name == title
 
-    @pytest.mark.parametrize('stream_name, title, muted_topics,\
-                              is_muted_called', [
+    @pytest.mark.parametrize(['stream_name', 'title', 'muted_topics',
+                              'is_muted_called'], [
         ('Django', 'topic1', [['Django', 'topic1']], True),
         ('Django', 'topic2', [['Django', 'topic1']], False),
         ('GSoC', 'topic1', [['Django', 'topic1']], False),

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -163,8 +163,8 @@ class TestMessageView:
                             side_effect=[ids_in_narrow,
                                          ids_in_narrow | new_msg_ids])
         create_msg_box_list = mocker.patch(VIEWS + ".create_msg_box_list",
-                                           return_value=(new_msg_widgets +
-                                                         [top_widget]))
+                                           return_value=(new_msg_widgets
+                                                         + [top_widget]))
         initial_log = [top_widget] + len(other_ids_in_narrow) * ["existing"]
         msg_view.log = initial_log[:]
 
@@ -174,8 +174,8 @@ class TestMessageView:
         assert msg_view.log == new_msg_widgets + initial_log
         if messages_fetched:
             create_msg_box_list.assert_called_once_with(msg_view.model,
-                                                        {top_id_in_narrow} |
-                                                        new_msg_ids)
+                                                        {top_id_in_narrow}
+                                                        | new_msg_ids)
             self.model.controller.update_screen.assert_called_once_with()
         else:
             create_msg_box_list.assert_not_called()
@@ -1079,8 +1079,8 @@ class TestLeftColumnView:
                          width=width,
                          view=self.view,
                          count=1)
-             for stream in (self.view.pinned_streams +
-                            self.view.unpinned_streams)])
+             for stream in (self.view.pinned_streams
+                            + self.view.unpinned_streams)])
 
     def test_topics_view(self, mocker, stream_button, width=40):
         mocker.patch(VIEWS + ".LeftColumnView.streams_view")
@@ -1809,8 +1809,8 @@ class TestMessageBox:
 
         assert len(view_components) == 2
         assert isinstance(view_components[0], Columns)
-        assert ([w.text for w in view_components[0].widget_list] ==
-                expected_header)
+        assert ([w.text for w in view_components[0].widget_list]
+                == expected_header)
         assert isinstance(view_components[1], Padding)
 
     @pytest.mark.parametrize('to_vary_in_each_message', [
@@ -2088,8 +2088,8 @@ class TestTopButton:
         expected_text = ' {}{}{}{}'.format(
                 (prefix + ' ') if prefix else '',
                 short_text,
-                (width - 2 - (2 if prefix else 0) - len(short_text) -
-                 len(count_str)) * ' ',
+                (width - 2 - (2 if prefix else 0) - len(short_text)
+                 - len(count_str)) * ' ',
                 count_str)
         assert len(text[0]) == len(expected_text) == (width - 1)
         assert text[0] == expected_text

--- a/tests/ui/test_utils.py
+++ b/tests/ui/test_utils.py
@@ -3,8 +3,8 @@ import pytest
 from zulipterminal.ui_tools.utils import create_msg_box_list, is_muted
 
 
-@pytest.mark.parametrize('msg, narrow, muted_streams, muted_topics,\
-                         muted', [
+@pytest.mark.parametrize(['msg', 'narrow', 'muted_streams', 'muted_topics',
+                          'muted'], [
     (   # PM TEST
         {
             'type': 'private',
@@ -89,8 +89,8 @@ def test_is_muted(mocker, msg, narrow, muted_streams, muted_topics, muted):
     assert return_value is muted
 
 
-@pytest.mark.parametrize('narrow, messages, focus_msg_id, muted,\
-                          unsubscribed, len_w_list', [
+@pytest.mark.parametrize(['narrow', 'messages', 'focus_msg_id', 'muted',
+                          'unsubscribed', 'len_w_list'], [
     (
         # No muted messages
         [],

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -117,19 +117,19 @@ def get_api_key(realm_url: str) -> Tuple[requests.Response, str]:
 
 
 def fetch_zuliprc(zuliprc_path: str) -> None:
-    print(in_color('red', "zuliprc file was not found at " + zuliprc_path) +
-          "\nPlease enter your credentials to login into your"
-          " Zulip organization."
-          "\n" +
-          "\nNOTE: The " + in_color('blue', "Zulip URL") +
-          " is where you would go in a web browser to log in to Zulip." +
-          "\nIt often looks like one of the following:" +
-          in_color('green', "\n   your-org.zulipchat.com") +
-          " (Zulip cloud)" +
-          in_color('green', "\n   zulip.your-org.com") +
-          " (self-hosted servers)" +
-          in_color('green', "\n   chat.zulip.org") +
-          " (the Zulip community server)")
+    print(in_color('red', "zuliprc file was not found at " + zuliprc_path)
+          + "\nPlease enter your credentials to login into your"
+            " Zulip organization."
+            "\n"
+            "\nNOTE: The " + in_color('blue', "Zulip URL")
+          + " is where you would go in a web browser to log in to Zulip."
+            "\nIt often looks like one of the following:"
+            "\n   " + in_color('green', "your-org.zulipchat.com")
+          + " (Zulip cloud)"
+            "\n   " + in_color('green', "zulip.your-org.com")
+          + " (self-hosted servers)"
+            "\n   " + in_color('green', "chat.zulip.org")
+          + " (the Zulip community server)")
     realm_url = styled_input('Zulip URL: ')
     if realm_url.startswith("localhost"):
         realm_url = "http://" + realm_url
@@ -145,10 +145,10 @@ def fetch_zuliprc(zuliprc_path: str) -> None:
         res, login_id = get_api_key(realm_url)
 
     with open(zuliprc_path, 'w') as f:
-        f.write('[api]' +
-                '\nemail=' + login_id +
-                '\nkey=' + str(res.json()['api_key']) +
-                '\nsite=' + realm_url)
+        f.write('[api]'
+                + '\nemail=' + login_id
+                + '\nkey=' + str(res.json()['api_key'])
+                + '\nsite=' + realm_url)
     print('Generated API key saved at ' + zuliprc_path)
 
 
@@ -174,13 +174,13 @@ def parse_zuliprc(zuliprc_str: str) -> Dict[str, Any]:
         res = zuliprc.read(zuliprc_path)
         if len(res) == 0:
             print(in_color('red',
-                           "\nZuliprc file could not be accessed at " +
-                           zuliprc_path + "\n"))
+                           "\nZuliprc file could not be accessed at "
+                           + zuliprc_path + "\n"))
             sys.exit(1)
     except configparser.MissingSectionHeaderError:
         print(in_color('red',
-                       "\nFailed to parse zuliprc file at " +
-                       zuliprc_path + "\n"))
+                       "\nFailed to parse zuliprc file at "
+                       + zuliprc_path + "\n"))
         sys.exit(1)
 
     # default settings

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -45,8 +45,8 @@ def parse_args(argv: List[str]) -> argparse.Namespace:
 
     parser.add_argument('--config-file', '-c',
                         action='store',
-                        help='config file downloaded from your zulip\
-                             organization.(e.g. ~/zuliprc)')
+                        help='config file downloaded from your zulip '
+                             'organization.(e.g. ~/zuliprc)')
     parser.add_argument('--theme', '-t',
                         help='choose color theme. (e.g. blue, light)')
     parser.add_argument('--color-depth',
@@ -69,8 +69,8 @@ def parse_args(argv: List[str]) -> argparse.Namespace:
 
     autohide_group.add_argument('--no-autohide', dest='autohide', default=None,
                                 action="store_const", const='no_autohide',
-                                help='Don\'t autohide list of\
-                                        users and streams.')
+                                help='Don\'t autohide list of '
+                                     'users and streams.')
 
     parser.add_argument('-v',
                         '--version',

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -140,8 +140,8 @@ class Controller:
     def stream_muting_confirmation_popup(self, button: Any) -> None:
         currently_muted = self.model.is_muted_stream(button.stream_id)
         type_of_action = "unmuting" if currently_muted else "muting"
-        question = urwid.Text(("bold", "Confirm " + type_of_action +
-                               " of stream '" + button.stream_name + "' ?"),
+        question = urwid.Text(("bold", "Confirm " + type_of_action
+                               + " of stream '" + button.stream_name + "' ?"),
                               "center")
         mute_this_stream = partial(self.model.toggle_stream_muted_status,
                                    button.stream_id)

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -156,8 +156,8 @@ def _set_count_in_view(controller: Any, new_count: int,
                 for stream_button in stream_buttons_log:
                     if stream_button.stream_id == stream_id:
                         # FIXME: Update unread_count[streams]?
-                        stream_button.update_count(stream_button.count +
-                                                   new_count)
+                        stream_button.update_count(stream_button.count
+                                                   + new_count)
                         break
             # FIXME: Update unread_counts['unread_topics']?
             if ([message['display_recipient'], msg_topic] in
@@ -168,8 +168,8 @@ def _set_count_in_view(controller: Any, new_count: int,
                 # We update the respective TopicButton count accordingly.
                 for topic_button in topic_buttons_log:
                     if topic_button.topic_name == msg_topic:
-                        topic_button.update_count(topic_button.count +
-                                                  new_count)
+                        topic_button.update_count(topic_button.count
+                                                  + new_count)
         else:
             for user_button in user_buttons_log:
                 if user_button.user_id == user_id:
@@ -365,8 +365,8 @@ def index_messages(messages: List[Message],
 
                 if narrow[0][0] == 'pm_with':
                     narrow_emails = ([model.user_dict[email]['user_id']
-                                      for email in narrow[0][1].split(', ')] +
-                                     [model.user_id])
+                                      for email in narrow[0][1].split(', ')]
+                                     + [model.user_id])
                     if recipients == frozenset(narrow_emails):
                         (index['private_msg_ids_by_user_ids'][recipients]
                          .add(msg['id']))

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -375,9 +375,8 @@ def index_messages(messages: List[Message],
                 (index['stream_msg_ids_by_stream_id'][msg['stream_id']]
                  .add(msg['id']))
 
-        if msg['type'] == 'stream' and len(narrow) == 2 and\
-                narrow[1][1] == msg['subject']:
-
+        if (msg['type'] == 'stream' and len(narrow) == 2
+                and narrow[1][1] == msg['subject']):
             topics_in_stream = index['topic_msg_ids'][msg['stream_id']]
             if not topics_in_stream.get(msg['subject']):
                 topics_in_stream[msg['subject']] = set()

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -254,10 +254,8 @@ class Model:
         existing_reactions = [
             reaction['emoji_code']
             for reaction in message['reactions']
-            if ('user_id' in reaction['user'] and
-                reaction['user']['user_id'] == self.user_id) or
-               ('id' in reaction['user'] and
-                reaction['user']['id'] == self.user_id)
+            if (reaction['user'].get('user_id', None) == self.user_id or
+                reaction['user'].get('id', None) == self.user_id)
         ]
         if reaction_to_toggle_spec['emoji_code'] in existing_reactions:
             response = self.client.remove_reaction(reaction_to_toggle_spec)
@@ -610,8 +608,7 @@ class Model:
         Handle changes in subscription (eg. muting/unmuting streams)
         """
         if hasattr(self.controller, 'view'):
-            if ('property' in event and
-                    event['property'] == 'in_home_view'):
+            if event.get('property', None) == 'in_home_view':
                 stream_id = event['stream_id']
 
                 # FIXME: Does this always contain the stream_id?

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -499,8 +499,8 @@ class Model:
                             if aggregate_status != 'active':
                                 aggregate_status = status
                         if status == 'offline':
-                            if aggregate_status != 'active' and\
-                                    aggregate_status != 'idle':
+                            if (aggregate_status != 'active'
+                                    and aggregate_status != 'idle'):
                                 aggregate_status = status
 
                 status = aggregate_status
@@ -612,8 +612,9 @@ class Model:
                 stream_id = event['stream_id']
 
                 # FIXME: Does this always contain the stream_id?
-                stream_button = self.controller.view.\
-                    stream_id_to_button[stream_id]
+                stream_button = (
+                    self.controller.view.stream_id_to_button[stream_id]
+                )
 
                 if event['value']:  # Unmuting streams
                     self.muted_streams.remove(stream_id)
@@ -630,8 +631,9 @@ class Model:
         """
         if hasattr(self.controller, 'view'):
             # If the user is in pm narrow with the person typing
-            if len(self.narrow) == 1 and self.narrow[0][0] == 'pm_with' and\
-                    event['sender']['email'] in self.narrow[0][1].split(','):
+            narrow = self.narrow
+            if (len(narrow) == 1 and narrow[0][0] == 'pm_with'
+                    and event['sender']['email'] in narrow[0][1].split(',')):
                 if event['op'] == 'start':
                     user = self.user_dict[event['sender']['email']]
                     self.controller.view.set_footer_text([
@@ -715,16 +717,16 @@ class Model:
             if not self.narrow:
                 self.msg_list.log.append(msg_w)
 
-            elif self.narrow[0][1] == 'mentioned' and \
-                    'mentioned' in message['flags']:
+            elif (self.narrow[0][1] == 'mentioned'
+                    and 'mentioned' in message['flags']):
                 self.msg_list.log.append(msg_w)
 
-            elif self.narrow[0][1] == message['type'] and\
-                    len(self.narrow) == 1:
+            elif (self.narrow[0][1] == message['type']
+                    and len(self.narrow) == 1):
                 self.msg_list.log.append(msg_w)
 
-            elif message['type'] == 'stream' and \
-                    self.narrow[0][0] == "stream":
+            elif (message['type'] == 'stream'
+                    and self.narrow[0][0] == "stream"):
                 recipient_stream = message['display_recipient']
                 narrow_stream = self.narrow[0][1]
                 append_to_stream = recipient_stream == narrow_stream
@@ -735,8 +737,8 @@ class Model:
                              and self.narrow[1][1] == message['subject']))):
                     self.msg_list.log.append(msg_w)
 
-            elif message['type'] == 'private' and len(self.narrow) == 1 and\
-                    self.narrow[0][0] == "pm_with":
+            elif (message['type'] == 'private' and len(self.narrow) == 1
+                    and self.narrow[0][0] == "pm_with"):
                 narrow_recipients = self.recipients
                 message_recipients = frozenset(
                     [user['id'] for user in message['display_recipient']])
@@ -778,9 +780,9 @@ class Model:
             # 'subject' is not present in update event if
             # the event didn't have a 'subject' update.
             if 'subject' in event:
+                new_subject = event['subject']
                 for msg_id in event['message_ids']:
-                    self.index['messages'][msg_id]['subject']\
-                        = event['subject']
+                    self.index['messages'][msg_id]['subject'] = new_subject
                     self._update_rendered_view(msg_id)
 
     def _handle_reaction_event(self, event: Event) -> None:
@@ -857,8 +859,8 @@ class Model:
             if msg_box.message['id'] == msg_id:
                 # Remove the message if it no longer belongs in the current
                 # narrow.
-                if len(self.narrow) == 2 and\
-                        msg_box.message['subject'] != self.narrow[1][1]:
+                if (len(self.narrow) == 2
+                        and msg_box.message['subject'] != self.narrow[1][1]):
                     self.msg_list.log.remove(msg_w)
                     # Change narrow if there are no messages left in the
                     # current narrow.

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -164,8 +164,8 @@ class Model:
             if pm_with is not None and new_narrow[0][0] == 'pm_with':
                 users = pm_with.split(', ')
                 self.recipients = frozenset(
-                    [self.user_dict[user]['user_id'] for user in users] +
-                    [self.user_id]
+                    [self.user_dict[user]['user_id'] for user in users]
+                    + [self.user_id]
                 )
             else:
                 self.recipients = frozenset()
@@ -254,8 +254,8 @@ class Model:
         existing_reactions = [
             reaction['emoji_code']
             for reaction in message['reactions']
-            if (reaction['user'].get('user_id', None) == self.user_id or
-                reaction['user'].get('id', None) == self.user_id)
+            if (reaction['user'].get('user_id', None) == self.user_id
+                or reaction['user'].get('id', None) == self.user_id)
         ]
         if reaction_to_toggle_spec['emoji_code'] in existing_reactions:
             response = self.client.remove_reaction(reaction_to_toggle_spec)
@@ -669,8 +669,8 @@ class Model:
                                                 message['subject'])
 
         if recipient:
-            notify((self.server_name + ":\n" +
-                    message['sender_full_name'] + recipient),
+            notify((self.server_name + ":\n"
+                    + message['sender_full_name'] + recipient),
                    message['content'])
 
     def _handle_message_event(self, event: Event) -> None:
@@ -688,9 +688,9 @@ class Model:
             # If the topic view is toggled for incoming message's
             # recipient stream, then we re-arrange topic buttons
             # with most recent at the top.
-            if (hasattr(self.controller, 'view') and
-                self.controller.view.left_panel.is_in_topic_view and
-                message['stream_id'] == self.controller.view.
+            if (hasattr(self.controller, 'view')
+                and self.controller.view.left_panel.is_in_topic_view
+                and message['stream_id'] == self.controller.view.
                     topic_w.stream_button.stream_id):
                 self.controller.view.topic_w.update_topics_list(
                     message['stream_id'], message['subject'],
@@ -729,10 +729,10 @@ class Model:
                 narrow_stream = self.narrow[0][1]
                 append_to_stream = recipient_stream == narrow_stream
 
-                if append_to_stream and (len(self.narrow) == 1 or
-                                         (len(self.narrow) == 2 and
-                                          self.narrow[1][1] ==
-                                          message['subject'])):
+                if (append_to_stream
+                    and (len(self.narrow) == 1
+                         or (len(self.narrow) == 2
+                             and self.narrow[1][1] == message['subject']))):
                     self.msg_list.log.append(msg_w)
 
             elif message['type'] == 'private' and len(self.narrow) == 1 and\

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -149,10 +149,10 @@ class View(urwid.WidgetWrap):
         if self.controller.editor_mode:
             return self.controller.editor.keypress((size[1],), key)
         # Redirect commands to message_view.
-        elif is_command_key('SEARCH_MESSAGES', key) or\
-                is_command_key('NEXT_UNREAD_TOPIC', key) or\
-                is_command_key('NEXT_UNREAD_PM', key) or\
-                is_command_key('PRIVATE_MESSAGE', key):
+        elif (is_command_key('SEARCH_MESSAGES', key)
+                or is_command_key('NEXT_UNREAD_TOPIC', key)
+                or is_command_key('NEXT_UNREAD_PM', key)
+                or is_command_key('PRIVATE_MESSAGE', key)):
             self.body.focus_col = 1
             self.middle_column.keypress(size, key)
             return key

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -175,8 +175,8 @@ class View(urwid.WidgetWrap):
             self.controller.editor_mode = True
             self.controller.editor = self.user_search
             return key
-        elif (is_command_key('SEARCH_STREAMS', key) or
-                is_command_key('SEARCH_TOPICS', key)):
+        elif (is_command_key('SEARCH_STREAMS', key)
+              or is_command_key('SEARCH_TOPICS', key)):
             # jump stream search
             self.body.focus_position = 0
             self.left_panel.keypress(size, 'q')

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -256,22 +256,22 @@ class MessageBox(urwid.Pile):
 
         last_msg = self.last_message
         if self.message['type'] == 'stream':
-            if (last_msg['type'] == 'stream' and
-                    self.topic_name == last_msg['subject'] and
-                    self.stream_name == last_msg['display_recipient']):
-                return False
-            return True
+            return not (
+                last_msg['type'] == 'stream' and
+                self.topic_name == last_msg['subject'] and
+                self.stream_name == last_msg['display_recipient']
+            )
         elif self.message['type'] == 'private':
             recipient_ids = [{recipient['id']
                               for recipient in message['display_recipient']
                               if 'id' in recipient}
                              for message in (self.message, last_msg)
                              if 'display_recipient' in message]
-            if (len(recipient_ids) == 2 and
-                    recipient_ids[0] == recipient_ids[1] and
-                    last_msg['type'] == 'private'):
-                return False
-            return True
+            return not (
+                len(recipient_ids) == 2 and
+                recipient_ids[0] == recipient_ids[1] and
+                last_msg['type'] == 'private'
+            )
         else:
             raise RuntimeError("Invalid message type")
 
@@ -295,9 +295,6 @@ class MessageBox(urwid.Pile):
         return header
 
     def private_header(self) -> Any:
-        if self._is_private_message_to_self():
-            self.recipients_names = \
-                self.message['display_recipient'][0]['full_name']
         title_markup = ('header', [
             ('custom', 'You and '),
             ('custom', self.recipients_names)
@@ -536,15 +533,18 @@ class MessageBox(urwid.Pile):
         }
         different = {  # How this message differs from the previous one
             'recipients': recipient_header is not None,
-            'author': message['last']['author'] != message['this']['author'],
+            'author': message['this']['author'] != message['last']['author'],
             '24h': (message['last']['datetime'] is not None and
                     ((message['this']['datetime'] -
                       message['last']['datetime'])
                      .days)),
-            'timestamp': (message['last']['time'] is not None and
-                          message['this']['time'] != message['last']['time']),
-            'star_status': (message['this']['is_starred'] !=
-                            message['last']['is_starred']),
+            'timestamp': (
+                message['last']['time'] is not None and
+                message['this']['time'] != message['last']['time']
+            ),
+            'star_status': (
+                message['this']['is_starred'] != message['last']['is_starred']
+            ),
         }
         any_differences = any(different.values())
 

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -222,8 +222,8 @@ class MessageBox(urwid.Pile):
 
         if self.message['type'] == 'private':
             if self._is_private_message_to_self():
-                self.recipients_names = \
-                    self.message['display_recipient'][0]['full_name']
+                recipient = self.message['display_recipient'][0]
+                self.recipients_names = recipient['full_name']
                 self.recipients_emails = self.model.user_email
             else:
                 self.recipients_names = ', '.join(list(
@@ -247,11 +247,11 @@ class MessageBox(urwid.Pile):
 
     def need_recipient_header(self) -> bool:
         # Prevent redundant information in recipient bar
-        if len(self.model.narrow) == 1 and \
-                self.model.narrow[0][0] == 'pm_with':
+        if (len(self.model.narrow) == 1
+                and self.model.narrow[0][0] == 'pm_with'):
             return False
-        if len(self.model.narrow) == 2 and \
-                self.model.narrow[1][0] == 'topic':
+        if (len(self.model.narrow) == 2
+                and self.model.narrow[1][0] == 'topic'):
             return False
 
         last_msg = self.last_message
@@ -277,8 +277,8 @@ class MessageBox(urwid.Pile):
 
     def _is_private_message_to_self(self) -> bool:
         recipient_list = self.message['display_recipient']
-        return len(recipient_list) == 1 and \
-            recipient_list[0]['email'] == self.model.user_email
+        return (len(recipient_list) == 1
+                and recipient_list[0]['email'] == self.model.user_email)
 
     def stream_header(self) -> Any:
         stream_topic_separator = '▶'
@@ -417,8 +417,8 @@ class MessageBox(urwid.Pile):
         for element in soup:
             if isinstance(element, NavigableString):
                 # NORMAL STRINGS
-                if hasattr(self, 'bq_len') and element == '\n' and \
-                        self.bq_len > 0:
+                if (hasattr(self, 'bq_len') and element == '\n'
+                        and self.bq_len > 0):
                     self.bq_len -= 1
                     continue
                 markup.append(element)
@@ -486,8 +486,8 @@ class MessageBox(urwid.Pile):
                 markup.append((
                     'msg_code', element.text
                 ))
-            elif element.name == 'div' and element.attrs and\
-                    'codehilite' in element.attrs.get('class', []):
+            elif (element.name == 'div' and element.attrs
+                    and 'codehilite' in element.attrs.get('class', [])):
                 # CODE (BLOCK?)
                 markup.append((
                     'msg_code', element.text

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -257,9 +257,9 @@ class MessageBox(urwid.Pile):
         last_msg = self.last_message
         if self.message['type'] == 'stream':
             return not (
-                last_msg['type'] == 'stream' and
-                self.topic_name == last_msg['subject'] and
-                self.stream_name == last_msg['display_recipient']
+                last_msg['type'] == 'stream'
+                and self.topic_name == last_msg['subject']
+                and self.stream_name == last_msg['display_recipient']
             )
         elif self.message['type'] == 'private':
             recipient_ids = [{recipient['id']
@@ -268,9 +268,9 @@ class MessageBox(urwid.Pile):
                              for message in (self.message, last_msg)
                              if 'display_recipient' in message]
             return not (
-                len(recipient_ids) == 2 and
-                recipient_ids[0] == recipient_ids[1] and
-                last_msg['type'] == 'private'
+                len(recipient_ids) == 2
+                and recipient_ids[0] == recipient_ids[1]
+                and last_msg['type'] == 'private'
             )
         else:
             raise RuntimeError("Invalid message type")
@@ -422,17 +422,17 @@ class MessageBox(urwid.Pile):
                     self.bq_len -= 1
                     continue
                 markup.append(element)
-            elif (element.name == 'div' and element.attrs and
-                    any(cls in element.attrs.get('class', [])
-                        for cls in unrendered_div_classes)):
+            elif (element.name == 'div' and element.attrs
+                  and any(cls in element.attrs.get('class', [])
+                          for cls in unrendered_div_classes)):
                 # UNRENDERED DIV CLASSES
-                matching_class = (set(unrendered_div_classes) &
-                                  set(element.attrs.get('class')))
+                matching_class = (set(unrendered_div_classes)
+                                  & set(element.attrs.get('class')))
                 text = unrendered_div_classes[matching_class.pop()]
                 if text:
                     markup.append(unrendered_template.format(text))
-            elif (element.name == 'img' and
-                    element.attrs.get('class', []) == ['emoji']):
+            elif (element.name == 'img'
+                  and element.attrs.get('class', []) == ['emoji']):
                 # CUSTOM EMOJIS AND ZULIP_EXTRA_EMOJI
                 emoji_name = element.attrs.get('title', [])
                 markup.append(('msg_emoji', ":" + emoji_name + ":"))
@@ -444,18 +444,18 @@ class MessageBox(urwid.Pile):
             elif element.name in ('p', 'ul', 'del'):
                 # PARAGRAPH, LISTS, STRIKE-THROUGH
                 markup.extend(self.soup2markup(element))
-            elif (element.name == 'span' and element.attrs and
-                  'emoji' in element.attrs.get('class', [])):
+            elif (element.name == 'span' and element.attrs
+                  and 'emoji' in element.attrs.get('class', [])):
                 # EMOJI
                 markup.append(('msg_emoji', element.text))
-            elif (element.name == 'span' and element.attrs and
-                  ('katex-display' in element.attrs.get('class', []) or
-                   'katex' in element.attrs.get('class', []))):
+            elif (element.name == 'span' and element.attrs
+                  and ('katex-display' in element.attrs.get('class', [])
+                       or 'katex' in element.attrs.get('class', []))):
                 # MATH TEXT
                 markup.append(element.text)
-            elif element.name == 'span' and element.attrs and\
-                    ('user-mention' in element.attrs.get('class', []) or
-                     'user-group-mention' in element.attrs.get('class', [])):
+            elif (element.name == 'span' and element.attrs
+                  and ('user-group-mention' in element.attrs.get('class', [])
+                       or 'user-mention' in element.attrs.get('class', []))):
                 # USER MENTIONS & USER-GROUP MENTIONS
                 markup.append(('msg_mention', element.text))
             elif element.name == 'a':
@@ -534,13 +534,13 @@ class MessageBox(urwid.Pile):
         different = {  # How this message differs from the previous one
             'recipients': recipient_header is not None,
             'author': message['this']['author'] != message['last']['author'],
-            '24h': (message['last']['datetime'] is not None and
-                    ((message['this']['datetime'] -
-                      message['last']['datetime'])
-                     .days)),
+            '24h': (message['last']['datetime'] is not None
+                    and ((message['this']['datetime']
+                          - message['last']['datetime'])
+                         .days)),
             'timestamp': (
-                message['last']['time'] is not None and
-                message['this']['time'] != message['last']['time']
+                message['last']['time'] is not None
+                and message['this']['time'] != message['last']['time']
             ),
             'star_status': (
                 message['this']['is_starred'] != message['last']['is_starred']
@@ -724,8 +724,10 @@ class MessageBox(urwid.Pile):
         elif is_command_key('TOGGLE_NARROW', key):
             self.model.unset_search_narrow()
             if self.message['type'] == 'private':
-                if (len(self.model.narrow) == 1 and
-                        self.model.narrow[0][0] == 'pm_with'):
+                if (
+                    len(self.model.narrow) == 1
+                    and self.model.narrow[0][0] == 'pm_with'
+                   ):
                     self.model.controller.show_all_pm(self)
                 else:
                     self.model.controller.narrow_to_user(self)
@@ -801,9 +803,9 @@ class SearchBox(urwid.Pile):
         super().__init__(self.main_view())
 
     def main_view(self) -> Any:
-        search_text = ("Search [" +
-                       ", ".join(keys_for_command("SEARCH_MESSAGES")) +
-                       "]: ")
+        search_text = ("Search ["
+                       + ", ".join(keys_for_command("SEARCH_MESSAGES"))
+                       + "]: ")
         self.text_box = ReadlineEdit(search_text + " ")
         # Add some text so that when packing,
         # urwid doesn't hide the widget.
@@ -845,9 +847,9 @@ class PanelSearchBox(urwid.Edit):
                  update_function: Callable[..., None]) -> None:
         self.panel_view = panel_view
         self.search_command = search_command
-        self.search_text = ("Search [" +
-                            ", ".join(keys_for_command(search_command)) +
-                            "]: ")
+        self.search_text = ("Search ["
+                            + ", ".join(keys_for_command(search_command))
+                            + "]: ")
         urwid.connect_signal(self, 'change', update_function)
         super().__init__(edit_text=self.search_text)
 

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -136,8 +136,8 @@ class StreamButton(TopButton):
                  count: int=0) -> None:
         # FIXME Is having self.stream_id the best way to do this?
         # (self.stream_id is used elsewhere)
-        self.stream_name, self.stream_id, self.color, is_private, \
-            self.description = properties
+        (self.stream_name, self.stream_id, self.color, is_private,
+         self.description) = properties
         self.model = controller.model
         self.count = count
         self.view = view
@@ -241,8 +241,8 @@ class TopicButton(TopButton):
                          width=width,
                          count=count)
 
-        if [self.stream_name, self.topic_name] in \
-                controller.model.muted_topics:
+        topic_pair = [self.stream_name, self.topic_name]
+        if topic_pair in controller.model.muted_topics:
             self.mark_muted()
 
     def mark_muted(self) -> None:

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -52,11 +52,11 @@ class TopButton(urwid.Button):
 
     def update_widget(self, count_text: str) -> Any:
         # Note that we don't modify self._caption
-        max_caption_length = (self.width_for_text_and_count -
-                              len(count_text))
+        max_caption_length = (self.width_for_text_and_count
+                              - len(count_text))
         if len(self._caption) > max_caption_length:
-            caption = (self._caption[:max_caption_length - 1] +
-                       '\N{HORIZONTAL ELLIPSIS}')
+            caption = (self._caption[:max_caption_length - 1]
+                       + '\N{HORIZONTAL ELLIPSIS}')
         else:
             caption = self._caption
         num_extra_spaces = (
@@ -86,9 +86,9 @@ class TopButton(urwid.Button):
 
 class HomeButton(TopButton):
     def __init__(self, controller: Any, width: int, count: int=0) -> None:
-        button_text = ("All messages   [" +
-                       keys_for_command("GO_BACK").pop() +  # FIXME
-                       "]")
+        button_text = ("All messages   ["
+                       + keys_for_command("GO_BACK").pop()  # FIXME
+                       + "]")
         super().__init__(controller, button_text,
                          controller.show_all_messages, count=count,
                          prefix_character='',
@@ -97,9 +97,9 @@ class HomeButton(TopButton):
 
 class PMButton(TopButton):
     def __init__(self, controller: Any, width: int, count: int=0) -> None:
-        button_text = ("Private messages [" +
-                       keys_for_command("ALL_PM").pop() +
-                       "]")
+        button_text = ("Private messages ["
+                       + keys_for_command("ALL_PM").pop()
+                       + "]")
         super().__init__(controller, button_text,
                          controller.show_all_pm, count=count,
                          prefix_character='',
@@ -108,9 +108,9 @@ class PMButton(TopButton):
 
 class MentionedButton(TopButton):
     def __init__(self, controller: Any, width: int, count: int=0) -> None:
-        button_text = ("Mentions         [" +
-                       keys_for_command("ALL_MENTIONS").pop() +
-                       "]")
+        button_text = ("Mentions         ["
+                       + keys_for_command("ALL_MENTIONS").pop()
+                       + "]")
         super().__init__(controller, button_text,
                          controller.show_all_mentions,
                          width=width,
@@ -120,9 +120,9 @@ class MentionedButton(TopButton):
 
 class StarredButton(TopButton):
     def __init__(self, controller: Any, width: int) -> None:
-        button_text = ("Starred messages [" +
-                       keys_for_command("ALL_STARRED").pop() +
-                       "]")
+        button_text = ("Starred messages ["
+                       + keys_for_command("ALL_STARRED").pop()
+                       + "]")
         super().__init__(controller, button_text,
                          controller.show_all_starred,
                          width=width,

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -94,8 +94,8 @@ class MessageView(urwid.ListBox):
             no_update_baseline = set()
 
         self.model.get_messages(num_before=30, num_after=0, anchor=anchor)
-        ids_to_process = (self.model.get_message_ids_in_current_narrow() -
-                          ids_to_keep)
+        ids_to_process = (self.model.get_message_ids_in_current_narrow()
+                          - ids_to_keep)
 
         # Only update if more messages are provided
         if ids_to_process != no_update_baseline:
@@ -561,9 +561,9 @@ class RightColumnView(urwid.Frame):
                          new_text: str="",
                          user_list: Any=None) -> None:
 
-        assert ((user_list is None and search_box is not None) or
-                (user_list is not None and search_box is None and
-                 new_text == ""))
+        assert ((user_list is None and search_box is not None)
+                or (user_list is not None and search_box is None
+                    and new_text == ""))
 
         if not self.view.controller.editor_mode and not user_list:
             return
@@ -747,8 +747,10 @@ class LeftColumnView(urwid.Pile):
         return w
 
     def keypress(self, size: urwid_Size, key: str) -> Optional[str]:
-        if (is_command_key('SEARCH_STREAMS', key) or
-                is_command_key('SEARCH_TOPICS', key)):
+        if (
+            is_command_key('SEARCH_STREAMS', key)
+            or is_command_key('SEARCH_TOPICS', key)
+           ):
             self.focus_position = 1
             if self.is_in_topic_view:
                 self.view.topic_w.keypress(size, key)
@@ -871,11 +873,11 @@ class MsgInfoView(PopUpView):
 
         if msg['reactions']:
             reactions = sorted(
-                        [reaction['emoji_name'] +
-                            ": " +
-                            reaction['user']['full_name'] +
-                            "\n"
-                            for reaction in msg['reactions']])
+                        [reaction['emoji_name']
+                         + ": "
+                         + reaction['user']['full_name']
+                         + "\n"
+                         for reaction in msg['reactions']])
             reactions[-1] = reactions[-1].rstrip("\n")
 
         msg_info = OrderedDict([

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -171,15 +171,15 @@ class MessageView(urwid.ListBox):
                 return key
 
         elif is_command_key('SCROLL_UP', key) and not self.old_loading:
-            if self.focus is not None and \
-               self.focus_position == 0:
+            if (self.focus is not None
+                    and self.focus_position == 0):
                 return self.keypress(size, 'up')
             else:
                 return super().keypress(size, 'page up')
 
         elif is_command_key('SCROLL_DOWN', key) and not self.old_loading:
-            if self.focus is not None and \
-               self.focus_position == len(self.log) - 1:
+            if (self.focus is not None
+                    and self.focus_position == len(self.log) - 1):
                 return self.keypress(size, 'down')
             else:
                 return super().keypress(size, 'page down')
@@ -593,8 +593,8 @@ class RightColumnView(urwid.Frame):
         users_btn_list = list()
         for user in users:
             # Only include `inactive` users in search result.
-            if user['status'] == 'inactive' and\
-                    not self.view.controller.editor_mode:
+            if (user['status'] == 'inactive'
+                    and not self.view.controller.editor_mode):
                 continue
             unread_count = (self.view.model.unread_counts['unread_pms'].
                             get(user['user_id'], 0))


### PR DESCRIPTION
This commit slightly adjusts the layout of many files, with other minor
adjustments to:
* combine quoted strings on adjacent lines
* simplify some conditionals using .get()
* return directly the result of boolean expressions
* generally adjust indentation/ordering for readability & linting

An example of the change in acceptable behavior is from (accepting W503, ignoring W504):

    (foo and
     bar)

to (accepting W504, ignoring W503):

    (foo
     and bar)

While both are acceptable according to PEP8, the latter is now recommended:
https://www.python.org/dev/peps/pep-0008/#should-a-line-break-before-or-after-a-binary-operator