### PR TITLE
Move unread_count from StreamButton updates to Model.

### DIFF
--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -1481,6 +1481,8 @@ class TestModel:
                                                      stream_button, event,
                                                      final_muted_streams):
         model.muted_streams = {15, 19}
+        model.unread_counts = {'all_msg': 300,
+                               'streams': {event['stream_id']: 99}}
         model.controller.view.stream_id_to_button = {
             event['stream_id']: stream_button  # stream id is known
         }
@@ -1493,9 +1495,11 @@ class TestModel:
 
         assert model.muted_streams == final_muted_streams
         if event['value']:
-            mark_unmuted.assert_called_once_with()
+            mark_unmuted.assert_called_once_with(99)
+            assert model.unread_counts['all_msg'] == 399
         else:
             mark_muted.assert_called_once_with()
+            assert model.unread_counts['all_msg'] == 201
         model.controller.update_screen.assert_called_once_with()
 
     @pytest.mark.parametrize(['event', 'expected_pinned_streams',

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -2506,46 +2506,6 @@ class TestStreamButton:
         assert len(text[0]) == len(expected_text) == (width - 1)
         assert text[0] == expected_text
 
-    @pytest.mark.parametrize(['stream_id', 'muted_streams', 'called_value',
-                              'is_action_muting', 'updated_all_msgs'], [
-        (86, set(), 50, False, 400),
-        (86, {86, 205}, None, True, 300),
-        (205, {14, 99}, 0, False, 350),
-    ], ids=[
-        'unmuting stream 86 - 204 unreads',
-        'muting stream 86',
-        'unmuting stream 205 - 0 unreads',
-    ])
-    def test_mark_stream_muted(self, mocker, stream_button, is_action_muting,
-                               stream_id, muted_streams, called_value,
-                               updated_all_msgs) -> None:
-        stream_button.stream_id = stream_id
-        stream_button.count = 50  # Override value in fixture
-        update_count = mocker.patch(TOPBUTTON + ".update_count")
-        stream_button.controller.model.unread_counts = {
-            'streams': {
-                86: 50,
-                14: 34,
-            },
-            'all_msg': 350,
-        }
-        stream_button.controller.model.is_muted_stream = (
-            mocker.Mock(return_value=(stream_id in muted_streams))
-        )
-        stream_button.view.home_button.update_count = mocker.Mock()
-
-        if is_action_muting:
-            stream_button.mark_muted()
-        else:
-            stream_button.mark_unmuted()
-
-        if called_value is not None:
-            stream_button.update_count.assert_called_once_with(called_value)
-        if called_value != 0:
-            (stream_button.view.home_button.update_count
-             .assert_called_once_with(updated_all_msgs))
-        assert stream_button.model.unread_counts['all_msg'] == updated_all_msgs
-
     @pytest.mark.parametrize('key', keys_for_command('TOGGLE_TOPIC'))
     def test_keypress_ENTER_TOGGLE_TOPIC(self, mocker, stream_button, key):
         size = (200, 20)

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -423,7 +423,7 @@ def classify_unread_counts(model: Any) -> UnreadCounts:
         unread_topics=dict(),
         unread_pms=dict(),
         unread_huddles=dict(),
-        streams=dict(),
+        streams=defaultdict(int),
     )
 
     mentions_count = len(unread_msg_counts['mentions'])

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -667,11 +667,14 @@ class Model:
                         self.controller.view.stream_id_to_button[stream_id]
                     )
 
+                    unread_count = self.unread_counts['streams'][stream_id]
                     if event['value']:  # Unmuting streams
                         self.muted_streams.remove(stream_id)
-                        stream_button.mark_unmuted()
+                        self.unread_counts['all_msg'] += unread_count
+                        stream_button.mark_unmuted(unread_count)
                     else:  # Muting streams
                         self.muted_streams.add(stream_id)
+                        self.unread_counts['all_msg'] -= unread_count
                         stream_button.mark_muted()
                     self.controller.update_screen()
                 elif event.get('property', None) == 'pin_to_top':

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -168,20 +168,13 @@ class StreamButton(TopButton):
 
     def mark_muted(self) -> None:
         self.update_widget('M')
-        self.model.unread_counts['all_msg'] -= self.count
         self.view.home_button.update_count(
             self.model.unread_counts['all_msg'])
 
-    def mark_unmuted(self) -> None:
-        if self.stream_id in self.model.unread_counts['streams']:
-            unmuted_count = self.model.unread_counts['streams'][self.stream_id]
-            self.update_count(unmuted_count)
-            self.model.unread_counts['all_msg'] += self.count
-            self.view.home_button.update_count(
-                self.model.unread_counts['all_msg'])
-        else:
-            # All messages in this stream are read.
-            self.update_count(0)
+    def mark_unmuted(self, unread_count: int) -> None:
+        self.update_count(unread_count)
+        self.view.home_button.update_count(
+            self.model.unread_counts['all_msg'])
 
     def keypress(self, size: urwid_Size, key: str) -> Optional[str]:
         if is_command_key('TOGGLE_TOPIC', key):


### PR DESCRIPTION
Currently, logic for updating unread counts after muting/unmuting
streams is present in StreamButton. This commit moves this logic to the
Model.

unread_counts['streams'] has been changed to defaultdict(int) so that it
returns 0 when a stream id is not present.

Tests amended.

Fixes #722.