### PR TITLE
[WIP] Add support for viewing a message in the web browser

### DIFF
--- a/docs/hotkeys.md
+++ b/docs/hotkeys.md
@@ -50,6 +50,7 @@
 |New message to a person or group of people|<kbd>x</kbd>|
 |Narrow to the stream of the current message|<kbd>s</kbd>|
 |Narrow to the topic of the current message|<kbd>S</kbd>|
+|View current message in the web browser|<kbd>v</kbd>|
 |Narrow to a topic/private-chat, or stream/all-private-messages|<kbd>z</kbd>|
 |Add/remove thumbs-up reaction to the current message|<kbd>+</kbd>|
 |Add/remove star status of the current message|<kbd>ctrl</kbd> + <kbd>s</kbd> / <kbd>*</kbd>|

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -1,3 +1,4 @@
+import os
 from platform import platform
 from typing import Any
 
@@ -270,6 +271,18 @@ class TestController:
                    .call_args_list[0][0][0])
         msg_ids = {widget.original_widget.message['id'] for widget in widgets}
         assert msg_ids == id_list
+
+    def test_view_in_browser(self, mocker, controller):
+        # Set DISPLAY environ to be able to run test in Travis
+        os.environ['DISPLAY'] = ':0'
+        mock_open = mocker.patch('webbrowser.open', mocker.Mock())
+        message_id = 123456
+        controller.model.server_url = 'https://foo.zulipchat.com/'
+        controller.view_in_browser(message_id)
+        assert mock_open.call_count == 1
+        url = mock_open.call_args[0][0]
+        assert url.startswith(controller.model.server_url)
+        assert url.endswith('/{}'.format(message_id))
 
     def test_main(self, mocker, controller):
         controller.view.palette = {

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -272,17 +272,20 @@ class TestController:
         msg_ids = {widget.original_widget.message['id'] for widget in widgets}
         assert msg_ids == id_list
 
-    def test_view_in_browser(self, mocker, controller):
+    @pytest.mark.parametrize('server_url', [
+        'https://chat.zulip.org/',
+        'https://foo.zulipchat.com/',
+    ])
+    def test_view_in_browser(self, mocker, controller, message_fixture,
+                             server_url):
         # Set DISPLAY environ to be able to run test in Travis
         os.environ['DISPLAY'] = ':0'
-        mock_open = mocker.patch('webbrowser.open', mocker.Mock())
-        message_id = 123456
-        controller.model.server_url = 'https://foo.zulipchat.com/'
-        controller.view_in_browser(message_id)
-        assert mock_open.call_count == 1
-        url = mock_open.call_args[0][0]
-        assert url.startswith(controller.model.server_url)
-        assert url.endswith('/{}'.format(message_id))
+        controller.model.server_url = server_url
+        mocked_open = mocker.patch(CORE + '.webbrowser.open')
+
+        controller.view_in_browser(message_fixture)
+
+        mocked_open.assert_called_once_with(controller.url)
 
     def test_main(self, mocker, controller):
         controller.view.palette = {

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -504,8 +504,17 @@ class TestMsgInfoView:
         self.msg_info_view.keypress(size, key)
         assert self.controller.exit_popup.called
 
+    @pytest.mark.parametrize('key', keys_for_command('VIEW_IN_BROWSER'))
+    def test_keypress_view_in_browser(self, widget_size, message_fixture, key):
+        size = widget_size(self.msg_info_view)
+
+        self.msg_info_view.keypress(size, key)
+
+        (self.controller.view_in_browser.
+         assert_called_once_with(message_fixture['id']))
+
     def test_height_noreactions(self):
-        expected_height = 3
+        expected_height = 4
         assert self.msg_info_view.height == expected_height
 
     # FIXME This is the same parametrize as MessageBox:test_reactions_view
@@ -553,8 +562,9 @@ class TestMsgInfoView:
         self.msg_info_view = MsgInfoView(self.controller, varied_message,
                                          'Message Information', OrderedDict(),
                                          list())
-        # 9 = 3 labels + 1 blank line + 1 'Reactions' (category) + 4 reactions.
-        expected_height = 9
+        # 10 = 4 labels + 1 blank line + 1 'Reactions' (category) + 4
+        # reactions (excluding 'Message Links').
+        expected_height = 10
         assert self.msg_info_view.height == expected_height
 
     def test_keypress_navigation(self, mocker, widget_size,

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -511,7 +511,7 @@ class TestMsgInfoView:
         self.msg_info_view.keypress(size, key)
 
         (self.controller.view_in_browser.
-         assert_called_once_with(message_fixture['id']))
+         assert_called_once_with(message_fixture))
 
     def test_height_noreactions(self):
         expected_height = 4

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -143,6 +143,11 @@ KEY_BINDINGS: 'OrderedDict[str, KeyBinding]' = OrderedDict([
         'help_text': 'Narrow to the topic of the current message',
         'key_category': 'msg_actions',
     }),
+    ('VIEW_IN_BROWSER', {
+        'keys': ['v'],
+        'help_text': 'View current message in the web browser',
+        'key_category': 'msg_actions',
+    }),
     ('TOGGLE_NARROW', {
         'keys': ['z'],
         'help_text':

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -2,6 +2,7 @@ import os
 import signal
 import sys
 import time
+import webbrowser
 from collections import OrderedDict
 from functools import partial
 from platform import platform
@@ -363,6 +364,14 @@ class Controller:
         # NOTE: Should we allow maintaining anchor focus here?
         # (nothing currently requires narrowing around a message id)
         self._narrow_to(anchor=None, mentioned=True)
+
+    def view_in_browser(self, message_id: int) -> None:
+        url = '{}#narrow/near/{}'.format(self.model.server_url, message_id)
+        if (sys.platform != 'darwin' and sys.platform[:3] != 'win'
+                and not os.environ.get('DISPLAY') and os.environ.get('TERM')):
+            # Don't try to open web browser if running without a GUI
+            return
+        webbrowser.open(url)
 
     def deregister_client(self) -> None:
         queue_id = self.model.queue_id

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -17,6 +17,7 @@ from zulipterminal.api_types import Composition, Message
 from zulipterminal.config.themes import ThemeSpec
 from zulipterminal.helper import MACOS, WSL, asynch, suppress_output
 from zulipterminal.model import Model
+from zulipterminal.server_url import near_message_url
 from zulipterminal.ui import Screen, View
 from zulipterminal.ui_tools.utils import create_msg_box_list
 from zulipterminal.ui_tools.views import (
@@ -365,15 +366,16 @@ class Controller:
         # (nothing currently requires narrowing around a message id)
         self._narrow_to(anchor=None, mentioned=True)
 
-    def view_in_browser(self, message_id: int) -> None:
-        url = '{}#narrow/near/{}'.format(self.model.server_url, message_id)
+    def view_in_browser(self, message: Message) -> None:
+        # Truncate extra '/' from the server url.
+        self.url = near_message_url(self.model.server_url[:-1], message)
         if (not MACOS and not WSL and not os.environ.get('DISPLAY')
                 and os.environ.get('TERM')):
             # Don't try to open web browser if running without a GUI
             return
         with suppress_output():
             # Suppress anything on stdout or stderr when opening the browser
-            webbrowser.open(url)
+            webbrowser.open(self.url)
 
     def deregister_client(self) -> None:
         queue_id = self.model.queue_id

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -15,7 +15,7 @@ from typing_extensions import Literal
 
 from zulipterminal.api_types import Composition, Message
 from zulipterminal.config.themes import ThemeSpec
-from zulipterminal.helper import asynch
+from zulipterminal.helper import asynch, suppress_output
 from zulipterminal.model import Model
 from zulipterminal.ui import Screen, View
 from zulipterminal.ui_tools.utils import create_msg_box_list
@@ -371,7 +371,9 @@ class Controller:
                 and not os.environ.get('DISPLAY') and os.environ.get('TERM')):
             # Don't try to open web browser if running without a GUI
             return
-        webbrowser.open(url)
+        with suppress_output():
+            # Suppress anything on stdout or stderr when opening the browser
+            webbrowser.open(url)
 
     def deregister_client(self) -> None:
         queue_id = self.model.queue_id

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -15,7 +15,7 @@ from typing_extensions import Literal
 
 from zulipterminal.api_types import Composition, Message
 from zulipterminal.config.themes import ThemeSpec
-from zulipterminal.helper import asynch, suppress_output
+from zulipterminal.helper import MACOS, WSL, asynch, suppress_output
 from zulipterminal.model import Model
 from zulipterminal.ui import Screen, View
 from zulipterminal.ui_tools.utils import create_msg_box_list
@@ -367,8 +367,8 @@ class Controller:
 
     def view_in_browser(self, message_id: int) -> None:
         url = '{}#narrow/near/{}'.format(self.model.server_url, message_id)
-        if (sys.platform != 'darwin' and sys.platform[:3] != 'win'
-                and not os.environ.get('DISPLAY') and os.environ.get('TERM')):
+        if (not MACOS and not WSL and not os.environ.get('DISPLAY')
+                and os.environ.get('TERM')):
             # Don't try to open web browser if running without a GUI
             return
         with suppress_output():

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -3,6 +3,7 @@ import platform
 import subprocess
 import time
 from collections import OrderedDict, defaultdict
+from contextlib import contextmanager
 from functools import wraps
 from itertools import chain, combinations
 from re import ASCII, MULTILINE, findall, match
@@ -14,6 +15,7 @@ from typing import (
     Dict,
     FrozenSet,
     Iterable,
+    Iterator,
     List,
     Set,
     Tuple,
@@ -702,3 +704,21 @@ def get_unused_fence(content: str) -> str:
                                len(max(matches, key=len)) + 1)
 
     return '`' * max_length_fence
+
+
+@contextmanager
+def suppress_output() -> Iterator[None]:
+    """Context manager to redirect stdout and stderr to /dev/null.
+
+    Adapted from https://stackoverflow.com/a/2323563
+    """
+    out = os.dup(1)
+    err = os.dup(2)
+    os.close(1)
+    os.close(2)
+    os.open(os.devnull, os.O_RDWR)
+    try:
+        yield
+    finally:
+        os.dup2(out, 1)
+        os.dup2(err, 2)

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -1551,6 +1551,8 @@ class MessageBox(urwid.Pile):
             self.model.controller.show_msg_info(self.message,
                                                 self.message_links,
                                                 self.time_mentions)
+        elif is_command_key('VIEW_IN_BROWSER', key):
+            self.model.controller.view_in_browser(self.message['id'])
         return key
 
 

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1307,7 +1307,7 @@ class MsgInfoView(PopUpView):
                 time_mentions=self.time_mentions,
             )
         elif is_command_key('VIEW_IN_BROWSER', key):
-            self.controller.view_in_browser(self.msg['id'])
+            self.controller.view_in_browser(self.msg)
         return super().keypress(size, key)
 
 

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1232,7 +1232,10 @@ class MsgInfoView(PopUpView):
         msg_info = [
             ('', [('Date & Time', date_and_time),
                   ('Sender', msg['sender_full_name']),
-                  ('Sender\'s Email ID', msg['sender_email'])]),
+                  ('Sender\'s Email ID', msg['sender_email']),
+                  ('View message in the web browser', 'Press {}'.format(
+                   ', '.join(map(repr, keys_for_command('VIEW_IN_BROWSER'))))),
+                  ]),
         ]
         # Only show the 'Edit History' label for edited messages.
         self.show_edit_history_label = (
@@ -1303,6 +1306,8 @@ class MsgInfoView(PopUpView):
                 message_links=self.message_links,
                 time_mentions=self.time_mentions,
             )
+        elif is_command_key('VIEW_IN_BROWSER', key):
+            self.controller.view_in_browser(self.msg['id'])
         return super().keypress(size, key)
 
 


### PR DESCRIPTION
Thanks to @punchagan for the initial work in #397. :+1: 

Unlike the original PR, which narrowed every message to All Messages in the web app, this opens a message in `stream/topic/near` if it belongs to a stream or `pm-with/near` narrow if it belongs to a PM/huddle (see [discussion](https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/View.20message.20in.20browser/near/908851)).

The original commit has been split to facilitate reviews. Moreover, the test has been improved based on @neiljp's feedback on the original PR.

The logic for generating near message URLs has been borrowed from Zulip's [`zerver/lib/url_encoding.py`](https://github.com/zulip/zulip/blob/master/zerver/lib/url_encoding.py).

Partially fixes #452.