### PR TITLE
Topic editing improvements

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -17,10 +17,10 @@ from zulipterminal.ui_tools.buttons import (
     StreamButton, TopButton, TopicButton, UserButton,
 )
 from zulipterminal.ui_tools.views import (
-    AboutView, HelpView, LeftColumnView, MessageView, MiddleColumnView,
-    ModListWalker, MsgInfoView, PopUpConfirmationView, PopUpView,
-    RightColumnView, StreamInfoView, StreamsView, StreamsViewDivider,
-    TopicsView, UsersView,
+    AboutView, EditModeView, HelpView, LeftColumnView, MessageView,
+    MiddleColumnView, ModListWalker, MsgInfoView, PopUpConfirmationView,
+    PopUpView, RightColumnView, StreamInfoView, StreamsView,
+    StreamsViewDivider, TopicsView, UsersView,
 )
 from zulipterminal.version import MINIMUM_SUPPORTED_SERVER_VERSION, ZT_VERSION
 
@@ -1398,6 +1398,32 @@ class TestPopUpConfirmationView:
         popup_view.keypress(size, key)
         self.callback.assert_not_called()
         assert self.controller.exit_popup.called
+
+
+class TestEditModeView:
+    @pytest.fixture()
+    def edit_mode_view(self, mocker):
+        controller = mocker.Mock()
+        controller.maximum_popup_dimensions.return_value = (64, 64)
+        mocker.patch(VIEWS + ".urwid.SimpleFocusListWalker", return_value=[])
+        button = mocker.Mock()
+        return EditModeView(controller, button)
+
+    @pytest.mark.parametrize(['index_in_widgets', 'mode'], [
+        (0, 'change_one'),
+        (1, 'change_all'),
+        (2, 'change_later'),
+    ])
+    @pytest.mark.parametrize('key', keys_for_command('ENTER'))
+    def test_select_edit_mode(self, mocker, edit_mode_view,
+                              index_in_widgets, mode, key):
+        radio_button = edit_mode_view.widgets[index_in_widgets]
+        size = (20, 20)
+
+        radio_button.keypress(size, key)
+
+        mode_button = edit_mode_view.edit_mode_button
+        mode_button.set_selected_mode.assert_called_once_with(mode)
 
 
 class TestStreamInfoView:

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -5,6 +5,7 @@ from zulipterminal.ui_tools.boxes import PanelSearchBox, WriteBox
 
 
 BOXES = "zulipterminal.ui_tools.boxes"
+BUTTONS = "zulipterminal.ui_tools.buttons"
 
 
 class TestWriteBox:
@@ -484,6 +485,7 @@ class TestWriteBox:
                                           mocker, stream_id=10):
         if box_type == "stream":
             if message_being_edited:
+                mocker.patch(BOXES + ".EditModeButton")
                 write_box.stream_box_edit_view(stream_id)
                 write_box.msg_edit_id = 10
             else:

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -394,6 +394,7 @@ class TestWriteBox:
         write_box.to_write_box = None
         size = (20,)
         write_box.msg_edit_id = msg_edit_id
+        write_box.edit_mode_button = mocker.Mock(mode=propagate_mode)
 
         write_box.keypress(size, key)
 

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -445,18 +445,29 @@ class TestWriteBox:
                               "expected_focus_position",
                               "expected_focus_col",
                               "box_type",
-                              "msg_body_edit_enabled"], [
-        (0, 0, 0, 1, "stream", True),
-        (0, 1, 1, 0, "stream", True),
-        (0, 1, 0, 1, "stream", False),
-        (1, 0, 0, 0, "stream", True),
-        (0, 0, 1, 0, "private", True),
-        (1, 0, 0, 0, "private", True),
+                              "msg_body_edit_enabled",
+                              "message_being_edited"], [
+        (0, 0, 0, 1, "stream", True, False),
+        (0, 1, 1, 0, "stream", True, False),
+        (0, 1, 0, 2, "stream", False, True),
+        (0, 2, 0, 1, "stream", False, True),
+        (1, 0, 0, 0, "stream", True, False),
+        (0, 0, 0, 1, "stream", True, True),
+        (0, 1, 0, 2, "stream", True, True),
+        (0, 2, 1, 0, "stream", True, True),
+        (1, 0, 0, 0, "stream", True, True),
+        (0, 0, 1, 0, "private", True, False),
+        (1, 0, 0, 0, "private", True, False),
     ], ids=[
         'stream_name_to_topic_box',
         'topic_to_message_box',
-        'topic_edit_only',
+        'topic_edit_only-topic_to_edit_mode_box',
+        'topic_edit_only-edit_mode_to_topic_box',
         'message_to_stream_name_box',
+        'edit_box-stream_name_to_topic_box',
+        'edit_box-topic_to_edit_mode_box',
+        'edit_box-edit_mode_to_message_box',
+        'edit_box-message_to_stream_name_box',
         'recipient_to_message_box',
         'message_to_recipient_box',
     ])
@@ -468,9 +479,14 @@ class TestWriteBox:
                                           initial_focus_col,
                                           expected_focus_col, box_type,
                                           msg_body_edit_enabled,
+                                          message_being_edited,
                                           mocker, stream_id=10):
         if box_type == "stream":
-            write_box.stream_box_view(stream_id)
+            if message_being_edited:
+                write_box.stream_box_edit_view(stream_id)
+                write_box.msg_edit_id = 10
+            else:
+                write_box.stream_box_view(stream_id)
         else:
             write_box.private_box_view()
         size = (20,)

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -16,8 +16,8 @@ from zulipterminal.model import Model
 from zulipterminal.ui import Screen, View
 from zulipterminal.ui_tools.utils import create_msg_box_list
 from zulipterminal.ui_tools.views import (
-    AboutView, HelpView, MsgInfoView, NoticeView, PopUpConfirmationView,
-    StreamInfoView,
+    AboutView, EditModeView, HelpView, MsgInfoView, NoticeView,
+    PopUpConfirmationView, StreamInfoView,
 )
 from zulipterminal.version import ZT_VERSION
 
@@ -135,6 +135,9 @@ class Controller:
     def show_help(self) -> None:
         help_view = HelpView(self, "Help Menu (up/down scrolls)")
         self.show_pop_up(help_view)
+
+    def show_topic_edit_mode(self, button: Any) -> None:
+        self.show_pop_up(EditModeView(self, button))
 
     def show_msg_info(self, msg: Message,
                       message_links: 'OrderedDict[str, Tuple[str, int, bool]]',

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -100,6 +100,8 @@ UnreadCounts = TypedDict('UnreadCounts', {
 })
 edit_mode_captions = {
         'change_one': 'Edit only this message topic',
+        'change_all': 'Edit all messages to this topic',
+        'change_later': 'Edit later messages to this topic',
 }
 
 

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -98,6 +98,9 @@ UnreadCounts = TypedDict('UnreadCounts', {
     'unread_huddles': Dict[FrozenSet[int], int],  # Group pms
     'streams': Dict[int, int],  # stream_id
 })
+edit_mode_captions = {
+        'change_one': 'Edit only this message topic',
+}
 
 
 def asynch(func: Callable[..., None]) -> Callable[..., None]:

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -61,13 +61,13 @@ class WriteBox(urwid.Pile):
             key=keys_for_command('AUTOCOMPLETE').pop(),
             key_reverse=keys_for_command('AUTOCOMPLETE_REVERSE').pop()
         )
-        to_write_box = urwid.LineBox(
+        self.header_write_box = urwid.LineBox(
             self.to_write_box, tlcorner='─', tline='─', lline='',
             trcorner='─', blcorner='─', rline='',
             bline='─', brcorner='─'
         )
         self.contents = [
-            (to_write_box, self.options()),
+            (self.header_write_box, self.options()),
             (self.msg_write_box, self.options()),
         ]
         self.focus_position = 1
@@ -102,7 +102,7 @@ class WriteBox(urwid.Pile):
             key_reverse=keys_for_command('AUTOCOMPLETE_REVERSE').pop()
         )
 
-        header_write_box = urwid.Columns([
+        self.header_write_box = urwid.Columns([
             urwid.LineBox(
                 self.stream_write_box, tlcorner='─', tline='─', lline='',
                 trcorner='┬', blcorner='─', rline='│',
@@ -115,7 +115,7 @@ class WriteBox(urwid.Pile):
             ),
         ])
         write_box = [
-            (header_write_box, self.options()),
+            (self.header_write_box, self.options()),
             (self.msg_write_box, self.options()),
         ]
         self.contents = write_box

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -23,6 +23,7 @@ from zulipterminal.helper import (
     Message, format_string, match_emoji, match_group, match_stream,
     match_topics, match_user,
 )
+from zulipterminal.ui_tools.buttons import EditModeButton
 from zulipterminal.ui_tools.tables import render_table
 from zulipterminal.urwid_types import urwid_Size
 
@@ -123,11 +124,11 @@ class WriteBox(urwid.Pile):
     def stream_box_edit_view(self, stream_id: int, caption: str='',
                              title: str='') -> None:
         self.stream_box_view(stream_id, caption, title)
-        self.edit_mode = urwid.Text('Edit current topic only.')
+        self.edit_mode_button = EditModeButton(self.model.controller, 20)
 
         self.header_write_box.widget_list.append(
             urwid.LineBox(
-                self.edit_mode, tlcorner='┬', tline='─', lline='│',
+                self.edit_mode_button, tlcorner='┬', tline='─', lline='│',
                 trcorner='─', blcorner='┴', rline='',
                 bline='─', brcorner='─'
             ))
@@ -286,7 +287,7 @@ class WriteBox(urwid.Pile):
                 if self.msg_edit_id:
                     args = dict(message_id=self.msg_edit_id,
                                 topic=topic,
-                                propagate_mode="change_one")
+                                propagate_mode=self.edit_mode_button.mode)
                     if self.msg_body_edit_enabled:
                         args['content'] = self.msg_write_box.edit_text
 

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -120,6 +120,18 @@ class WriteBox(urwid.Pile):
         ]
         self.contents = write_box
 
+    def stream_box_edit_view(self, stream_id: int, caption: str='',
+                             title: str='') -> None:
+        self.stream_box_view(stream_id, caption, title)
+        self.edit_mode = urwid.Text('Edit current topic only.')
+
+        self.header_write_box.widget_list.append(
+            urwid.LineBox(
+                self.edit_mode, tlcorner='┬', tline='─', lline='│',
+                trcorner='─', blcorner='┴', rline='',
+                bline='─', brcorner='─'
+            ))
+
     def _topic_box_autocomplete(self, text: str, state: Optional[int]
                                 ) -> Optional[str]:
         topic_names = self.model.topics_in_stream(self.stream_id)
@@ -310,8 +322,6 @@ class WriteBox(urwid.Pile):
         elif is_command_key('CYCLE_COMPOSE_FOCUS', key):
             if len(self.contents) == 0:
                 return key
-            if not self.msg_body_edit_enabled:
-                return key
             header = self.contents[0][0]
             # toggle focus position
             if self.focus_position == 0:
@@ -336,6 +346,16 @@ class WriteBox(urwid.Pile):
 
                         header.focus_col = 1
                         return key
+                    elif header.focus_col == 1 and self.msg_edit_id:
+                        header.focus_col = 2
+                        return key
+                    elif header.focus_col == 2:
+                        if self.msg_body_edit_enabled:
+                            header.focus_col = 0
+                            self.focus_position = 1
+                        else:
+                            header.focus_col = 1
+                        return key
                     else:
                         header.focus_col = 0
                 else:
@@ -353,6 +373,8 @@ class WriteBox(urwid.Pile):
                     self.recipient_user_ids = [users[email]['user_id']
                                                for email in recipient_emails]
 
+            if not self.msg_body_edit_enabled:
+                return key
             self.focus_position = self.focus_position == 0
             header.focus_col = 0
 
@@ -1130,7 +1152,14 @@ class MessageBox(urwid.Pile):
                             " been exceeded.", 3)
                     msg_body_edit_enabled = False
 
-            self.keypress(size, 'enter')
+            if self.message['type'] == 'private':
+                self.keypress(size, 'enter')
+            elif self.message['type'] == 'stream':
+                self.model.controller.view.write_box.stream_box_edit_view(
+                    stream_id=self.stream_id,
+                    caption=self.message['display_recipient'],
+                    title=self.message['subject']
+                )
             msg_id = self.message['id']
             msg = self.model.client.get_raw_message(msg_id)['raw_content']
             write_box = self.model.controller.view.write_box

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -3,7 +3,7 @@ from typing import Any, Callable, Dict, Optional, Tuple, Union
 import urwid
 
 from zulipterminal.config.keys import is_command_key, keys_for_command
-from zulipterminal.helper import StreamData
+from zulipterminal.helper import StreamData, edit_mode_captions
 from zulipterminal.urwid_types import urwid_Size
 
 
@@ -277,3 +277,18 @@ class MessageLinkButton(urwid.Button):
         """
         Classifies and handles link.
         """
+        pass
+
+
+class EditModeButton(urwid.Button):
+    def __init__(self, controller: Any, width: int) -> None:
+        self.controller = controller
+        self.width = width
+        super().__init__(label="",
+                         on_press=controller.show_topic_edit_mode)
+        self.set_selected_mode('change_one')
+
+    def set_selected_mode(self, mode: str) -> None:
+        self.mode = mode
+        self._w = urwid.AttrMap(urwid.SelectableIcon(
+            edit_mode_captions[self.mode], self.width), None, 'selected')

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1137,7 +1137,33 @@ class MsgInfoView(PopUpView):
 
 class EditModeView(PopUpView):
     def __init__(self, controller: Any, button: Any):
-        self.selected_mode = button.mode
-        widgets = [urwid.Text(edit_mode_captions[self.selected_mode])]
-        super().__init__(controller, widgets, 'ENTER', 50,
+        self.edit_mode_button = button
+        self.widgets = []  # type: List[urwid.RadioButton]
+
+        for mode in ['change_one', 'change_all', 'change_later']:
+            self.add_radio_button(mode)
+        super().__init__(controller, self.widgets, 'ENTER', 50,
                          'Topic edit propogation mode')
+        # Set cursor to marked checkbox.
+        for i in range(len(self.widgets)):
+            if self.widgets[i].state:
+                self.set_focus(i)
+
+    def set_selected_mode(self, button: Any, new_state: bool,
+                          mode: str) -> None:
+        if new_state:
+            self.edit_mode_button.set_selected_mode(mode)
+
+    def add_radio_button(self, mode: str) -> None:
+        state = mode == self.edit_mode_button.mode
+        radio_button = urwid.RadioButton(self.widgets,
+                                         edit_mode_captions[mode],
+                                         state=state)
+        urwid.connect_signal(radio_button, 'change', self.set_selected_mode,
+                             mode)
+
+    def keypress(self, size: urwid_Size, key: str) -> str:
+        # Use space to select radio-button and exit popup too.
+        if key == ' ':
+            key = 'enter'
+        return super().keypress(size, key)

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -11,7 +11,9 @@ from zulipterminal.config.keys import (
 from zulipterminal.config.symbols import (
     CHECK_MARK, LIST_TITLE_BAR_LINE, PINNED_STREAMS_DIVIDER,
 )
-from zulipterminal.helper import Message, asynch, match_stream, match_user
+from zulipterminal.helper import (
+    Message, asynch, edit_mode_captions, match_stream, match_user,
+)
 from zulipterminal.ui_tools.boxes import PanelSearchBox
 from zulipterminal.ui_tools.buttons import (
     HomeButton, MentionedButton, MessageLinkButton, PMButton, StarredButton,
@@ -1131,3 +1133,11 @@ class MsgInfoView(PopUpView):
             popup_width = max(popup_width, message_link_width)
 
         super().__init__(controller, widgets, 'MSG_INFO', popup_width, title)
+
+
+class EditModeView(PopUpView):
+    def __init__(self, controller: Any, button: Any):
+        self.selected_mode = button.mode
+        widgets = [urwid.Text(edit_mode_captions[self.selected_mode])]
+        super().__init__(controller, widgets, 'ENTER', 50,
+                         'Topic edit propogation mode')


### PR DESCRIPTION
This PR can (and probably should) be merged in two parts - 
## Part 1
**Allow editing of topics after message edit time limit expires** (Commits 1-3) - This improvement is basically done by adding a `msg_body_edit_enabled`attribute to `WriteBox` for differentiating topic-only editing from topic+body editing. After adding this, two changes need to be done - 
1. Modify `WriteBox` UI so that focus is not set to message box if only topic editing is permitted. Additional test for `TAB`/`CYCLE_COMPOSE_BOX` keypress has been added in commit 1
2. Do not send message content in the server request if its editing is not permitted. This requires a model refactor to make content optional which has been done in commit 2.

## Part 2
**Let user specify propagate mode while editing**(Commits 4-8) - This is done by adding a button in `WriteBox` header which opens up a popup to select propagate mode. This popup is initially read-only, and checkboxes are added for selection in the last commit. Tests for this part are lacking, which I'll add after a little feedback.

## Follow-ups:
1. Adding community editing support.