### PR TITLE
Render ordered lists

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1521,6 +1521,10 @@ class TestMessageBox:
         ('<ul><li>text</li></ul>', ['', '  \N{BULLET} ', '', 'text']),
         ('<ul>\n<li>text</li>\n</ul>',
             ['', '', '  \N{BULLET} ', '', 'text', '']),
+        ('<ol><li>text</li></ol>', ['', '  1. ', '', 'text']),
+        ('<ol>\n<li>text</li>\n</ol>',
+            ['', '', '  1. ', '', 'text', '']),
+        ('<ol start="5"><li>text</li></ol>', ['', '  5. ', '', 'text']),
         ('<del>text</del>', ['', 'text']),  # FIXME Strikethrough
         ('<div class="message_inline_image">'
          '<a href="x"><img src="x"></a></div>', []),
@@ -1545,6 +1549,7 @@ class TestMessageBox:
         'table_with_the_bare_minimum',
         'math', 'math2',
         'ul', 'ul_with_ul_li_newlines',
+        'ol', 'ol_with_ol_li_newlines', 'ol_starting_at_5',
         'strikethrough_del', 'inline_image', 'inline_ref',
         'emoji', 'preview-twitter', 'zulip_extra_emoji', 'custom_emoji'
     ])


### PR DESCRIPTION
This is a followup to #634 - not only does it render numbered lists, but since it handles them explicitly then we can remove extra newlines in that case, as we did in the other PR.

Numbering starts with the first number specified in the list, as per the Zulip revised scheme:
https://github.com/zulip/zulip/blob/master/docs/subsystems/markdown.md#lists

soup2markup now has a kw-args parameter 'state', in which a 'list_index'
entry is set by the ordered-lists code to have an index, incremented
through each list item, starting at the value specified in the 'start'
attribute of the html ordered list (ol).

Tests added.