### PR TITLE
Add support for edit history

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ source ~/.zshenv
 | Add/remove thumbs-up reaction to the current message  | <kbd>+</kbd>                                  |
 | Add/remove star status of the current message         | <kbd>*</kbd>                                  |
 | Show message information                              | <kbd>i</kbd>                                  |
+| View edit history from message information box        | <kbd>e</kbd>                                  |
 
 ### Stream list actions
 | Command                                               | Key Combination                               |

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -333,6 +333,42 @@ def zulip_version(request):
     return request.param
 
 
+@pytest.fixture(params=[
+        [{
+            'content': 'Hello!',
+            'timestamp': 1530129122,
+            'topic': 'hello world',
+            'user_id': 1001,
+            # ...
+        }],
+        [{
+            'content': 'Hello!',
+            'timestamp': 1530129122,
+            'topic': 'party at my houz',
+            'user_id': 1001,
+            # ...
+        }, {
+            'content': 'Howdy!',
+            'prev_content': 'Hello!',
+            'prev_topic': 'party at my houz',
+            'timestamp': 1530129134,
+            'topic': 'party at my house',
+            'user_id': 1001,
+            # ...
+        }],
+    ],
+    ids=[
+        'unedited_message',
+        'edited_message',
+    ]
+)
+def message_history(request):
+    """
+    Returns message edit history for a message.
+    """
+    return request.param
+
+
 @pytest.fixture
 def topics():
     return ['Topic 1', 'This is a topic', 'Hello there!']

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -1665,3 +1665,35 @@ class TestModel:
         return_value = model.is_user_subscribed_to_stream(stream_id)
 
         assert return_value == expected_response
+
+    @pytest.mark.parametrize('response', [{
+        'result': 'success',
+        'msg': '',
+    }])
+    def test_fetch_message_history_success(self, mocker, model,
+                                           message_history, response,
+                                           message_id=1):
+        response['message_history'] = message_history
+        expected_return_value = message_history
+        self.client.get_message_history.return_value = response
+
+        return_value = model.fetch_message_history(message_id)
+
+        self.client.get_message_history.assert_called_once_with(message_id)
+        assert not self.display_error_if_present.called
+        assert return_value == expected_return_value
+
+    @pytest.mark.parametrize('response', [{
+        'result': 'error',
+        'msg': 'Invalid message(s)',
+    }])
+    def test_fetch_message_history_error(self, mocker, model, response,
+                                         message_id=1,
+                                         expected_return_value=list()):
+        self.client.get_message_history.return_value = response
+
+        return_value = model.fetch_message_history(message_id)
+
+        self.client.get_message_history.assert_called_once_with(message_id)
+        assert self.display_error_if_present.called
+        assert return_value == expected_return_value

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -1697,3 +1697,20 @@ class TestModel:
         self.client.get_message_history.assert_called_once_with(message_id)
         assert self.display_error_if_present.called
         assert return_value == expected_return_value
+
+    @pytest.mark.parametrize('user_id, full_name', [(1001, 'Human Myself')])
+    def test_user_name_from_id_valid(self, model, user_dict, user_id,
+                                     full_name):
+        model.user_id_email_dict = {1001: 'FOOBOO@gmail.com'}
+        model.user_dict = user_dict
+
+        return_value = model.user_name_from_id(user_id)
+
+        assert return_value == full_name
+
+    @pytest.mark.parametrize('user_id', [-1])
+    def test_user_name_from_id_invalid(self, model, user_id):
+        model.user_id_email_dict = {1001: 'FOOBOO@gmail.com'}
+
+        with pytest.raises(RuntimeError, match='Invalid user ID.'):
+            model.user_name_from_id(user_id)

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -86,13 +86,110 @@ class TestEditHistoryView:
             'topic': 'party at my house',
             # ...
     }])
-    def test__make_edit_block(self, snapshot, tag='(Current Version)'):
+    @pytest.mark.parametrize('user_id, user_name_from_id_called', [
+            (1001, True),
+            (None, False),
+        ],
+        ids=[
+            'with_user_id',
+            'without_user_id',
+        ]
+    )
+    def test__make_edit_block(self, mocker, snapshot, user_id,
+                              user_name_from_id_called,
+                              tag='(Current Version)'):
+        self._get_author_prefix = mocker.patch(
+            VIEWS + '.EditHistoryView._get_author_prefix',
+        )
+        snapshot = dict(**snapshot, user_id=user_id) if user_id else snapshot
+
         contents = self.edit_history_view._make_edit_block(snapshot, tag)
 
         assert isinstance(contents[0], Columns)  # Header.
         assert isinstance(contents[0][0], Text)  # Header: Topic.
         assert isinstance(contents[0][1], Text)  # Header: Tag.
         assert isinstance(contents[1], Columns)  # Subheader.
-        assert isinstance(contents[1][0], Text)  # Subheader: Timestamp.
+        assert isinstance(contents[1][0], Text)  # Subheader: Author.
+        assert isinstance(contents[1][1], Text)  # Subheader: Timestamp.
         assert isinstance(contents[2], Text)     # Content.
         assert contents[0][1].text == tag
+        assert (self.controller.model.user_name_from_id.called
+                == user_name_from_id_called)
+
+    @pytest.mark.parametrize('snapshot', [{
+            'content': 'Howdy!',
+            'timestamp': 1530129134,
+            'topic': 'party at my house',
+            # ...
+    }])
+    @pytest.mark.parametrize(['to_vary_in_snapshot', 'tag',
+                              'expected_author_prefix'], [
+            (
+                {},
+                '(Original Version)',
+                'Posted',
+            ),
+            (
+                {
+                    'prev_content': 'Hi!',
+                    'prev_topic': 'no party at my house',
+                },
+                '',
+                'Content & Topic edited',
+            ),
+            (
+                {
+                    'prev_content': 'Hi!',
+                },
+                '',
+                'Content edited',
+            ),
+            (
+                {
+                    'prev_topic': 'no party at my house',
+                },
+                '',
+                'Topic edited',
+            ),
+            (
+                {
+                    'prev_content': 'Howdy!',
+                    'prev_topic': 'party at my house',
+                },
+                '',
+                'Edited but no changes made',
+            ),
+            (
+                {
+                    'prev_content': 'Hi!',
+                    'prev_topic': 'party at my house',
+                },
+                '',
+                'Content edited',
+            ),
+            (
+                {
+                    'prev_content': 'Howdy!',
+                    'prev_topic': 'no party at my house',
+                },
+                '',
+                'Topic edited',
+            ),
+        ],
+        ids=[
+            'posted',
+            'content_&_topic_edited',
+            'content_edited',
+            'topic_edited',
+            'false_alarm_content_&_topic',
+            'content_edited_with_false_alarm_topic',
+            'topic_edited_with_false_alarm_content',
+        ]
+    )
+    def test__get_author_prefix(self, snapshot, to_vary_in_snapshot, tag,
+                                expected_author_prefix):
+        snapshot = dict(**snapshot, **to_vary_in_snapshot)
+
+        return_value = EditHistoryView._get_author_prefix(snapshot, tag)
+
+        assert return_value == expected_author_prefix

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -1,0 +1,74 @@
+from collections import OrderedDict
+
+import pytest
+
+from zulipterminal.config.keys import keys_for_command
+from zulipterminal.ui_tools.views import EditHistoryView
+
+
+VIEWS = "zulipterminal.ui_tools.views"
+
+
+class TestEditHistoryView:
+    @pytest.fixture(autouse=True)
+    def mock_external_classes(self, mocker):
+        self.controller = mocker.Mock()
+        mocker.patch.object(self.controller, 'maximum_popup_dimensions',
+                            return_value=(64, 64))
+        mocker.patch(VIEWS + '.urwid.SimpleFocusListWalker', return_value=[])
+        # NOTE: Given that the EditHistoryView just uses the message ID from
+        # the message data currently, message_fixture is not used to avoid
+        # adding extra test runs unnecessarily.
+        self.message = {'id': 1}
+        self.edit_history_view = EditHistoryView(
+            controller=self.controller,
+            message=self.message,
+            message_links=OrderedDict(),
+            time_mentions=list(),
+            title='Edit History',
+        )
+
+    def test_init(self):
+        assert self.edit_history_view.controller == self.controller
+        assert self.edit_history_view.message == self.message
+        assert self.edit_history_view.message_links == OrderedDict()
+        assert self.edit_history_view.time_mentions == list()
+
+    @pytest.mark.parametrize('key', keys_for_command('MSG_INFO'))
+    def test_keypress_exit_popup(self, key):
+        size = (200, 20)
+
+        self.edit_history_view.keypress(size, key)
+
+        assert self.controller.exit_popup.called
+
+    def test_keypress_exit_popup_invalid_key(self):
+        size = (200, 20)
+        key = 'a'
+
+        self.edit_history_view.keypress(size, key)
+
+        assert not self.controller.exit_popup.called
+
+    @pytest.mark.parametrize('key', {*keys_for_command('EDIT_HISTORY'),
+                                     *keys_for_command('GO_BACK')})
+    def test_keypress_show_msg_info(self, key):
+        size = (200, 20)
+
+        self.edit_history_view.keypress(size, key)
+
+        self.controller.show_msg_info.assert_called_once_with(
+            msg=self.message,
+            message_links=OrderedDict(),
+            time_mentions=list(),
+        )
+
+    def test_keypress_navigation(self, mocker,
+                                 navigation_key_expected_key_pair):
+        size = (200, 20)
+        key, expected_key = navigation_key_expected_key_pair
+        super_keypress = mocker.patch(VIEWS + '.urwid.ListBox.keypress')
+
+        self.edit_history_view.keypress(size, key)
+
+        super_keypress.assert_called_once_with(size, expected_key)

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -221,6 +221,12 @@ KEY_BINDINGS = OrderedDict([
         'help_text': 'View message information',
         'key_category': 'msg_actions',
     }),
+    ('EDIT_HISTORY', {
+        'keys': {'e'},
+        'help_text': 'View edit history from message information box',
+        'excluded_from_random_tips': True,
+        'key_category': 'msg_actions',
+    }),
     ('STREAM_DESC', {
         'keys': {'i'},
         'help_text': 'View stream information & modify settings',

--- a/zulipterminal/config/themes.py
+++ b/zulipterminal/config/themes.py
@@ -39,6 +39,10 @@ required_styles = {  # style-name: monochrome-bit-depth-style
     'popup_category': 'bold',
     'unread_count': 'bold',
     'filter_results': 'bold',
+    'edit_topic': 'standout',
+    'edit_tag': 'standout',
+    'edit_author': 'bold',
+    'edit_time': 'bold',
 }
 
 
@@ -154,6 +158,14 @@ THEMES = {
          None,             DEF['white:bold'],         DEF['black']),
         ('filter_results', 'white',                   'dark green',
          None,             DEF['white'],              DEF['dark_green']),
+        ('edit_topic',     'white',                   'dark gray',
+         None,             DEF['white'],              DEF['dark_gray']),
+        ('edit_tag',       'white',                   'dark gray',
+         None,             DEF['white'],              DEF['dark_gray']),
+        ('edit_author',    'yellow',                  'black',
+         None,             DEF['yellow'],             DEF['black']),
+        ('edit_time',      'light blue',              'black',
+         None,             DEF['light_blue'],         DEF['black']),
     ],
     'gruvbox_dark': [
         # default colorscheme on 16 colors, gruvbox colorscheme
@@ -222,6 +234,14 @@ THEMES = {
          None,             WHITEBOLD,         BLACK),
         ('filter_results', 'black',           'light green',
          None,             BLACK,             LIGHTGREEN),
+        ('edit_topic',     'black',           'dark gray',
+         None,             BLACK,             GRAY),
+        ('edit_tag',       'black',           'dark gray',
+         None,             BLACK,             GRAY),
+        ('edit_author',    'yellow',          'black',
+         None,             YELLOW,            BLACK),
+        ('edit_time',      'light blue',      'black',
+         None,             LIGHTBLUE,         BLACK),
     ],
     'zt_light': [
         (None,             'black',           'white'),
@@ -256,6 +276,10 @@ THEMES = {
         ('unread_count',   'dark blue, bold', 'white'),
         ('table_head',     'black, bold',     'white'),
         ('filter_results', 'white',           'dark green'),
+        ('edit_topic',     'white',           'dark gray'),
+        ('edit_tag',       'white',           'dark gray'),
+        ('edit_author',    'dark green',      'white'),
+        ('edit_time',      'dark blue',       'white'),
     ],
     'zt_blue': [
         (None,             'black',           'light blue'),
@@ -290,6 +314,10 @@ THEMES = {
         ('unread_count',   'yellow',          'light blue'),
         ('table_head',     'black, bold',     'light blue'),
         ('filter_results', 'white',           'dark green'),
+        ('edit_topic',     'white',           'dark blue'),
+        ('edit_tag',       'white',           'dark blue'),
+        ('edit_author',    'dark gray',       'light blue'),
+        ('edit_time',      'dark blue',       'light blue'),
     ]
 }  # type: Dict[str, ThemeSpec]
 

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -16,8 +16,8 @@ from zulipterminal.model import Model
 from zulipterminal.ui import Screen, View
 from zulipterminal.ui_tools.utils import create_msg_box_list
 from zulipterminal.ui_tools.views import (
-    AboutView, EditModeView, HelpView, MsgInfoView, NoticeView,
-    PopUpConfirmationView, StreamInfoView,
+    AboutView, EditHistoryView, EditModeView, HelpView, MsgInfoView,
+    NoticeView, PopUpConfirmationView, StreamInfoView,
 )
 from zulipterminal.version import ZT_VERSION
 
@@ -161,6 +161,16 @@ class Controller:
             AboutView(self, 'About', zt_version=ZT_VERSION,
                       server_version=self.model.server_version,
                       server_feature_level=self.model.server_feature_level)
+        )
+
+    def show_edit_history(
+        self, message: Message,
+        message_links: 'OrderedDict[str, Tuple[str, int, bool]]',
+        time_mentions: List[Tuple[str, str]],
+    ) -> None:
+        self.show_pop_up(
+            EditHistoryView(self, message, message_links, time_mentions,
+                            'Edit History (up/down scrolls)')
         )
 
     def search_messages(self, text: str) -> None:

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -609,6 +609,17 @@ class Model:
 
         return user_list
 
+    def user_name_from_id(self, user_id: int) -> str:
+        """
+        Returns user's full name given their ID.
+        """
+        user_email = self.user_id_email_dict.get(user_id)
+
+        if not user_email:
+            raise RuntimeError('Invalid user ID.')
+
+        return self.user_dict[user_email]['full_name']
+
     @staticmethod
     def _stream_info_from_subscriptions(
             subscriptions: List[Dict[str, Any]]

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -396,6 +396,17 @@ class Model:
         display_error_if_present(response, self.controller)
         return response['msg']
 
+    def fetch_message_history(self, message_id: int,
+                              ) -> List[Dict[str, Union[int, str]]]:
+        """
+        Fetches message edit history for a message using its ID.
+        """
+        response = self.client.get_message_history(message_id)
+        if response['result'] == 'success':
+            return response['message_history']
+        display_error_if_present(response, self.controller)
+        return list()
+
     def _fetch_topics_in_streams(self, stream_list: Iterable[int]) -> str:
         """
         Fetch all topics with specified stream_id's and

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1103,6 +1103,10 @@ class MsgInfoView(PopUpView):
             and controller.model.initial_data['realm_allow_edit_history']
         )
         if self.show_edit_history_label:
+            msg_info[0][1][0] = (
+                'Date & Time (Original)', time.ctime(msg['timestamp'])[:-5]
+            )
+
             keys = ', '.join(map(repr, keys_for_command('EDIT_HISTORY')))
             msg_info[0][1].append(
                 ('Edit History', 'Press {} to view'.format(keys))

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1171,3 +1171,28 @@ class EditModeView(PopUpView):
         if key == ' ':
             key = 'enter'
         return super().keypress(size, key)
+
+
+class EditHistoryView(PopUpView):
+    def __init__(self, controller: Any, message: Message,
+                 message_links: 'OrderedDict[str, Tuple[str, int, bool]]',
+                 time_mentions: List[Tuple[str, str]],
+                 title: str) -> None:
+        self.controller = controller
+        self.message = message
+        self.message_links = message_links
+        self.time_mentions = time_mentions
+        width = 64
+        widgets = []  # type: List[Any]
+        super().__init__(controller, widgets, 'MSG_INFO', width, title)
+
+    def keypress(self, size: urwid_Size, key: str) -> str:
+        if (is_command_key('GO_BACK', key)
+                or is_command_key('EDIT_HISTORY', key)):
+            self.controller.show_msg_info(
+                msg=self.message,
+                message_links=self.message_links,
+                time_mentions=self.time_mentions,
+            )
+            return key
+        return super().keypress(size, key)


### PR DESCRIPTION
This PR builds up on @shreyamalviya's #354 to show edit history for a message. :+1:

The popup can be triggered by pressing  `d`  from the `MsgInfoView` for any message (we could discuss other key options and whether it would be better to show the popup only for messages that are edited).

For **v1**, the popup only shows the content for every snapshot in the 'message_history' (not the diff). 

I have split the last two commits for making it easier to review. We could squash the two if necessary.

Fixes #135 partially.