### PR TITLE
Add an explore mode to run the app without marking messages as read

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ If it doesn't find this file, you have two options:
 
    Your personal zuliprc file can be obtained from Zulip servers in your account settings in the web application, which gives you all the permissions you have there. Bot zuliprc files can be downloaded from a similar area for each bot, and will have more limited permissions.
 
+We suggest running `zulip-term` using the `-e` or `--explore` option (in explore mode) when you are trying Zulip Terminal for the first time, where we intentionally do not mark messages as read.
+
 ## Configuration
 
 The `zuliprc` file contains information to connect to your chat server in the `[api]` section, but also optional configuration for `zulip-term` in the `[zterm]` section:

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -62,6 +62,7 @@ def test_main_help(capsys, options):
         '--autohide',
         '--no-autohide',
         '-v, --version',
+        '-e, --explore',
         '--color-depth'
     }
     optional_argument_lines = {line[2:] for line in lines

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -29,10 +29,12 @@ class TestController:
 
         self.config_file = 'path/to/zuliprc'
         self.theme = 'default'
+        self.in_explore_mode = False
         self.autohide = True  # FIXME Add tests for no-autohide
         self.notify_enabled = False
         self.footlinks_enabled = True
-        result = Controller(self.config_file, self.theme, 256, self.autohide,
+        result = Controller(self.config_file, self.theme, 256,
+                            self.in_explore_mode, self.autohide,
                             self.notify_enabled, self.footlinks_enabled)
         result.view.message_view = mocker.Mock()  # set in View.__init__
         return result

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -338,6 +338,7 @@ class TestMessageView:
         mocker.patch(VIEWS + ".MessageView.update_search_box_narrow")
         msg_view = MessageView(self.model, self.view)
         msg_view.model.is_search_narrow = lambda: False
+        msg_view.model.controller.in_explore_mode = False
         msg_view.log = mocker.Mock()
         msg_view.body = mocker.Mock()
         msg_w = mocker.MagicMock()
@@ -384,6 +385,22 @@ class TestMessageView:
 
         self.model.mark_message_ids_as_read.assert_not_called()
 
+    def test_read_message_in_explore_mode(self, mocker, msg_box):
+        mocker.patch(VIEWS + ".MessageView.main_view", return_value=[msg_box])
+        mocker.patch(VIEWS + ".MessageView.set_focus")
+        mocker.patch(VIEWS + ".MessageView.update_search_box_narrow")
+        msg_view = MessageView(self.model, self.view)
+        msg_w = mocker.Mock()
+        msg_view.body = mocker.Mock()
+        msg_view.body.get_focus.return_value = (msg_w, 0)
+        msg_view.model.is_search_narrow = lambda: False
+        msg_view.model.controller.in_explore_mode = True
+
+        msg_view.read_message()
+
+        assert msg_view.update_search_box_narrow.called
+        assert not self.model.mark_message_ids_as_read.called
+
     def test_read_message_search_narrow(self, mocker, msg_box):
         mocker.patch(VIEWS + ".MessageView.main_view", return_value=[msg_box])
         mocker.patch(VIEWS + ".MessageView.set_focus")
@@ -394,6 +411,7 @@ class TestMessageView:
         msg_view.body = mocker.Mock()
         msg_view.body.get_focus.return_value = (msg_w, 0)
         msg_view.model.is_search_narrow = lambda: True
+        msg_view.model.controller.in_explore_mode = False
 
         msg_view.read_message()
 
@@ -407,6 +425,7 @@ class TestMessageView:
         mocker.patch(VIEWS + ".MessageView.set_focus")
         msg_view = MessageView(self.model, self.view)
         msg_view.model.is_search_narrow = lambda: False
+        msg_view.model.controller.in_explore_mode = False
         msg_view.log = [0, 1]
         msg_view.body = mocker.Mock()
         msg_view.update_search_box_narrow = mocker.Mock()

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -85,6 +85,9 @@ def parse_args(argv: List[str]) -> argparse.Namespace:
                                 help='Don\'t autohide list of '
                                      'users and streams.')
 
+    parser.add_argument('-e', '--explore', action='store_true',
+                        help='Do not mark messages as read in the session.')
+
     parser.add_argument('-v',
                         '--version',
                         action='store_true',
@@ -321,6 +324,7 @@ def main(options: Optional[List[str]]=None) -> None:
         Controller(zuliprc_path,
                    theme_data,
                    int(args.color_depth),
+                   args.explore,
                    **boolean_settings).main()
     except ServerConnectionFailure as e:
         print(in_color('red',

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -29,10 +29,11 @@ class Controller:
     """
 
     def __init__(self, config_file: str, theme: ThemeSpec,
-                 color_depth: int,
+                 color_depth: int, in_explore_mode: bool,
                  autohide: bool, notify: bool, footlinks: bool) -> None:
         self.theme = theme
         self.color_depth = color_depth
+        self.in_explore_mode = in_explore_mode
         self.autohide = autohide
         self.notify_enabled = notify
         self.footlinks_enabled = footlinks

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -225,6 +225,10 @@ class MessageView(urwid.ListBox):
             return
         self.update_search_box_narrow(msg_w.original_widget)
 
+        # Do not read messages in explore mode.
+        if self.model.controller.in_explore_mode:
+            return
+
         # Do not read messages in any search narrow.
         if self.model.is_search_narrow():
             return


### PR DESCRIPTION
This introduces an optional argument, `--explore/-e`, to run the app in an explore mode where messages are not marked as read intentionally.

Tests amended and added.

Fixes #585.