### PR TITLE
Markup markdown text in stream description

### DIFF
--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -9,6 +9,8 @@ from zulipterminal.version import ZT_VERSION
 
 CORE = "zulipterminal.core"
 
+SERVER_URL = "https://chat.zulip.zulip"
+
 
 class TestController:
     @pytest.fixture(autouse=True)
@@ -40,6 +42,7 @@ class TestController:
                             self.in_explore_mode, self.autohide,
                             self.notify_enabled, self.footlinks_enabled)
         result.view.message_view = mocker.Mock()  # set in View.__init__
+        result.model.server_url = SERVER_URL
         return result
 
     def test_initialize_controller(self, controller, mocker) -> None:

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -15,7 +15,7 @@ SERVER_URL = "https://chat.zulip.zulip"
 class TestController:
     @pytest.fixture(autouse=True)
     def mock_external_classes(self, mocker: Any) -> None:
-        mocker.patch('zulipterminal.ui_tools.boxes.MessageBox.footlinks_view')
+        mocker.patch('zulipterminal.ui_tools.boxes.MessageBox.main_view')
         self.client = mocker.patch('zulip.Client')
         # Patch init only, in general, allowing specific patching elsewhere
         self.model = mocker.patch(CORE + '.Model.__init__', return_value=None)

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -2015,33 +2015,37 @@ class TestMessageBox:
         ]
 
     @pytest.mark.parametrize(['message_links', 'expected_text',
-                              'expected_attrib'], [
+                              'expected_attrib', 'expected_footlinks_width'], [
             (OrderedDict([
                 ('https://github.com/zulip/zulip-terminal/pull/1', ('#T1', 1,
                                                                     True)),
              ]),
              '1: https://github.com/zulip/zulip-terminal/pull/1',
-             [('msg_link_index', 2), (None, 1), ('msg_link', 46)]),
+             [('msg_link_index', 2), (None, 1), ('msg_link', 46)],
+             49),
             (OrderedDict([
                 ('https://foo.com', ('Foo!', 1, True)),
                 ('https://bar.com', ('Bar!', 2, True)),
              ]),
              '1: https://foo.com\n2: https://bar.com',
              [('msg_link_index', 2), (None, 1), ('msg_link', 15), (None, 1),
-              ('msg_link_index', 2), (None, 1), ('msg_link', 15)]),
+              ('msg_link_index', 2), (None, 1), ('msg_link', 15)],
+             18),
             (OrderedDict([
                 ('https://example.com', ('https://example.com', 1, False)),
                 ('http://example.com', ('http://example.com', 2, False)),
              ]),
              None,
-             None),
+             None,
+             0),
             (OrderedDict([
                 ('https://foo.com', ('https://foo.com, Text', 1, True)),
                 ('https://bar.com', ('Text, https://bar.com', 2, True)),
              ]),
              '1: https://foo.com\n2: https://bar.com',
              [('msg_link_index', 2), (None, 1), ('msg_link', 15), (None, 1),
-              ('msg_link_index', 2), (None, 1), ('msg_link', 15)]),
+              ('msg_link_index', 2), (None, 1), ('msg_link', 15)],
+             18),
             (OrderedDict([
                 ('https://foo.com', ('Foo!', 1, True)),
                 ('http://example.com', ('example.com', 2, False)),
@@ -2049,7 +2053,8 @@ class TestMessageBox:
              ]),
              '1: https://foo.com\n3: https://bar.com',
              [('msg_link_index', 2), (None, 1), ('msg_link', 15), (None, 1),
-              ('msg_link_index', 2), (None, 1), ('msg_link', 15)]),
+              ('msg_link_index', 2), (None, 1), ('msg_link', 15)],
+             18),
         ],
         ids=[
             'one_footlink',
@@ -2060,15 +2065,18 @@ class TestMessageBox:
         ]
     )
     def test_footlinks_view(self, message_links, expected_text,
-                            expected_attrib):
-        footlinks = MessageBox.footlinks_view(
+                            expected_attrib, expected_footlinks_width):
+        footlinks, footlinks_width = MessageBox.footlinks_view(
             message_links,
             footlinks_enabled=True,
+            padded=True,
+            wrap='ellipsis',
         )
 
         if expected_text:
             assert footlinks.original_widget.text == expected_text
             assert footlinks.original_widget.attrib == expected_attrib
+            assert footlinks_width == expected_footlinks_width
         else:
             assert footlinks is None
             assert not hasattr(footlinks, 'original_widget')
@@ -2082,9 +2090,11 @@ class TestMessageBox:
             ('https://github.com/zulip/zulip-terminal', ('ZT', 1, True)),
         ])
 
-        footlinks = MessageBox.footlinks_view(
+        footlinks, _ = MessageBox.footlinks_view(
             message_links,
             footlinks_enabled=footlinks_enabled,
+            padded=True,
+            wrap='ellipsis',
         )
 
         assert isinstance(footlinks, expected_instance)

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -2059,12 +2059,12 @@ class TestMessageBox:
             'http_default_scheme',
         ]
     )
-    def test_footlinks_view(self, message_fixture, message_links,
-                            expected_text, expected_attrib):
-        self.model.controller.footlinks_enabled = True
-        msg_box = MessageBox(message_fixture, self.model, None)
-
-        footlinks = msg_box.footlinks_view(message_links)
+    def test_footlinks_view(self, message_links, expected_text,
+                            expected_attrib):
+        footlinks = MessageBox.footlinks_view(
+            message_links,
+            footlinks_enabled=True,
+        )
 
         if expected_text:
             assert footlinks.original_widget.text == expected_text
@@ -2077,15 +2077,15 @@ class TestMessageBox:
         (False, type(None)),
         (True, Padding),
     ])
-    def test_footlinks_enabled(self, message_fixture, footlinks_enabled,
-                               expected_instance):
+    def test_footlinks_enabled(self, footlinks_enabled, expected_instance):
         message_links = OrderedDict([
             ('https://github.com/zulip/zulip-terminal', ('ZT', 1, True)),
         ])
-        self.model.controller.footlinks_enabled = footlinks_enabled
-        msg_box = MessageBox(message_fixture, self.model, None)
 
-        footlinks = msg_box.footlinks_view(message_links)
+        footlinks = MessageBox.footlinks_view(
+            message_links,
+            footlinks_enabled=footlinks_enabled,
+        )
 
         assert isinstance(footlinks, expected_instance)
 

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -564,7 +564,7 @@ class TestStreamInfoView:
             self.stream_id: {
                 'name': 'books',
                 'invite_only': False,
-                'description': 'hey',
+                'rendered_description': '<p>Hey</p>',
                 'subscribers': [],
                 'stream_weekly_traffic': 123,
             }
@@ -584,6 +584,34 @@ class TestStreamInfoView:
         self.controller.show_stream_members.assert_called_once_with(
             stream_id=self.stream_id,
         )
+
+    @pytest.mark.parametrize('rendered_description, expected_markup', [
+        (
+            '<p>Simple</p>',
+            (None, ['', '', 'Simple']),
+        ),
+        (
+            '<p>A city in Italy <a href="http://genericlink.com">ABC</a>'
+            '<strong>Bold</strong>',
+            (None, ['', '', 'A city in Italy ', ('msg_link', 'ABC'), ' ',
+                    ('msg_link_index', '[1]'), ('msg_bold', 'Bold')]),
+        ),
+    ])
+    def test_markup_descrption(self, rendered_description, expected_markup,
+                               stream_id=10):
+        self.controller.model.stream_dict = {
+            stream_id: {
+                'name': 'ZT',
+                'invite_only': False,
+                'subscribers': [],
+                'stream_weekly_traffic': 123,
+                'rendered_description': rendered_description,
+            }
+        }
+
+        stream_info_view = StreamInfoView(self.controller, stream_id)
+
+        assert stream_info_view.markup_desc == expected_markup
 
     @pytest.mark.parametrize('key', {*keys_for_command('GO_BACK'),
                                      *keys_for_command('STREAM_DESC')})

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -4,6 +4,7 @@ import pytest
 from urwid import Columns, Text
 
 from zulipterminal.config.keys import is_command_key, keys_for_command
+from zulipterminal.ui_tools.boxes import MessageBox
 from zulipterminal.ui_tools.views import (
     AboutView, EditHistoryView, EditModeView, HelpView, MsgInfoView,
     PopUpConfirmationView, PopUpView, StreamInfoView, StreamMembersView,
@@ -612,6 +613,31 @@ class TestStreamInfoView:
         stream_info_view = StreamInfoView(self.controller, stream_id)
 
         assert stream_info_view.markup_desc == expected_markup
+
+    @pytest.mark.parametrize(['message_links', 'expected_text',
+                              'expected_attrib', 'expected_footlinks_width'], [
+            (OrderedDict([
+                ('https://example.com', ('Example', 1, True)),
+                ('https://generic.com', ('Generic', 2, True)),
+             ]),
+             '1: https://example.com\n2: https://generic.com',
+             [('msg_link_index', 2), (None, 1), ('msg_link', 19), (None, 1),
+              ('msg_link_index', 2), (None, 1), ('msg_link', 19)],
+             22),
+        ],
+    )
+    def test_footlinks(self, message_links, expected_text, expected_attrib,
+                       expected_footlinks_width):
+        footlinks, footlinks_width = MessageBox.footlinks_view(
+            message_links,
+            footlinks_enabled=True,
+            padded=False,
+            wrap='space',
+        )
+
+        assert footlinks.text == expected_text
+        assert footlinks.attrib == expected_attrib
+        assert footlinks_width == expected_footlinks_width
 
     @pytest.mark.parametrize('key', {*keys_for_command('GO_BACK'),
                                      *keys_for_command('STREAM_DESC')})

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -735,12 +735,17 @@ class MessageBox(urwid.Pile):
                              align='left', left=8, width=('relative', 100),
                              min_width=10, right=2)
 
-    def soup2markup(self, soup: Any, **state: Any) -> List[Any]:
+    @classmethod
+    def soup2markup(cls, soup: Any, metadata: Dict[str, Any],
+                    **state: Any
+                    ) -> Tuple[List[Any],
+                               'OrderedDict[str, Tuple[str, int, bool]]',
+                               List[Tuple[str, str]]]:
         # Ensure a string is provided, in case the soup finds none
         # This could occur if eg. an image is removed or not shown
         markup = ['']  # type: List[Union[str, Tuple[Optional[str], Any]]]
         if soup is None:  # This is not iterable, so return promptly
-            return markup
+            return markup, metadata['message_links'], metadata['time_mentions']
         unrendered_tags = {  # In pairs of 'tag_name': 'text'
             # TODO: Some of these could be implemented
             'br': '',  # No indicator of absence
@@ -758,9 +763,8 @@ class MessageBox(urwid.Pile):
         for element in soup:
             if isinstance(element, NavigableString):
                 # NORMAL STRINGS
-                if (hasattr(self, 'bq_len') and element == '\n'
-                        and self.bq_len > 0):
-                    self.bq_len -= 1
+                if element == '\n' and metadata.get('bq_len', 0) > 0:
+                    metadata['bq_len'] -= 1
                     continue
                 markup.append(element)
             elif (element.name == 'div' and element.attrs
@@ -784,7 +788,7 @@ class MessageBox(urwid.Pile):
                     markup.append(unrendered_template.format(text))
             elif element.name in ('p', 'del'):
                 # PARAGRAPH, STRIKE-THROUGH
-                markup.extend(self.soup2markup(element))
+                markup.extend(cls.soup2markup(element, metadata)[0])
             elif (element.name == 'span' and element.attrs
                   and 'emoji' in element.attrs.get('class', [])):
                 # EMOJI
@@ -810,7 +814,7 @@ class MessageBox(urwid.Pile):
                 parsed_link = urlparse(link)
                 if not parsed_link.scheme:  # => relative link
                     # Prepend org url to convert it to an absolute link
-                    link = urljoin(self.model.server_url, link)
+                    link = urljoin(metadata['server_url'], link)
 
                 text = text if text else link
 
@@ -829,9 +833,9 @@ class MessageBox(urwid.Pile):
                     last_segment = text.split('/')[-1]
                     if '.' in last_segment:
                         new_text = last_segment  # Filename.
-                    elif text.startswith(self.model.server_url):
+                    elif text.startswith(metadata['server_url']):
                         # Relative URL.
-                        new_text = text.split(self.model.server_url)[-1]
+                        new_text = text.split(metadata['server_url'])[-1]
                     else:
                         new_text = (
                             parsed_link.netloc if parsed_link.netloc
@@ -845,18 +849,18 @@ class MessageBox(urwid.Pile):
                         show_footlink = False
 
                 # Detect duplicate links to save screen real estate.
-                if link not in self.message_links:
-                    self.message_links[link] = (
-                        text, len(self.message_links) + 1, show_footlink
+                if link not in metadata['message_links']:
+                    metadata['message_links'][link] = (
+                        text, len(metadata['message_links']) + 1, show_footlink
                     )
                 else:
                     # Append the text if its link already exist with a
                     # different text.
                     saved_text, saved_link_index, saved_footlink_status = (
-                        self.message_links[link]
+                        metadata['message_links'][link]
                     )
                     if saved_text != text:
-                        self.message_links[link] = (
+                        metadata['message_links'][link] = (
                             '{}, {}'.format(saved_text, text),
                             saved_link_index,
                             show_footlink or saved_footlink_status,
@@ -866,12 +870,12 @@ class MessageBox(urwid.Pile):
                     ('msg_link', text),
                     ' ',
                     ('msg_link_index',
-                     '[{}]'.format(self.message_links[link][1])),
+                     '[{}]'.format(metadata['message_links'][link][1])),
                 ])
             elif element.name == 'blockquote':
                 # BLOCKQUOTE TEXT
                 markup.append((
-                    'msg_quote', self.soup2markup(element)
+                    'msg_quote', cls.soup2markup(element, metadata)[0]
                 ))
             elif element.name == 'code':
                 # CODE (INLINE?)
@@ -902,12 +906,14 @@ class MessageBox(urwid.Pile):
                 if element.name == 'ol':
                     start_number = int(element.attrs.get('start', 1))
                     state['list_index'] = start_number
-                    markup.extend(self.soup2markup(element, **state))
+                    markup.extend(cls.soup2markup(element, metadata,
+                                                  **state)[0])
                     del state['list_index']  # reset at end of this list
                 else:
                     if 'list_index' in state:
                         del state['list_index']  # this is unordered
-                    markup.extend(self.soup2markup(element, **state))
+                    markup.extend(cls.soup2markup(element, metadata,
+                                                  **state)[0])
                 del state['indent_level']  # reset indents after any list
             elif element.name == 'li':
                 # LIST ITEMS (LI)
@@ -931,7 +937,7 @@ class MessageBox(urwid.Pile):
                     markup.append('{}{} '.format('  ' * indent,
                                                  chars[(indent - 1) % 3]))
                 state['list_start'] = False
-                markup.extend(self.soup2markup(element, **state))
+                markup.extend(cls.soup2markup(element, metadata, **state)[0])
             elif element.name == 'table':
                 markup.extend(render_table(element))
             elif element.name == 'time':
@@ -956,10 +962,10 @@ class MessageBox(urwid.Pile):
                 source_text = (
                     'Original text was {}'.format(element.text.strip())
                 )
-                self.time_mentions.append((time_string, source_text))
+                metadata['time_mentions'].append((time_string, source_text))
             else:
-                markup.extend(self.soup2markup(element))
-        return markup
+                markup.extend(cls.soup2markup(element, metadata)[0])
+        return markup, metadata['message_links'], metadata['time_mentions']
 
     def main_view(self) -> List[Any]:
 
@@ -1040,7 +1046,10 @@ class MessageBox(urwid.Pile):
                 '<strong>' + self.message['sender_full_name'] + '</strong>', 1)
 
         # Transform raw message content into markup (As needed by urwid.Text)
-        content = self.transform_content()
+        content, self.message_links, self.time_mentions = (
+            self.transform_content(self.message['content'],
+                                   self.model.server_url)
+        )
 
         if self.message['id'] in self.model.index['edited_messages']:
             edited_label_size = 7
@@ -1080,15 +1089,30 @@ class MessageBox(urwid.Pile):
         ]
         return [part for part, condition in parts if condition]
 
-    def transform_content(self) -> Tuple[None, Any]:
-        soup = BeautifulSoup(self.message['content'], 'lxml')
+    @classmethod
+    def transform_content(cls, content: Any, server_url: str,
+                          ) -> Tuple[Tuple[None, Any],
+                                     'OrderedDict[str, Tuple[str, int, bool]]',
+                                     List[Tuple[str, str]]]:
+        soup = BeautifulSoup(content, 'lxml')
         body = soup.find(name='body')
+
+        metadata = dict(
+            server_url=server_url,
+            message_links=OrderedDict(),
+            time_mentions=list(),
+        )  # type: Dict[str, Any]
+
         if body and body.find(name='blockquote'):
-            self.indent_quoted_content(soup, QUOTED_TEXT_MARKER)
+            metadata['bq_len'] = (
+                cls.indent_quoted_content(soup, QUOTED_TEXT_MARKER)
+            )
 
-        return (None, self.soup2markup(body))
+        markup, message_links, time_mentions = cls.soup2markup(body, metadata)
+        return (None, markup), message_links, time_mentions
 
-    def indent_quoted_content(self, soup: Any, padding_char: str) -> None:
+    @staticmethod
+    def indent_quoted_content(soup: Any, padding_char: str) -> int:
         """
         We indent quoted text by padding them.
         The extent of indentation depends on their level of quoting.
@@ -1104,7 +1128,7 @@ class MessageBox(urwid.Pile):
         """
         pad_count = 1
         blockquote_list = soup.find_all('blockquote')
-        self.bq_len = len(blockquote_list)
+        bq_len = len(blockquote_list)
         for tag in blockquote_list:
             child_list = tag.findChildren(recursive=False)
             actual_padding = (padding_char + ' ') * pad_count
@@ -1128,6 +1152,7 @@ class MessageBox(urwid.Pile):
                             next_s.replace_with(insert_tag)
                 child.insert_before(new_tag)
             pad_count += 1
+        return bq_len
 
     def selectable(self) -> bool:
         # Returning True, indicates that this widget

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -708,11 +708,14 @@ class MessageBox(urwid.Pile):
 
     # Use quotes as a workaround for OrderedDict typing issue.
     # See https://github.com/python/mypy/issues/6904.
+    @staticmethod
     def footlinks_view(
-        self, message_links: 'OrderedDict[str, Tuple[str, int, bool]]',
+        message_links: 'OrderedDict[str, Tuple[str, int, bool]]',
+        *,
+        footlinks_enabled: bool,
     ) -> Any:
         # Return if footlinks are disabled by the user.
-        if not self.model.controller.footlinks_enabled:
+        if not footlinks_enabled:
             return None
 
         footlinks = []
@@ -1077,7 +1080,10 @@ class MessageBox(urwid.Pile):
         reactions = self.reactions_view(self.message['reactions'])
 
         # Footlinks.
-        footlinks = self.footlinks_view(self.message_links)
+        footlinks = self.footlinks_view(
+            self.message_links,
+            footlinks_enabled=self.model.controller.footlinks_enabled,
+        )
 
         # Build parts together and return
         parts = [

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -17,7 +17,7 @@ from zulipterminal.config.symbols import (
 from zulipterminal.helper import (
     Message, asynch, edit_mode_captions, match_stream, match_user,
 )
-from zulipterminal.ui_tools.boxes import PanelSearchBox
+from zulipterminal.ui_tools.boxes import MessageBox, PanelSearchBox
 from zulipterminal.ui_tools.buttons import (
     HomeButton, MentionedButton, MessageLinkButton, PMButton, StarredButton,
     StreamButton, TopicButton, UnreadPMButton, UserButton,
@@ -1087,18 +1087,22 @@ class StreamInfoView(PopUpView):
         stream_marker = (STREAM_MARKER_PRIVATE if stream['invite_only']
                          else STREAM_MARKER_PUBLIC)
         title = '{} {}'.format(stream_marker, stream['name'])
+        rendered_desc = stream['rendered_description']
+        self.markup_desc, *_ = MessageBox.transform_content(
+            rendered_desc,
+            self.controller.model.server_url,
+        )
+        desc = urwid.Text(self.markup_desc)
 
-        desc = stream['description']
+        stream_info_content = [
+            ('Stream Details', [
+                ('Weekly Message Count', str(weekly_msg_count)),
+                ('Stream Members', '{} (Press {} to view list)'.format(
+                  total_members, member_keys)),
+            ]),
+            ('Stream settings', []),
+        ]  # type: PopUpViewTableContent
 
-        stream_info_content = [('', [desc]),
-                               ('Stream Details', [
-                                   ('Weekly Message Count',
-                                    str(weekly_msg_count)),
-                                   ('Stream Members',
-                                    '{} (Press {} to view list)'.format(
-                                        total_members, member_keys))
-                               ]),
-                               ('Stream settings', [])]
         popup_width, column_widths = self.calculate_table_widths(
             stream_info_content, len(title))
 
@@ -1117,9 +1121,14 @@ class StreamInfoView(PopUpView):
         # Manual because calculate_table_widths does not support checkboxes.
         # Add 4 to checkbox label to accomodate the checkbox itself.
         popup_width = max(popup_width, len(muted_setting.label) + 4,
-                          len(pinned_setting.label) + 4)
+                          len(pinned_setting.label) + 4, desc.pack()[0])
         self.widgets = self.make_table_with_categories(stream_info_content,
                                                        column_widths)
+
+        # Stream description.
+        self.widgets.insert(0, desc)
+        self.widgets.insert(1, urwid.Text(''))  # Add a newline.
+
         self.widgets.append(muted_setting)
         self.widgets.append(pinned_setting)
         super().__init__(controller, self.widgets, 'STREAM_DESC', popup_width,

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1088,7 +1088,7 @@ class StreamInfoView(PopUpView):
                          else STREAM_MARKER_PUBLIC)
         title = '{} {}'.format(stream_marker, stream['name'])
         rendered_desc = stream['rendered_description']
-        self.markup_desc, *_ = MessageBox.transform_content(
+        self.markup_desc, message_links, _ = MessageBox.transform_content(
             rendered_desc,
             self.controller.model.server_url,
         )
@@ -1118,16 +1118,28 @@ class StreamInfoView(PopUpView):
         urwid.connect_signal(pinned_setting, 'change',
                              self.toggle_pinned_status)
 
+        footlinks, footlinks_width = MessageBox.footlinks_view(
+            message_links=message_links,
+            footlinks_enabled=True,
+            padded=False,
+            wrap='space',
+        )
+
         # Manual because calculate_table_widths does not support checkboxes.
         # Add 4 to checkbox label to accomodate the checkbox itself.
         popup_width = max(popup_width, len(muted_setting.label) + 4,
-                          len(pinned_setting.label) + 4, desc.pack()[0])
+                          len(pinned_setting.label) + 4, desc.pack()[0],
+                          footlinks_width)
         self.widgets = self.make_table_with_categories(stream_info_content,
                                                        column_widths)
 
         # Stream description.
         self.widgets.insert(0, desc)
-        self.widgets.insert(1, urwid.Text(''))  # Add a newline.
+        desc_newline = 1
+        if footlinks:
+            self.widgets.insert(1, footlinks)
+            desc_newline = 2
+        self.widgets.insert(desc_newline, urwid.Text(''))  # Add a newline.
 
         self.widgets.append(muted_setting)
         self.widgets.append(pinned_setting)


### PR DESCRIPTION
While the PR's ultimate intent is to markup the stream description, the first commit has changes to decouple our markup methods.

#### Commits
* The first commit makes our primary markup methods, `transform_content`, `soup2markup` and `indent_quoted_content`, independent of their class object.
* The second commit uses `transform_content` in `StreamInfoView` for markup.
* The third commit makes `footlinks_view` static and more configurable.

Fixes #743.