### PR TITLE
[WIP] Handle media links

### DIFF
--- a/tests/helper/test_helper.py
+++ b/tests/helper/test_helper.py
@@ -329,12 +329,12 @@ def test_process_media(mocker, media_path='/tmp/zt-somerandomtext-image.png',
     # The command, which is platform dependent, does not matter for the test.
     mocker.patch('zulipterminal.helper.LINUX', True)
     controller = mocker.Mock()
-    mocked_open_media = mocker.patch('zulipterminal.helper.open_media')
 
     process_media(controller, media_link)
 
-    mocked_open_media.assert_called_once_with(controller, 'xdg-open',
-                                              media_path)
+    controller.show_media_confirmation_popup.assert_called_once_with(
+        open_media, 'xdg-open', media_path
+    )
 
 
 @pytest.mark.parametrize('returncode, error', [

--- a/tests/ui_tools/test_buttons.py
+++ b/tests/ui_tools/test_buttons.py
@@ -59,11 +59,12 @@ class TestMessageLinkButton:
     @pytest.mark.parametrize([
             'link',
             'handle_narrow_link_called',
+            'process_media_called',
         ],
         [
-            (SERVER_URL + '/#narrow/stream/1-Stream-1', True),
-            (SERVER_URL + '/user_uploads/some/path/image.png', False),
-            ('https://foo.com', False),
+            (SERVER_URL + '/#narrow/stream/1-Stream-1', True, False),
+            (SERVER_URL + '/user_uploads/some/path/image.png', False, True),
+            ('https://foo.com', False, False),
         ],
         ids=[
             'internal_narrow_link',
@@ -71,16 +72,20 @@ class TestMessageLinkButton:
             'external_link',
         ]
     )
-    def test_handle_link(self, mocker, link, handle_narrow_link_called):
+    def test_handle_link(self, mocker, link, handle_narrow_link_called,
+                         process_media_called):
         self.controller.model.server_url = SERVER_URL
+        self.controller.loop.widget = mocker.Mock(spec=Overlay)
         self.handle_narrow_link = (
             mocker.patch(BUTTONS + '.MessageLinkButton.handle_narrow_link')
         )
+        self.process_media = mocker.patch(BUTTONS + '.process_media')
         mocked_button = self.message_link_button(link=link)
 
         mocked_button.handle_link()
 
         assert self.handle_narrow_link.called == handle_narrow_link_called
+        assert self.process_media.called == process_media_called
 
     @pytest.mark.parametrize('stream_data, expected_response', [
             ('206-zulip-terminal', dict(stream_id=206, stream_name=None)),

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -181,7 +181,8 @@ class Controller:
             ('bold', media_path),
             '. Do you want to view it?'
         ])
-        self.loop.widget = PopUpConfirmationView(self, question, callback)
+        self.loop.widget = PopUpConfirmationView(self, question, callback,
+                                                 location='center')
 
     def search_messages(self, text: str) -> None:
         # Search for a text in messages

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -173,6 +173,16 @@ class Controller:
                             'Edit History (up/down scrolls)')
         )
 
+    def show_media_confirmation_popup(self, func: Any, command: str,
+                                      media_path: str) -> None:
+        callback = partial(func, self, command, media_path)
+        question = urwid.Text([
+            'Your requested media has been downloaded at ',
+            ('bold', media_path),
+            '. Do you want to view it?'
+        ])
+        self.loop.widget = PopUpConfirmationView(self, question, callback)
+
     def search_messages(self, text: str) -> None:
         # Search for a text in messages
         self.model.index['search'].clear()

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -678,7 +678,7 @@ def process_media(controller: Any, media_link: str) -> None:
     elif MACOS:
         command = 'open'
 
-    open_media(controller, command, media_path)
+    controller.show_media_confirmation_popup(open_media, command, media_path)
 
 
 @asynch

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -665,6 +665,11 @@ def process_media(controller: Any, media_link: str) -> None:
             for chunk in r.iter_content(chunk_size=8192):
                 if chunk:  # Filter out keep-alive new chunks.
                     f.write(chunk)
+                    controller.view.set_footer_text([
+                        ' Downloading ', ('bold', media_name),
+                    ])
+        controller.view.set_footer_text([' Downloaded ', ('bold', media_name)],
+                                        duration=3)
 
     if LINUX:
         command = 'xdg-open'

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -7,7 +7,7 @@ from typing_extensions import TypedDict
 
 from zulipterminal.config.keys import is_command_key, keys_for_command
 from zulipterminal.helper import (
-    StreamData, edit_mode_captions, hash_util_decode,
+    StreamData, edit_mode_captions, hash_util_decode, process_media,
 )
 from zulipterminal.urwid_types import urwid_Size
 
@@ -300,6 +300,11 @@ class MessageLinkButton(urwid.Button):
         server_url = self.model.server_url
         if self.link.startswith(urljoin(server_url, '/#narrow/')):
             self.handle_narrow_link()
+        elif self.link.startswith(urljoin(server_url, '/user_uploads/')):
+            # Exit pop-up promptly, let the media download in the background.
+            if isinstance(self.controller.loop.widget, urwid.Overlay):
+                self.controller.exit_popup()
+            process_media(self.controller, self.link)
 
     @staticmethod
     def _decode_stream_data(encoded_stream_data: str) -> DecodedStream:


### PR DESCRIPTION
Thanks to @amanagr for his initial work in #359. :+1:

The PR extracts a few common elements from the PR but has changes to make the function compatible with `MessageLinkButton`.

#### Commits
* The first commit is cherry-picked from #708.
* The second commit is from #359 with a few amendments that were necessary to make it work with `MessageLinkButton`.
* The third commit integrates the introduced function in `MesssageLinkButton` to handle media links.
* The fourth commit makes `open_media` asynch and shows downloading updates in the footer.
* The fifth commit is a refactor that extracts `PopUpConfirmationView` instantiation for its subsequent commit where it is used in `open_media`.

#### Potential follow-up
* Skip downloading existing media.


I would greatly appreciate any early feedback and bug/caveats report.

Partially fixes #764.