### PR TITLE
Improve monochrome rendering of narrows & streams.

### DIFF
--- a/zulipterminal/config/themes.py
+++ b/zulipterminal/config/themes.py
@@ -19,7 +19,7 @@ required_styles = {  # style-name: monochrome-bit-depth-style
     'user_idle': '',
     'user_offline': '',
     'user_inactive': '',
-    'title': 'standout',
+    'title': 'bold',
     'time': '',
     'bar': 'standout',
     'popup_contrast': 'standout',
@@ -34,7 +34,7 @@ required_styles = {  # style-name: monochrome-bit-depth-style
     'footer': 'standout',
     'starred': 'bold',
     'popup_category': 'bold',
-    'unread_count': '',
+    'unread_count': 'bold',
     'filter_results': 'bold',
 }
 

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -148,9 +148,9 @@ class StreamButton(TopButton):
                 inverse_text = background if background else 'black'
                 break
         view.palette.append((
-            self.color, '', '', '', self.color + ', bold', background))
+            self.color, '', '', 'bold', self.color + ', bold', background))
         view.palette.append((
-            's' + self.color, '', '', '', inverse_text, self.color))
+            's' + self.color, '', '', 'standout', inverse_text, self.color))
 
         super().__init__(controller,
                          caption=self.stream_name,


### PR DESCRIPTION
I noticed this while testing the thin-colorer-barbranch.

Prior to this commit:
* narrow text (excluding topics) was plain, with topic names in
  standout; this commit broadly inverts this, setting non-topics in
  standout and topics in bold, to produce the expected visual ordering
* stream '#'/'P' marks and unreads were visually undistinguishable from
  the stream name; this commit sets these all as bold