### PR TITLE
Toggle stream settings

### DIFF
--- a/tests/helper/test_helper.py
+++ b/tests/helper/test_helper.py
@@ -190,13 +190,13 @@ def test_powerset(iterable, map_func, expected_powerset):
 
 @pytest.mark.parametrize('muted_streams, muted_topics, vary_in_unreads', [
     ([99], [['Some general stream', 'Some general unread topic']], {
-        'all_msg': 9,
+        'all_msg': 8,
         'streams': {99: 1},
         'unread_topics': {(99, 'Some private unread topic'): 1},
         'all_mentions': 0,
     }),
     ([1000], [['Secret stream', 'Some private unread topic']], {
-        'all_msg': 11,
+        'all_msg': 8,
         'streams': {1000: 3},
         'unread_topics': {(1000, 'Some general unread topic'): 3},
         'all_mentions': 0,

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -1312,6 +1312,31 @@ class TestModel:
         elif event_op == 'remove':
             set_count.assert_not_called()
 
+    @pytest.mark.parametrize('pinned_streams, pin_to_top', [
+        ([['all', 2]], True),
+        ([['design', 1], ['all', 2]], False),
+        ([], True),
+        ([['design', 1]], False),
+    ], ids=['pinning', 'unpinning', 'first_pinned',
+            'last_unpinned'])
+    def test_toggle_stream_pinned_status(self, mocker, model,
+                                         pinned_streams, pin_to_top,
+                                         stream_id=1):
+        model.pinned_streams = deepcopy(pinned_streams)
+        model.client.update_subscription_settings.return_value = {
+            'result': "success"
+        }
+
+        model.toggle_stream_pinned_status(stream_id)
+
+        request = [{
+            'stream_id': stream_id,
+            'property': 'pin_to_top',
+            'value': pin_to_top
+        }]
+        (model.client.update_subscription_settings
+         .assert_called_once_with(request))
+
     @pytest.mark.parametrize('narrow, event, called', [
         # Not in PM Narrow
         ([], {}, False),

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1399,6 +1399,7 @@ class TestStreamInfoView:
         mocker.patch.object(self.controller, 'maximum_popup_dimensions',
                             return_value=(64, 64))
         self.controller.model.is_muted_stream.return_value = False
+        self.controller.model.is_pinned_stream.return_value = False
         mocker.patch(VIEWS + ".urwid.SimpleFocusListWalker", return_value=[])
         stream_id = 10
         self.controller.model.stream_dict = {stream_id: {'name': 'books',
@@ -1430,6 +1431,17 @@ class TestStreamInfoView:
         mute_checkbox.keypress(size, key)
 
         toggle_mute_status.assert_called_once_with(stream_id)
+
+    @pytest.mark.parametrize('key', (*keys_for_command('ENTER'), ' '))
+    def test_checkbox_toggle_pin_stream(self, mocker, key):
+        pin_checkbox = self.stream_info_view.widgets[4]
+        toggle_pin_status = self.controller.model.toggle_stream_pinned_status
+        stream_id = self.stream_info_view.stream_id
+        size = (20, 20)
+
+        pin_checkbox.keypress(size, key)
+
+        toggle_pin_status.assert_called_once_with(stream_id)
 
 
 class TestMsgInfoView:

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -2443,9 +2443,8 @@ class TestStreamButton:
     def test_text_content(self, mocker,
                           is_private, expected_prefix,
                           width, count, short_text, caption='caption'):
-        mocker.patch(STREAMBUTTON + ".mark_muted")
         controller = mocker.Mock()
-        controller.model.muted_streams = {}
+        controller.model.is_muted_stream.return_value = False
         properties = [
             caption, 5, '#ffffff', is_private, 'Some Stream Description'
         ]

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1399,8 +1399,10 @@ class TestStreamInfoView:
         mocker.patch.object(self.controller, 'maximum_popup_dimensions',
                             return_value=(64, 64))
         mocker.patch(VIEWS + ".urwid.SimpleFocusListWalker", return_value=[])
-        self.stream_info_view = StreamInfoView(self.controller, color='',
-                                               desc='', title='# stream-name')
+        stream_id = 10
+        self.controller.model.stream_dict = {stream_id: {'name': 'books',
+                                                         'description': 'hey'}}
+        self.stream_info_view = StreamInfoView(self.controller, stream_id)
 
     @pytest.mark.parametrize('key', {*keys_for_command('GO_BACK'),
                                      *keys_for_command('STREAM_DESC')})

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1398,6 +1398,7 @@ class TestStreamInfoView:
         self.controller = mocker.Mock()
         mocker.patch.object(self.controller, 'maximum_popup_dimensions',
                             return_value=(64, 64))
+        self.controller.model.is_muted_stream.return_value = False
         mocker.patch(VIEWS + ".urwid.SimpleFocusListWalker", return_value=[])
         stream_id = 10
         self.controller.model.stream_dict = {stream_id: {'name': 'books',
@@ -1418,6 +1419,17 @@ class TestStreamInfoView:
         super_keypress = mocker.patch(VIEWS + '.urwid.ListBox.keypress')
         self.stream_info_view.keypress(size, key)
         super_keypress.assert_called_once_with(size, expected_key)
+
+    @pytest.mark.parametrize('key', (*keys_for_command('ENTER'), ' '))
+    def test_checkbox_toggle_mute_stream(self, mocker, key):
+        mute_checkbox = self.stream_info_view.widgets[3]
+        toggle_mute_status = self.controller.model.toggle_stream_muted_status
+        stream_id = self.stream_info_view.stream_id
+        size = (20, 20)
+
+        mute_checkbox.keypress(size, key)
+
+        toggle_mute_status.assert_called_once_with(stream_id)
 
 
 class TestMsgInfoView:

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -143,9 +143,8 @@ class Controller:
                                     message_links)
         self.show_pop_up(msg_info_view)
 
-    def show_stream_info(self, color: str, name: str, desc: str) -> None:
-        show_stream_view = StreamInfoView(self, color, desc,
-                                          "# {}".format(name))
+    def show_stream_info(self, stream_id: int) -> None:
+        show_stream_view = StreamInfoView(self, stream_id)
         self.show_pop_up(show_stream_view)
 
     def popup_with_message(self, text: str, width: int) -> None:

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -451,7 +451,8 @@ def classify_unread_counts(model: Any) -> UnreadCounts:
             unread_counts['streams'][stream_id] = count
         else:
             unread_counts['streams'][stream_id] += count
-        unread_counts['all_msg'] += count
+        if stream_id not in model.muted_streams:
+            unread_counts['all_msg'] += count
 
     # store unread count of group pms in `unread_huddles`
     for group_pm in unread_msg_counts['huddles']:

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -621,6 +621,18 @@ class Model:
         response = self.client.update_subscription_settings(request)
         return response['result'] == 'success'
 
+    def is_pinned_stream(self, stream_id: int) -> bool:
+        return stream_id in list(stream[1] for stream in self.pinned_streams)
+
+    def toggle_stream_pinned_status(self, stream_id: int) -> bool:
+        request = [{
+            'stream_id': stream_id,
+            'property': 'pin_to_top',
+            'value': not self.is_pinned_stream(stream_id)
+        }]
+        response = self.client.update_subscription_settings(request)
+        return response['result'] == 'success'
+
     def _handle_subscription_event(self, event: Event) -> None:
         """
         Handle changes in subscription (eg. muting/unmuting,

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -57,6 +57,13 @@ class ServerConnectionFailure(Exception):
     pass
 
 
+def sort_streams(streams: List[List[str]]) -> None:
+    """
+    Used for sorting model.pinned_streams and model.unpinned_streams.
+    """
+    streams.sort(key=lambda s: s[0].lower())
+
+
 class Model:
     """
     A class responsible for storing the data to be displayed.
@@ -570,6 +577,13 @@ class Model:
         for subscription in subscriptions:
             subscription['color'] = canonicalize_color(subscription['color'])
 
+        pinned_streams = [[stream[key] for key in stream_keys]
+                          for stream in subscriptions if stream['pin_to_top']]
+        unpinned_streams = [[stream[key] for key in stream_keys]
+                            for stream in subscriptions
+                            if not stream['pin_to_top']]
+        sort_streams(pinned_streams)
+        sort_streams(unpinned_streams)
         # Mapping of stream-id to all available stream info
         # Stream IDs for muted streams
         # Limited stream info sorted by name (used in display)
@@ -577,12 +591,8 @@ class Model:
             {stream['stream_id']: stream for stream in subscriptions},
             {stream['stream_id'] for stream in subscriptions
              if stream['in_home_view'] is False},
-            sorted([[stream[key] for key in stream_keys]
-                    for stream in subscriptions if stream['pin_to_top']],
-                   key=lambda s: s[0].lower()),
-            sorted([[stream[key] for key in stream_keys]
-                    for stream in subscriptions if not stream['pin_to_top']],
-                   key=lambda s: s[0].lower())
+            pinned_streams,
+            unpinned_streams,
         )
 
     def _group_info_from_realm_user_groups(self,

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -194,8 +194,7 @@ class StreamButton(TopButton):
         elif is_command_key('TOGGLE_MUTE_STREAM', key):
             self.controller.stream_muting_confirmation_popup(self)
         elif is_command_key('STREAM_DESC', key):
-            self.model.controller.show_stream_info(
-                self.color, self.stream_name, self.description)
+            self.model.controller.show_stream_info(self.stream_id)
         return super().keypress(size, key)
 
 

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -164,7 +164,7 @@ class StreamButton(TopButton):
 
         # Mark muted streams 'M' during button creation.
         if self.model.is_muted_stream(self.stream_id):
-            self.mark_muted()
+            self.update_widget('M')
 
     def mark_muted(self) -> None:
         self.update_widget('M')

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -782,6 +782,17 @@ class LeftColumnView(urwid.Pile):
             )
         return w
 
+    def update_structure(self) -> None:
+        self.stream_v = self.streams_view()
+        if self.is_in_topic_view:
+            return
+
+        self.left_column_structure = [
+            (self.menu_v, ('given', 4)),
+            (self.stream_v, ('weight', 1)),
+        ]
+        self.contents = self.left_column_structure
+
     def keypress(self, size: urwid_Size, key: str) -> Optional[str]:
         if (
             is_command_key('SEARCH_STREAMS', key)

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1000,8 +1000,10 @@ class PopUpConfirmationView(urwid.Overlay):
 
 
 class StreamInfoView(PopUpView):
-    def __init__(self, controller: Any, color: str,
-                 desc: str, title: str) -> None:
+    def __init__(self, controller: Any, stream_id: int) -> None:
+        stream = controller.model.stream_dict[stream_id]
+        title = '# {}'.format(stream['name'])
+        desc = stream['description']
         stream_info_content = [('', [desc])]
         popup_width, column_widths = self.calculate_table_widths(
             stream_info_content, len(title))

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1,7 +1,7 @@
 import threading
 import time
 from collections import OrderedDict
-from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
 import urwid
 
@@ -798,7 +798,8 @@ class LeftColumnView(urwid.Pile):
         return super().keypress(size, key)
 
 
-PopUpViewTableContent = Sequence[Tuple[str, Sequence[Tuple[str, str]]]]
+PopUpViewTableContent = Sequence[Tuple[str, Sequence[Union[str,
+                                                           Tuple[str, str]]]]]
 
 
 class PopUpView(urwid.ListBox):
@@ -841,21 +842,28 @@ class PopUpView(urwid.ListBox):
         title_width = title_len + 4
 
         category_width = 0
+        text_width = 0
         strip_widths = []
         for category, content in contents:
             category_width = max(category_width, len(category))
             for row in content:
-                # Measure the longest line if the text is seperated by
-                # newline(s).
-                max_row_lengths = [
-                    len(max(text.split('\n'), key=len))
-                    for text in row
-                ]
-                strip_widths.append(max_row_lengths)
+                if isinstance(row, str):
+                    # Measure the longest line if the text is seperated by
+                    # newline(s).
+                    text_width = max(text_width, len(max(row.split('\n'),
+                                                         key=len)))
+                elif isinstance(row, tuple):
+                    # Measure the longest line if the text is seperated by
+                    # newline(s).
+                    max_row_lengths = [
+                        len(max(text.split('\n'), key=len))
+                        for text in row
+                    ]
+                    strip_widths.append(max_row_lengths)
         column_widths = [max(width) for width in zip(*strip_widths)]
 
         popup_width = max(sum(column_widths) + dividechars, title_width,
-                          category_width)
+                          category_width, text_width)
         return (popup_width, column_widths)
 
     @staticmethod
@@ -872,14 +880,17 @@ class PopUpView(urwid.ListBox):
                     widgets.append(urwid.Text(''))
                 widgets.append(urwid.Text(('popup_category', category)))
             for index, row in enumerate(content):
-                label, data = row
-                strip = urwid.Columns([
-                        (column_widths[0], urwid.Text(label)),
-                        urwid.Text(data)
-                    ], dividechars=dividechars)
-                widgets.append(urwid.AttrWrap(
-                    strip, None if index % 2 else 'popup_contrast')
-                )
+                if isinstance(row, str) and row:
+                    widgets.append(urwid.Text(row))
+                elif isinstance(row, tuple):
+                    label, data = row
+                    strip = urwid.Columns([
+                            (column_widths[0], urwid.Text(label)),
+                            urwid.Text(data)
+                        ], dividechars=dividechars)
+                    widgets.append(urwid.AttrWrap(
+                        strip, None if index % 2 else 'popup_contrast')
+                    )
         return widgets
 
     def keypress(self, size: urwid_Size, key: str) -> str:
@@ -991,12 +1002,12 @@ class PopUpConfirmationView(urwid.Overlay):
 class StreamInfoView(PopUpView):
     def __init__(self, controller: Any, color: str,
                  desc: str, title: str) -> None:
-        # Add 4 (for 2 Unicode characters on either side) to the popup title
-        # length to make sure that the title gets displayed even when the
-        # content is shorter than the title length (+4 Unicode characters).
-        width = max(len(desc) + 2, len(title) + 4)
-        stream_info_content = [urwid.Text(desc, align='center')]
-        super().__init__(controller, stream_info_content, 'STREAM_DESC', width,
+        stream_info_content = [('', [desc])]
+        popup_width, column_widths = self.calculate_table_widths(
+            stream_info_content, len(title))
+        widgets = self.make_table_with_categories(stream_info_content,
+                                                  column_widths)
+        super().__init__(controller, widgets, 'STREAM_DESC', popup_width,
                          title)
 
 

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1026,18 +1026,29 @@ class StreamInfoView(PopUpView):
                                            stream_id),
                                        checked_symbol='✓')
         urwid.connect_signal(muted_setting, 'change', self.toggle_mute_status)
+        pinned_state = controller.model.is_pinned_stream(stream_id)
+        pinned_setting = urwid.CheckBox(label="Pinned to top",
+                                        state=pinned_state,
+                                        checked_symbol='✓')
+        urwid.connect_signal(pinned_setting, 'change',
+                             self.toggle_pinned_status)
 
         # Manual because calculate_table_widths does not support checkboxes.
         # Add 4 to checkbox label to accomodate the checkbox itself.
-        popup_width = max(popup_width, len(muted_setting.label) + 4)
+        popup_width = max(popup_width, len(muted_setting.label) + 4,
+                          len(pinned_setting.label) + 4)
         self.widgets = self.make_table_with_categories(stream_info_content,
                                                        column_widths)
         self.widgets.append(muted_setting)
+        self.widgets.append(pinned_setting)
         super().__init__(controller, self.widgets, 'STREAM_DESC', popup_width,
                          title)
 
     def toggle_mute_status(self, button: Any, new_state: bool) -> None:
         self.controller.model.toggle_stream_muted_status(self.stream_id)
+
+    def toggle_pinned_status(self, button: Any, new_state: bool) -> None:
+        self.controller.model.toggle_stream_pinned_status(self.stream_id)
 
 
 class MsgInfoView(PopUpView):


### PR DESCRIPTION
This PR adds checkboxes to `StreamInfoView` for toggling muted and pinned settings for streams.

There are two parts to this PR and a bunch of minor refactors:
**1. Add support for muting** - We already handle mute events, so all we have to do here is add a checkbox that will toggle mute status.
**2. Add support for pinning** - First support for pinning events are added, then a checkbox is added to `StreamInfoView`.
