### PR TITLE
Split API call and traceback logging into different log files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ dist/*
 build/*
 zulip_term.egg-info
 zulip-terminal-tracebacks.log
+zulip-terminal-API-requests.log
 
 .vscode/*
 .DS_Store


### PR DESCRIPTION
Previously the zulip-terminal-traceback.log file was polluted with urllib3/requests debug messages. This separates these two sources.

In future, we could enable API call logging only in a debug or development mode.

We could potentially do the latter sooner rather than later - thoughts?