### PR TITLE
Upgrade core dependencies

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,7 +6,7 @@ name = "pypi"
 [packages]
 urwid = "==2.1.0"
 zulip = ">=0.7.0"
-urwid-readline = "==0.11"
+urwid-readline = ">=0.11"
 beautifulsoup4 = ">=4.9.0"
 lxml = "==4.2.3"
 mypy_extensions = ">=0.4"

--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,7 @@ name = "pypi"
 urwid = "==2.1.0"
 zulip = ">=0.7.0"
 urwid-readline = "==0.11"
-beautifulsoup4 = "==4.6.0"
+beautifulsoup4 = ">=4.9.0"
 lxml = "==4.2.3"
 mypy_extensions = ">=0.4"
 

--- a/Pipfile
+++ b/Pipfile
@@ -8,7 +8,7 @@ urwid = "==2.1.0"
 zulip = ">=0.7.0"
 urwid-readline = ">=0.11"
 beautifulsoup4 = ">=4.9.0"
-lxml = "==4.2.3"
+lxml = ">=4.5.2"
 mypy_extensions = ">=0.4"
 
 [dev-packages]

--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ url = "https://pypi.python.org/simple"
 name = "pypi"
 
 [packages]
-urwid = "==2.1.0"
+urwid = "~=2.1.1"
 zulip = ">=0.7.0"
 urwid-readline = ">=0.11"
 beautifulsoup4 = ">=4.9.0"

--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,7 @@ name = "pypi"
 
 [packages]
 urwid = "==2.1.0"
-zulip = "==0.6.3"
+zulip = ">=0.7.0"
 urwid-readline = "==0.11"
 beautifulsoup4 = "==4.6.0"
 lxml = "==4.2.3"

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,5 +1,11 @@
 # Frequently Asked Questions (FAQ)
 
+## Colors appear mismatched, don't change with theme, or look strange
+
+Some terminal emulators support specifying custom colors, or custom color schemes. If you do this then this can override the colors that Zulip Terminal attempts to use.
+
+**NOTE** If you have color issues, also note that urwid version 2.1.1 should have fixed these for various terminal emulators (including rxvt, urxvt, mosh and Terminal.app), so please ensure you are running the latest Zulip Terminal release and at least this urwid version before reporting issues.
+
 ## It doesn't seem to run or display properly in my terminal (emulator)?
 
 We have reports of success on the following terminal emulators:

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -6,6 +6,8 @@ We have reports of success on the following terminal emulators:
 
 * xterm
 * uxterm (see xterm)
+* rxvt
+* urxvt
 * gnome-terminal (https://help.gnome.org/users/gnome-terminal/stable/)
 * kitty (https://sw.kovidgoyal.net/kitty/)
 * Konsole (KDE) (https://konsole.kde.org/)
@@ -13,14 +15,11 @@ We have reports of success on the following terminal emulators:
 * Terminator (https://github.com/gnome-terminator/terminator)
 * iterm2 (https://iterm2.com/) **Mac only**
 * Microsoft/Windows Terminal (https://github.com/Microsoft/Terminal) **Windows only**
+* mosh (https://mosh.org/)
 
 Issues have been reported with the following:
 
-* urxvt - **Issues with color rendering**
-* mosh (https://mosh.org/) - **Issues with color rendering**
 * terminal app **Mac only** - **Issues with some default keypresses, including for sending messages** [zulip-terminal#680](https://github.com/zulip/zulip-terminal/issues/680)
-
-Color issues may be related to the support listed on the urwid page here: http://urwid.org/manual/displayattributes.html#foreground-and-background-settings
 
 Please let us know if you have feedback on the success or failure in these or any other terminal emulator!
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 urwid==2.1.0
-zulip==0.6.3
+zulip>=0.7.0
 pytest==5.3.5
 pytest-cov==2.5.1
 pytest-mock==1.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ snakeviz==0.4.2
 gitlint==0.10.0
 mypy==0.770
 isort==4.3.21
-urwid_readline==0.11
+urwid_readline>=0.11
 beautifulsoup4>=4.9.0
 lxml==4.2.3
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ gitlint==0.10.0
 mypy==0.770
 isort==4.3.21
 urwid_readline==0.11
-beautifulsoup4==4.6.0
+beautifulsoup4>=4.9.0
 lxml==4.2.3
 
 zipp==1.0.0  # To support Python 3.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-urwid==2.1.0
+urwid~=2.1.1
 zulip>=0.7.0
 pytest==5.3.5
 pytest-cov==2.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,6 @@ mypy==0.770
 isort==4.3.21
 urwid_readline>=0.11
 beautifulsoup4>=4.9.0
-lxml==4.2.3
+lxml>=4.5.2
 
 zipp==1.0.0  # To support Python 3.5

--- a/setup.py
+++ b/setup.py
@@ -109,7 +109,7 @@ setup(
         'zulip>=0.7.0',
         'urwid_readline>=0.11',
         'beautifulsoup4>=4.9.0',
-        'lxml==4.2.3',
+        'lxml>=4.5.2',
         'mypy_extensions>=0.4',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ setup(
     install_requires=[
         'urwid==2.1.0',
         'zulip>=0.7.0',
-        'urwid_readline==0.11',
+        'urwid_readline>=0.11',
         'beautifulsoup4>=4.9.0',
         'lxml==4.2.3',
         'mypy_extensions>=0.4',

--- a/setup.py
+++ b/setup.py
@@ -108,7 +108,7 @@ setup(
         'urwid==2.1.0',
         'zulip>=0.7.0',
         'urwid_readline==0.11',
-        'beautifulsoup4==4.6.0',
+        'beautifulsoup4>=4.9.0',
         'lxml==4.2.3',
         'mypy_extensions>=0.4',
     ],

--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ setup(
     },
     tests_require=testing_deps,
     install_requires=[
-        'urwid==2.1.0',
+        'urwid~=2.1.1',
         'zulip>=0.7.0',
         'urwid_readline>=0.11',
         'beautifulsoup4>=4.9.0',

--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,7 @@ setup(
     tests_require=testing_deps,
     install_requires=[
         'urwid==2.1.0',
-        'zulip==0.6.3',
+        'zulip>=0.7.0',
         'urwid_readline==0.11',
         'beautifulsoup4==4.6.0',
         'lxml==4.2.3',


### PR DESCRIPTION
This sets dependencies as generally more flexible:
* 2.1.x (x>=1) for urwid, to allow bugfixes
* '>=' current latest versions for zulip, beautifulsoup4, urwid-readline and lxml

Feedback welcome!

Note that the urwid upgrade fixes 256-color support for at least `mosh` and `urxvt`, is likely to do so for `Terminal.app` (macos) and may for others too. If anyone tests those and has feedback for this in particular, we can update the `FAQ` to improve those notes on terminal emulator support :+1: