### PR TITLE
Limit rapid keypresses

### DIFF
--- a/tests/ui/test_ui.py
+++ b/tests/ui/test_ui.py
@@ -342,3 +342,26 @@ class TestView:
             assert return_value == key
         else:
             assert return_value == 'super_key'
+
+    @pytest.mark.parametrize('pressed_too_often', [True, False])
+    def test_keypress_multiple_presses(self, mocker, view, pressed_too_often,
+                                       key='ctrl s'):
+        mocker.patch('zulipterminal.ui.View.set_footer_text')
+        mocker.patch("zulipterminal.ui.urwid.WidgetWrap.keypress",
+                     return_value='super_key')
+        view.keypress_counter = mocker.Mock()
+        view.middle_column = mocker.Mock()
+        view.controller.is_in_editor_mode = lambda: False
+        view.keypress_counter.pressed_too_often.return_value = (
+                pressed_too_often
+        )
+        size = (20,)
+
+        return_value = view.keypress(size, key)
+
+        if pressed_too_often:
+            assert return_value == key
+            view.set_footer_text.assert_called_once_with(
+                            '\'{}\' pressed too often.'.format(key), 3)
+        else:
+            assert return_value == 'super_key'

--- a/tests/ui/test_ui.py
+++ b/tests/ui/test_ui.py
@@ -15,7 +15,7 @@ class TestView:
 
     @pytest.fixture
     def view(self, mocker):
-        main_window = mocker.patch('zulipterminal.ui.View.main_window')
+        self.main_window = mocker.patch('zulipterminal.ui.View.main_window')
         return View(self.controller)
 
     def test_init(self, mocker):
@@ -216,6 +216,9 @@ class TestView:
         view.users_view = mocker.Mock()
         view.body = mocker.Mock()
         view.user_search = mocker.Mock()
+        view.middle_column = mocker.Mock()
+        view.middle_column.body.old_loading = False
+        view.middle_column.body.new_loading = False
         size = (20,)
 
         super_keypress = mocker.patch("zulipterminal.ui.urwid.WidgetWrap"
@@ -310,3 +313,32 @@ class TestView:
 
         (view.controller.current_editor().keypress
          .assert_called_once_with((28,), key))
+
+    @pytest.mark.parametrize('key, old_loading, new_loading', [
+            (keys_for_command('GO_UP').pop(), True, False),
+            (keys_for_command('GO_DOWN').pop(), False, True),
+            (keys_for_command('GO_UP').pop(), False, False),
+            (keys_for_command('GO_DOWN').pop(), False, False),
+    ], ids=[
+            'loading_old_messages',
+            'loading_new_messages',
+            'scroll_up',
+            'scroll_down',
+    ])
+    def test_keypress_message_loading(self, view, mocker, key, old_loading,
+                                      new_loading):
+        mocker.patch("zulipterminal.ui.urwid.WidgetWrap.keypress",
+                     return_value='super_key')
+        view.middle_column = mocker.Mock()
+        view.middle_column.body.new_loading = new_loading
+        view.middle_column.body.old_loading = old_loading
+        view.controller.is_in_editor_mode = lambda: False
+        size = (20,)
+
+        return_value = view.keypress(size, key)
+
+        # if loading message
+        if old_loading or new_loading:
+            assert return_value == key
+        else:
+            assert return_value == 'super_key'

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -177,6 +177,12 @@ class View(urwid.WidgetWrap):
         self.model.new_user_input = True
         if self.controller.is_in_editor_mode():
             return self.controller.current_editor().keypress((size[1],), key)
+        # Ignore keypress if messages being loaded.
+        if((is_command_key('GO_UP', key)
+            and self.middle_column.body.old_loading)
+           or (is_command_key('GO_DOWN', key)
+               and self.middle_column.body.new_loading)):
+            return key
         # Redirect commands to message_view.
         elif (is_command_key('SEARCH_MESSAGES', key)
                 or is_command_key('NEXT_UNREAD_TOPIC', key)

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -9,7 +9,7 @@ from zulipterminal.config.keys import commands_for_random_tips, is_command_key
 from zulipterminal.config.symbols import (
     APPLICATION_TITLE_BAR_LINE, LIST_TITLE_BAR_LINE,
 )
-from zulipterminal.helper import WSL, asynch
+from zulipterminal.helper import WSL, KeypressCounter, asynch
 from zulipterminal.ui_tools.boxes import SearchBox, WriteBox
 from zulipterminal.ui_tools.views import (
     LeftColumnView, MiddleColumnView, RightColumnView,
@@ -33,6 +33,7 @@ class View(urwid.WidgetWrap):
         self.unpinned_streams = self.model.unpinned_streams
         self.write_box = WriteBox(self)
         self.search_box = SearchBox(self.controller)
+        self.keypress_counter = KeypressCounter()
 
         self.message_view = None  # type: Any
 
@@ -175,6 +176,9 @@ class View(urwid.WidgetWrap):
     # FIXME: The type of size should be urwid_Size; this needs checking
     def keypress(self, size: Tuple[int, int], key: str) -> Optional[str]:
         self.model.new_user_input = True
+        if self.keypress_counter.pressed_too_often(key):
+            self.set_footer_text('\'{}\' pressed too often.'.format(key), 3)
+            return key
         if self.controller.is_in_editor_mode():
             return self.controller.current_editor().keypress((size[1],), key)
         # Ignore keypress if messages being loaded.


### PR DESCRIPTION
This PR solves the rate-limiting issues by due to rapid keypresses by:
* Preventing concurrent up/down when at the top or bottom of the `MessageView`.
* Rate limits pressing of other keys to 15 consecutive presses.