### PR TITLE
Delegate link text for raw links in a better way

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1630,15 +1630,15 @@ class TestMessageBox:
          [('msg_link', 'bar.png'), ' ', ('msg_link_index', '[1]')]),
         ('<a href="http://foo">bar</a>',
          [('msg_link', 'bar'), ' ', ('msg_link_index', '[1]')]),
-        ('<a href="/user_uploads/blah"',
-         [('msg_link', 'blah'), ' ', ('msg_link_index', '[1]')]),
+        ('<a href="/user_uploads/blah.gif"',
+         [('msg_link', 'blah.gif'), ' ', ('msg_link_index', '[1]')]),
         ('<a href="/api"',
-         [('msg_link', 'api'), ' ', ('msg_link_index', '[1]')]),
+         [('msg_link', '/api'), ' ', ('msg_link_index', '[1]')]),
         ('<a href="some/relative_url">{}/some/relative_url</a>'
          .format(SERVER_URL),
-         [('msg_link', 'relative_url'), ' ', ('msg_link_index', '[1]')]),
+         [('msg_link', '/some/relative_url'), ' ', ('msg_link_index', '[1]')]),
         ('<a href="http://foo.com/bar">foo.com/bar</a>',
-         [('msg_link', 'bar'), ' ', ('msg_link_index', '[1]')]),
+         [('msg_link', 'foo.com'), ' ', ('msg_link_index', '[1]')]),
         ('<a href="http://foo.com">foo.com</a>'
          '<a href="http://foo.com">http://foo.com</a>'
          '<a href="https://foo.com">https://foo.com</a>'

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -580,11 +580,19 @@ class MessageBox(urwid.Pile):
                     for data in [link, text]
                 ]   # Split on '://' is for cases where text == link.
                 if link_without_scheme == text_without_scheme:
-                    segment = text.split('/')[-1]
-                    # Replace text with its last segment if the segment has
-                    # something significant than simply the 'domain name'.
-                    if segment != text_without_scheme:
-                        text = segment
+                    last_segment = text.split('/')[-1]
+                    if '.' in last_segment:
+                        new_text = last_segment  # Filename.
+                    elif text.startswith(self.model.server_url):
+                        # Relative URL.
+                        new_text = text.split(self.model.server_url)[-1]
+                    else:
+                        new_text = (
+                            parsed_link.netloc if parsed_link.netloc
+                            else text.split('/')[0]
+                        )  # Domain name.
+                    if new_text != text_without_scheme:
+                        text = new_text
                     else:
                         # Do not show as a footlink as the text is sufficient
                         # to represent the link.


### PR DESCRIPTION
Currently, we use the last segment of a link for this purpose. It works well for links that have an image or a file. For instance,
https://foo.com/image.png gets rendered as image.png, but it does have a few caveats.

This shows the ending for a filename, the domain name for a general link and the relative URL for an internal link.

Test amended.

Fixes #742.