### PR TITLE
Indicate panel searches in progress

### DIFF
--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -150,6 +150,8 @@ class TestWriteBox:
 
 
 class TestPanelSearchBox:
+    search_caption = "Search Results "
+
     @pytest.fixture
     def panel_search_box(self, mocker):
         # X is the return from keys_for_command("UNTESTED_TOKEN")
@@ -160,13 +162,16 @@ class TestPanelSearchBox:
 
     def test_init(self, panel_search_box):
         assert panel_search_box.search_text == "Search [X]: "
+        assert panel_search_box.caption == ""
         assert panel_search_box.edit_text == panel_search_box.search_text
 
     def test_reset_search_text(self, panel_search_box):
+        panel_search_box.set_caption(self.search_caption)
         panel_search_box.edit_text = "key words"
 
         panel_search_box.reset_search_text()
 
+        assert panel_search_box.caption == ""
         assert panel_search_box.edit_text == panel_search_box.search_text
 
     @pytest.mark.parametrize("log, expect_body_focus_set", [
@@ -179,11 +184,15 @@ class TestPanelSearchBox:
         size = (20,)
         panel_search_box.panel_view.view.controller.editor_mode = True
         panel_search_box.panel_view.log = log
+        panel_search_box.set_caption("")
         panel_search_box.edit_text = "key words"
 
         panel_search_box.keypress(size, enter_key)
 
         # Update this display
+        # FIXME We can't test for the styled version?
+        # We'd compare to [('filter_results', 'Search Results'), ' ']
+        assert panel_search_box.caption == self.search_caption
         assert panel_search_box.edit_text == "key words"
 
         # Leave editor mode
@@ -202,11 +211,13 @@ class TestPanelSearchBox:
     def test_keypress_GO_BACK(self, panel_search_box, back_key):
         size = (20,)
         panel_search_box.panel_view.view.controller.editor_mode = True
+        panel_search_box.set_caption(self.search_caption)
         panel_search_box.edit_text = "key words"
 
         panel_search_box.keypress(size, back_key)
 
         # Reset display
+        assert panel_search_box.caption == ""
         assert panel_search_box.edit_text == panel_search_box.search_text
 
         # Leave editor mode

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -860,20 +860,22 @@ class PanelSearchBox(urwid.Edit):
                             + ", ".join(keys_for_command(search_command))
                             + "]: ")
         urwid.connect_signal(self, 'change', update_function)
-        super().__init__(edit_text=self.search_text)
+        super().__init__(caption='', edit_text=self.search_text)
 
     def reset_search_text(self) -> None:
+        self.set_caption('')
         self.set_edit_text(self.search_text)
 
     def keypress(self, size: urwid_Size, key: str) -> Optional[str]:
         if is_command_key('ENTER', key):
             self.panel_view.view.controller.editor_mode = False
+            self.set_caption([('filter_results', 'Search Results'), ' '])
             self.panel_view.set_focus("body")
             if hasattr(self.panel_view, 'log') and len(self.panel_view.log):
                 self.panel_view.body.set_focus(0)
         elif is_command_key('GO_BACK', key):
             self.panel_view.view.controller.editor_mode = False
-            self.set_edit_text(self.search_text)
+            self.reset_search_text()
             self.panel_view.set_focus("body")
             self.panel_view.keypress(size, 'esc')
         return super().keypress(size, key)


### PR DESCRIPTION
This applies the styling in the message-view which indicates when a search is in progress, to the streams, topics and users views - making it visually clearer when the values shown in the view (being listed) are filtered, ie. a search result. This goes partially toward fixing #552.

GIven there were no tests for the `PanelSearchBox`, modified for this feature, this PR also includes a commit adding tests for this class first.