### PR TITLE
Invalidate leading spaces (in panel boxes)

### DIFF
--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -1,4 +1,5 @@
 import pytest
+from pytest import param
 
 from zulipterminal.config.keys import keys_for_command
 from zulipterminal.ui_tools.boxes import PanelSearchBox, WriteBox
@@ -529,6 +530,27 @@ class TestPanelSearchBox:
 
         assert panel_search_box.caption == ""
         assert panel_search_box.edit_text == panel_search_box.search_text
+
+    @pytest.mark.parametrize("search_text, entered_string, expected_result", [
+        # NOTE: In both backspace cases it is not validated (backspace is not
+        #       shown), but still is handled during editing as normal
+        # NOTE: Unicode backspace case likely doesn't get triggered
+        param('', 'backspace', False, id="no_text-disallow_urwid_backspace"),
+        param('', '\u0008', False, id="no_text-disallow_unicode_backspace"),
+        param('', '\u2003', False, id="no_text-disallow_unicode_em_space"),
+        param('', 'x', True, id="no_text-allow_entry_of_x"),
+        param('', '\u0394', True, id="no_text-allow_entry_of_delta"),
+        param('', ' ', False, id="no_text-disallow_entry_of_space"),
+        param('x', ' ', True, id="text-allow_entry_of_space"),
+        param('x', 'backspace', False, id="text-disallow_urwid_backspace"),
+    ])
+    def test_valid_char(self, panel_search_box,
+                        search_text, entered_string, expected_result):
+        panel_search_box.edit_text = search_text
+
+        result = panel_search_box.valid_char(entered_string)
+
+        assert result == expected_result
 
     @pytest.mark.parametrize("log, expect_body_focus_set", [
         ([], False),

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -1,4 +1,5 @@
 import re
+import unicodedata
 from collections import OrderedDict, defaultdict
 from datetime import date, datetime
 from sys import platform
@@ -1263,6 +1264,20 @@ class PanelSearchBox(urwid.Edit):
     def reset_search_text(self) -> None:
         self.set_caption('')
         self.set_edit_text(self.search_text)
+
+    def valid_char(self, ch: str) -> bool:
+        # This method 'strips' leading space *before* entering it in the box
+        if self.edit_text:
+            # Use regular validation if already have text
+            return super().valid_char(ch)
+        elif len(ch) != 1:
+            # urwid expands some unicode to strings to be useful
+            # (so we need to work around eg 'backspace')
+            return False
+        else:
+            # Skip unicode 'Control characters' and 'space Zeperators'
+            # This includes various invalid characters and complex spaces
+            return unicodedata.category(ch) not in ('Cc', 'Zs')
 
     def keypress(self, size: urwid_Size, key: str) -> Optional[str]:
         if ((is_command_key('ENTER', key) and self.get_edit_text() == '')


### PR DESCRIPTION
This is an alternative to a commit from #700 - instead of allowing (leading) spaces in the text box, leading to "   x" being valid, they're just not accepted, by use of `valid_char()`.