### PR TITLE
Fetch and indicate server version and feature level 

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,10 @@ source ~/.zshenv
 
 **Note:** You can use `arrows`, `home`, `end`, `Page up` and `Page down` keys to move around in Zulip-Terminal.
 
+## Supported Server Versions
+
+The minimum server version that Zulip Terminal supports is [`2.1.0`](https://zulip.readthedocs.io/en/latest/overview/changelog.html#id7). Though, it may still work with earlier versions.
+
 ## Contributor Guidelines
 
 Zulip Terminal is being built by the awesome [Zulip](https://zulip.com/team) community.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ from zulipterminal.config.keys import keys_for_command
 from zulipterminal.helper import initial_index as helper_initial_index
 from zulipterminal.ui_tools.boxes import MessageBox
 from zulipterminal.ui_tools.buttons import StreamButton, UserButton
+from zulipterminal.version import MINIMUM_SUPPORTED_SERVER_VERSION
 
 
 @pytest.fixture(autouse=True)
@@ -467,6 +468,10 @@ def initial_data(logged_on_user, users_fixture, streams_fixture):
         'last_event_id': -1,
         'muted_topics': [],
         'realm_user_groups': [],
+        # Deliberately use hard-coded zulip version and feature level to avoid
+        # adding extra tests unnecessarily.
+        'zulip_version': MINIMUM_SUPPORTED_SERVER_VERSION[0],
+        'zulip_feature_level': MINIMUM_SUPPORTED_SERVER_VERSION[1],
     }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,9 @@ from zulipterminal.config.keys import keys_for_command
 from zulipterminal.helper import initial_index as helper_initial_index
 from zulipterminal.ui_tools.boxes import MessageBox
 from zulipterminal.ui_tools.buttons import StreamButton, UserButton
-from zulipterminal.version import MINIMUM_SUPPORTED_SERVER_VERSION
+from zulipterminal.version import (
+    MINIMUM_SUPPORTED_SERVER_VERSION, SUPPORTED_SERVER_VERSIONS,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -311,6 +313,19 @@ def messages_successful_response() -> Dict[str, Any]:
         'result': 'success',
         'msg': '',
     })
+
+
+@pytest.fixture(
+    params=SUPPORTED_SERVER_VERSIONS,
+    ids=(lambda param:
+         'server_version:{}-server_feature_level:{}'.format(*param)),
+)
+def zulip_version(request):
+    """
+    Fixture to test different components based on the server version and the
+    feature level.
+    """
+    return request.param
 
 
 @pytest.fixture

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -53,6 +53,10 @@ class TestModel:
                                                    num_after=10,
                                                    anchor=None)
         assert model.initial_data == initial_data
+        assert model.server_version == initial_data['zulip_version']
+        assert model.server_feature_level == (
+            initial_data.get('zulip_feature_level')
+        )
         assert model.user_id == user_profile['user_id']
         assert model.user_full_name == user_profile['full_name']
         assert model.user_email == user_profile['email']
@@ -136,6 +140,7 @@ class TestModel:
             'muted_topics',
             'realm_user',
             'realm_user_groups',
+            'zulip_version',
         ]
         model.client.register.assert_called_once_with(
                 event_types=event_types,

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -17,6 +17,7 @@ from zulipterminal.ui_tools.views import (
     ModListWalker, MsgInfoView, PopUpConfirmationView, PopUpView,
     RightColumnView, StreamInfoView, StreamsView, TopicsView, UsersView,
 )
+from zulipterminal.version import MINIMUM_SUPPORTED_SERVER_VERSION, ZT_VERSION
 
 
 VIEWS = "zulipterminal.ui_tools.views"
@@ -1246,8 +1247,11 @@ class TestAboutView:
         mocker.patch.object(self.controller, 'maximum_popup_dimensions',
                             return_value=(64, 64))
         mocker.patch(VIEWS + '.urwid.SimpleFocusListWalker', return_value=[])
+        server_version, server_feature_level = MINIMUM_SUPPORTED_SERVER_VERSION
         self.about_view = AboutView(self.controller, 'About',
-                                    zt_version='0.5.1+git')
+                                    zt_version=ZT_VERSION,
+                                    server_version=server_version,
+                                    server_feature_level=server_feature_level)
 
     @pytest.mark.parametrize('key', {*keys_for_command('GO_BACK'),
                                      *keys_for_command('ABOUT')})
@@ -1269,6 +1273,21 @@ class TestAboutView:
         super_keypress = mocker.patch(VIEWS + '.urwid.ListBox.keypress')
         self.about_view.keypress(size, key)
         super_keypress.assert_called_once_with(size, expected_key)
+
+    def test_feature_level_content(self, mocker, zulip_version):
+        self.controller = mocker.Mock()
+        mocker.patch.object(self.controller, 'maximum_popup_dimensions',
+                            return_value=(64, 64))
+        mocker.patch(VIEWS + '.urwid.SimpleFocusListWalker', return_value=[])
+        server_version, server_feature_level = zulip_version
+
+        about_view = AboutView(self.controller, 'About', zt_version=ZT_VERSION,
+                               server_version=server_version,
+                               server_feature_level=server_feature_level)
+
+        assert len(about_view.feature_level_content) == (
+            1 if server_feature_level else 0
+        )
 
 
 class TestPopUpConfirmationView:

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -148,7 +148,11 @@ class Controller:
         self.show_pop_up(NoticeView(self, text, width, "NOTICE"))
 
     def show_about(self) -> None:
-        self.show_pop_up(AboutView(self, 'About', zt_version=ZT_VERSION))
+        self.show_pop_up(
+            AboutView(self, 'About', zt_version=ZT_VERSION,
+                      server_version=self.model.server_version,
+                      server_feature_level=self.model.server_feature_level)
+        )
 
     def search_messages(self, text: str) -> None:
         # Search for a text in messages

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -98,6 +98,11 @@ class Model:
         # lose any updates while messages are being fetched.
         self._update_initial_data()
 
+        self.server_version = self.initial_data['zulip_version']
+        self.server_feature_level = (
+            self.initial_data.get('zulip_feature_level')
+        )
+
         self.users = self.get_all_users()
 
         subscriptions = self.initial_data['subscriptions']
@@ -936,7 +941,10 @@ class Model:
             'update_message_flags',
             'muted_topics',
             'realm_user',  # Enables cross_realm_bots
-            'realm_user_groups'
+            'realm_user_groups',
+            # zulip_version and zulip_feature_level are always returned in
+            # POST /register from Feature level 3.
+            'zulip_version',
         ]
         event_types = list(self.event_actions)
         try:

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -879,10 +879,17 @@ class NoticeView(PopUpView):
 
 
 class AboutView(PopUpView):
-    def __init__(self, controller: Any, title: str, *,
-                 zt_version: str) -> None:
+    def __init__(self, controller: Any, title: str, *, zt_version: str,
+                 server_version: str,
+                 server_feature_level: Optional[int]) -> None:
+        self.feature_level_content = (
+            [('Feature level', str(server_feature_level))]
+            if server_feature_level else []
+        )
         contents = [
             ('Application', [('Zulip Terminal', zt_version)]),
+            ('Server', [('Version', server_version)]
+             + self.feature_level_content),
         ]
 
         popup_width, column_widths = self.calculate_table_widths(contents,

--- a/zulipterminal/version.py
+++ b/zulipterminal/version.py
@@ -1,1 +1,8 @@
 ZT_VERSION = '0.5.1+git'
+
+SUPPORTED_SERVER_VERSIONS = [
+    ('2.1', None),
+    ('3.0', 1),  # NOTE: 3.0 is not yet released.
+]
+
+MINIMUM_SUPPORTED_SERVER_VERSION = SUPPORTED_SERVER_VERSIONS[0]


### PR DESCRIPTION
This introduces `AboutView` to show server version and feature level within the app and makes other related amendments.

Fixes #616.