### PR TITLE
[WIP] Unify case sensitive topic names

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -551,7 +551,8 @@ def index_topic(empty_index):
     Expected index of initial_data when model.narrow = [['stream', '7'],
                                                         ['topic', 'Test']]
     """
-    diff = {'topic_msg_ids': defaultdict(dict, {205: {'Test': {537286}}})}
+    # NOTE: Use canonicalized topic name for indexing.
+    diff = {'topic_msg_ids': defaultdict(dict, {205: {'test': {537286}}})}
     return dict(empty_index, **diff)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -800,8 +800,8 @@ def classified_unread_counts():
         'all_msg': 12,
         'all_pms': 8,
         'unread_topics': {
-            (1000, 'Some general unread topic'): 3,
-            (99, 'Some private unread topic'): 1
+            (1000, 'some general unread topic'): 3,
+            (99, 'some private unread topic'): 1
         },
         'unread_pms': {
             1: 2,

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -122,7 +122,8 @@ class TestController:
         widget = (controller.view.message_view.log
                   .extend.call_args_list[0][0][0][0])
         stream_id, topic_name = msg_box.stream_id, msg_box.topic_name
-        id_list = index_topic['topic_msg_ids'][stream_id][topic_name]
+        # NOTE: Use canonicalized topic name for lookup.
+        id_list = index_topic['topic_msg_ids'][stream_id][topic_name.lower()]
         assert {widget.original_widget.message['id']} == id_list
 
     def test_narrow_to_user(self, mocker, controller, user_button, index_user):

--- a/tests/helper/test_helper.py
+++ b/tests/helper/test_helper.py
@@ -189,16 +189,16 @@ def test_powerset(iterable, map_func, expected_powerset):
 
 
 @pytest.mark.parametrize('muted_streams, muted_topics, vary_in_unreads', [
-    ([99], [['Some general stream', 'Some general unread topic']], {
+    ([99], [['Some general stream', 'some general unread topic']], {
         'all_msg': 8,
         'streams': {99: 1},
-        'unread_topics': {(99, 'Some private unread topic'): 1},
+        'unread_topics': {(99, 'some private unread topic'): 1},
         'all_mentions': 0,
     }),
-    ([1000], [['Secret stream', 'Some private unread topic']], {
+    ([1000], [['Secret stream', 'some private unread topic']], {
         'all_msg': 8,
         'streams': {1000: 3},
-        'unread_topics': {(1000, 'Some general unread topic'): 3},
+        'unread_topics': {(1000, 'some general unread topic'): 3},
         'all_mentions': 0,
     }),
     ([1], [], {'all_mentions': 0})
@@ -214,7 +214,7 @@ def test_classify_unread_counts(mocker, initial_data, stream_dict,
     model.initial_data = initial_data
     model.is_muted_topic = mocker.Mock(side_effect=(
         lambda stream_id, topic:
-        [model.stream_dict[stream_id]['name'], topic] in muted_topics
+        [model.stream_dict[stream_id]['name'], topic.lower()] in muted_topics
     ))
     model.muted_streams = muted_streams
     assert classify_unread_counts(model) == dict(classified_unread_counts,

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -286,7 +286,8 @@ class TestModel:
           ['topic', 'BOO']], {
              'topic_msg_ids': {
                  1: {
-                     'BOO': {0, 1}
+                     # NOTE: Use canonicalized topic name for indexing.
+                     'boo': {0, 1}
                  }
              }
          }, {0, 1}),
@@ -294,7 +295,8 @@ class TestModel:
           ['topic', 'BOOBOO']], {
              'topic_msg_ids': {
                  1: {
-                     'BOO': {0, 1}
+                     # NOTE: Use canonicalized topic name for indexing.
+                     'boo': {0, 1}
                  }
              }
          }, set()),

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1144,8 +1144,8 @@ class TestLeftColumnView:
                 1000: 1,
             },
             'unread_topics': {
-                (205, 'TOPIC1'): 34,
-                (205, 'TOPIC2'): 100,
+                (205, 'topic1'): 34,
+                (205, 'topic2'): 100,
             },
             'all_mentions': 1,
         }
@@ -1200,7 +1200,7 @@ class TestLeftColumnView:
         topic_button = mocker.patch(VIEWS + '.TopicButton')
         topics_view = mocker.patch(VIEWS + '.TopicsView')
         line_box = mocker.patch(VIEWS + '.urwid.LineBox')
-        topic_list = ['TOPIC1', 'TOPIC2', 'TOPIC3']
+        topic_list = ['topic1', 'topic2', 'topic3']
         unread_count_list = [34, 100, 0]
         self.view.model.topics_in_stream = (
             mocker.Mock(return_value=topic_list)

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -409,12 +409,14 @@ def index_messages(messages: List[Message],
                 (index['stream_msg_ids_by_stream_id'][msg['stream_id']]
                  .add(msg['id']))
 
-        if (msg['type'] == 'stream' and len(narrow) == 2
-                and narrow[1][1] == msg['subject']):
-            topics_in_stream = index['topic_msg_ids'][msg['stream_id']]
-            if not topics_in_stream.get(msg['subject']):
-                topics_in_stream[msg['subject']] = set()
-            topics_in_stream[msg['subject']].add(msg['id'])
+        if msg['type'] == 'stream' and len(narrow) == 2:
+            narrow_topic = narrow[1][1]
+            message_topic = msg['subject']
+            if narrow_topic == message_topic:
+                topics_in_stream = index['topic_msg_ids'][msg['stream_id']]
+                if not topics_in_stream.get(message_topic):
+                    topics_in_stream[message_topic] = set()
+                topics_in_stream[message_topic].add(msg['id'])
 
     return index
 

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -245,6 +245,7 @@ def index_messages(messages: List[Message],
     {
         'pointer': {
             '[]': 30  # str(ZulipModel.narrow)
+            # NOTE: canonicalize_topic() is used for indexing.
             '[["stream", "verona"]]': 32,
             ...
         }

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -126,8 +126,9 @@ class Model:
         muted_topics = self.initial_data['muted_topics']
         assert set(map(len, muted_topics)) in (set(), {2}, {3})
         self._muted_topics = {
-            (stream_name, topic): (None if self.server_feature_level is None
-                                   else date_muted[0])
+            (stream_name, canonicalize_topic(topic)): (
+                None if self.server_feature_level is None else date_muted[0]
+            )
             for stream_name, topic, *date_muted in muted_topics
         }  # type: Dict[Tuple[str, str], Optional[int]]
 
@@ -440,7 +441,7 @@ class Model:
         Returns True if topic is muted via muted_topics.
         """
         stream_name = self.stream_dict[stream_id]['name']
-        topic_to_search = (stream_name, topic)
+        topic_to_search = (stream_name, canonicalize_topic(topic))
         return topic_to_search in self._muted_topics.keys()
 
     def _update_initial_data(self) -> None:

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -13,8 +13,9 @@ from typing_extensions import Literal, TypedDict
 
 from zulipterminal.config.keys import keys_for_command
 from zulipterminal.helper import (
-    Message, StreamData, asynch, canonicalize_color, classify_unread_counts,
-    display_error_if_present, index_messages, initial_index, notify, set_count,
+    Message, StreamData, asynch, canonicalize_color, canonicalize_topic,
+    classify_unread_counts, display_error_if_present, index_messages,
+    initial_index, notify, set_count,
 )
 from zulipterminal.ui_tools.utils import create_msg_box_list
 
@@ -219,7 +220,7 @@ class Model:
             if len(narrow) == 1:
                 ids = index['stream_msg_ids_by_stream_id'][stream_id]
             elif len(narrow) == 2:
-                topic = narrow[1][1]
+                topic = canonicalize_topic(narrow[1][1])
                 ids = index['topic_msg_ids'][stream_id].get(topic, set())
         elif narrow[0][1] == 'private':
             ids = index['private_msg_ids']

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -15,8 +15,8 @@ from typing_extensions import Literal, TypedDict
 from zulipterminal.config.keys import keys_for_command
 from zulipterminal.helper import (
     Message, StreamData, asynch, canonicalize_color, canonicalize_topic,
-    classify_unread_counts, display_error_if_present, index_messages,
-    initial_index, notify, set_count,
+    classify_unread_counts, compare_lowercase, display_error_if_present,
+    index_messages, initial_index, notify, set_count,
 )
 from zulipterminal.ui_tools.utils import create_msg_box_list
 
@@ -911,7 +911,8 @@ class Model:
                 if (append_to_stream
                     and (len(self.narrow) == 1
                          or (len(self.narrow) == 2
-                             and self.narrow[1][1] == message['subject']))):
+                             and compare_lowercase(self.narrow[1][1],
+                                                   message['subject'])))):
                     msg_log.append(msg_w)
 
             elif (message['type'] == 'private' and len(self.narrow) == 1
@@ -1040,7 +1041,8 @@ class Model:
                 # Remove the message if it no longer belongs in the current
                 # narrow.
                 if (len(self.narrow) == 2
-                        and msg_box.message['subject'] != self.narrow[1][1]):
+                        and not compare_lowercase(msg_box.message['subject'],
+                                                  self.narrow[1][1])):
                     view.message_view.log.remove(msg_w)
                     # Change narrow if there are no messages left in the
                     # current narrow.

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -20,8 +20,8 @@ from zulipterminal.config.symbols import (
     STREAM_TOPIC_SEPARATOR, TIME_MENTION_MARKER,
 )
 from zulipterminal.helper import (
-    Message, format_string, match_emoji, match_group, match_stream,
-    match_topics, match_user,
+    Message, compare_lowercase, format_string, match_emoji, match_group,
+    match_stream, match_topics, match_user,
 )
 from zulipterminal.ui_tools.tables import render_table
 from zulipterminal.urwid_types import urwid_Size
@@ -432,7 +432,7 @@ class MessageBox(urwid.Pile):
         if self.message['type'] == 'stream':
             return not (
                 last_msg['type'] == 'stream'
-                and self.topic_name == last_msg['subject']
+                and compare_lowercase(self.topic_name, last_msg['subject'])
                 and self.stream_name == last_msg['display_recipient']
             )
         elif self.message['type'] == 'private':

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -11,7 +11,9 @@ from zulipterminal.config.keys import (
 from zulipterminal.config.symbols import (
     CHECK_MARK, LIST_TITLE_BAR_LINE, PINNED_STREAMS_DIVIDER,
 )
-from zulipterminal.helper import Message, asynch, match_stream, match_user
+from zulipterminal.helper import (
+    Message, asynch, canonicalize_topic, match_stream, match_user,
+)
 from zulipterminal.ui_tools.boxes import PanelSearchBox
 from zulipterminal.ui_tools.buttons import (
     HomeButton, MentionedButton, MessageLinkButton, PMButton, StarredButton,
@@ -790,7 +792,7 @@ class LeftColumnView(urwid.Pile):
                 controller=self.controller,
                 width=self.width,
                 count=self.model.unread_counts['unread_topics'].
-                get((stream_id, topic), 0)
+                get((stream_id, canonicalize_topic(topic)), 0)
             )
             for topic in topics
         ]


### PR DESCRIPTION
This unifies case sensitive topic names using lowercase topic names as an invariant.

#### Crux
We need some kind of invariant which we can rely upon for lookups and comparisons given that topics can change their casing at any point. Consequently, I propose to use lowercase topics as keys wherever store/index data.

#### Commits
The current commit structure is temporary. I have fixed one thing per commit to represent how I went about the changes but we would definitely want to squash them (except the first) before merging.

I would greatly appreciate feedback about the proposal and what else should be fixed.
