### PR TITLE
[WIP] Add warning when sending message to announcement streams 

### DIFF
--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -519,6 +519,43 @@ def match_topics(topic_names: List[str], search_text: str) -> List[str]:
 DataT = TypeVar('DataT')
 
 
+def unauthorised_warning(model: Any, stream_identifier: Any) -> bool:
+    """
+    Identify target stream based on stream id or stream name
+    and update footer based on the user rights.
+    """
+    stream_id = None
+    if isinstance(stream_identifier, int):
+        stream_id = stream_identifier
+    elif isinstance(stream_identifier, str):
+        for s_id, stream in model.stream_dict.items():
+            if stream['name'] == stream_identifier:
+                stream_id = s_id
+                break
+
+    if not stream_id:
+        msg_footer = (
+            model.controller.view.set_footer_text(
+                "Specified stream does not exist.",
+                5))
+        return True
+    else:
+        if (model.stream_dict[stream_id].
+                get('is_announcement_only', None) == 1
+                or (model.initial_data.get('is_admin', None)
+                    or model.initial_data.get('is_owner', None)
+                    and model.stream_dict[stream_id].
+                    get('stream_post_policy', None) == 2)):
+            msg_footer = (
+                model.controller.view.set_footer_text(
+                    "You are not authorised to send messages "
+                    "to this stream.",
+                    5))
+            return True
+        else:
+            return False
+
+
 def match_stream(data: List[Tuple[DataT, str]], search_text: str,
                  pinned_streams: List[StreamData]
                  ) -> Tuple[List[DataT], List[str]]:

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -24,7 +24,7 @@ from zulipterminal.config.symbols import (
 )
 from zulipterminal.helper import (
     Message, format_string, match_emoji, match_group, match_stream,
-    match_topics, match_user,
+    match_topics, match_user, unauthorised_warning,
 )
 from zulipterminal.ui_tools.buttons import EditModeButton
 from zulipterminal.ui_tools.tables import render_table
@@ -439,6 +439,8 @@ class WriteBox(urwid.Pile):
                                         ))
                             )
                             self.view.set_footer_text(invalid_stream_error, 3)
+                            return key
+                        elif unauthorised_warning(self.model, stream_name):
                             return key
                         user_ids = self.model.get_other_subscribers_in_stream(
                                                     stream_name=stream_name)
@@ -1166,11 +1168,13 @@ class MessageBox(urwid.Pile):
                     recipient_user_ids=self.recipient_ids,
                 )
             elif self.message['type'] == 'stream':
-                self.model.controller.view.write_box.stream_box_view(
-                    caption=self.message['display_recipient'],
-                    title=self.message['subject'],
-                    stream_id=self.stream_id,
-                )
+                if not unauthorised_warning(self.model,
+                                            self.message.get('stream_id')):
+                    self.model.controller.view.write_box.stream_box_view(
+                        caption=self.message['display_recipient'],
+                        title=self.message['subject'],
+                        stream_id=self.stream_id,
+                    )
         elif is_command_key('STREAM_MESSAGE', key):
             if self.message['type'] == 'private':
                 self.model.controller.view.write_box.private_box_view(


### PR DESCRIPTION
Normal users are not allowed to send messages in announcement streams,
currently when an unauthorised user sends message to this stream, nothing happens.
This commit changes this behaviour and adds a footer warning for the same.

Fixes: https://github.com/zulip/zulip-terminal/issues/682