### PR TITLE
Show loading screen in urwid.

### DIFF
--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -93,10 +93,6 @@ def test_valid_zuliprc_but_no_connection(capsys, mocker, minimal_zuliprc,
 
     lines = captured.out.strip().split("\n")
     expected_lines = [
-        "Loading with:",
-        "   theme 'zt_dark' specified with no config.",
-        "   autohide setting 'no_autohide' specified with no config.",
-        "   footlinks setting 'enabled' specified with no config.",
         "\x1b[91m",
         ("Error connecting to Zulip server: {}.\x1b[0m".
             format(server_connection_error)),
@@ -127,14 +123,10 @@ def test_warning_regarding_incomplete_theme(capsys, mocker, monkeypatch,
 
     lines = captured.out.strip().split("\n")
     expected_lines = [
-        "Loading with:",
-        "   theme '{}' specified on command line.".format(bad_theme),
         "\x1b[93m"
         "   WARNING: Incomplete theme; results may vary!",
         "      (you could try: {}, {})"
         "\x1b[0m".format('a', 'b'),
-        "   autohide setting 'no_autohide' specified with no config.",
-        "   footlinks setting 'enabled' specified with no config.",
         "\x1b[91m",
         ("Error connecting to Zulip server: {}.\x1b[0m".
             format(server_connection_error)),

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -8,6 +8,7 @@ from zulipterminal.version import ZT_VERSION
 
 
 CORE = "zulipterminal.core"
+VIEWS = 'zulipterminal.ui_tools.views'
 
 
 class TestController:
@@ -16,16 +17,19 @@ class TestController:
         mocker.patch('zulipterminal.ui_tools.boxes.MessageBox.footlinks_view')
         self.client = mocker.patch('zulip.Client')
         # Patch init only, in general, allowing specific patching elsewhere
+        self.loading_view = mocker.patch(VIEWS + '.LoadingView.__init__',
+                                         return_value=None)
         self.model = mocker.patch(CORE + '.Model.__init__', return_value=None)
         self.view = mocker.patch(CORE + '.View.__init__', return_value=None)
         self.model.view = self.view
         self.view.focus_col = 1
+        mocker.patch('zulipterminal.core.Controller.capture_stdout')
+        mocker.patch('zulipterminal.core.Controller.update_screen')
 
     @pytest.fixture
     def controller(self, mocker) -> None:
         # Patch these unconditionally to avoid calling in __init__
         self.poll_for_events = mocker.patch(CORE + '.Model.poll_for_events')
-        mocker.patch(CORE + '.Controller.show_loading')
 
         self.config_file = 'path/to/zuliprc'
         self.theme = 'default'
@@ -42,6 +46,7 @@ class TestController:
             config_file=self.config_file,
             client='ZulipTerminal/' + ZT_VERSION + ' ' + platform(),
         )
+        self.loading_view.assert_called_once_with(controller)
         self.model.assert_called_once_with(controller)
         self.view.assert_called_once_with(controller)
         self.poll_for_events.assert_called_once_with()

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -36,8 +36,10 @@ class TestController:
         self.autohide = True  # FIXME Add tests for no-autohide
         self.notify_enabled = False
         self.footlinks_enabled = True
-        result = Controller(self.config_file, self.theme, 256, self.autohide,
-                            self.notify_enabled, self.footlinks_enabled)
+        self.settings = mocker.Mock()
+        result = Controller(self.config_file, self.theme, 256, self.settings,
+                            self.autohide, self.notify_enabled,
+                            self.footlinks_enabled)
         result.view.message_view = mocker.Mock()  # set in View.__init__
         return result
 
@@ -46,7 +48,7 @@ class TestController:
             config_file=self.config_file,
             client='ZulipTerminal/' + ZT_VERSION + ' ' + platform(),
         )
-        self.loading_view.assert_called_once_with(controller)
+        self.loading_view.assert_called_once_with(controller, self.settings)
         self.model.assert_called_once_with(controller)
         self.view.assert_called_once_with(controller)
         self.poll_for_events.assert_called_once_with()

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -16,10 +16,10 @@ from zulipterminal.ui_tools.buttons import (
     StreamButton, TopButton, TopicButton, UserButton,
 )
 from zulipterminal.ui_tools.views import (
-    AboutView, HelpView, LeftColumnView, MessageView, MiddleColumnView,
-    ModListWalker, MsgInfoView, PopUpConfirmationView, PopUpView,
-    RightColumnView, StreamInfoView, StreamsView, StreamsViewDivider,
-    TopicsView, UsersView,
+    AboutView, HelpView, LeftColumnView, LoadingView, MessageView,
+    MiddleColumnView, ModListWalker, MsgInfoView, PopUpConfirmationView,
+    PopUpView, RightColumnView, StreamInfoView, StreamsView,
+    StreamsViewDivider, TopicsView, UsersView,
 )
 from zulipterminal.version import MINIMUM_SUPPORTED_SERVER_VERSION, ZT_VERSION
 
@@ -2703,3 +2703,14 @@ class TestTopicButton:
             mark_muted.assert_called_once_with()
         else:
             mark_muted.assert_not_called()
+
+
+class TestLoadingView:
+    @pytest.fixture
+    def loading_view(self, mocker):
+        self.controller = mocker.Mock()
+        loading_view = LoadingView(self.controller)
+        return loading_view
+
+    def test_init(self, loading_view):
+        assert loading_view.controller == self.controller

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -2709,7 +2709,10 @@ class TestLoadingView:
     @pytest.fixture
     def loading_view(self, mocker):
         self.controller = mocker.Mock()
-        loading_view = LoadingView(self.controller)
+        self.settings = {'theme': ('wombat', 'on commandline'),
+                         'autohide': ('autohide', 'default'),
+                         'footlinks': ('enabled', 'default')}
+        loading_view = LoadingView(self.controller, self.settings)
         return loading_view
 
     def test_init(self, loading_view):

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -259,8 +259,6 @@ def main(options: Optional[List[str]]=None) -> None:
                 "{} (by alias '{}')".format(theme_to_use[1], theme_to_use[0])
             )
 
-        print("Loading with:")
-        print("   theme '{}' specified {}.".format(*theme_to_use))
         complete, incomplete = complete_and_incomplete_themes()
         if theme_to_use[0] in incomplete:
             print(in_color('yellow',
@@ -268,10 +266,6 @@ def main(options: Optional[List[str]]=None) -> None:
                            "results may vary!\n"
                            "      (you could try: {})".
                            format(", ".join(complete))))
-        print("   autohide setting '{}' specified {}."
-              .format(*zterm['autohide']))
-        print("   footlinks setting '{}' specified {}."
-              .format(*zterm['footlinks']))
         # For binary settings
         # Specify setting in order True, False
         valid_settings = {
@@ -297,9 +291,14 @@ def main(options: Optional[List[str]]=None) -> None:
         else:
             theme_data = THEMES[theme_to_use[0]]
 
+        settings = {'theme': theme_to_use,
+                    'autohide': zterm['autohide'],
+                    'footlinks': zterm['footlinks']}
+
         Controller(zuliprc_path,
                    theme_data,
                    int(args.color_depth),
+                   settings,
                    **boolean_settings).main()
     except ServerConnectionFailure as e:
         print(in_color('red',

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -43,9 +43,11 @@ class Controller:
         self.client = zulip.Client(config_file=config_file,
                                    client='ZulipTerminal/{} {}'.
                                           format(ZT_VERSION, platform()))
+        self.init_model_view()
+
+    def init_model_view(self) -> None:
         self.model = Model(self)
         self.view = View(self)
-        # Start polling for events after view is rendered.
         self.model.poll_for_events()
 
     def is_in_editor_mode(self) -> bool:

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -5,7 +5,7 @@ import time
 from collections import OrderedDict
 from functools import partial
 from platform import platform
-from typing import Any, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 import urwid
 import zulip
@@ -29,7 +29,7 @@ class Controller:
     """
 
     def __init__(self, config_file: str, theme: ThemeSpec,
-                 color_depth: int,
+                 color_depth: int, settings: Dict[str, Any],
                  autohide: bool, notify: bool, footlinks: bool) -> None:
         self.theme = theme
         self.color_depth = color_depth
@@ -43,7 +43,7 @@ class Controller:
         self.client = zulip.Client(config_file=config_file,
                                    client='ZulipTerminal/{} {}'.
                                           format(ZT_VERSION, platform()))
-        self.loading_view = LoadingView(self)
+        self.loading_view = LoadingView(self, settings)
         self.init_model_view()
 
     @asynch

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1125,3 +1125,6 @@ class LoadingView(urwid.Filler):
 
     def keypress(self, size: Tuple[int, int], key: str) -> str:
         return key
+
+    def set_spinner(self, spinner: str) -> None:
+        self.base_widget.set_text(self.text + [spinner])

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1113,12 +1113,19 @@ class MsgInfoView(PopUpView):
 
 
 class LoadingView(urwid.Filler):
-    def __init__(self, controller: Any) -> None:
+    def __init__(self, controller: Any, settings: Dict[str, Any]) -> None:
         self.controller = controller
-        self.text = ["Welcome to Zulip.\n\n",
+        self.text = [('user_active', "Welcome to Zulip.\n\n\n"),
+                     "Loading with:\n",
+                     "theme '{}' specified {}.\n".format(*settings['theme']),
+                     "autohide setting '{}' specified {}.\n"
+                     .format(*settings['autohide']),
+                     "footlinks setting '{}' specified {}.\n\n"
+                     .format(*settings['footlinks']),
                      "Loading..."]
-        text_wid = urwid.Text(self.text, 'center')
-        super().__init__(text_wid, 'middle', 'pack')
+        text_wid = urwid.Text(self.text)
+        padding = urwid.Padding(text_wid, 'center', ('relative', 50))
+        super().__init__(padding, 'middle', 'pack')
 
     def selectable(self) -> bool:
         return True
@@ -1127,4 +1134,4 @@ class LoadingView(urwid.Filler):
         return key
 
     def set_spinner(self, spinner: str) -> None:
-        self.base_widget.set_text(self.text + [spinner])
+        self.body.base_widget.set_text(self.text + [spinner])

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1110,3 +1110,18 @@ class MsgInfoView(PopUpView):
             popup_width = max(popup_width, message_link_width)
 
         super().__init__(controller, widgets, 'MSG_INFO', popup_width, title)
+
+
+class LoadingView(urwid.Filler):
+    def __init__(self, controller: Any) -> None:
+        self.controller = controller
+        self.text = ["Welcome to Zulip.\n\n",
+                     "Loading..."]
+        text_wid = urwid.Text(self.text, 'center')
+        super().__init__(text_wid, 'middle', 'pack')
+
+    def selectable(self) -> bool:
+        return True
+
+    def keypress(self, size: Tuple[int, int], key: str) -> str:
+        return key


### PR DESCRIPTION
These commits are not perfectly isolated, because there are a lot of things to be done here:
* Show `LoadingView` first and run `Model` and `View` initialization asynchronously.
* Move settings from `run.py` to `LoadingView`
* Move spinning cursor from `Controller` to `LoadingView`