### PR TITLE
Encapsulate editor/editor_mode

### DIFF
--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -43,6 +43,23 @@ class TestController:
         self.model.poll_for_events.assert_called_once_with()
         assert controller.theme == self.theme
 
+    def test_initial_editor_mode(self, controller):
+        assert not controller.is_in_editor_mode()
+
+    def test_editor_mode_entered_from_initial(self, mocker, controller):
+        editor = mocker.Mock()
+
+        controller.enter_editor_mode_with(editor)
+
+        assert controller.is_in_editor_mode()
+        assert controller.current_editor() == editor
+
+    def test_editor_mode_exits_after_entering(self, mocker, controller):
+        controller.enter_editor_mode_with(mocker.Mock())
+        controller.exit_editor_mode()
+
+        assert not controller.is_in_editor_mode()
+
     def test_narrow_to_stream(self, mocker, controller,
                               stream_button, index_stream) -> None:
         controller.model.narrow = []

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -46,6 +46,10 @@ class TestController:
     def test_initial_editor_mode(self, controller):
         assert not controller.is_in_editor_mode()
 
+    def test_current_editor_error_if_no_editor(self, controller):
+        with pytest.raises(AssertionError):
+            controller.current_editor()
+
     def test_editor_mode_entered_from_initial(self, mocker, controller):
         editor = mocker.Mock()
 
@@ -53,6 +57,12 @@ class TestController:
 
         assert controller.is_in_editor_mode()
         assert controller.current_editor() == editor
+
+    def test_editor_mode_error_on_multiple_enter(self, mocker, controller):
+        controller.enter_editor_mode_with(mocker.Mock())
+
+        with pytest.raises(AssertionError):
+            controller.enter_editor_mode_with(mocker.Mock())
 
     def test_editor_mode_exits_after_entering(self, mocker, controller):
         controller.enter_editor_mode_with(mocker.Mock())

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -431,7 +431,7 @@ class TestStreamsView:
         self.view.pinned_streams = to_pin
         stream_names.sort(key=lambda stream_name: stream_name in [
             stream[0] for stream in to_pin], reverse=True)
-        self.view.controller.editor_mode = True
+        self.view.controller.is_in_editor_mode = lambda: True
         search_box = "SEARCH_BOX"
         stream_view.streams_btn_list = [
             mocker.Mock(stream_name=stream_name)
@@ -551,7 +551,7 @@ class TestTopicsView:
             'FOO', 'FOOBAR', 'foo', 'fan',
             'boo', 'BOO', 'bar', '(no topic)',
         ]
-        self.view.controller.editor_mode = True
+        self.view.controller.is_in_editor_mode = lambda: True
         new_text = new_text
         search_box = "SEARCH_BOX"
         topic_view.topics_btn_list = [
@@ -817,8 +817,8 @@ class TestMiddleColumnView:
 
         mid_col_view.keypress(size, key)
 
-        assert mid_col_view.controller.editor_mode is True
-        assert mid_col_view.controller.editor == mid_col_view.search_box
+        (mid_col_view.controller.enter_editor_mode_with
+         .assert_called_once_with(mid_col_view.search_box))
         mid_col_view.set_focus.assert_called_once_with('header')
 
     @pytest.mark.parametrize('enter_key', keys_for_command('ENTER'))
@@ -969,7 +969,7 @@ class TestRightColumnView:
 
     def test_update_user_list_editor_mode(self, mocker, right_col_view):
         right_col_view.view.controller.update_screen = mocker.Mock()
-        right_col_view.view.controller.editor_mode = False
+        right_col_view.view.controller.is_in_editor_mode = lambda: False
 
         right_col_view.update_user_list("SEARCH_BOX", "NEW_TEXT")
 
@@ -984,7 +984,7 @@ class TestRightColumnView:
     ])
     def test_update_user_list(self, right_col_view, mocker,
                               search_string, assert_list, match_return_value):
-        right_col_view.view.controller.editor_mode = True
+        right_col_view.view.controller.is_in_editor_mode = lambda: True
         self.view.users = ["USER1", "USER2"]
         mocker.patch(VIEWS + ".match_user", return_value=match_return_value)
         mocker.patch(VIEWS + ".UsersView")
@@ -1019,7 +1019,7 @@ class TestRightColumnView:
             'user_id': 1,
             'status': status
         }]
-        self.view.controller.editor_mode = editor_mode
+        self.view.controller.is_in_editor_mode = lambda: editor_mode
         user_btn = mocker.patch(VIEWS + ".UserButton")
         users_view = mocker.patch(VIEWS + ".UsersView")
         right_col_view = RightColumnView(width, self.view)

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -208,7 +208,9 @@ class TestPanelSearchBox:
     def test_keypress_ENTER(self, panel_search_box,
                             enter_key, log, expect_body_focus_set):
         size = (20,)
-        panel_search_box.panel_view.view.controller.editor_mode = True
+        panel_search_box.panel_view.view.controller.is_in_editor_mode = (
+            lambda: True
+        )
         panel_search_box.panel_view.log = log
         panel_search_box.set_caption("")
         panel_search_box.edit_text = "key words"
@@ -222,7 +224,8 @@ class TestPanelSearchBox:
         assert panel_search_box.edit_text == "key words"
 
         # Leave editor mode
-        assert panel_search_box.panel_view.view.controller.editor_mode is False
+        (panel_search_box.panel_view.view.controller.exit_editor_mode
+         .assert_called_once_with())
 
         # Switch focus to body; if have results, move to them
         panel_search_box.panel_view.set_focus.assert_called_once_with("body")
@@ -236,7 +239,9 @@ class TestPanelSearchBox:
     @pytest.mark.parametrize("back_key", keys_for_command("GO_BACK"))
     def test_keypress_GO_BACK(self, panel_search_box, back_key):
         size = (20,)
-        panel_search_box.panel_view.view.controller.editor_mode = True
+        panel_search_box.panel_view.view.controller.is_in_editor_mode = (
+            lambda: True
+        )
         panel_search_box.set_caption(self.search_caption)
         panel_search_box.edit_text = "key words"
 
@@ -247,7 +252,8 @@ class TestPanelSearchBox:
         assert panel_search_box.edit_text == panel_search_box.search_text
 
         # Leave editor mode
-        assert panel_search_box.panel_view.view.controller.editor_mode is False
+        (panel_search_box.panel_view.view.controller.exit_editor_mode
+         .assert_called_once_with())
 
         # Switch focus to body; focus should return to previous in body
         panel_search_box.panel_view.set_focus.assert_called_once_with("body")

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -33,6 +33,7 @@ class Controller:
         self.color_depth = color_depth
         self.autohide = autohide
         self.notify_enabled = notify
+
         self.editor_mode = False
         self.editor = None  # type: Any
 
@@ -44,6 +45,21 @@ class Controller:
         self.view = View(self)
         # Start polling for events after view is rendered.
         self.model.poll_for_events()
+
+    def is_in_editor_mode(self) -> bool:
+        return self.editor_mode
+
+    def enter_editor_mode_with(self, editor: Any) -> None:
+        # if not in the editor mode already set editor_mode to True.
+        if not self.editor_mode:
+            self.editor_mode = True
+            self.editor = editor
+
+    def exit_editor_mode(self) -> None:
+        self.editor_mode = False
+
+    def current_editor(self) -> Any:
+        return self.editor
 
     @asynch
     def show_loading(self) -> None:

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -34,8 +34,7 @@ class Controller:
         self.autohide = autohide
         self.notify_enabled = notify
 
-        self._editor_mode = False
-        self._editor = None  # type: Any
+        self._editor = None  # type: Optional[Any]
 
         self.show_loading()
         self.client = zulip.Client(config_file=config_file,
@@ -47,18 +46,17 @@ class Controller:
         self.model.poll_for_events()
 
     def is_in_editor_mode(self) -> bool:
-        return self._editor_mode
+        return self._editor is not None
 
     def enter_editor_mode_with(self, editor: Any) -> None:
-        # if not in the editor mode already set editor_mode to True.
-        if not self._editor_mode:
-            self._editor_mode = True
-            self._editor = editor
+        assert self._editor is None, "Already in editor mode"
+        self._editor = editor
 
     def exit_editor_mode(self) -> None:
-        self._editor_mode = False
+        self._editor = None
 
     def current_editor(self) -> Any:
+        assert self._editor is not None, "Current editor is None"
         return self._editor
 
     @asynch

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -34,8 +34,8 @@ class Controller:
         self.autohide = autohide
         self.notify_enabled = notify
 
-        self.editor_mode = False
-        self.editor = None  # type: Any
+        self._editor_mode = False
+        self._editor = None  # type: Any
 
         self.show_loading()
         self.client = zulip.Client(config_file=config_file,
@@ -47,19 +47,19 @@ class Controller:
         self.model.poll_for_events()
 
     def is_in_editor_mode(self) -> bool:
-        return self.editor_mode
+        return self._editor_mode
 
     def enter_editor_mode_with(self, editor: Any) -> None:
         # if not in the editor mode already set editor_mode to True.
-        if not self.editor_mode:
-            self.editor_mode = True
-            self.editor = editor
+        if not self._editor_mode:
+            self._editor_mode = True
+            self._editor = editor
 
     def exit_editor_mode(self) -> None:
-        self.editor_mode = False
+        self._editor_mode = False
 
     def current_editor(self) -> Any:
-        return self.editor
+        return self._editor
 
     @asynch
     def show_loading(self) -> None:
@@ -270,7 +270,7 @@ class Controller:
             self.model.msg_view.extend(w_list, focus_position)
         else:
             self.model.msg_view.extend(w_list)
-        self.editor_mode = False
+        self.exit_editor_mode()
 
     def deregister_client(self) -> None:
         queue_id = self.model.queue_id

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -146,8 +146,8 @@ class View(urwid.WidgetWrap):
     # FIXME: The type of size should be urwid_Size; this needs checking
     def keypress(self, size: Tuple[int, int], key: str) -> Optional[str]:
         self.model.new_user_input = True
-        if self.controller.editor_mode:
-            return self.controller.editor.keypress((size[1],), key)
+        if self.controller.is_in_editor_mode():
+            return self.controller.current_editor().keypress((size[1],), key)
         # Redirect commands to message_view.
         elif (is_command_key('SEARCH_MESSAGES', key)
                 or is_command_key('NEXT_UNREAD_TOPIC', key)
@@ -172,8 +172,7 @@ class View(urwid.WidgetWrap):
             self.show_left_panel(visible=False)
             self.show_right_panel(visible=True)
             self.user_search.set_edit_text("")
-            self.controller.editor_mode = True
-            self.controller.editor = self.user_search
+            self.controller.enter_editor_mode_with(self.user_search)
             return key
         elif (is_command_key('SEARCH_STREAMS', key)
               or is_command_key('SEARCH_TOPICS', key)):
@@ -187,8 +186,7 @@ class View(urwid.WidgetWrap):
             else:
                 search_box = self.stream_w.stream_search_box
             search_box.set_edit_text("")
-            self.controller.editor_mode = True
-            self.controller.editor = search_box
+            self.controller.enter_editor_mode_with(search_box)
             return key
         elif is_command_key('HELP', key):
             # Show help menu

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -33,10 +33,7 @@ class WriteBox(urwid.Pile):
             self.contents.clear()
 
     def set_editor_mode(self) -> None:
-        # if not in the editor mode already set editor_mode to True.
-        if not self.view.controller.editor_mode:
-            self.view.controller.editor_mode = True
-            self.view.controller.editor = self
+        self.view.controller.enter_editor_mode_with(self)
 
     def private_box_view(self, button: Any=None, email: str='') -> None:
         self.set_editor_mode()
@@ -174,7 +171,7 @@ class WriteBox(urwid.Pile):
                     self.keypress(size, 'esc')
         elif is_command_key('GO_BACK', key):
             self.msg_edit_id = None
-            self.view.controller.editor_mode = False
+            self.view.controller.exit_editor_mode()
             self.main_view(False)
             self.view.middle_column.set_focus('body')
         elif is_command_key('TAB', key):
@@ -873,12 +870,12 @@ class SearchBox(urwid.Pile):
     def keypress(self, size: urwid_Size, key: str) -> Optional[str]:
         if is_command_key('GO_BACK', key):
             self.text_box.set_edit_text("")
-            self.controller.editor_mode = False
+            self.controller.exit_editor_mode()
             self.controller.view.middle_column.set_focus('body')
             return key
 
         elif is_command_key('ENTER', key):
-            self.controller.editor_mode = False
+            self.controller.exit_editor_mode()
             self.controller.search_messages(self.text_box.edit_text)
             self.controller.view.middle_column.set_focus('body')
             return key
@@ -907,13 +904,13 @@ class PanelSearchBox(urwid.Edit):
 
     def keypress(self, size: urwid_Size, key: str) -> Optional[str]:
         if is_command_key('ENTER', key):
-            self.panel_view.view.controller.editor_mode = False
+            self.panel_view.view.controller.exit_editor_mode()
             self.set_caption([('filter_results', 'Search Results'), ' '])
             self.panel_view.set_focus("body")
             if hasattr(self.panel_view, 'log') and len(self.panel_view.log):
                 self.panel_view.body.set_focus(0)
         elif is_command_key('GO_BACK', key):
-            self.panel_view.view.controller.editor_mode = False
+            self.panel_view.view.controller.exit_editor_mode()
             self.reset_search_text()
             self.panel_view.set_focus("body")
             self.panel_view.keypress(size, 'esc')

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -265,7 +265,7 @@ class StreamsView(urwid.Frame):
 
     @asynch
     def update_streams(self, search_box: Any, new_text: str) -> None:
-        if not self.view.controller.editor_mode:
+        if not self.view.controller.is_in_editor_mode():
             return
         # wait for any previously started search to finish to avoid
         # displaying wrong stream list.
@@ -332,7 +332,7 @@ class TopicsView(urwid.Frame):
 
     @asynch
     def update_topics(self, search_box: Any, new_text: str) -> None:
-        if not self.view.controller.editor_mode:
+        if not self.view.controller.is_in_editor_mode():
             return
         # wait for any previously started search to finish to avoid
         # displaying wrong topics list.
@@ -480,8 +480,7 @@ class MiddleColumnView(urwid.Frame):
             return super().keypress(size, key)
 
         elif is_command_key('SEARCH_MESSAGES', key):
-            self.controller.editor_mode = True
-            self.controller.editor = self.search_box
+            self.controller.enter_editor_mode_with(self.search_box)
             self.set_focus('header')
             return key
 
@@ -570,7 +569,7 @@ class RightColumnView(urwid.Frame):
                 or (user_list is not None and search_box is None
                     and new_text == ""))
 
-        if not self.view.controller.editor_mode and not user_list:
+        if not self.view.controller.is_in_editor_mode() and not user_list:
             return
         if not self.allow_update_user_list and new_text == "":
             return
@@ -599,7 +598,7 @@ class RightColumnView(urwid.Frame):
         for user in users:
             # Only include `inactive` users in search result.
             if (user['status'] == 'inactive'
-                    and not self.view.controller.editor_mode):
+                    and not self.view.controller.is_in_editor_mode()):
                 continue
             unread_count = (self.view.model.unread_counts['unread_pms'].
                             get(user['user_id'], 0))


### PR DESCRIPTION
This was previously partially encapsulated in WriteBox for local use,
but this wraps all functionality with access via the Controller using:
* is_in_editor_mode()
* enter_edit_mode_with(editor)
* exit_editor_mode()
* current_editor()

This then allows further tests for this and refactoring, as well as being more descriptive.