### PR TITLE
boxes: Enter on a empty string cancels the stream/user/message search.

### DIFF
--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -200,28 +200,34 @@ class TestPanelSearchBox:
         assert panel_search_box.caption == ""
         assert panel_search_box.edit_text == panel_search_box.search_text
 
-    @pytest.mark.parametrize("log, expect_body_focus_set", [
-        ([], False),
-        (["SOMETHING"], True)
+    @pytest.mark.parametrize("log, expect_body_focus_set, edit_text", [
+        ([], False, ""),
+        ([], False, "some search with no results"),
+        (["SOMETHING"], True, "key words")
     ])
     @pytest.mark.parametrize("enter_key", keys_for_command("ENTER"))
     def test_keypress_ENTER(self, panel_search_box,
-                            enter_key, log, expect_body_focus_set):
+                            enter_key, log, expect_body_focus_set, edit_text):
         size = (20,)
         panel_search_box.panel_view.view.controller.is_in_editor_mode = (
             lambda: True
         )
         panel_search_box.panel_view.log = log
         panel_search_box.set_caption("")
-        panel_search_box.edit_text = "key words"
+        panel_search_box.edit_text = edit_text
 
         panel_search_box.keypress(size, enter_key)
 
         # Update this display
         # FIXME We can't test for the styled version?
         # We'd compare to [('filter_results', 'Search Results'), ' ']
-        assert panel_search_box.caption == self.search_caption
-        assert panel_search_box.edit_text == "key words"
+        # If search is an 'empty' search
+        if edit_text == "":
+            assert panel_search_box.caption == ""
+            assert panel_search_box.edit_text == panel_search_box.search_text
+        else:
+            assert panel_search_box.caption == self.search_caption
+            assert panel_search_box.edit_text == edit_text
 
         # Leave editor mode
         (panel_search_box.panel_view.view.controller.exit_editor_mode

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -871,7 +871,8 @@ class SearchBox(urwid.Pile):
         return [self.search_bar, self.recipient_bar]
 
     def keypress(self, size: urwid_Size, key: str) -> Optional[str]:
-        if is_command_key('GO_BACK', key):
+        if (is_command_key('GO_BACK', key) or is_command_key('ENTER', key)
+                and self.text_box.edit_text == ''):
             self.text_box.set_edit_text("")
             self.controller.exit_editor_mode()
             self.controller.view.middle_column.set_focus('body')
@@ -906,15 +907,16 @@ class PanelSearchBox(urwid.Edit):
         self.set_edit_text(self.search_text)
 
     def keypress(self, size: urwid_Size, key: str) -> Optional[str]:
-        if is_command_key('ENTER', key):
+        if (is_command_key('ENTER', key) and self.get_edit_text() == ''
+                or is_command_key('GO_BACK', key)):
+            self.panel_view.view.controller.exit_editor_mode()
+            self.reset_search_text()
+            self.panel_view.set_focus("body")
+            self.panel_view.keypress(size, 'esc')
+        elif is_command_key('ENTER', key):
             self.panel_view.view.controller.exit_editor_mode()
             self.set_caption([('filter_results', 'Search Results'), ' '])
             self.panel_view.set_focus("body")
             if hasattr(self.panel_view, 'log') and len(self.panel_view.log):
                 self.panel_view.body.set_focus(0)
-        elif is_command_key('GO_BACK', key):
-            self.panel_view.view.controller.exit_editor_mode()
-            self.reset_search_text()
-            self.panel_view.set_focus("body")
-            self.panel_view.keypress(size, 'esc')
         return super().keypress(size, key)


### PR DESCRIPTION
An empty search string shows an empty search box and
jumps to eg. the full selection of streams,
leaving the search box blank. This caused confusion because
it was an empty search.

This fix causes an empty string search for a stream/user,
with enter, to now act the same as 'esc';ie. it
cancels the search and returns to the full list of streams/users.
For messages, it returns to the body.
A test for this behavior in PanelSearchBox was also added.

Fixes: #551.