### PR TITLE
bugfix: ui: Do not update footer if new text is same as current.

### DIFF
--- a/tests/ui/test_ui.py
+++ b/tests/ui/test_ui.py
@@ -76,6 +76,15 @@ class TestView:
         assert view.users_view == right_view()
         assert return_value == (line_box(), right_tab())
 
+    def test_set_footer_text_same_test(
+        self, view: View, mocker: MockerFixture, text: List[str] = ["heya"]
+    ) -> None:
+        view._w.footer.text = text
+
+        view.set_footer_text(text)
+
+        view._w.footer.set_text.assert_not_called()
+
     def test_set_footer_text_default(self, view: View, mocker: MockerFixture) -> None:
         mocker.patch(VIEW + ".get_random_help", return_value=["some help text"])
 

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -103,6 +103,11 @@ class View(urwid.WidgetWrap):
         style: str = "footer",
         duration: Optional[float] = None,
     ) -> None:
+        # Avoid updating repeatedly (then pausing and showing default text)
+        # This is simple, though doesn't avoid starting one thread for each call
+        if text_list == self._w.footer.text:
+            return
+
         if text_list is None:
             text = self.get_random_help()
         else:


### PR DESCRIPTION
This prevents rapid footer updates if an error message is triggered
multiple times. An example of this would be a user holding-down/pressing
too often the edit message key on a message that cannot be edited.

This fix does not account for updates that might happen for different
messages, but we can safely assume that the time difference between such
messages would not be too small and such a bug would most likely not
occur.

Test added.

Fixes #647.