### PR TITLE
Check validity of recipients on manual modification

### DIFF
--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -654,6 +654,18 @@ class Model:
                 else:
                     raise RuntimeError("Unknown typing event operation")
 
+    def get_invalid_recipient_emails(self, recipient_emails: List[str]
+                                     ) -> List[str]:
+
+        return [email for email in recipient_emails
+                if email not in self.user_dict]
+
+    def is_valid_stream(self, stream_name: str) -> bool:
+        for stream in self.stream_dict.values():
+            if stream['name'] == stream_name:
+                return True
+        return False
+
     def notify_user(self, message: Message) -> str:
         """
         return value signifies if notification failed, if it should occur

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -232,12 +232,30 @@ class WriteBox(urwid.Pile):
                 return key
             header = self.contents[0][0]
             # toggle focus position
-            if self.focus_position == 0 and self.to_write_box is None:
-                if header.focus_col == 0:
-                    header.focus_col = 1
-                    return key
+            if self.focus_position == 0:
+                if self.to_write_box is None:
+                    if header.focus_col == 0:
+                        stream_name = header[0].edit_text
+                        if not self.model.is_valid_stream(stream_name):
+                            self.view.set_footer_text("Invalid stream name", 3)
+                            return key
+
+                        header.focus_col = 1
+                        return key
+                    else:
+                        header.focus_col = 0
                 else:
-                    header.focus_col = 0
+                    recipient_box = header.original_widget
+                    recipient_emails = [email.strip() for email in
+                                        recipient_box.edit_text.split(',')]
+                    invalid_emails = self.model.get_invalid_recipient_emails(
+                                                              recipient_emails)
+                    if invalid_emails:
+                        invalid_emails_error = ('Invalid recipient(s) - '
+                                                + ', '.join(invalid_emails))
+                        self.view.set_footer_text(invalid_emails_error, 3)
+                        return key
+
             self.focus_position = self.focus_position == 0
             header.focus_col = 0
 

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -230,15 +230,16 @@ class WriteBox(urwid.Pile):
         elif is_command_key('TAB', key):
             if len(self.contents) == 0:
                 return key
+            header = self.contents[0][0]
             # toggle focus position
             if self.focus_position == 0 and self.to_write_box is None:
-                if self.contents[0][0].focus_col == 0:
-                    self.contents[0][0].focus_col = 1
+                if header.focus_col == 0:
+                    header.focus_col = 1
                     return key
                 else:
-                    self.contents[0][0].focus_col = 0
+                    header.focus_col = 0
             self.focus_position = self.focus_position == 0
-            self.contents[0][0].focus_col = 0
+            header.focus_col = 0
 
         key = super().keypress(size, key)
         return key


### PR DESCRIPTION
Users can manually alter the recipients/stream name, but there is
currently to check in place to ensure validity of these modifications.
This commit checks the recipients everytime the user presses TAB on the
boxes (stream name and recipients for private messages).