### PR TITLE
bugfix: TopicsView: Focus Frame header (search box) on search.

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -608,6 +608,7 @@ class TestTopicsView:
         size = (200, 20)
         mocker.patch(VIEWS + '.TopicsView.set_focus')
         topic_view.keypress(size, key)
+        topic_view.set_focus.assert_called_once_with('header')
         topic_view.header_list.set_focus.assert_called_once_with(2)
 
     @pytest.mark.parametrize('key', keys_for_command('GO_BACK'))

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -393,6 +393,7 @@ class TopicsView(urwid.Frame):
             self.view.show_left_panel(visible=False)
             self.view.body.focus_col = 1
         if is_command_key('SEARCH_TOPICS', key):
+            self.set_focus('header')
             self.header_list.set_focus(2)
             return key
         elif is_command_key('GO_BACK', key):


### PR DESCRIPTION
Previously the focus was moved into the search box part of the Frame
header, but the header itself was not focused. The search worked, but
entries remained selected in the topic list (body).

Test added.