### PR TITLE
model: Notify user if a request fails.

### DIFF
--- a/tests/helper/test_helper.py
+++ b/tests/helper/test_helper.py
@@ -2,8 +2,8 @@ import pytest
 
 import zulipterminal.helper
 from zulipterminal.helper import (
-    canonicalize_color, classify_unread_counts, index_messages, notify,
-    powerset,
+    canonicalize_color, classify_unread_counts, display_error_if_present,
+    index_messages, notify, powerset,
 )
 
 
@@ -280,3 +280,19 @@ def test_notify_quotes(monkeypatch, mocker,
     assert len(params[0][0][0]) == cmd_length
 
     # NOTE: If there is a quoting error, we may get a ValueError too
+
+
+@pytest.mark.parametrize(['response', 'footer_updated'], [
+    ({'result': 'error', 'msg': 'Request failed.'}, True),
+    ({'result': 'success', 'msg': 'msg content'}, False),
+])
+def test_display_error_if_present(mocker, response, footer_updated):
+    controller = mocker.Mock()
+    set_footer_text = controller.view.set_footer_text
+
+    display_error_if_present(response, controller)
+
+    if footer_updated:
+        set_footer_text.assert_called_once_with(response['msg'], 3)
+    else:
+        set_footer_text.assert_not_called()

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -535,11 +535,10 @@ class TestModel:
     ], ids=['muting_205', 'unmuting_205', 'first_muted_205',
             'last_unmuted_205'])
     def test_toggle_stream_muted_status(self, mocker, model,
-                                        initial_muted_streams, value):
+                                        initial_muted_streams, value,
+                                        response={'result': 'success'}):
         model.muted_streams = initial_muted_streams
-        model.client.update_subscription_settings.return_value = {
-            'result': "success"
-        }
+        model.client.update_subscription_settings.return_value = response
         model.toggle_stream_muted_status(205)
         request = [{
             'stream_id': 205,

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -558,7 +558,6 @@ class TestModel:
     ])
     def test_toggle_message_star_status(self, mocker, model, flags_before,
                                         expected_operator):
-        mocker.patch('zulip.Client')
         message = {
             'id': 99,
             'flags': flags_before,

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -630,3 +630,9 @@ def notify(title: str, html_text: str) -> str:
             # This likely means the notification command could not be found
             return command_list[0]
     return ""
+
+
+def display_error_if_present(response: Dict[str, Any], controller: Any
+                             ) -> None:
+    if response['result'] == 'error':
+        controller.view.set_footer_text(response['msg'], 3)

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -14,7 +14,7 @@ from mypy_extensions import TypedDict
 from zulipterminal.config.keys import keys_for_command
 from zulipterminal.helper import (
     Message, asynch, canonicalize_color, classify_unread_counts,
-    index_messages, initial_index, notify, set_count,
+    display_error_if_present, index_messages, initial_index, notify, set_count,
 )
 from zulipterminal.ui_tools.utils import create_msg_box_list
 
@@ -269,6 +269,7 @@ class Model:
             response = self.client.remove_reaction(reaction_to_toggle_spec)
         else:
             response = self.client.add_reaction(reaction_to_toggle_spec)
+        display_error_if_present(response, self.controller)
 
     @asynch
     def toggle_message_star_status(self, message: Message) -> None:
@@ -278,16 +279,18 @@ class Model:
         else:
             request = dict(base_request, op='add')
         response = self.client.update_message_flags(request)
+        display_error_if_present(response, self.controller)
 
     @asynch
     def mark_message_ids_as_read(self, id_list: List[int]) -> None:
         if not id_list:
             return
-        self.client.update_message_flags({
+        response = self.client.update_message_flags({
             'messages': id_list,
             'flag': 'read',
             'op': 'add',
         })
+        display_error_if_present(response, self.controller)
 
     def send_private_message(self, recipients: str,
                              content: str) -> bool:
@@ -297,6 +300,7 @@ class Model:
             'content': content,
         }
         response = self.client.send_message(request)
+        display_error_if_present(response, self.controller)
         return response['result'] == 'success'
 
     def send_stream_message(self, stream: str, topic: str,
@@ -308,6 +312,7 @@ class Model:
             'content': content,
         }
         response = self.client.send_message(request)
+        display_error_if_present(response, self.controller)
         return response['result'] == 'success'
 
     def update_private_message(self, msg_id: int, content: str) -> bool:
@@ -316,6 +321,7 @@ class Model:
             "content": content,
         }
         response = self.client.update_message(request)
+        display_error_if_present(response, self.controller)
         return response['result'] == 'success'
 
     def update_stream_message(self, topic: str, msg_id: int,
@@ -328,6 +334,7 @@ class Model:
             "subject": topic,
         }
         response = self.client.update_message(request)
+        display_error_if_present(response, self.controller)
         return response['result'] == 'success'
 
     def get_messages(self, *,
@@ -359,6 +366,7 @@ class Model:
                 query_range = num_after + num_before + 1
                 self.found_newest = len(response['messages']) < query_range
             return ""
+        display_error_if_present(response, self.controller)
         return response['msg']
 
     def get_topics_in_stream(self, stream_list: Iterable[int]) -> str:
@@ -373,6 +381,7 @@ class Model:
                 self.index['topics'][stream_id] = [topic['name'] for
                                                    topic in response['topics']]
             else:
+                display_error_if_present(response, self.controller)
                 return response['msg']
         return ""
 
@@ -609,6 +618,7 @@ class Model:
             # True for muting and False for unmuting.
         }]
         response = self.client.update_subscription_settings(request)
+        display_error_if_present(response, self.controller)
         return response['result'] == 'success'
 
     def _handle_subscription_event(self, event: Event) -> None:


### PR DESCRIPTION
This commit displays an error message in the footer for server requests
involving user interactions. By this the user can be notified for
different failures like:
* Hitting API rate limits.
* Posting in streams where user doesn't have the required permissions.
* Message sending/editing errors.
* Toggling reaction errors.
* etc.

Error responses from some requests are not displayed, since they are not
triggered directly by a user action. Example of these include event
polling requests, event registration, and updating presence.

Fixes #427.