### PR TITLE
Do not mark as read on search narrows

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -322,6 +322,7 @@ class TestMessageView:
         mocker.patch(VIEWS + ".MessageView.set_focus")
         mocker.patch(VIEWS + ".MessageView.update_search_box_narrow")
         msg_view = MessageView(self.model)
+        msg_view.model.is_search_narrow = lambda: False
         msg_view.log = mocker.Mock()
         msg_view.body = mocker.Mock()
         msg_w = mocker.MagicMock()
@@ -368,12 +369,29 @@ class TestMessageView:
 
         self.model.mark_message_ids_as_read.assert_not_called()
 
+    def test_read_message_search_narrow(self, mocker, msg_box):
+        mocker.patch(VIEWS + ".MessageView.main_view", return_value=[msg_box])
+        mocker.patch(VIEWS + ".MessageView.set_focus")
+        mocker.patch(VIEWS + ".MessageView.update_search_box_narrow")
+        msg_view = MessageView(self.model)
+        msg_view.model.controller.view = mocker.Mock()
+        msg_w = mocker.Mock()
+        msg_view.body = mocker.Mock()
+        msg_view.body.get_focus.return_value = (msg_w, 0)
+        msg_view.model.is_search_narrow = lambda: True
+
+        msg_view.read_message()
+
+        assert msg_view.update_search_box_narrow.called
+        assert not self.model.mark_message_ids_as_read.called
+
     def test_read_message_last_unread_message_focused(self, mocker,
                                                       message_fixture,
                                                       empty_index, msg_box):
         mocker.patch(VIEWS + ".MessageView.main_view", return_value=[msg_box])
         mocker.patch(VIEWS + ".MessageView.set_focus")
         msg_view = MessageView(self.model)
+        msg_view.model.is_search_narrow = lambda: False
         msg_view.log = [0, 1]
         msg_view.body = mocker.Mock()
         msg_view.update_search_box_narrow = mocker.Mock()

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -222,6 +222,11 @@ class MessageView(urwid.ListBox):
         if msg_w is None:
             return
         self.update_search_box_narrow(msg_w.original_widget)
+
+        # Do not read messages in any search narrow.
+        if self.model.is_search_narrow():
+            return
+
         # If this the last message in the view and focus is set on this message
         # then read the message.
         last_message_focused = (curr_pos == len(self.log) - 1)


### PR DESCRIPTION
This doesn't mark messages as read on any search narrow like the web app.

Fixes #624.