### PR TITLE
Show time mentions (with source text) in MsgInfoView

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1456,7 +1456,8 @@ class TestMsgInfoView:
                             return_value=(64, 64))
         mocker.patch(VIEWS + ".urwid.SimpleFocusListWalker", return_value=[])
         self.msg_info_view = MsgInfoView(self.controller, message_fixture,
-                                         'Message Information', OrderedDict())
+                                         'Message Information', OrderedDict(),
+                                         list())
 
     def test_keypress_any_key(self):
         key = "a"
@@ -1518,7 +1519,8 @@ class TestMsgInfoView:
     def test_height_reactions(self, message_fixture, to_vary_in_each_message):
         varied_message = dict(message_fixture, **to_vary_in_each_message)
         self.msg_info_view = MsgInfoView(self.controller, varied_message,
-                                         'Message Information', OrderedDict())
+                                         'Message Information', OrderedDict(),
+                                         list())
         # 9 = 3 labels + 1 blank line + 1 'Reactions' (category) + 4 reactions.
         expected_height = 9
         assert self.msg_info_view.height == expected_height
@@ -1564,6 +1566,7 @@ class TestMessageBox:
         for field, invalid_default in set_fields:
             assert getattr(msg_box, field) != invalid_default
         assert msg_box.message_links == OrderedDict()
+        assert msg_box.time_mentions == list()
 
     def test_init_fails_with_bad_message_type(self):
         message = dict(type='BLAH')

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -5,7 +5,7 @@ import time
 from collections import OrderedDict
 from functools import partial
 from platform import platform
-from typing import Any, Optional, Tuple
+from typing import Any, List, Optional, Tuple
 
 import urwid
 import zulip
@@ -138,10 +138,11 @@ class Controller:
 
     def show_msg_info(self, msg: Message,
                       message_links: 'OrderedDict[str, Tuple[str, int, bool]]',
+                      time_mentions: List[Tuple[str, str]],
                       ) -> None:
         msg_info_view = MsgInfoView(self, msg,
                                     "Message Information (up/down scrolls)",
-                                    message_links)
+                                    message_links, time_mentions)
         self.show_pop_up(msg_info_view)
 
     def show_stream_info(self, stream_id: int) -> None:

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -312,6 +312,7 @@ class MessageBox(urwid.Pile):
         self.message_links = (
             OrderedDict()
         )   # type: OrderedDict[str, Tuple[str, int, bool]]
+        self.time_mentions = list()  # type: List[Tuple[str, str]]
         self.last_message = last_message
         # if this is the first message
         if self.last_message is None:
@@ -760,6 +761,11 @@ class MessageBox(urwid.Pile):
                     'msg_time',
                     ' {} {} '.format(TIME_MENTION_MARKER, time_string)
                 ))
+
+                source_text = (
+                    'Original text was {}'.format(element.text.strip())
+                )
+                self.time_mentions.append((time_string, source_text))
             else:
                 markup.extend(self.soup2markup(element))
         return markup
@@ -1063,7 +1069,8 @@ class MessageBox(urwid.Pile):
             self.model.controller.view.middle_column.set_focus('footer')
         elif is_command_key('MSG_INFO', key):
             self.model.controller.show_msg_info(self.message,
-                                                self.message_links)
+                                                self.message_links,
+                                                self.time_mentions)
         return key
 
 

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1064,6 +1064,7 @@ class StreamInfoView(PopUpView):
 class MsgInfoView(PopUpView):
     def __init__(self, controller: Any, msg: Message, title: str,
                  message_links: 'OrderedDict[str, Tuple[str, int, bool]]',
+                 time_mentions: List[Tuple[str, str]],
                  ) -> None:
         self.msg = msg
 
@@ -1075,6 +1076,8 @@ class MsgInfoView(PopUpView):
         # Render the category using the existing table methods if links exist.
         if message_links:
             msg_info.append(('Message Links', []))
+        if time_mentions:
+            msg_info.append(('Time mentions', time_mentions))
         if msg['reactions']:
             reactions = sorted(
                 (reaction['emoji_name'], reaction['user']['full_name'])


### PR DESCRIPTION
This adds an instance attribute, `time_mentions`, to the class `MessageBox` to log time mentions (with their source text) and eventually show them in `MsgInfoView`.