### PR TITLE
boxes.py: Change behaviour of 'z' on broad narrows

### DIFF
--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -69,6 +69,8 @@ class Model:
         self.msg_view = None  # type: Any
         self.msg_list = None  # type: Any
         self.narrow = []  # type: List[Any]
+        self.previous_narrow = None
+        self.previous_narrow_key = None
         self.found_newest = False
         self.stream_id = -1
         self.recipients = frozenset()  # type: FrozenSet[Any]

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -212,7 +212,9 @@ class View(urwid.WidgetWrap):
             key = 'page down'
         elif is_command_key('GO_TO_BOTTOM', key):
             key = 'end'
-        return super().keypress(size, key)
+        retval = super().keypress(size, key)
+        self.model.previous_narrow_key = key
+        return retval
 
 
 class Screen(urwid.raw_display.Screen):

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -771,19 +771,35 @@ class MessageBox(urwid.Pile):
                 self.model.controller.narrow_to_stream(self)
         elif is_command_key('TOGGLE_NARROW', key):
             self.model.unset_search_narrow()
-            if self.message['type'] == 'private':
-                if (
-                    len(self.model.narrow) == 1
-                    and self.model.narrow[0][0] == 'pm_with'
-                   ):
-                    self.model.controller.show_all_pm(self)
-                else:
-                    self.model.controller.narrow_to_user(self)
-            elif self.message['type'] == 'stream':
-                if len(self.model.narrow) > 1:  # in a topic
-                    self.model.controller.narrow_to_stream(self)
-                else:
-                    self.model.controller.narrow_to_topic(self)
+            if (self.model.previous_narrow is not None
+                    and self.model.previous_narrow_key == 'z'):
+                if len(self.model.previous_narrow) == 1:
+                    if self.model.previous_narrow[0][1] == 'private':
+                        self.model.controller.show_all_pm(self)
+                    elif self.model.previous_narrow[0][1] == 'mentioned':
+                        self.model.controller.show_all_mentions(self)
+                    elif self.model.previous_narrow[0][1] == 'starred':
+                        self.model.controller.show_all_starred(self)
+                    else:
+                        self.model.controller.narrow_to_stream(self)
+                elif len(self.model.previous_narrow) == 0:
+                    self.model.controller.show_all_messages(self)
+                self.model.previous_narrow = None
+            else:
+                self.model.previous_narrow = self.model.narrow
+                if self.message['type'] == 'private':
+                    if (
+                        len(self.model.narrow) == 1
+                        and self.model.narrow[0][0] == 'pm_with'
+                       ):
+                        self.model.controller.show_all_pm(self)
+                    else:
+                        self.model.controller.narrow_to_user(self)
+                elif self.message['type'] == 'stream':
+                    if len(self.model.narrow) > 1:  # in a topic
+                        self.model.controller.narrow_to_stream(self)
+                    else:
+                        self.model.controller.narrow_to_topic(self)
         elif is_command_key('TOPIC_NARROW', key):
             if self.message['type'] == 'private':
                 self.model.controller.narrow_to_user(self)


### PR DESCRIPTION
Currently `z` acts as a toggle key to switch between stream view and
topic view, however when pressing the key on broad narrows like
**All Messages/Private Messages/Starred Messages/Mentions**, it behaves as defined
`All Messages->Topic->Stream->Topic`, this commit fixes this behaviour to
`All Messages->Topic->All Messages`, acting at a Zoom-in and Zoom-out view
toggle key. Stream to Topic narrow behaviour remains unaffected with this fix.

Fixes: #692