### PR TITLE
Fetch topics on demand to prevent heavy load on /topics

### DIFF
--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -339,7 +339,7 @@ class TestModel:
 
         assert model._fetch_topics_in_streams.called == fetched
         assert model.index['topics'][stream_id] == return_value
-        assert model.index['topics'][stream_id] is return_value
+        assert model.index['topics'][stream_id] is not return_value
 
     @pytest.mark.parametrize("user_key", ['user_id', 'id'])
     @pytest.mark.parametrize("msg_id, existing_reactions, expected_method", [

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -119,7 +119,6 @@ class TestModel:
         mocker.patch('zulipterminal.model.Model.get_messages',
                      return_value='')
         mocker.patch('zulipterminal.model.Model.get_all_users')
-        mocker.patch('zulipterminal.model.Model.fetch_all_topics')
         self.client.register.return_value = initial_data
 
         model = Model(self.controller)
@@ -326,6 +325,21 @@ class TestModel:
         if response['result'] != 'success':
             (self.display_error_if_present.
              assert_called_once_with(response, self.controller))
+
+    @pytest.mark.parametrize('topics_index, fetched', [
+        (['test'], False),
+        ([], True),
+    ])
+    def test_topics_in_stream(self, mocker, model, topics_index, fetched,
+                              stream_id=1):
+        model.index['topics'][stream_id] = topics_index
+        model._fetch_topics_in_streams = mocker.Mock()
+
+        return_value = model.topics_in_stream(stream_id)
+
+        assert model._fetch_topics_in_streams.called == fetched
+        assert model.index['topics'][stream_id] == return_value
+        assert model.index['topics'][stream_id] is return_value
 
     @pytest.mark.parametrize("user_key", ['user_id', 'id'])
     @pytest.mark.parametrize("msg_id, existing_reactions, expected_method", [
@@ -811,7 +825,7 @@ class TestModel:
         # LOG REMAINS THE SAME IF UPDATE IS FALSE
         assert self.controller.view.message_view.log == log
 
-    @pytest.mark.parametrize(['topic_name', 'topic_order_intial',
+    @pytest.mark.parametrize(['topic_name', 'topic_order_initial',
                               'topic_order_final'], [
         ('TOPIC3', ['TOPIC2', 'TOPIC3', 'TOPIC1'],
                    ['TOPIC3', 'TOPIC2', 'TOPIC1']),
@@ -822,14 +836,20 @@ class TestModel:
         ('TOPIC1', [], ['TOPIC1'])
     ], ids=['reorder_topic3', 'topic1_discussion_continues', 'new_topic4',
             'first_topic_1'])
-    def test__update_topic_index(self, topic_name, topic_order_intial,
-                                 topic_order_final, model):
+    def test__update_topic_index(self, topic_name, topic_order_initial,
+                                 topic_order_final, model, mocker):
         model.index = {
             'topics': {
-                86: topic_order_intial,
+                86: topic_order_initial,
             }
         }
+        model.topics_in_stream = (
+            mocker.Mock(return_value=topic_order_initial)
+        )
+
         model._update_topic_index(86, topic_name)
+
+        model.topics_in_stream.assert_called_once_with(86)
         assert model.index['topics'][86] == topic_order_final
 
     # TODO: Ideally message_fixture would use standardized ids?

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -314,11 +314,11 @@ class TestModel:
         ({'result': 'failure', 'msg': 'Some Error', 'topics': []},
          {23: []}, 'Some Error')
     ])
-    def test_get_topics_in_streams(self, mocker, response, model, return_value,
-                                   expected_index) -> None:
+    def test__fetch_topics_in_streams(self, mocker, response, model,
+                                      return_value, expected_index) -> None:
         self.client.get_stream_topics = mocker.Mock(return_value=response)
 
-        result = model.get_topics_in_stream([23])
+        result = model._fetch_topics_in_streams([23])
 
         self.client.get_stream_topics.assert_called_once_with(23)
         assert model.index['topics'] == expected_index

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1197,14 +1197,14 @@ class TestLeftColumnView:
         line_box = mocker.patch(VIEWS + '.urwid.LineBox')
         topic_list = ['TOPIC1', 'TOPIC2', 'TOPIC3']
         unread_count_list = [34, 100, 0]
-        self.view.model.index = {
-            'topics': {
-                205: topic_list,
-            }
-        }
+        self.view.model.topics_in_stream = (
+            mocker.Mock(return_value=topic_list)
+        )
         left_col_view = LeftColumnView(width, self.view)
+
         left_col_view.topics_view(stream_button)
 
+        self.view.model.topics_in_stream.assert_called_once_with(205)
         topic_button.assert_has_calls([
             mocker.call(stream_id=205,
                         topic=topic,

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -376,7 +376,7 @@ class Model:
         display_error_if_present(response, self.controller)
         return response['msg']
 
-    def get_topics_in_stream(self, stream_list: Iterable[int]) -> str:
+    def _fetch_topics_in_streams(self, stream_list: Iterable[int]) -> str:
         """
         Fetch all topics with specified stream_id's and
         index their names (Version 1)
@@ -407,7 +407,7 @@ class Model:
         with ThreadPoolExecutor(max_workers=workers) as executor:
             list_of_streams = list(self.stream_dict.keys())
             thread_objects = {
-                i: executor.submit(self.get_topics_in_stream,
+                i: executor.submit(self._fetch_topics_in_streams,
                                    list_of_streams[i::workers])
                 for i in range(workers)
             }  # type: Dict[int, Future[str]]

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -397,7 +397,7 @@ class Model:
         if not self.index['topics'][stream_id]:
             self._fetch_topics_in_streams([stream_id])
 
-        return self.index['topics'][stream_id]
+        return list(self.index['topics'][stream_id])
 
     @staticmethod
     def exception_safe_result(future: 'Future[str]') -> str:
@@ -745,6 +745,11 @@ class Model:
         message['flags'] = event.get('flags', [])
         # We need to update the topic order in index, unconditionally.
         if message['type'] == 'stream':
+            # NOTE: The subsequent helper only updates the topic index based
+            # on the message event not the UI (the UI is updated in a
+            # consecutive block independently). However, it is critical to keep
+            # the topics index synchronized as it used whenever the topics list
+            # view is reconstructed later.
             self._update_topic_index(message['stream_id'],
                                      message['subject'])
             # If the topic view is toggled for incoming message's
@@ -836,14 +841,18 @@ class Model:
         Update topic order in index based on incoming message.
         Helper method called by _handle_message_event
         """
-        topic_index = self.topics_in_stream(stream_id)
-        for topic_iterator, topic in enumerate(topic_index):
+        topic_list = self.topics_in_stream(stream_id)
+        for topic_iterator, topic in enumerate(topic_list):
             if topic == topic_name:
-                topic_index.insert(0, topic_index.pop(topic_iterator))
-                return
-        # No previous topics with same topic names are found
-        # hence, it must be a new topic.
-        topic_index.insert(0, topic_name)
+                topic_list.insert(0, topic_list.pop(topic_iterator))
+                break
+        else:
+            # No previous topics with same topic names are found
+            # hence, it must be a new topic.
+            topic_list.insert(0, topic_name)
+
+        # Update the index.
+        self.index['topics'][stream_id] = topic_list
 
     def _handle_update_message_event(self, event: Event) -> None:
         """

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -767,6 +767,7 @@ class LeftColumnView(urwid.Pile):
 
     def topics_view(self, stream_button: Any) -> Any:
         stream_id = stream_button.stream_id
+        topics = self.model.topics_in_stream(stream_id)
         topics_btn_list = [
             TopicButton(
                 stream_id=stream_id,
@@ -775,7 +776,9 @@ class LeftColumnView(urwid.Pile):
                 width=self.width,
                 count=self.model.unread_counts['unread_topics'].
                 get((stream_id, topic), 0)
-            ) for topic in self.model.index['topics'][stream_id]]
+            )
+            for topic in topics
+        ]
 
         self.view.topic_w = TopicsView(topics_btn_list, self.view,
                                        stream_button)


### PR DESCRIPTION
This is the v1 that we discussed in [zulip-terminal > Topics on demand](https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/Topics.20on.20demand/near/967222).

Now, topics are only fetched when they required for the `topics_view()` (for the topic toggle) or for the `_update_topic_index()`.

Tests amended with a few spelling corrections.

Fixes #493.