### PR TITLE
Order typeahead by narrow/recipients

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -134,6 +134,7 @@ general_stream = {
     'stream_weekly_traffic': 0,
     'push_notifications': False,
     'email_address': 'general@example.comm',
+    'subscribers': [1001, 11, 12]
 }
 
 # This is a private stream;
@@ -152,6 +153,7 @@ secret_stream = {
     'desktop_notifications': False,
     'stream_weekly_traffic': 0,
     'push_notifications': False,
+    'subscribers': [1001, 11]
 }
 
 
@@ -173,6 +175,7 @@ def streams_fixture():
             'stream_weekly_traffic': 0,
             'push_notifications': False,
             'email_address': 'stream{}@example.com'.format(i),
+            'subscribers': [1001, 11, 12]
         })
     return deepcopy(streams)
 

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -151,6 +151,7 @@ class TestController:
         controller.model.index = index_all_messages
         controller.view.message_view = mocker.patch('urwid.ListBox')
         controller.model.user_email = "some@email"
+        controller.model.user_id = 1
         controller.model.stream_dict = {
             205: {
                 'color': '#ffffff',
@@ -174,6 +175,7 @@ class TestController:
         controller.model.narrow = []
         controller.model.index = index_user
         controller.view.message_view = mocker.patch('urwid.ListBox')
+        controller.model.user_id = 1
         controller.model.user_email = "some@email"
 
         controller.show_all_pm('')
@@ -191,6 +193,7 @@ class TestController:
         controller.model.narrow = []
         controller.model.index = index_all_starred
         controller.model.muted_streams = set()  # FIXME Expand upon this
+        controller.model.user_id = 1
         controller.model.muted_topics = []  # FIXME Expand upon this
         controller.model.user_email = "some@email"
         controller.model.stream_dict = {
@@ -217,6 +220,7 @@ class TestController:
         controller.model.muted_streams = set()  # FIXME Expand upon this
         controller.model.muted_topics = []  # FIXME Expand upon this
         controller.model.user_email = "some@email"
+        controller.model.user_id = 1
         controller.model.stream_dict = {
             205: {
                 'color': '#ffffff',

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -1441,12 +1441,14 @@ class TestModel:
     @pytest.mark.parametrize('event, final_muted_streams, ', [
         (
             {'property': 'in_home_view',
+             'op': 'update',
              'stream_id': 19,
              'value': True},
             {15}
         ),
         (
             {'property': 'in_home_view',
+             'op': 'update',
              'stream_id': 30,
              'value': False},
             {15, 19, 30}
@@ -1480,6 +1482,7 @@ class TestModel:
         (
             {
                 'property': 'pin_to_top',
+                'op': 'update',
                 'stream_id': 6,
                 'value': True
             },
@@ -1489,6 +1492,7 @@ class TestModel:
         (
             {
                 'property': 'pin_to_top',
+                'op': 'update',
                 'stream_id': 8,
                 'value': False
             },

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -147,6 +147,23 @@ class TestWriteBox:
         typeahead_string = write_box.generic_autocomplete(text, state)
         assert typeahead_string == required_typeahead
 
+    @pytest.mark.parametrize('text, state, required_typeahead, recipients', [
+        ('@', 0, '@**Human 2**', [12]),
+        ('@', 1, '@**Human Myself**', [12]),
+        ('@', 2, '@**Human 1**', [12]),
+        ('@', -1, '@*Group 4*', [12]),
+        ('@', 0, '@**Human 1**', [11, 12]),
+        ('@', 1, '@**Human 2**', [11, 12]),
+        ('@', 2, '@**Human Myself**', [11, 12]),
+        ('@', -1, '@*Group 4*', [11, 12]),
+    ])
+    def test_generic_autocomplete_mentions_subscribers(self, write_box, text,
+                                                       required_typeahead,
+                                                       state, recipients):
+        write_box.recipient_user_ids = recipients
+        typeahead_string = write_box.generic_autocomplete(text, state)
+        assert typeahead_string == required_typeahead
+
     @pytest.mark.parametrize('text, state, required_typeahead, to_pin', [
         # With no streams pinned.
         ('#Stream', 0, '#**Stream 1**', []),  # 1st-word startswith match.

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -107,13 +107,13 @@ class TestWriteBox:
         ('@Gro', 1, '@*Group 2*'),
         ('@Grou', 1, '@*Group 2*'),
         # Expected sequence of autocompletes from '@'
-        ('@', 0, '@*Group 1*'),
-        ('@', 1, '@*Group 2*'),
-        ('@', 2, '@*Group 3*'),
-        ('@', 3, '@*Group 4*'),
-        ('@', 4, '@**Human Myself**'),
-        ('@', 5, '@**Human 1**'),
-        ('@', 6, '@**Human 2**'),
+        ('@', 0, '@**Human Myself**'),
+        ('@', 1, '@**Human 1**'),
+        ('@', 2, '@**Human 2**'),
+        ('@', 3, '@*Group 1*'),
+        ('@', 4, '@*Group 2*'),
+        ('@', 5, '@*Group 3*'),
+        ('@', 6, '@*Group 4*'),
         ('@', 7, None),  # Reached last match
         ('@', 8, None),  # Beyond end
         # Expected sequence of autocompletes from '@_'

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -655,44 +655,47 @@ class Model:
                     return stream
             return []
 
-        if hasattr(self.controller, 'view'):
-            if event.get('property', None) == 'in_home_view':
-                stream_id = event['stream_id']
+        if event['op'] == 'update':
+            if hasattr(self.controller, 'view'):
+                if event.get('property', None) == 'in_home_view':
+                    stream_id = event['stream_id']
 
-                # FIXME: Does this always contain the stream_id?
-                stream_button = (
-                    self.controller.view.stream_id_to_button[stream_id]
-                )
+                    # FIXME: Does this always contain the stream_id?
+                    stream_button = (
+                        self.controller.view.stream_id_to_button[stream_id]
+                    )
 
-                if event['value']:  # Unmuting streams
-                    self.muted_streams.remove(stream_id)
-                    stream_button.mark_unmuted()
-                else:  # Muting streams
-                    self.muted_streams.add(stream_id)
-                    stream_button.mark_muted()
-                self.controller.update_screen()
-            elif event.get('property', None) == 'pin_to_top':
-                stream_id = event['stream_id']
+                    if event['value']:  # Unmuting streams
+                        self.muted_streams.remove(stream_id)
+                        stream_button.mark_unmuted()
+                    else:  # Muting streams
+                        self.muted_streams.add(stream_id)
+                        stream_button.mark_muted()
+                    self.controller.update_screen()
+                elif event.get('property', None) == 'pin_to_top':
+                    stream_id = event['stream_id']
 
-                # FIXME: Does this always contain the stream_id?
-                stream_button = (
-                    self.controller.view.stream_id_to_button[stream_id]
-                )
+                    # FIXME: Does this always contain the stream_id?
+                    stream_button = (
+                        self.controller.view.stream_id_to_button[stream_id]
+                    )
 
-                if event['value']:
-                    stream = get_stream_by_id(self.unpinned_streams, stream_id)
-                    if stream:
-                        self.unpinned_streams.remove(stream)
-                        self.pinned_streams.append(stream)
-                else:
-                    stream = get_stream_by_id(self.pinned_streams, stream_id)
-                    if stream:
-                        self.pinned_streams.remove(stream)
-                        self.unpinned_streams.append(stream)
-                sort_streams(self.unpinned_streams)
-                sort_streams(self.pinned_streams)
-                self.controller.view.left_panel.update_structure()
-                self.controller.update_screen()
+                    if event['value']:
+                        stream = get_stream_by_id(self.unpinned_streams,
+                                                  stream_id)
+                        if stream:
+                            self.unpinned_streams.remove(stream)
+                            self.pinned_streams.append(stream)
+                    else:
+                        stream = get_stream_by_id(self.pinned_streams,
+                                                  stream_id)
+                        if stream:
+                            self.pinned_streams.remove(stream)
+                            self.unpinned_streams.append(stream)
+                    sort_streams(self.unpinned_streams)
+                    sort_streams(self.pinned_streams)
+                    self.controller.view.left_panel.update_structure()
+                    self.controller.update_screen()
 
     def _handle_typing_event(self, event: Event) -> None:
         """

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -45,6 +45,7 @@ Event = TypedDict('Event', {
     'subject': str,
     # subscription:
     'property': str,
+    'user_id': int,  # Present when a streams subscribers are updated.
     'stream_id': int,
     'value': bool,
     'message_ids': List[int]  # Present when subject of msg(s) is updated
@@ -696,6 +697,12 @@ class Model:
                     sort_streams(self.pinned_streams)
                     self.controller.view.left_panel.update_structure()
                     self.controller.update_screen()
+        elif event['op'] == 'peer_add':
+            subscribers = self.stream_dict[event['stream_id']]['subscribers']
+            subscribers.append(event['user_id'])
+        elif event['op'] == 'peer_remove':
+            subscribers = self.stream_dict[event['stream_id']]['subscribers']
+            subscribers.remove(event['user_id'])
 
     def _handle_typing_event(self, event: Event) -> None:
         """
@@ -1030,7 +1037,8 @@ class Model:
             response = self.client.register(event_types=event_types,
                                             fetch_event_types=fetch_types,
                                             client_gravatar=True,
-                                            apply_markdown=True)
+                                            apply_markdown=True,
+                                            include_subscribers=True)
         except zulip.ZulipError as e:
             return str(e)
 

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -470,6 +470,24 @@ class Model:
             ]
             raise ServerConnectionFailure(", ".join(failure_text))
 
+    def get_other_subscribers_in_stream(self, stream_id: Optional[int]=None,
+                                        stream_name: Optional[str]=None,
+                                        ) -> List[int]:
+        assert stream_id is not None or stream_name is not None
+
+        if stream_id:
+            assert stream_id in self.stream_dict
+
+            return [sub
+                    for sub in self.stream_dict[stream_id]['subscribers']
+                    if sub != self.user_id]
+        else:
+            return [sub
+                    for _, stream in self.stream_dict.items()
+                    for sub in stream['subscribers']
+                    if stream['name'] == stream_name
+                    if sub != self.user_id]
+
     def get_all_users(self) -> List[Dict[str, Any]]:
         # Dict which stores the active/idle status of users (by email)
         presences = self.initial_data['presences']

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -66,8 +66,11 @@ class WriteBox(urwid.Pile):
         ]
         self.focus_position = 1
 
-    def stream_box_view(self, caption: str='', title: str='') -> None:
+    def stream_box_view(self, stream_id: int, caption: str='', title: str='',
+                        ) -> None:
         self.set_editor_mode()
+        self.recipient_user_ids = self.model.get_other_subscribers_in_stream(
+                                            stream_id=stream_id)
         self.to_write_box = None
         self.msg_write_box = ReadlineEdit(multiline=True)
         self.msg_write_box.enable_autocomplete(
@@ -257,6 +260,9 @@ class WriteBox(urwid.Pile):
                         if not self.model.is_valid_stream(stream_name):
                             self.view.set_footer_text("Invalid stream name", 3)
                             return key
+                        user_ids = self.model.get_other_subscribers_in_stream(
+                                                    stream_name=stream_name)
+                        self.recipient_user_ids = user_ids
 
                         header.focus_col = 1
                         return key
@@ -929,7 +935,8 @@ class MessageBox(urwid.Pile):
             elif self.message['type'] == 'stream':
                 self.model.controller.view.write_box.stream_box_view(
                     caption=self.message['display_recipient'],
-                    title=self.message['subject']
+                    title=self.message['subject'],
+                    stream_id=self.stream_id,
                 )
         elif is_command_key('STREAM_MESSAGE', key):
             if self.message['type'] == 'private':
@@ -939,7 +946,8 @@ class MessageBox(urwid.Pile):
                 )
             elif self.message['type'] == 'stream':
                 self.model.controller.view.write_box.stream_box_view(
-                    caption=self.message['display_recipient']
+                    caption=self.message['display_recipient'],
+                    stream_id=self.stream_id,
                 )
         elif is_command_key('STREAM_NARROW', key):
             if self.message['type'] == 'private':

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -161,8 +161,8 @@ class WriteBox(urwid.Pile):
                  if match_user(user, text[len(prefix_string):])]
         user_typeahead = format_string(users, prefix_string + '**{}**')
 
-        combined_typeahead = group_typeahead + user_typeahead
-        combined_names = groups + users
+        combined_typeahead = user_typeahead + group_typeahead
+        combined_names = users + groups
 
         return combined_typeahead, combined_names
 


### PR DESCRIPTION
This PR orders the mentions typeahead such that participants/subscribers in the current conversation are shown first.
There are two parts to this:

**Part 1: Add ordering logic (Commits 1 & 2)** - This is done by adding a `recipient_user_ids` attribute to `WriteBox`, storing the user ids of the participants. This is supported only for private messages because subscriber data for streams is not available. Note that storing recipient ids in `MessageBox` is necessary because there is no other way to obtain the user ids.
**Part 2: Add subscriber data for streams thus enabling ordering (Commits 4 & 5)** - Set `include_subscribers` to True while fetching initial data to get stream subscriber data. Just store this in `WriteBox.recipient_user_ids` and voila!