### PR TITLE
views: Refactor popups to expedite the popup creation process.

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1154,10 +1154,13 @@ class TestPopUpView:
     @pytest.fixture(autouse=True)
     def pop_up_view(self, mocker):
         self.controller = mocker.Mock()
+        mocker.patch.object(self.controller, 'maximum_popup_dimensions',
+                            return_value=(64, 64))
         self.command = 'COMMAND'
         self.title = 'Generic title'
         self.width = 16
         self.widget = mocker.Mock()
+        mocker.patch.object(self.widget, 'rows', return_value=1)
         self.widgets = [self.widget, ]
         self.list_walker = mocker.patch(VIEWS + '.urwid.SimpleFocusListWalker',
                                         return_value=[])
@@ -1208,6 +1211,8 @@ class TestHelpMenu:
     @pytest.fixture(autouse=True)
     def mock_external_classes(self, mocker, monkeypatch):
         self.controller = mocker.Mock()
+        mocker.patch.object(self.controller, 'maximum_popup_dimensions',
+                            return_value=(64, 64))
         mocker.patch(VIEWS + ".urwid.SimpleFocusListWalker", return_value=[])
         self.help_view = HelpView(self.controller, 'Help Menu')
 
@@ -1279,6 +1284,8 @@ class TestStreamInfoView:
     @pytest.fixture(autouse=True)
     def mock_external_classes(self, mocker, monkeypatch):
         self.controller = mocker.Mock()
+        mocker.patch.object(self.controller, 'maximum_popup_dimensions',
+                            return_value=(64, 64))
         mocker.patch(VIEWS + ".urwid.SimpleFocusListWalker", return_value=[])
         self.stream_info_view = StreamInfoView(self.controller, color='',
                                                desc='', title='# stream-name')
@@ -1303,6 +1310,8 @@ class TestMsgInfoView:
     @pytest.fixture(autouse=True)
     def mock_external_classes(self, mocker, monkeypatch, message_fixture):
         self.controller = mocker.Mock()
+        mocker.patch.object(self.controller, 'maximum_popup_dimensions',
+                            return_value=(64, 64))
         mocker.patch(VIEWS + ".urwid.SimpleFocusListWalker", return_value=[])
         self.msg_info_view = MsgInfoView(self.controller, message_fixture,
                                          'Message Information')
@@ -1321,7 +1330,7 @@ class TestMsgInfoView:
         assert self.controller.exit_popup.called
 
     def test_height_noreactions(self):
-        expected_height = 5
+        expected_height = 4
         assert self.msg_info_view.height == expected_height
 
     # FIXME This is the same parametrize as MessageBox:test_reactions_view
@@ -1368,7 +1377,8 @@ class TestMsgInfoView:
         varied_message = dict(message_fixture, **to_vary_in_each_message)
         self.msg_info_view = MsgInfoView(self.controller, varied_message,
                                          'Message Information')
-        expected_height = 8
+        # 7 = 3 labels + 4 reactions.
+        expected_height = 7
         assert self.msg_info_view.height == expected_height
 
     def test_keypress_navigation(self, mocker,

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1155,6 +1155,7 @@ class TestPopUpView:
     def pop_up_view(self, mocker):
         self.controller = mocker.Mock()
         self.command = 'COMMAND'
+        self.title = 'Generic title'
         self.width = 16
         self.widget = mocker.Mock()
         self.widgets = [self.widget, ]
@@ -1163,11 +1164,12 @@ class TestPopUpView:
         self.super_init = mocker.patch(VIEWS + '.urwid.ListBox.__init__')
         self.super_keypress = mocker.patch(VIEWS + '.urwid.ListBox.keypress')
         self.pop_up_view = PopUpView(self.controller, self.widgets,
-                                     self.command, self.width)
+                                     self.command, self.width, self.title)
 
     def test_init(self):
         assert self.pop_up_view.controller == self.controller
         assert self.pop_up_view.command == self.command
+        assert self.pop_up_view.title == self.title
         assert self.pop_up_view.width == self.width
         self.list_walker.assert_called_once_with(self.widgets)
         self.super_init.assert_called_once_with(self.pop_up_view.log)
@@ -1207,7 +1209,7 @@ class TestHelpMenu:
     def mock_external_classes(self, mocker, monkeypatch):
         self.controller = mocker.Mock()
         mocker.patch(VIEWS + ".urwid.SimpleFocusListWalker", return_value=[])
-        self.help_view = HelpView(self.controller)
+        self.help_view = HelpView(self.controller, 'Help Menu')
 
     def test_keypress_any_key(self):
         key = "a"
@@ -1278,7 +1280,8 @@ class TestStreamInfoView:
     def mock_external_classes(self, mocker, monkeypatch):
         self.controller = mocker.Mock()
         mocker.patch(VIEWS + ".urwid.SimpleFocusListWalker", return_value=[])
-        self.stream_info_view = StreamInfoView(self.controller, '', '', '')
+        self.stream_info_view = StreamInfoView(self.controller, color='',
+                                               desc='', title='# stream-name')
 
     @pytest.mark.parametrize('key', {*keys_for_command('GO_BACK'),
                                      *keys_for_command('STREAM_DESC')})
@@ -1301,7 +1304,8 @@ class TestMsgInfoView:
     def mock_external_classes(self, mocker, monkeypatch, message_fixture):
         self.controller = mocker.Mock()
         mocker.patch(VIEWS + ".urwid.SimpleFocusListWalker", return_value=[])
-        self.msg_info_view = MsgInfoView(self.controller, message_fixture)
+        self.msg_info_view = MsgInfoView(self.controller, message_fixture,
+                                         'Message Information')
 
     def test_keypress_any_key(self):
         key = "a"
@@ -1316,8 +1320,7 @@ class TestMsgInfoView:
         self.msg_info_view.keypress(size, key)
         assert self.controller.exit_popup.called
 
-    def test_height_noreactions(self, message_fixture):
-        self.msg_info_view = MsgInfoView(self.controller, message_fixture)
+    def test_height_noreactions(self):
         expected_height = 5
         assert self.msg_info_view.height == expected_height
 
@@ -1363,7 +1366,8 @@ class TestMsgInfoView:
         ])
     def test_height_reactions(self, message_fixture, to_vary_in_each_message):
         varied_message = dict(message_fixture, **to_vary_in_each_message)
-        self.msg_info_view = MsgInfoView(self.controller, varied_message)
+        self.msg_info_view = MsgInfoView(self.controller, varied_message,
+                                         'Message Information')
         expected_height = 8
         assert self.msg_info_view.height == expected_height
 

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1330,7 +1330,7 @@ class TestMsgInfoView:
         assert self.controller.exit_popup.called
 
     def test_height_noreactions(self):
-        expected_height = 4
+        expected_height = 3
         assert self.msg_info_view.height == expected_height
 
     # FIXME This is the same parametrize as MessageBox:test_reactions_view
@@ -1377,8 +1377,8 @@ class TestMsgInfoView:
         varied_message = dict(message_fixture, **to_vary_in_each_message)
         self.msg_info_view = MsgInfoView(self.controller, varied_message,
                                          'Message Information')
-        # 7 = 3 labels + 4 reactions.
-        expected_height = 7
+        # 9 = 3 labels + 1 blank line + 1 'Reactions' (category) + 4 reactions.
+        expected_height = 9
         assert self.msg_info_view.height == expected_height
 
     def test_keypress_navigation(self, mocker,

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1155,6 +1155,7 @@ class TestPopUpView:
     def pop_up_view(self, mocker):
         self.controller = mocker.Mock()
         self.command = 'COMMAND'
+        self.width = 16
         self.widget = mocker.Mock()
         self.widgets = [self.widget, ]
         self.list_walker = mocker.patch(VIEWS + '.urwid.SimpleFocusListWalker',
@@ -1162,11 +1163,12 @@ class TestPopUpView:
         self.super_init = mocker.patch(VIEWS + '.urwid.ListBox.__init__')
         self.super_keypress = mocker.patch(VIEWS + '.urwid.ListBox.keypress')
         self.pop_up_view = PopUpView(self.controller, self.widgets,
-                                     self.command)
+                                     self.command, self.width)
 
     def test_init(self):
         assert self.pop_up_view.controller == self.controller
         assert self.pop_up_view.command == self.command
+        assert self.pop_up_view.width == self.width
         self.list_walker.assert_called_once_with(self.widgets)
         self.super_init.assert_called_once_with(self.pop_up_view.log)
 

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -4,7 +4,7 @@ import sys
 import time
 from functools import partial
 from platform import platform
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Tuple
 
 import urwid
 import zulip
@@ -88,11 +88,18 @@ class Controller:
     def draw_screen(self, *args: Any, **kwargs: Any) -> None:
         self.loop.draw_screen()
 
+    def maximum_popup_dimensions(self) -> Tuple[int, int]:
+        """
+        Returns 3/4th of the screen estate's columns and rows.
+        """
+        max_cols, max_rows = map(lambda num: 3 * num // 4,
+                                 self.loop.screen.get_cols_rows())
+        return max_cols, max_rows
+
     def show_pop_up(self, to_show: Any) -> None:
         double_lines = dict(tlcorner='╔', tline='═', trcorner='╗',
                             rline='║', lline='║',
                             blcorner='╚', bline='═', brcorner='╝')
-        cols, rows = self.loop.screen.get_cols_rows()
         self.loop.widget = urwid.Overlay(
             urwid.LineBox(to_show,
                           to_show.title,
@@ -102,7 +109,7 @@ class Controller:
             valign='middle',
             # +2 to both of the following, due to LineBox
             width=to_show.width + 2,
-            height=min(3 * rows // 4, to_show.height) + 2
+            height=to_show.height + 2,
         )
 
     def exit_popup(self) -> None:
@@ -122,8 +129,8 @@ class Controller:
                                           "# {}".format(name))
         self.show_pop_up(show_stream_view)
 
-    def popup_with_message(self, text: str, width: int, height: int) -> None:
-        self.show_pop_up(NoticeView(self, text, width, height, "NOTICE"))
+    def popup_with_message(self, text: str, width: int) -> None:
+        self.show_pop_up(NoticeView(self, text, width, "NOTICE"))
 
     def search_messages(self, text: str) -> None:
         # Search for a text in messages

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -88,14 +88,14 @@ class Controller:
     def draw_screen(self, *args: Any, **kwargs: Any) -> None:
         self.loop.draw_screen()
 
-    def show_pop_up(self, to_show: Any, title: str) -> None:
+    def show_pop_up(self, to_show: Any) -> None:
         double_lines = dict(tlcorner='╔', tline='═', trcorner='╗',
                             rline='║', lline='║',
                             blcorner='╚', bline='═', brcorner='╝')
         cols, rows = self.loop.screen.get_cols_rows()
         self.loop.widget = urwid.Overlay(
             urwid.LineBox(to_show,
-                          title,
+                          to_show.title,
                           **double_lines),
             self.view,
             align='center',
@@ -109,20 +109,21 @@ class Controller:
         self.loop.widget = self.view
 
     def show_help(self) -> None:
-        help_view = HelpView(self)
-        self.show_pop_up(help_view, "Help Menu (up/down scrolls)")
+        help_view = HelpView(self, "Help Menu (up/down scrolls)")
+        self.show_pop_up(help_view)
 
     def show_msg_info(self, msg: Message) -> None:
-        msg_info_view = MsgInfoView(self, msg)
-        self.show_pop_up(msg_info_view,
-                         "Message Information (up/down scrolls)")
+        msg_info_view = MsgInfoView(self, msg,
+                                    "Message Information (up/down scrolls)")
+        self.show_pop_up(msg_info_view)
 
     def show_stream_info(self, color: str, name: str, desc: str) -> None:
-        show_stream_view = StreamInfoView(self, color, name, desc)
-        self.show_pop_up(show_stream_view, "# {}".format(name))
+        show_stream_view = StreamInfoView(self, color, desc,
+                                          "# {}".format(name))
+        self.show_pop_up(show_stream_view)
 
     def popup_with_message(self, text: str, width: int, height: int) -> None:
-        self.show_pop_up(NoticeView(self, text, width, height), "NOTICE")
+        self.show_pop_up(NoticeView(self, text, width, height, "NOTICE"))
 
     def search_messages(self, text: str) -> None:
         # Search for a text in messages

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -727,7 +727,7 @@ class Model:
             )
             notice = notice_template.format(failed_command,
                                             keys_for_command("GO_BACK").pop())
-            self.controller.popup_with_message(notice, width=50, height=11)
+            self.controller.popup_with_message(notice, width=50)
             self.controller.update_screen()
             self._notified_user_of_notification_failure = True
 

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1,6 +1,5 @@
 import threading
 import time
-from collections import OrderedDict
 from typing import Any, Callable, List, Optional, Sequence, Tuple
 
 import urwid
@@ -814,7 +813,13 @@ class PopUpView(urwid.ListBox):
         for category, content in contents:
             category_width = max(category_width, len(category))
             for row in content:
-                strip_widths.append(list(map(len, row)))
+                # Measure the longest line if the text is seperated by
+                # newline(s).
+                max_row_lengths = [
+                    len(max(text.split('\n'), key=len))
+                    for text in row
+                ]
+                strip_widths.append(max_row_lengths)
         column_widths = [max(width) for width in zip(*strip_widths)]
 
         popup_width = max(sum(column_widths) + dividechars, title_width,
@@ -955,28 +960,15 @@ class MsgInfoView(PopUpView):
                          for reaction in msg['reactions']])
             reactions[-1] = reactions[-1].rstrip("\n")
 
-        msg_info = OrderedDict([
-            ('Date & Time', time.ctime(msg['timestamp'])[:-5]),
-            ('Sender', msg['sender_full_name']),
-            ('Sender\'s Email ID', msg['sender_email']),
-            ('Reactions', reactions if msg['reactions'] else '---None---'),
-            ])
+        msg_info = [
+            ('', [('Date & Time', time.ctime(msg['timestamp'])[:-5]),
+                  ('Sender', msg['sender_full_name']),
+                  ('Sender\'s Email ID', msg['sender_email']),
+                  ('Reactions', ''.join(reactions) if msg['reactions']
+                   else '---None---')]),
+        ]
 
-        widths = [(len(field) + 7,
-                  max(len(reaction_users) for reaction_users in data)
-                  if isinstance(data, list)
-                  else len(data) + 2)
-                  for field, data in msg_info.items()]
-        max_widths = [max(width) for width in zip(*widths)]
-        width = sum(max_widths)
-
-        msg_info_content = [urwid.AttrWrap(
-                urwid.Columns([
-                    urwid.Text(field),
-                    (max_widths[1], urwid.Text(data))
-                ], dividechars=2),
-                None if index % 2 else 'popup_contrast')
-             for index, (field, data) in enumerate(msg_info.items())]
-
-        super().__init__(controller, msg_info_content, 'MSG_INFO', width,
-                         title)
+        popup_width, column_widths = self.calculate_table_widths(msg_info,
+                                                                 len(title))
+        widgets = self.make_table_with_categories(msg_info, column_widths)
+        super().__init__(controller, widgets, 'MSG_INFO', popup_width, title)

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1,6 +1,6 @@
 import threading
 import time
-from typing import Any, Callable, List, Optional, Sequence, Tuple
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
 
 import urwid
 
@@ -951,22 +951,23 @@ class MsgInfoView(PopUpView):
     def __init__(self, controller: Any, msg: Message, title: str) -> None:
         self.msg = msg
 
-        if msg['reactions']:
-            reactions = sorted(
-                        [reaction['emoji_name']
-                         + ": "
-                         + reaction['user']['full_name']
-                         + "\n"
-                         for reaction in msg['reactions']])
-            reactions[-1] = reactions[-1].rstrip("\n")
-
         msg_info = [
             ('', [('Date & Time', time.ctime(msg['timestamp'])[:-5]),
                   ('Sender', msg['sender_full_name']),
-                  ('Sender\'s Email ID', msg['sender_email']),
-                  ('Reactions', ''.join(reactions) if msg['reactions']
-                   else '---None---')]),
+                  ('Sender\'s Email ID', msg['sender_email'])]),
         ]
+        if msg['reactions']:
+            reactions = sorted(
+                (reaction['emoji_name'], reaction['user']['full_name'])
+                for reaction in msg['reactions']
+            )
+            grouped_reactions = dict()  # type: Dict[str, str]
+            for reaction, user in reactions:
+                if reaction in grouped_reactions:
+                    grouped_reactions[reaction] += '\n{}'.format(user)
+                else:
+                    grouped_reactions[reaction] = user
+            msg_info.append(('Reactions', list(grouped_reactions.items())))
 
         popup_width, column_widths = self.calculate_table_widths(msg_info,
                                                                  len(title))

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -772,9 +772,10 @@ PopUpViewTableContent = Sequence[Tuple[str, Sequence[Tuple[str, str]]]]
 
 class PopUpView(urwid.ListBox):
     def __init__(self, controller: Any, widgets: List[Any],
-                 command: str, requested_width: int) -> None:
+                 command: str, requested_width: int, title: str) -> None:
         self.controller = controller
         self.command = command
+        self.title = title
         self.log = urwid.SimpleFocusListWalker(widgets)
         self.width = requested_width
         super().__init__(self.log)
@@ -839,18 +840,19 @@ class NoticeView(PopUpView):
     def __init__(self, controller: Any,
                  notice_text: str,
                  width: int,
-                 height: int) -> None:
+                 height: int,
+                 title: str) -> None:
         self.height = height
         widgets = [
             urwid.Divider(),
             urwid.Padding(urwid.Text(notice_text), left=1, right=1),
             urwid.Divider(),
         ]
-        super().__init__(controller, widgets, 'GO_BACK', width)
+        super().__init__(controller, widgets, 'GO_BACK', width, title)
 
 
 class HelpView(PopUpView):
-    def __init__(self, controller: Any) -> None:
+    def __init__(self, controller: Any, title: str) -> None:
         help_menu_content = []
         for category in HELP_CATEGORIES:
             keys_in_category = (binding for binding in KEY_BINDINGS.values()
@@ -867,7 +869,7 @@ class HelpView(PopUpView):
                                                   column_widths)
         self.height = len(widgets)
 
-        super().__init__(controller, widgets, 'HELP', popup_width)
+        super().__init__(controller, widgets, 'HELP', popup_width, title)
 
 
 class PopUpConfirmationView(urwid.Overlay):
@@ -908,19 +910,20 @@ class PopUpConfirmationView(urwid.Overlay):
 
 class StreamInfoView(PopUpView):
     def __init__(self, controller: Any, color: str,
-                 name: str, desc: str) -> None:
+                 desc: str, title: str) -> None:
         # TODO: Height handling could be improved
         # Add 4 (for 2 Unicode characters on either side) to the popup title
         # length to make sure that the title gets displayed even when the
         # content is shorter than the title length (+4 Unicode characters).
-        width = max(len(desc) + 2, len("# {}".format(name)) + 4)
+        width = max(len(desc) + 2, len(title) + 4)
         self.height = 2
         stream_info_content = [urwid.Text(desc, align='center')]
-        super().__init__(controller, stream_info_content, 'STREAM_DESC', width)
+        super().__init__(controller, stream_info_content, 'STREAM_DESC', width,
+                         title)
 
 
 class MsgInfoView(PopUpView):
-    def __init__(self, controller: Any, msg: Message) -> None:
+    def __init__(self, controller: Any, msg: Message, title: str) -> None:
         self.msg = msg
 
         if msg['reactions']:
@@ -956,4 +959,5 @@ class MsgInfoView(PopUpView):
                 None if index % 2 else 'popup_contrast')
              for index, (field, data) in enumerate(msg_info.items())]
 
-        super().__init__(controller, msg_info_content, 'MSG_INFO', width)
+        super().__init__(controller, msg_info_content, 'MSG_INFO', width,
+                         title)

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -782,18 +782,28 @@ class PopUpView(urwid.ListBox):
 
     @staticmethod
     def calculate_table_widths(contents: PopUpViewTableContent,
+                               title_len: int,
                                dividechars: int=2) -> Tuple[int, List[int]]:
         """
         Returns a tuple that contains the required width for the popup and a
         list that has column widths.
         """
+        # Add 4 (for 2 Unicode characters on either side) to the popup title
+        # length to make sure that the title gets displayed even when the
+        # content or the category is shorter than the title length (+4 Unicode
+        # characters).
+        title_width = title_len + 4
+
+        category_width = 0
         strip_widths = []
         for category, content in contents:
+            category_width = max(category_width, len(category))
             for row in content:
                 strip_widths.append(list(map(len, row)))
         column_widths = [max(width) for width in zip(*strip_widths)]
 
-        popup_width = sum(column_widths) + dividechars
+        popup_width = max(sum(column_widths) + dividechars, title_width,
+                          category_width)
         return (popup_width, column_widths)
 
     @staticmethod
@@ -864,7 +874,7 @@ class HelpView(PopUpView):
             help_menu_content.append((HELP_CATEGORIES[category], key_bindings))
 
         popup_width, column_widths = self.calculate_table_widths(
-            help_menu_content)
+            help_menu_content, len(title))
         widgets = self.make_table_with_categories(help_menu_content,
                                                   column_widths)
         self.height = len(widgets)

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -772,10 +772,11 @@ PopUpViewTableContent = Sequence[Tuple[str, Sequence[Tuple[str, str]]]]
 
 class PopUpView(urwid.ListBox):
     def __init__(self, controller: Any, widgets: List[Any],
-                 command: str) -> None:
+                 command: str, requested_width: int) -> None:
         self.controller = controller
         self.command = command
         self.log = urwid.SimpleFocusListWalker(widgets)
+        self.width = requested_width
         super().__init__(self.log)
 
     @staticmethod
@@ -839,14 +840,13 @@ class NoticeView(PopUpView):
                  notice_text: str,
                  width: int,
                  height: int) -> None:
-        self.width = width
         self.height = height
         widgets = [
             urwid.Divider(),
             urwid.Padding(urwid.Text(notice_text), left=1, right=1),
             urwid.Divider(),
         ]
-        super().__init__(controller, widgets, 'GO_BACK')
+        super().__init__(controller, widgets, 'GO_BACK', width)
 
 
 class HelpView(PopUpView):
@@ -863,12 +863,11 @@ class HelpView(PopUpView):
 
         popup_width, column_widths = self.calculate_table_widths(
             help_menu_content)
-        self.width = popup_width
         widgets = self.make_table_with_categories(help_menu_content,
                                                   column_widths)
         self.height = len(widgets)
 
-        super().__init__(controller, widgets, 'HELP')
+        super().__init__(controller, widgets, 'HELP', popup_width)
 
 
 class PopUpConfirmationView(urwid.Overlay):
@@ -914,10 +913,10 @@ class StreamInfoView(PopUpView):
         # Add 4 (for 2 Unicode characters on either side) to the popup title
         # length to make sure that the title gets displayed even when the
         # content is shorter than the title length (+4 Unicode characters).
-        self.width = max(len(desc) + 2, len("# {}".format(name)) + 4)
+        width = max(len(desc) + 2, len("# {}".format(name)) + 4)
         self.height = 2
         stream_info_content = [urwid.Text(desc, align='center')]
-        super().__init__(controller, stream_info_content, 'STREAM_DESC')
+        super().__init__(controller, stream_info_content, 'STREAM_DESC', width)
 
 
 class MsgInfoView(PopUpView):
@@ -946,7 +945,7 @@ class MsgInfoView(PopUpView):
                   else len(data) + 2)
                   for field, data in msg_info.items()]
         max_widths = [max(width) for width in zip(*widths)]
-        self.width = sum(max_widths)
+        width = sum(max_widths)
         self.height = len(msg_info['Reactions']) + 4 if msg['reactions'] else 5
 
         msg_info_content = [urwid.AttrWrap(
@@ -957,4 +956,4 @@ class MsgInfoView(PopUpView):
                 None if index % 2 else 'popup_contrast')
              for index, (field, data) in enumerate(msg_info.items())]
 
-        super().__init__(controller, msg_info_content, 'MSG_INFO')
+        super().__init__(controller, msg_info_content, 'MSG_INFO', width)


### PR DESCRIPTION
The intention is to extract and generalize duplicate code to expedite the popup creation process.

Along with that, it tidies up popups, that derive from PopUpView, by calculating their required width and height based on the content instead of using hard-coded values.

Tests amended.

As a side effect, fixes #654 and #658.