### PR TITLE
bugfix: Left strip search text to avoid empty search results

### DIFF
--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -1212,6 +1212,13 @@ class PanelSearchBox(urwid.Edit):
         self.set_caption('')
         self.set_edit_text(self.search_text)
 
+    def reset_active_search_focus(self) -> None:
+        """
+        Sets focus to the start on every callback to update_function.
+        """
+        if len(self.panel_view.log):
+            self.panel_view.body.set_focus(0)
+
     def keypress(self, size: urwid_Size, key: str) -> Optional[str]:
         if ((is_command_key('ENTER', key)
              and self.get_edit_text().lstrip() == '')

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -1213,7 +1213,8 @@ class PanelSearchBox(urwid.Edit):
         self.set_edit_text(self.search_text)
 
     def keypress(self, size: urwid_Size, key: str) -> Optional[str]:
-        if ((is_command_key('ENTER', key) and self.get_edit_text() == '')
+        if ((is_command_key('ENTER', key)
+             and self.get_edit_text().lstrip() == '')
                 or is_command_key('GO_BACK', key)):
             self.panel_view.view.controller.exit_editor_mode()
             self.reset_search_text()

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -317,6 +317,7 @@ class StreamsView(urwid.Frame):
 
             self.log.clear()
             self.log.extend(streams_display)
+            self.stream_search_box.reset_active_search_focus()
             self.view.controller.update_screen()
 
     def mouse_event(self, size: urwid_Size, event: str, button: int, col: int,
@@ -386,6 +387,7 @@ class TopicsView(urwid.Frame):
             ]
             self.log.clear()
             self.log.extend(topics_to_display)
+            self.topic_search_box.reset_active_search_focus()
             self.view.controller.update_screen()
 
     def update_topics_list(self, stream_id: int, topic_name: str,

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -283,6 +283,8 @@ class StreamsView(urwid.Frame):
 
     @asynch
     def update_streams(self, search_box: Any, new_text: str) -> None:
+        new_text = new_text.lstrip()
+
         if not self.view.controller.is_in_editor_mode():
             return
         # wait for any previously started search to finish to avoid
@@ -369,6 +371,8 @@ class TopicsView(urwid.Frame):
 
     @asynch
     def update_topics(self, search_box: Any, new_text: str) -> None:
+        new_text = new_text.lstrip()
+
         if not self.view.controller.is_in_editor_mode():
             return
         # wait for any previously started search to finish to avoid
@@ -625,6 +629,9 @@ class RightColumnView(urwid.Frame):
         # search, via PanelSearchBox, is active.
         if not self.allow_update_user_list and new_text is None:
             return
+
+        if new_text is not None:
+            new_text = new_text.lstrip()
 
         # wait for any previously started search to finish to avoid
         # displaying wrong user list.


### PR DESCRIPTION
This amends `PanelSearchBox`'s update functions to avoid empty search results for spaces.

@neiljp Thanks for reporting the bug in https://github.com/zulip/zulip-terminal/pull/699#pullrequestreview-434369722. :+1: 
