### PR TITLE
Multiple footer reset bug fix

### DIFF
--- a/tests/ui/test_ui.py
+++ b/tests/ui/test_ui.py
@@ -69,18 +69,22 @@ class TestView:
 
     def test_set_footer_text_with_duration(self, view, mocker,
                                            custom_text="custom", duration=5.3):
-        mocker.patch('zulipterminal.ui.View.get_random_help',
-                     return_value=['some help text'])
-        mock_sleep = mocker.patch('time.sleep')
+        mocker.patch('zulipterminal.ui.View._reset_footer_text')
 
         view.set_footer_text([custom_text], duration)
 
-        view._w.footer.set_text.assert_has_calls([
-            mocker.call([custom_text]),
-            mocker.call(['some help text'])
-        ])
+        view._w.footer.set_text.assert_called_once_with([custom_text])
+        view.controller.update_screen.assert_called_once_with()
+        view._reset_footer_text.assert_called_once_with(duration)
+
+    def test__reset_footer_text(self, view, mocker, duration=46.2):
+        mock_sleep = mocker.patch('time.sleep')
+        mocker.patch('zulipterminal.ui.View.set_footer_text')
+
+        view._reset_footer_text(duration)
+
         mock_sleep.assert_called_once_with(duration)
-        assert view.controller.update_screen.call_count == 2
+        view.set_footer_text.assert_called_once_with()
 
     @pytest.mark.parametrize('suggestions, state, truncated, footer_text', [
         ([], None, False, [' [No matches found]']),

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -1,3 +1,4 @@
+import queue
 import random
 import re
 import time
@@ -33,6 +34,7 @@ class View(urwid.WidgetWrap):
         self.unpinned_streams = self.model.unpinned_streams
         self.write_box = WriteBox(self)
         self.search_box = SearchBox(self.controller)
+        self.footer_reset_threads = queue.Queue()  # type: queue.Queue[float]
 
         self.message_view = None  # type: Any
 
@@ -86,8 +88,12 @@ class View(urwid.WidgetWrap):
     @asynch
     def _reset_footer_text(self, duration: float) -> None:
         assert duration > 0
+        self.footer_reset_threads.put(duration)
         time.sleep(duration)
-        self.set_footer_text()
+        self.footer_reset_threads.get()
+
+        if self.footer_reset_threads.empty():
+            self.set_footer_text()
 
     @asynch
     def set_typeahead_footer(self, suggestions: List[str],

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -81,9 +81,13 @@ class View(urwid.WidgetWrap):
         self._w.footer.set_text(text)
         self.controller.update_screen()
         if duration is not None:
-            assert duration > 0
-            time.sleep(duration)
-            self.set_footer_text()
+            self._reset_footer_text(duration)
+
+    @asynch
+    def _reset_footer_text(self, duration: float) -> None:
+        assert duration > 0
+        time.sleep(duration)
+        self.set_footer_text()
 
     @asynch
     def set_typeahead_footer(self, suggestions: List[str],


### PR DESCRIPTION
This PR introduces a queue to keep track of the currently active sleep threads, and resets the footer only if the queue is empty.

Fixes #647
(Alternate fix: #748)