### PR TITLE
bugfix: helper: Check view is rendered before displaying errors.

### DIFF
--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -616,5 +616,5 @@ def notify(title: str, html_text: str) -> str:
 
 def display_error_if_present(response: Dict[str, Any], controller: Any
                              ) -> None:
-    if response['result'] == 'error':
+    if response['result'] == 'error' and hasattr(controller, 'view'):
         controller.view.set_footer_text(response['msg'], 3)


### PR DESCRIPTION
A quick oneliner which hopefully fixes some errors which are caused trying to display an error in the footer, before the view is loaded.