### PR TITLE
Visually separate pinned and unpinned streams while searching

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -422,6 +422,7 @@ class TestStreamsView:
             stream_view, 'SEARCH_STREAMS', stream_view.update_streams)
 
     @pytest.mark.parametrize('new_text, expected_log, to_pin', [
+        # NOTE: '' represents StreamsViewDivider's stream name.
         ('f', ['fan', 'FOO', 'foo', 'FOOBAR'], []),
         ('bar', ['bar'], []),
         ('foo', ['FOO', 'foo', 'FOOBAR'], []),
@@ -430,8 +431,10 @@ class TestStreamsView:
         ('here', ['test here'], []),
         ('test here', ['test here'], []),
         # With 'foo' pinned.
-        ('f', ['foo', 'fan', 'FOO', 'FOOBAR'], [['foo'], ]),
-        ('FOO', ['foo', 'FOO', 'FOOBAR'], [['foo'], ]),
+        ('f', ['foo', '', 'fan', 'FOO', 'FOOBAR'], [['foo'], ]),
+        ('FOO', ['foo', '', 'FOO', 'FOOBAR'], [['foo'], ]),
+        # With 'bar' pinned.
+        ('bar', ['bar'], [['bar'], ]),
     ])
     def test_update_streams(self, mocker, stream_view, new_text, expected_log,
                             to_pin):

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -15,7 +15,8 @@ from zulipterminal.ui_tools.buttons import (
 from zulipterminal.ui_tools.views import (
     AboutView, HelpView, LeftColumnView, MessageView, MiddleColumnView,
     ModListWalker, MsgInfoView, PopUpConfirmationView, PopUpView,
-    RightColumnView, StreamInfoView, StreamsView, TopicsView, UsersView,
+    RightColumnView, StreamInfoView, StreamsView, StreamsViewDivider,
+    TopicsView, UsersView,
 )
 from zulipterminal.version import MINIMUM_SUPPORTED_SERVER_VERSION, ZT_VERSION
 
@@ -390,6 +391,15 @@ class TestMessageView:
         msg_view.read_message(1)
         self.model.mark_message_ids_as_read.assert_called_once_with(
             [message_fixture['id']])
+
+
+class TestStreamsViewDivider:
+    def test_init(self):
+        streams_view_divider = StreamsViewDivider()
+
+        assert isinstance(streams_view_divider, Divider)
+        assert streams_view_divider.stream_id == -1
+        assert streams_view_divider.stream_name == ''
 
 
 class TestStreamsView:
@@ -1107,13 +1117,13 @@ class TestLeftColumnView:
         stream_button = mocker.patch(VIEWS + '.StreamButton')
         stream_view = mocker.patch(VIEWS + '.StreamsView')
         line_box = mocker.patch(VIEWS + '.urwid.LineBox')
-        divider = mocker.patch(VIEWS + '.urwid.Divider')
+        divider = mocker.patch(VIEWS + '.StreamsViewDivider')
         mocker.patch(STREAMBUTTON + ".mark_muted")
 
         left_col_view = LeftColumnView(width, self.view)
 
         if pinned:
-            divider.assert_called_once_with('-')
+            assert divider.called
         else:
             divider.assert_not_called()
 

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -287,6 +287,25 @@ class StreamsView(urwid.Frame):
             ]
             streams_display = match_stream(stream_buttons, new_text,
                                            self.view.pinned_streams)[0]
+
+            # Add a divider to separate pinned streams from the rest.
+            pinned_stream_names = [
+                stream[0]
+                for stream in self.view.pinned_streams
+            ]
+            first_unpinned_index = len(streams_display)
+            for index, stream in enumerate(streams_display):
+                if stream.stream_name not in pinned_stream_names:
+                    first_unpinned_index = index
+                    break
+            if first_unpinned_index not in [0, len(streams_display)]:
+                # Do not add a divider when it is already present. This can
+                # happen when new_text=''.
+                if not isinstance(streams_display[first_unpinned_index],
+                                  StreamsViewDivider):
+                    streams_display.insert(first_unpinned_index,
+                                           StreamsViewDivider())
+
             self.log.clear()
             self.log.extend(streams_display)
             self.view.controller.update_screen()

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -245,6 +245,18 @@ class MessageView(urwid.ListBox):
         self.model.mark_message_ids_as_read(read_msg_ids)
 
 
+class StreamsViewDivider(urwid.Divider):
+    """
+    A custom urwid.Divider to visually separate pinned and unpinned streams.
+    """
+    def __init__(self) -> None:
+        # FIXME: Necessary since the divider is treated as a StreamButton.
+        # NOTE: This is specifically for stream search to work correctly.
+        self.stream_id = -1
+        self.stream_name = ''
+        super().__init__(div_char='-')
+
+
 class StreamsView(urwid.Frame):
     def __init__(self, streams_btn_list: List[Any], view: Any) -> None:
         self.view = view
@@ -696,14 +708,7 @@ class LeftColumnView(urwid.Pile):
                 ) for stream in self.view.pinned_streams]
 
         if len(streams_btn_list):
-            unpinned_divider = urwid.Divider("-")
-
-            # FIXME Necessary since the divider is treated as a StreamButton
-            # NOTE: This is specifically for stream search to work correctly
-            unpinned_divider.stream_id = -1
-            unpinned_divider.stream_name = ''
-
-            streams_btn_list += [unpinned_divider]
+            streams_btn_list += [StreamsViewDivider()]
 
         streams_btn_list += [
                 StreamButton(


### PR DESCRIPTION
The first commit is a refactor that extracts `streams_view_divider()` from `streams_view()`. 

The `streams_view_divider()` is used in the second commit, in `update_streams`, for inserting a divider between search results.

Fixes #577.