### PR TITLE
Ensure recipient headers are shown in message list

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1716,7 +1716,8 @@ class TestMessageBox:
         assert isinstance(view_components[0], Columns)
 
         assert isinstance(view_components[0][0], Text)
-        assert isinstance(view_components[0][1], Divider)
+        assert isinstance(view_components[0][1], Text)
+        assert isinstance(view_components[0][2], Divider)
 
     @pytest.mark.parametrize('message', [
         {

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -287,11 +287,12 @@ class MessageBox(urwid.Pile):
         stream_title_markup = ('bar', [
             (bar_color, '{} {} '.format(self.stream_name,
                                         stream_topic_separator)),
-            ('title', ' {} '.format(self.topic_name))
+            ('title', ' {}'.format(self.topic_name))
         ])
         stream_title = urwid.Text(stream_title_markup)
         header = urwid.Columns([
             ('pack', stream_title),
+            (1, urwid.Text((color, ' '))),
             urwid.AttrWrap(urwid.Divider('━'), color),
         ])
         header.markup = stream_title_markup
@@ -305,7 +306,7 @@ class MessageBox(urwid.Pile):
         title = urwid.Text(title_markup)
         header = urwid.Columns([
             ('pack', title),
-            (1, urwid.Text(' ')),
+            (1, urwid.Text(('general_bar', ' '))),
             urwid.AttrWrap(urwid.Divider('━'), 'general_bar'),
         ])
         header.markup = title_markup

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -291,7 +291,7 @@ class MessageBox(urwid.Pile):
         ])
         stream_title = urwid.Text(stream_title_markup)
         header = urwid.Columns([
-            (len(stream_title.text), stream_title),
+            ('pack', stream_title),
             urwid.AttrWrap(urwid.Divider('━'), color),
         ])
         header.markup = stream_title_markup
@@ -304,7 +304,7 @@ class MessageBox(urwid.Pile):
         ])
         title = urwid.Text(title_markup)
         header = urwid.Columns([
-            (len(title.text), title),
+            ('pack', title),
             (1, urwid.Text(' ')),
             urwid.AttrWrap(urwid.Divider('━'), 'general_bar'),
         ])


### PR DESCRIPTION
This fixes #671, which is reproducible by resizing the window to be very narrow and noting the 'blank' headers that appear where there is a change in recipients.

An additional commit is included, which improves the spacing between the header text and the new lines/bars, both fixing an existing bug (for PMs) and ensuring a space is shown in the narrow-window situation.