### PR TITLE
Single message drafts  

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ source ~/.zshenv
 | ----------------------------------------------------- | --------------------------------------------- |
 | Show/hide help menu                                   | <kbd>?</kbd>                                  |
 | Show/hide about menu                                  | <kbd>Meta</kbd> + <kbd>?</kbd>                |
+| Open draft message saved in this session              | <kbd>d</kbd>                                  |
 | Go back                                               | <kbd>esc</kbd>                                |
 | Redraw screen                                         | <kbd>Ctrl</kbd> + <kbd>l</kbd>                |
 | Quit                                                  | <kbd>Ctrl</kbd> + <kbd>C</kbd>                |
@@ -176,6 +177,7 @@ source ~/.zshenv
 | -----------------------------------------------------     | --------------------------------------------- |
 | Cycle through recipient and content boxes                 | <kbd>tab</kbd>                                |
 | Send a message                                            | <kbd>Alt Enter</kbd> / <kbd>Ctrl d</kbd>      |
+| Save current message as a draft                           | <kbd>Meta</kbd> + <kbd>s</kbd>                |
 | Autocomplete @mentions, #stream_names, :emoji: and topics | <kbd>Ctrl</kbd> + <kbd>f</kbd>                |
 | Cycle through autocomplete suggestions in reverse         | <kbd>Ctrl</kbd> + <kbd>r</kbd>                |
 | Jump to the beginning of line                             | <kbd>Ctrl</kbd> + <kbd>A</kbd>                |

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -29,6 +29,11 @@ KEY_BINDINGS = OrderedDict([
         'excluded_from_random_tips': False,
         'key_category': 'general',
     }),
+    ('OPEN_DRAFT', {
+        'keys': {'d'},
+        'help_text': 'Open draft message saved in this session',
+        'key_category': 'general',
+    }),
     ('GO_UP', {
         'keys': {'k', 'up'},
         'help_text': 'Go up/Previous message',
@@ -107,6 +112,11 @@ KEY_BINDINGS = OrderedDict([
     ('SEND_MESSAGE', {
         'keys': {'meta enter', 'ctrl d'},
         'help_text': 'Send a message',
+        'key_category': 'msg_compose',
+    }),
+    ('SAVE_AS_DRAFT', {
+        'keys': {'meta s'},
+        'help_text': 'Save current message as a draft',
         'key_category': 'msg_compose',
     }),
     ('AUTOCOMPLETE', {

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -174,6 +174,12 @@ class Controller:
         if 0 <= focus_position < len(w_list):
             self.view.message_view.set_focus(focus_position)
 
+    def save_draft_confirmation_popup(self, message: Message) -> None:
+        question = urwid.Text('Save this message as a draft?'
+                              ' (This will overwrite the existing draft.)')
+        save_draft = partial(self.model.save_draft, message)
+        self.loop.widget = PopUpConfirmationView(self, question, save_draft)
+
     def stream_muting_confirmation_popup(self, button: Any) -> None:
         currently_muted = self.model.is_muted_stream(button.stream_id)
         type_of_action = "unmuting" if currently_muted else "muting"

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -640,7 +640,7 @@ class Model:
         user_group_names.sort(key=str.lower)
         return user_group_names
 
-    def toggle_stream_muted_status(self, stream_id: int) -> bool:
+    def toggle_stream_muted_status(self, stream_id: int) -> None:
         request = [{
             'stream_id': stream_id,
             'property': 'is_muted',
@@ -649,7 +649,6 @@ class Model:
         }]
         response = self.client.update_subscription_settings(request)
         display_error_if_present(response, self.controller)
-        return response['result'] == 'success'
 
     def stream_id_from_name(self, stream_name: str) -> int:
         for stream_id, stream in self.stream_dict.items():

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -2,6 +2,7 @@ import json
 import time
 from collections import OrderedDict, defaultdict
 from concurrent.futures import Future, ThreadPoolExecutor, wait
+from copy import deepcopy
 from typing import (
     Any, Callable, DefaultDict, Dict, FrozenSet, Iterable, List, Optional, Set,
     Tuple, Union,
@@ -135,6 +136,7 @@ class Model:
 
         self.unread_counts = classify_unread_counts(self)
 
+        self._draft = None  # type: Optional[Message]
         self.new_user_input = True
         self._start_presence_updates()
 
@@ -284,6 +286,13 @@ class Model:
         else:
             response = self.client.add_reaction(reaction_to_toggle_spec)
         display_error_if_present(response, self.controller)
+
+    def session_draft_message(self) -> Optional[Message]:
+        return deepcopy(self._draft)
+
+    def save_draft(self, message: Message) -> None:
+        self._draft = deepcopy(message)
+        self.controller.view.set_footer_text("Saved message as draft", 3)
 
     @asynch
     def toggle_message_star_status(self, message: Message) -> None:

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -217,6 +217,27 @@ class View(urwid.WidgetWrap):
             search_box.set_edit_text("")
             self.controller.enter_editor_mode_with(search_box)
             return key
+        elif is_command_key('OPEN_DRAFT', key):
+            saved_draft = self.model.session_draft_message()
+            if saved_draft:
+                if saved_draft['type'] == 'stream':
+                    self.write_box.stream_box_view(
+                        caption=saved_draft['display_recipient'],
+                        title=saved_draft['subject'],
+                        stream_id=saved_draft['stream_id'],
+                    )
+                elif saved_draft['type'] == 'private':
+                    self.write_box.private_box_view(
+                        email=saved_draft['display_recipient'],
+                    )
+                content = saved_draft['content']
+                self.write_box.msg_write_box.edit_text = content
+                self.write_box.msg_write_box.edit_pos = len(content)
+                self.middle_column.set_focus('footer')
+            else:
+                self.set_footer_text('No draft message was saved in'
+                                     ' this session.', 3)
+            return key
         elif is_command_key('ABOUT', key):
             self.controller.show_about()
             return key

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -307,6 +307,27 @@ class WriteBox(urwid.Pile):
             self.view.controller.exit_editor_mode()
             self.main_view(False)
             self.view.middle_column.set_focus('body')
+        elif is_command_key('SAVE_AS_DRAFT', key):
+            if not self.msg_edit_id:
+                if self.to_write_box:
+                    message = Message(
+                            display_recipient=self.to_write_box.edit_text,
+                            content=self.msg_write_box.edit_text,
+                            type='private',
+                    )
+                elif self.stream_id:
+                    message = Message(
+                        display_recipient=self.stream_write_box.edit_text,
+                        content=self.msg_write_box.edit_text,
+                        subject=self.title_write_box.edit_text,
+                        stream_id=self.stream_id,
+                        type='stream',
+                    )
+                saved_draft = self.model.session_draft_message()
+                if not saved_draft:
+                    self.model.save_draft(message)
+                elif message != saved_draft:
+                    self.view.controller.save_draft_confirmation_popup(message)
         elif is_command_key('CYCLE_COMPOSE_FOCUS', key):
             if len(self.contents) == 0:
                 return key

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1001,7 +1001,7 @@ class HelpView(PopUpView):
 
 class PopUpConfirmationView(urwid.Overlay):
     def __init__(self, controller: Any, question: Any,
-                 success_callback: Callable[[], bool]):
+                 success_callback: Callable[[], None]):
         self.controller = controller
         self.success_callback = success_callback
         yes = urwid.Button('Yes', self.exit_popup_yes)


### PR DESCRIPTION
This PR adds support for a minimal draft message feature, storing a single
draft message when `meta s` is pressed.