### PR TITLE
docs: Update obsolete relative links in getting-started.md

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
 Hi, are you new to [Zulip](https://github.com/zulip/zulip)? If so, we recommend trying out our [web-client](https://chat.zulip.org) first to understand the concept of [streams/topics/PMs](https://zulip.com/help/about-streams-and-topics) in the world of Zulip. Just sending a message or two in [#test here](https://chat.zulip.org/#narrow/stream/7-test-here) stream should help you get started.
 
-Now let's help you get started with using zulip terminal. First, go ahead and complete the [installation](https://github.com/zulip/zulip-terminal#installation--running). If you encountered any issues, we have common issues and their solutions listed [here](https://github.com/zulip/zulip-terminal#troubleshooting-common-issues).
+Now let's help you get started with using zulip terminal. First, go ahead and complete the [installation](https://github.com/zulip/zulip-terminal#installation). If you encountered any issues, we have common issues and their solutions listed [here](https://github.com/zulip/zulip-terminal/blob/master/docs/FAQ.md).
 
 If you encountered any issues above or have any queries, feel free to ask for help at [#zulip-terminal](https://chat.zulip.org/#narrow/stream/206-zulip-terminal) or support@zulip.com.
 


### PR DESCRIPTION
These links were out-of-date against the recent documentation updates that were merged.