### PR TITLE
Ignore mouse click if compose box is open.

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -31,6 +31,14 @@ BOXES = "zulipterminal.ui_tools.boxes"
 SERVER_URL = "https://chat.zulip.zulip"
 
 
+@pytest.fixture(
+    params=[True, False],
+    ids=['ignore_mouse_click', 'handle_mouse_click']
+)
+def compose_box_is_open(request):
+    return request.param
+
+
 class TestModListWalker:
     @pytest.fixture
     def mod_walker(self):
@@ -686,7 +694,8 @@ class TestUsersView:
     @pytest.fixture
     def user_view(self, mocker):
         mocker.patch(VIEWS + ".urwid.SimpleFocusListWalker", return_value=[])
-        return UsersView("USER_BTN_LIST")
+        controller = mocker.Mock()
+        return UsersView(controller, "USER_BTN_LIST")
 
     def test_mouse_event(self, mocker, user_view):
         mocker.patch.object(user_view, 'keypress')
@@ -702,15 +711,31 @@ class TestUsersView:
         user_view.mouse_event(size, "mouse press", 5, col, row, focus)
         user_view.keypress.assert_called_with(size, "down")
 
+    def test_mouse_event_left_click(self, mocker, user_view,
+                                    compose_box_is_open):
+        super_mouse_event = mocker.patch(
+                        'zulipterminal.ui.urwid.ListBox.mouse_event')
+        user_view.controller.is_in_editor_mode.return_value = (
+                compose_box_is_open
+        )
+        size = (20, )
+        focus = mocker.Mock()
+
+        user_view.mouse_event(size, 'mouse press', 1, 1, 1, focus)
+
+        if compose_box_is_open:
+            super_mouse_event.assert_not_called()
+        else:
+            super_mouse_event.assert_called_once_with(size, 'mouse press', 1,
+                                                      1, 1, focus)
+
     @pytest.mark.parametrize('event, button', [
             ('mouse release', 0),
-            ('mouse press', 1),
             ('mouse press', 3),
             ('mouse release', 4),
         ],
         ids=[
             'unsupported_mouse_release_action',
-            'unsupported_left_click_mouse_press_action',
             'unsupported_right_click_mouse_press_action',
             'invalid_event_button_combination',
         ]
@@ -1048,7 +1073,8 @@ class TestRightColumnView:
                 color='user_' + self.view.users[0]['status'],
                 count=1
             )
-        users_view.assert_called_once_with(right_col_view.users_btn_list)
+        users_view.assert_called_once_with(self.view.controller,
+                                           right_col_view.users_btn_list)
         assert len(right_col_view.users_btn_list) == users_btn_len
 
     @pytest.mark.parametrize('key', keys_for_command('SEARCH_PEOPLE'))
@@ -2252,17 +2278,25 @@ class TestMessageBox:
         'key', keys_for_command('ENTER'),
         ids=lambda param: 'left_click-key:{}'.format(param)
     )
-    def test_mouse_event_left_click(self, mocker, msg_box, key):
+    def test_mouse_event_left_click(self, mocker, msg_box, key,
+                                    compose_box_is_open):
         size = (20, )
         col = 1
         row = 1
         focus = mocker.Mock()
         mocker.patch(BOXES + '.keys_for_command', return_value=[key])
         mocker.patch.object(msg_box, 'keypress')
+        msg_box.model = mocker.Mock()
+        msg_box.model.controller.is_in_editor_mode.return_value = (
+                compose_box_is_open
+        )
 
         msg_box.mouse_event(size, 'mouse press', 1, col, row, focus)
 
-        msg_box.keypress.assert_called_once_with(size, key)
+        if compose_box_is_open:
+            msg_box.keypress.assert_not_called()
+        else:
+            msg_box.keypress.assert_called_once_with(size, key)
 
 
 class TestTopButton:

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -833,6 +833,8 @@ class MessageBox(urwid.Pile):
                     col: int, row: int, focus: bool) -> bool:
         if event == 'mouse press':
             if button == 1:
+                if self.model.controller.is_in_editor_mode():
+                    return True
                 self.keypress(size, keys_for_command('ENTER').pop())
                 return True
         elif event == 'mouse drag':

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -440,13 +440,17 @@ class TopicsView(urwid.Frame):
 
 
 class UsersView(urwid.ListBox):
-    def __init__(self, users_btn_list: List[Any]) -> None:
+    def __init__(self, controller: Any, users_btn_list: List[Any]) -> None:
         self.log = urwid.SimpleFocusListWalker(users_btn_list)
+        self.controller = controller
         super().__init__(self.log)
 
     def mouse_event(self, size: urwid_Size, event: str, button: int, col: int,
                     row: int, focus: bool) -> bool:
         if event == 'mouse press':
+            if button == 1:
+                if self.controller.is_in_editor_mode():
+                    return True
             if button == 4:
                 for _ in range(5):
                     self.keypress(size, 'up')
@@ -642,7 +646,7 @@ class RightColumnView(urwid.Frame):
                     count=unread_count
                 )
             )
-        user_w = UsersView(users_btn_list)
+        user_w = UsersView(self.view.controller, users_btn_list)
         # Donot reset them while searching.
         if reset_default_view_users:
             self.users_btn_list = users_btn_list
@@ -657,7 +661,8 @@ class RightColumnView(urwid.Frame):
         elif is_command_key('GO_BACK', key):
             self.user_search.reset_search_text()
             self.allow_update_user_list = True
-            self.body = UsersView(self.users_btn_list)
+            self.body = UsersView(self.view.controller,
+                                  self.users_btn_list)
             self.set_body(self.body)
             self.set_focus('body')
             self.view.controller.update_screen()


### PR DESCRIPTION
Clicking on messages/user names when the compose box is open causes the
current message to be lost. This commits ignores the mouse click to
prevent the typed data to be lost, though better handling can be done
when the drafts feature is implemented.

Also, stored controller as an attribute for UsersView. Tests amended for
this.

Test added for mouse click event.

Fixes #652.