### PR TITLE
feat(model): show desktop notifications for enabled streams

### DIFF
--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -820,6 +820,10 @@ class TestModel:
                                            types_when_notify_called):
         message_fixture.update(vary_each_msg)
         model.user_id = user_id
+        if 'stream_id' in message_fixture:
+            model.stream_dict.update(
+                {message_fixture['stream_id']: {'desktop_notifications': True}}
+            )
         notify = mocker.patch('zulipterminal.model.notify')
         model.notify_user(message_fixture)
         if message_fixture['type'] in types_when_notify_called:

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -671,8 +671,12 @@ class Model:
                 ]
                 target = ', '.join(extra_targets)
             recipient = ' (to {})'.format(target)
-        elif {'mentioned', 'wildcard_mentioned'}.intersection(
-                set(message['flags'])) and message['type'] == 'stream':
+        elif message['type'] == 'stream' and (
+            {'mentioned', 'wildcard_mentioned'}.intersection(
+                set(message['flags'])
+            )
+            or self.stream_dict[message['stream_id']]['desktop_notifications']
+        ):
             recipient = ' (to {} -> {})'.format(message['display_recipient'],
                                                 message['subject'])
 


### PR DESCRIPTION
* Linked to #666 (probably only a partial fix so far)

---

As discussed with @neiljp in this topic:

* https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/Debug.20notifications