### PR TITLE
Shrink space to left of message by using unicode to mark edited messages.

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1889,8 +1889,8 @@ class TestMessageBox:
         assert len(view_components) == 1
         assert isinstance(view_components[0], Padding)
 
-    def test_main_view_generates_EDITED_label(self, mocker,
-                                              messages_successful_response):
+    def test_main_view_generates_edited_message_label(
+            self, mocker, messages_successful_response):
         messages = messages_successful_response['messages']
         for message in messages:
             self.model.index['edited_messages'].add(message['id'])
@@ -1898,8 +1898,8 @@ class TestMessageBox:
             view_components = msg_box.main_view()
 
             label = view_components[0].original_widget.contents[0]
-            assert label[0].text == 'EDITED'
-            assert label[1][1] == 7
+            assert label[0].text == '✎……'
+            assert label[1][1] == 4
 
     @pytest.mark.parametrize('key', keys_for_command('EDIT_MESSAGE'))
     @pytest.mark.parametrize(['to_vary_in_each_message',

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -629,16 +629,16 @@ class MessageBox(urwid.Pile):
         content = self.transform_content()
 
         if self.message['id'] in self.model.index['edited_messages']:
-            edited_label_size = 7
+            edited_label_size = 4
             left_padding = 1
         else:
             edited_label_size = 0
-            left_padding = 8
+            left_padding = 5
 
+        edit_mark = '\N{LOWER RIGHT PENCIL}' + (2 * '\N{HORIZONTAL ELLIPSIS}')
         content = urwid.Padding(
             urwid.Columns([
-                (edited_label_size,
-                 urwid.Text('EDITED')),
+                (edited_label_size, urwid.Text(edit_mark)),
                 urwid.LineBox(
                     urwid.Columns([
                         (1, urwid.Text('')),


### PR DESCRIPTION
By moving from 'EDITED' to '✎……' we avoid having a distracting label to
the left of the message, and can shrink wasted space to the left of the
message.

This commit reduces the space to the left by 3.

Based on a suggestion by Tim Abbott.