### PR TITLE
Migrate from mypy_extensions to typing_extensions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,9 @@ matrix:
       name: "Install & pytest - CPython 3.7 (default linux)"
     - python: 3.8
       name: "Install & pytest - CPython 3.8 (default linux)"
-    - python: pypy3.5
-      name: "Install & pytest - PyPy 3.5 (default linux)"
+    - python: pypy3.6-7.3.1
+      # Use PyPy3 7.3.1, which fixes a typing_extensions.TypedDict bug
+      name: "Install & pytest - PyPy 3.6 v7.3.1 (default linux)"
     - os: osx
       name: "Install & pytest - Python 3 (OS X; xcode10)"
       cache:

--- a/Pipfile
+++ b/Pipfile
@@ -9,7 +9,7 @@ zulip = ">=0.7.0"
 urwid-readline = ">=0.11"
 beautifulsoup4 = ">=4.9.0"
 lxml = ">=4.5.2"
-mypy_extensions = ">=0.4"
+typing_extensions = ">=3.7"
 
 [dev-packages]
 pytest = "==5.3.5"

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ flake8-continuation==1.0.5
 pudb==2017.1.4
 snakeviz==0.4.2
 gitlint==0.10.0
-mypy==0.770
+mypy==0.782
 isort==4.3.21
 urwid_readline>=0.11
 beautifulsoup4>=4.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 urwid~=2.1.1
 zulip>=0.7.0
+typing_extensions>=3.7
+
 pytest==5.3.5
 pytest-cov==2.5.1
 pytest-mock==1.7.1

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ testing_deps = [
 
 linting_deps = [
     'isort==4.3.21',
-    'mypy==0.770',
+    'mypy==0.782',
     'flake8==3.7.9',
     'flake8-quotes==3.0.0',
     'flake8-continuation==1.0.5',

--- a/setup.py
+++ b/setup.py
@@ -110,6 +110,6 @@ setup(
         'urwid_readline>=0.11',
         'beautifulsoup4>=4.9.0',
         'lxml>=4.5.2',
-        'mypy_extensions>=0.4',
+        'typing_extensions>=3.7',
     ],
 )

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 from typing import List, Set
 
-from mypy_extensions import TypedDict
+from typing_extensions import TypedDict
 
 
 KeyBinding = TypedDict('KeyBinding', {

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -13,7 +13,7 @@ from typing import (
 )
 
 import lxml.html
-from mypy_extensions import TypedDict
+from typing_extensions import TypedDict
 
 
 MACOS = platform.system() == "Darwin"

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -9,7 +9,7 @@ from typing import (
 from urllib.parse import urlparse
 
 import zulip
-from mypy_extensions import TypedDict
+from typing_extensions import TypedDict
 
 from zulipterminal.config.keys import keys_for_command
 from zulipterminal.helper import (


### PR DESCRIPTION
This requires the PyPy build to be upgraded due to a failure in earlier PyPy versions.

This also upgrades the mypy we test against - this doesn't require any changes, however.