### PR TITLE
Fix message updating bugs due to found_newest

### DIFF
--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -44,7 +44,7 @@ class TestModel:
         assert model.msg_view is None
         assert model.msg_list is None
         assert model.narrow == []
-        assert model._have_last_message is False
+        assert model._have_last_message == {}
         assert model.stream_id == -1
         assert model.stream_dict == {}
         assert model.recipients == frozenset()
@@ -467,7 +467,7 @@ class TestModel:
         anchor = messages_successful_response['anchor']
         if anchor < 10000000000000000:
             assert model.index['pointer'][repr(model.narrow)] == anchor
-        assert model._have_last_message is True
+        assert model._have_last_message[repr(model.narrow)] is True
 
     def test_get_message_false_first_anchor(
             self, mocker, messages_successful_response, index_all_messages,
@@ -503,9 +503,9 @@ class TestModel:
 
         # TEST `query_range` < no of messages received
         # RESET model._have_last_message value
-        model._have_last_message = False
+        model._have_last_message[repr(model.narrow)] = False
         model.get_messages(num_after=0, num_before=0, anchor=0)
-        assert model._have_last_message is False
+        assert model._have_last_message[repr(model.narrow)] is False
 
     # FIXME This only tests the case where the get_messages is in __init__
     def test_fail_get_messages(self, mocker, error_response,
@@ -653,7 +653,7 @@ class TestModel:
 
     def test__handle_message_event_with_Falsey_log(self, mocker,
                                                    model, message_fixture):
-        model._have_last_message = True
+        model._have_last_message[repr([])] = True
         mocker.patch('zulipterminal.model.Model._update_topic_index')
         index_msg = mocker.patch('zulipterminal.model.index_messages',
                                  return_value={})
@@ -674,7 +674,7 @@ class TestModel:
 
     def test__handle_message_event_with_valid_log(self, mocker,
                                                   model, message_fixture):
-        model._have_last_message = True
+        model._have_last_message[repr([])] = True
         mocker.patch('zulipterminal.model.Model._update_topic_index')
         index_msg = mocker.patch('zulipterminal.model.index_messages',
                                  return_value={})
@@ -697,7 +697,7 @@ class TestModel:
 
     def test__handle_message_event_with_flags(self, mocker,
                                               model, message_fixture):
-        model._have_last_message = True
+        model._have_last_message[repr([])] = True
         mocker.patch('zulipterminal.model.Model._update_topic_index')
         index_msg = mocker.patch('zulipterminal.model.index_messages',
                                  return_value={})
@@ -762,7 +762,7 @@ class TestModel:
             'mentioned_msg_in_mentioned_msg_narrow'])
     def test__handle_message_event(self, mocker, user_profile, response,
                                    narrow, recipients, model, log):
-        model._have_last_message = True
+        model._have_last_message[repr(narrow)] = True
         mocker.patch('zulipterminal.model.Model._update_topic_index')
         index_msg = mocker.patch('zulipterminal.model.index_messages',
                                  return_value={})
@@ -783,7 +783,7 @@ class TestModel:
         assert model.msg_list.log == log
         set_count.assert_called_once_with([response['id']], self.controller, 1)
 
-        model._have_last_message = False
+        model._have_last_message[repr(narrow)] = False
         model.notify_user.assert_called_once_with(response)
         model._handle_message_event(event)
         # LOG REMAINS THE SAME IF UPDATE IS FALSE

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -466,7 +466,7 @@ class TestModel:
         assert model.index == index_all_messages
         anchor = messages_successful_response['anchor']
         if anchor < 10000000000000000:
-            assert model.index['pointer'][str(model.narrow)] == anchor
+            assert model.index['pointer'][repr(model.narrow)] == anchor
         assert model.found_newest is True
 
     def test_get_message_false_first_anchor(
@@ -499,7 +499,7 @@ class TestModel:
         self.client.get_messages.return_value = messages_successful_response
         # anchor should have remained the same
         anchor = messages_successful_response['anchor']
-        assert model.index['pointer'][str(model.narrow)] == 0
+        assert model.index['pointer'][repr(model.narrow)] == 0
 
         # TEST `query_range` < no of messages received
         model.found_newest = False  # RESET model.found_newest value

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -44,7 +44,7 @@ class TestModel:
         assert model.msg_view is None
         assert model.msg_list is None
         assert model.narrow == []
-        assert model.found_newest is False
+        assert model._have_last_message is False
         assert model.stream_id == -1
         assert model.stream_dict == {}
         assert model.recipients == frozenset()
@@ -467,7 +467,7 @@ class TestModel:
         anchor = messages_successful_response['anchor']
         if anchor < 10000000000000000:
             assert model.index['pointer'][repr(model.narrow)] == anchor
-        assert model.found_newest is True
+        assert model._have_last_message is True
 
     def test_get_message_false_first_anchor(
             self, mocker, messages_successful_response, index_all_messages,
@@ -502,9 +502,10 @@ class TestModel:
         assert model.index['pointer'][repr(model.narrow)] == 0
 
         # TEST `query_range` < no of messages received
-        model.found_newest = False  # RESET model.found_newest value
+        # RESET model._have_last_message value
+        model._have_last_message = False
         model.get_messages(num_after=0, num_before=0, anchor=0)
-        assert model.found_newest is False
+        assert model._have_last_message is False
 
     # FIXME This only tests the case where the get_messages is in __init__
     def test_fail_get_messages(self, mocker, error_response,
@@ -652,7 +653,7 @@ class TestModel:
 
     def test__handle_message_event_with_Falsey_log(self, mocker,
                                                    model, message_fixture):
-        model.found_newest = True
+        model._have_last_message = True
         mocker.patch('zulipterminal.model.Model._update_topic_index')
         index_msg = mocker.patch('zulipterminal.model.index_messages',
                                  return_value={})
@@ -673,7 +674,7 @@ class TestModel:
 
     def test__handle_message_event_with_valid_log(self, mocker,
                                                   model, message_fixture):
-        model.found_newest = True
+        model._have_last_message = True
         mocker.patch('zulipterminal.model.Model._update_topic_index')
         index_msg = mocker.patch('zulipterminal.model.index_messages',
                                  return_value={})
@@ -696,7 +697,7 @@ class TestModel:
 
     def test__handle_message_event_with_flags(self, mocker,
                                               model, message_fixture):
-        model.found_newest = True
+        model._have_last_message = True
         mocker.patch('zulipterminal.model.Model._update_topic_index')
         index_msg = mocker.patch('zulipterminal.model.index_messages',
                                  return_value={})
@@ -761,7 +762,7 @@ class TestModel:
             'mentioned_msg_in_mentioned_msg_narrow'])
     def test__handle_message_event(self, mocker, user_profile, response,
                                    narrow, recipients, model, log):
-        model.found_newest = True
+        model._have_last_message = True
         mocker.patch('zulipterminal.model.Model._update_topic_index')
         index_msg = mocker.patch('zulipterminal.model.index_messages',
                                  return_value={})
@@ -782,7 +783,7 @@ class TestModel:
         assert model.msg_list.log == log
         set_count.assert_called_once_with([response['id']], self.controller, 1)
 
-        model.found_newest = False
+        model._have_last_message = False
         model.notify_user.assert_called_once_with(response)
         model._handle_message_event(event)
         # LOG REMAINS THE SAME IF UPDATE IS FALSE

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -159,7 +159,6 @@ class Controller:
         self.model.index['search'].clear()
         self.model.set_search_narrow(text)
 
-        self.model.found_newest = False
         self.model.get_messages(num_after=0, num_before=30, anchor=10000000000)
         msg_id_list = self.model.get_message_ids_in_current_narrow()
 
@@ -186,8 +185,6 @@ class Controller:
         already_narrowed = self.model.set_narrow(**narrow)
         if already_narrowed:
             return
-
-        self.model.found_newest = False
 
         # store the steam id in the model (required for get_message_ids...)
         if hasattr(button, 'stream_id'):  # FIXME Include in set_narrow?

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -69,7 +69,7 @@ class Model:
         self.msg_view = None  # type: Any
         self.msg_list = None  # type: Any
         self.narrow = []  # type: List[Any]
-        self.found_newest = False
+        self._have_last_message = False
         self.stream_id = -1
         self.recipients = frozenset()  # type: FrozenSet[Any]
         self.index = initial_index
@@ -352,12 +352,13 @@ class Model:
             if first_anchor and response['anchor'] != 10000000000000000:
                 self.index['pointer'][repr(self.narrow)] = response['anchor']
             if 'found_newest' in response:
-                self.found_newest = response['found_newest']
+                self._have_last_message = response['found_newest']
             else:
                 # Older versions of the server does not contain the
                 # 'found_newest' flag. Instead, we use this logic:
                 query_range = num_after + num_before + 1
-                self.found_newest = len(response['messages']) < query_range
+                self._have_last_message = (len(response['messages'])
+                                           < query_range)
             return ""
         return response['msg']
 
@@ -741,7 +742,7 @@ class Model:
         if 'read' not in message['flags']:
             set_count([message['id']], self.controller, 1)
 
-        if hasattr(self.controller, 'view') and self.found_newest:
+        if hasattr(self.controller, 'view') and self._have_last_message:
             if self.msg_list.log:
                 last_message = self.msg_list.log[-1].original_widget.message
             else:

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -129,10 +129,10 @@ class Model:
         Returns the focus in the current narrow.
         For no existing focus this returns {}, otherwise the message ID.
         """
-        return self.index['pointer'][str(self.narrow)]
+        return self.index['pointer'][repr(self.narrow)]
 
     def set_focus_in_current_narrow(self, focus_message: int) -> None:
-        self.index['pointer'][str(self.narrow)] = focus_message
+        self.index['pointer'][repr(self.narrow)] = focus_message
 
     def is_search_narrow(self) -> bool:
         """
@@ -350,7 +350,7 @@ class Model:
         if response['result'] == 'success':
             self.index = index_messages(response['messages'], self, self.index)
             if first_anchor and response['anchor'] != 10000000000000000:
-                self.index['pointer'][str(self.narrow)] = response['anchor']
+                self.index['pointer'][repr(self.narrow)] = response['anchor']
             if 'found_newest' in response:
                 self.found_newest = response['found_newest']
             else:


### PR DESCRIPTION
This PR fixes an update message bug which is caused by two different sources.
1. When a stream is not fully loaded, `Model.found_newest` is set to`False`. Now if a message is received on other streams which are fully loaded, it won't be appended to the view due to `found_newest` state. This is fixed by maintaining found_newest for each narrow.
2. On switching between narrows, `found_newest` is set to `False` in the `Controller`. This obviously prevents appending of new  messagea in the narrow, unless `down` is pressed.

Similar bugs are present (now fixed) for sending messages, since they too use the same `Model._handle_message_event` for adding messages to the view.