### PR TITLE
model/boxes: Allow users to post stream messages without a topic.

### DIFF
--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -234,6 +234,47 @@ class TestWriteBox:
         typeahead_string = write_box.generic_autocomplete(text, state)
         assert typeahead_string == required_typeahead
 
+    @pytest.mark.parametrize('topic_entered_by_user, topic_sent_to_server', [
+        ('', '(no topic)'),
+        ('hello', 'hello'),
+        ('  ', '(no topic)'),
+    ], ids=[
+        'empty_topic',
+        'non_empty_topic',
+        'topic_with_whitespace',
+    ])
+    @pytest.mark.parametrize('msg_edit_id', [10, None], ids=[
+        'update_message',
+        'send_message',
+    ])
+    @pytest.mark.parametrize('key', keys_for_command('SEND_MESSAGE'))
+    def test_keypress_SEND_MESSAGE_no_topic(self, mocker, write_box,
+                                            msg_edit_id, topic_entered_by_user,
+                                            topic_sent_to_server, key):
+        write_box.stream_write_box = mocker.Mock()
+        write_box.msg_write_box = mocker.Mock()
+        write_box.title_write_box = mocker.Mock()
+        write_box.msg_write_box.edit_text = ''
+        write_box.to_write_box = None
+        size = (20,)
+        write_box.msg_edit_id = msg_edit_id
+        write_box.title_write_box.edit_text = topic_entered_by_user
+
+        write_box.keypress(size, key)
+
+        if msg_edit_id:
+            write_box.model.update_stream_message.assert_called_once_with(
+                        topic=topic_sent_to_server,
+                        content=write_box.msg_write_box.edit_text,
+                        msg_id=msg_edit_id,
+                    )
+        else:
+            write_box.model.send_stream_message.assert_called_once_with(
+                        stream=write_box.stream_write_box.edit_text,
+                        topic=topic_sent_to_server,
+                        content=write_box.msg_write_box.edit_text
+                    )
+
     @pytest.mark.parametrize(['key', 'current_typeahead_mode',
                               'expected_typeahead_mode',
                               'expect_footer_was_reset'], [

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -1,3 +1,4 @@
+import re
 from collections import OrderedDict, defaultdict
 from datetime import date, datetime
 from sys import platform
@@ -198,16 +199,21 @@ class WriteBox(urwid.Pile):
 
         if is_command_key('SEND_MESSAGE', key):
             if not self.to_write_box:
+                if re.fullmatch(r'\s*', self.title_write_box.edit_text):
+                    topic = '(no topic)'
+                else:
+                    topic = self.title_write_box.edit_text
+
                 if self.msg_edit_id:
                     success = self.model.update_stream_message(
-                        topic=self.title_write_box.edit_text,
+                        topic=topic,
                         content=self.msg_write_box.edit_text,
                         msg_id=self.msg_edit_id,
                     )
                 else:
                     success = self.model.send_stream_message(
                         stream=self.stream_write_box.edit_text,
-                        topic=self.title_write_box.edit_text,
+                        topic=topic,
                         content=self.msg_write_box.edit_text
                     )
             else:

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -197,24 +197,24 @@ class WriteBox(urwid.Pile):
                 self.view.set_footer_text()
 
         if is_command_key('SEND_MESSAGE', key):
-            if self.msg_edit_id:
-                if not self.to_write_box:
+            if not self.to_write_box:
+                if self.msg_edit_id:
                     success = self.model.update_stream_message(
                         topic=self.title_write_box.edit_text,
                         content=self.msg_write_box.edit_text,
                         msg_id=self.msg_edit_id,
                     )
                 else:
-                    success = self.model.update_private_message(
-                        content=self.msg_write_box.edit_text,
-                        msg_id=self.msg_edit_id,
-                    )
-            else:
-                if not self.to_write_box:
                     success = self.model.send_stream_message(
                         stream=self.stream_write_box.edit_text,
                         topic=self.title_write_box.edit_text,
                         content=self.msg_write_box.edit_text
+                    )
+            else:
+                if self.msg_edit_id:
+                    success = self.model.update_private_message(
+                        content=self.msg_write_box.edit_text,
+                        msg_id=self.msg_edit_id,
                     )
                 else:
                     success = self.model.send_private_message(


### PR DESCRIPTION
This follows the convention used by other Zulip clients to
automatically post a message without a topic, or a topic with only
whitespaces, to a topic named '(no topic)'.

Tests amended.

Fixes #754.