### PR TITLE
model: Ignore peer subscription events for unsubscribed streams.

### DIFF
--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -1566,6 +1566,23 @@ class TestModel:
         new_subscribers = model.stream_dict[event['stream_id']]['subscribers']
         assert new_subscribers == expected_subscribers
 
+    @pytest.mark.parametrize('event', [
+        ({'type': 'subscription', 'op': 'peer_add',
+          'stream_id': 462, 'user_id': 12}),
+        ({'type': 'subscription', 'op': 'peer_remove',
+          'stream_id': 462, 'user_id': 12}),
+    ], ids=[
+        'peer_subscribed_to_stream_that_user_is_unsubscribed_to',
+        'peer_unsubscribed_from_stream_that_user_is_unsubscribed_to',
+    ])
+    def test__handle_subscription_event_subscribers_to_unsubscribed_streams(
+                            self, model, mocker, stream_dict, event):
+        model.stream_dict = deepcopy(stream_dict)
+
+        model._handle_subscription_event(event)
+
+        assert model.stream_dict == stream_dict
+
     @pytest.mark.parametrize('muted_streams, stream_id, is_muted', [
         ({1},   1, True),
         ({1},   2, False),

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -698,10 +698,12 @@ class Model:
                     sort_streams(self.pinned_streams)
                     self.controller.view.left_panel.update_structure()
                     self.controller.update_screen()
-        elif event['op'] == 'peer_add':
+        elif (event['op'] == 'peer_add'
+              and event['stream_id'] in self.stream_dict):
             subscribers = self.stream_dict[event['stream_id']]['subscribers']
             subscribers.append(event['user_id'])
-        elif event['op'] == 'peer_remove':
+        elif (event['op'] == 'peer_remove'
+              and event['stream_id'] in self.stream_dict):
             subscribers = self.stream_dict[event['stream_id']]['subscribers']
             subscribers.remove(event['user_id'])
 


### PR DESCRIPTION
Since Model.stream_dict does not contain data for unsubscribed streams,
trying to handle this event raises exceptions.