### PR TITLE
Support footlinks configuration via zuliprc

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ site=https://realm.zulipchat.com
 theme=default
 # Autohide defaults to 'no_autohide', but can be set to 'autohide' to hide the left & right panels except when focused.
 autohide=autohide
+# Footlinks default to 'enabled', but can be set to 'disabled' to hide footlinks.
+footlinks=disabled
 # Notify defaults to 'disabled', but can be set to 'enabled' to display notifications (see next section).
 notify=enabled
 ```

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -96,6 +96,7 @@ def test_valid_zuliprc_but_no_connection(capsys, mocker, minimal_zuliprc,
         "Loading with:",
         "   theme 'zt_dark' specified with no config.",
         "   autohide setting 'no_autohide' specified with no config.",
+        "   footlinks setting 'enabled' specified with no config.",
         "\x1b[91m",
         ("Error connecting to Zulip server: {}.\x1b[0m".
             format(server_connection_error)),
@@ -133,6 +134,7 @@ def test_warning_regarding_incomplete_theme(capsys, mocker, monkeypatch,
         "      (you could try: {}, {})"
         "\x1b[0m".format('a', 'b'),
         "   autohide setting 'no_autohide' specified with no config.",
+        "   footlinks setting 'enabled' specified with no config.",
         "\x1b[91m",
         ("Error connecting to Zulip server: {}.\x1b[0m".
             format(server_connection_error)),

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -13,6 +13,7 @@ CORE = "zulipterminal.core"
 class TestController:
     @pytest.fixture(autouse=True)
     def mock_external_classes(self, mocker: Any) -> None:
+        mocker.patch('zulipterminal.ui_tools.boxes.MessageBox.footlinks_view')
         self.client = mocker.patch('zulip.Client')
         # Patch init only, in general, allowing specific patching elsewhere
         self.model = mocker.patch(CORE + '.Model.__init__', return_value=None)
@@ -30,8 +31,9 @@ class TestController:
         self.theme = 'default'
         self.autohide = True  # FIXME Add tests for no-autohide
         self.notify_enabled = False
+        self.footlinks_enabled = True
         result = Controller(self.config_file, self.theme, 256, self.autohide,
-                            self.notify_enabled)
+                            self.notify_enabled, self.footlinks_enabled)
         result.view.message_view = mocker.Mock()  # set in View.__init__
         return result
 

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -2284,6 +2284,7 @@ class TestMessageBox:
     )
     def test_footlinks_view(self, message_fixture, message_links,
                             expected_text, expected_attrib):
+        self.model.controller.footlinks_enabled = True
         msg_box = MessageBox(message_fixture, self.model, None)
 
         footlinks = msg_box.footlinks_view(message_links)
@@ -2294,6 +2295,22 @@ class TestMessageBox:
         else:
             assert footlinks is None
             assert not hasattr(footlinks, 'original_widget')
+
+    @pytest.mark.parametrize('footlinks_enabled, expected_instance', [
+        (False, type(None)),
+        (True, Padding),
+    ])
+    def test_footlinks_enabled(self, message_fixture, footlinks_enabled,
+                               expected_instance):
+        message_links = OrderedDict([
+            ('https://github.com/zulip/zulip-terminal', ('ZT', 1, True)),
+        ])
+        self.model.controller.footlinks_enabled = footlinks_enabled
+        msg_box = MessageBox(message_fixture, self.model, None)
+
+        footlinks = msg_box.footlinks_view(message_links)
+
+        assert isinstance(footlinks, expected_instance)
 
     @pytest.mark.parametrize(
         'key', keys_for_command('ENTER'),

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -189,6 +189,7 @@ def parse_zuliprc(zuliprc_str: str) -> Dict[str, Any]:
         'theme': ('zt_dark', NO_CONFIG),
         'autohide': ('no_autohide', NO_CONFIG),
         'notify': ('disabled', NO_CONFIG),
+        'footlinks': ('enabled', NO_CONFIG),
     }
 
     if 'zterm' in zuliprc:
@@ -269,11 +270,14 @@ def main(options: Optional[List[str]]=None) -> None:
                            format(", ".join(complete))))
         print("   autohide setting '{}' specified {}."
               .format(*zterm['autohide']))
+        print("   footlinks setting '{}' specified {}."
+              .format(*zterm['footlinks']))
         # For binary settings
         # Specify setting in order True, False
         valid_settings = {
             'autohide': ['autohide', 'no_autohide'],
             'notify': ['enabled', 'disabled'],
+            'footlinks': ['enabled', 'disabled'],
         }
         boolean_settings = dict()  # type: Dict[str, bool]
         for setting, valid_values in valid_settings.items():

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -30,11 +30,12 @@ class Controller:
 
     def __init__(self, config_file: str, theme: ThemeSpec,
                  color_depth: int,
-                 autohide: bool, notify: bool) -> None:
+                 autohide: bool, notify: bool, footlinks: bool) -> None:
         self.theme = theme
         self.color_depth = color_depth
         self.autohide = autohide
         self.notify_enabled = notify
+        self.footlinks_enabled = footlinks
 
         self._editor = None  # type: Optional[Any]
 

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -460,6 +460,10 @@ class MessageBox(urwid.Pile):
     def footlinks_view(
         self, message_links: 'OrderedDict[str, Tuple[str, int, bool]]',
     ) -> Any:
+        # Return if footlinks are disabled by the user.
+        if not self.model.controller.footlinks_enabled:
+            return None
+
         footlinks = []
         for link, (text, index, show_footlink) in message_links.items():
             if not show_footlink:


### PR DESCRIPTION
This adds support for configuring footlinks view in MessageBox (defaults to 'enabled') via zuliprc.

README updated with instructions.

Tests amended.