### PR TITLE
Add support for 'starred' typeaheads

### DIFF
--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -48,8 +48,15 @@ class TestWriteBox:
         write_box.view.set_typeahead_footer.assert_not_called()
 
     @pytest.mark.parametrize('text, state, footer_text', [
+        # no-text mentions
+        ('@', 0,
+            ['Human Myself', 'Human 1', 'Human 2',
+             'Group 1', 'Group 2', 'Group 3', 'Group 4']),
+        ('@*', 0, ['Group 1', 'Group 2', 'Group 3', 'Group 4']),
+        ('@**', 0, ['Human Myself', 'Human 1', 'Human 2']),
         # mentions
         ('@Human', 0, ['Human Myself', 'Human 1', 'Human 2']),
+        ('@**Human', 0, ['Human Myself', 'Human 1', 'Human 2']),
         ('@_Human', 0, ['Human Myself', 'Human 1', 'Human 2']),
         ('@_*Human', None, []),  # NOTE: Optional single star fails
         ('@_**Human', 0, ['Human Myself', 'Human 1', 'Human 2']),
@@ -123,6 +130,19 @@ class TestWriteBox:
         ('@', 6, '@*Group 4*'),
         ('@', 7, None),  # Reached last match
         ('@', 8, None),  # Beyond end
+        # Expected sequence of autocompletes from '@**' (no groups)
+        ('@**', 0, '@**Human Myself**'),
+        ('@**', 1, '@**Human 1**'),
+        ('@**', 2, '@**Human 2**'),
+        ('@**', 3, None),  # Reached last match
+        ('@**', 4, None),  # Beyond end
+        # Expected sequence of autocompletes from '@*' (only groups)
+        ('@*', 0, '@*Group 1*'),
+        ('@*', 1, '@*Group 2*'),
+        ('@*', 2, '@*Group 3*'),
+        ('@*', 3, '@*Group 4*'),
+        ('@*', 4, None),  # Reached last match
+        ('@*', 5, None),  # Beyond end
         # Expected sequence of autocompletes from '@_'
         ('@_', 0, '@_**Human Myself**'),  # NOTE: No silent group mention
         ('@_', 1, '@_**Human 1**'),

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -56,6 +56,9 @@ class TestWriteBox:
         # streams
         ('#Stream', 0, ['Stream 1', 'Stream 2', 'Secret stream',
                         'Some general stream']),
+        ('#*Stream', None, []),  # NOTE: Optional single star fails
+        ('#**Stream', 0, ['Stream 1', 'Stream 2', 'Secret stream',
+                          'Some general stream']),  # Optional 2-stars
         ('#Stream', None, ['Stream 1', 'Stream 2', 'Secret stream',
                            'Some general stream']),
         ('#NoMatch', None, []),
@@ -199,6 +202,8 @@ class TestWriteBox:
         ('@_#Stream', 0, '@_#**Stream 1**', []),
         (':#Stream', 0, ':#**Stream 1**', []),
         ('##Stream', 0, '##**Stream 1**', []),
+        ('##*Stream', 0, None, []),  # NOTE: Optional single star fails
+        ('##**Stream', 0, '##**Stream 1**', []),  # Optional 2-stars
         # With 'Secret stream' pinned.
         ('#Stream', 0, '#**Secret stream**',
          ['Secret stream', ]),  # 2nd-word startswith match (pinned).

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -51,6 +51,8 @@ class TestWriteBox:
         # mentions
         ('@Human', 0, ['Human Myself', 'Human 1', 'Human 2']),
         ('@_Human', 0, ['Human Myself', 'Human 1', 'Human 2']),
+        ('@_*Human', None, []),  # NOTE: Optional single star fails
+        ('@_**Human', 0, ['Human Myself', 'Human 1', 'Human 2']),
         ('@Human', None, ['Human Myself', 'Human 1', 'Human 2']),
         ('@NoMatch', None, []),
         # streams
@@ -146,6 +148,8 @@ class TestWriteBox:
         (':@_H', 0, ':@_**Human Myself**'),
         ('#@_H', 0, '#@_**Human Myself**'),
         ('@@_H', 0, '@@_**Human Myself**'),
+        ('@@_*H', 0, None),  # Optional single star fails
+        ('@@_**H', 0, '@@_**Human Myself**'),  # Optional stars
     ])
     def test_generic_autocomplete_mentions(self, write_box, text,
                                            required_typeahead, state):

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -232,11 +232,21 @@ class WriteBox(urwid.Pile):
                               ) -> Tuple[List[str], List[str]]:
         # Handles user mentions (@ mentions and silent mentions)
         # and group mentions.
-        groups = [group_name
-                  for group_name in self.model.user_group_names
-                  if match_group(group_name, text[1:])]
-        group_typeahead = format_string(groups, '@*{}*')
 
+        user_typeahead, user_names = self.autocomplete_users(
+            text, prefix_string
+        )
+        group_typeahead, groups = self.autocomplete_groups(
+            text, prefix_string
+        )
+
+        combined_typeahead = user_typeahead + group_typeahead
+        combined_names = user_names + groups
+
+        return combined_typeahead, combined_names
+
+    def autocomplete_users(self, text: str, prefix_string: str
+                           ) -> Tuple[List[str], List[str]]:
         users_list = self.view.users
         matching_users = [user
                           for user in users_list
@@ -253,10 +263,15 @@ class WriteBox(urwid.Pile):
         user_names = [user['full_name'] for user in sorted_matching_users]
         user_typeahead = format_string(user_names, prefix_string + '**{}**')
 
-        combined_typeahead = user_typeahead + group_typeahead
-        combined_names = user_names + groups
+        return user_typeahead, user_names
 
-        return combined_typeahead, combined_names
+    def autocomplete_groups(self, text: str, prefix_string: str
+                            ) -> Tuple[List[str], List[str]]:
+        groups = [group_name
+                  for group_name in self.model.user_group_names
+                  if match_group(group_name, text[1:])]
+        group_typeahead = format_string(groups, '@*{}*')
+        return group_typeahead, groups
 
     def autocomplete_streams(self, text: str, prefix_string: str
                              ) -> Tuple[List[str], List[str]]:

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -167,6 +167,7 @@ class WriteBox(urwid.Pile):
                 ('@_', self.autocomplete_mentions),
                 ('@', self.autocomplete_mentions),
                 ('#', self.autocomplete_streams),
+                ('#**', self.autocomplete_streams),
                 (':', self.autocomplete_emojis),
             ])
 
@@ -265,7 +266,9 @@ class WriteBox(urwid.Pile):
         stream_typeahead = format_string(streams, '#**{}**')
         stream_data = list(zip(stream_typeahead, streams))
 
-        matched_data = match_stream(stream_data, text[1:],
+        prefix_length = len(prefix_string)
+
+        matched_data = match_stream(stream_data, text[prefix_length:],
                                     self.view.pinned_streams)
         return matched_data
 

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -167,6 +167,8 @@ class WriteBox(urwid.Pile):
                 ('@_', self.autocomplete_users),
                 ('@_**', self.autocomplete_users),
                 ('@', self.autocomplete_mentions),
+                ('@*', self.autocomplete_groups),
+                ('@**', self.autocomplete_users),
                 ('#', self.autocomplete_streams),
                 ('#**', self.autocomplete_streams),
                 (':', self.autocomplete_emojis),
@@ -273,10 +275,14 @@ class WriteBox(urwid.Pile):
 
     def autocomplete_groups(self, text: str, prefix_string: str
                             ) -> Tuple[List[str], List[str]]:
+        prefix_length = len(prefix_string)
         groups = [group_name
                   for group_name in self.model.user_group_names
-                  if match_group(group_name, text[1:])]
-        group_typeahead = format_string(groups, '@*{}*')
+                  if match_group(group_name, text[prefix_length:])]
+
+        extra_prefix = '*' if prefix_string[-1] != '*' else ''
+        group_typeahead = format_string(groups,
+                                        prefix_string + extra_prefix + '{}*')
         return group_typeahead, groups
 
     def autocomplete_streams(self, text: str, prefix_string: str

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -164,7 +164,8 @@ class WriteBox(urwid.Pile):
     def generic_autocomplete(self, text: str, state: Optional[int]
                              ) -> Optional[str]:
         autocomplete_map = OrderedDict([
-                ('@_', self.autocomplete_mentions),
+                ('@_', self.autocomplete_users),
+                ('@_**', self.autocomplete_users),
                 ('@', self.autocomplete_mentions),
                 ('#', self.autocomplete_streams),
                 ('#**', self.autocomplete_streams),
@@ -261,7 +262,12 @@ class WriteBox(urwid.Pile):
                                        reverse=True)
 
         user_names = [user['full_name'] for user in sorted_matching_users]
-        user_typeahead = format_string(user_names, prefix_string + '**{}**')
+        extra_prefix = "{}{}".format(
+            '*' if prefix_string[-1] != '*' else '',
+            '*' if prefix_string[-2:] != '**' else '',
+        )
+        user_typeahead = format_string(user_names,
+                                       prefix_string + extra_prefix + '{}**')
 
         return user_typeahead, user_names
 


### PR DESCRIPTION
This allows multiple aspects which improve the typeahead experience:
* editing of typeahead with stars (currently `@us` may generate `@**user**`, but backspacing to `@**u` doesn't autocomplete)
* specification of `@**` for autocompleting only users
* specification of `@*` for autocompleting only groups (fixing #732)

This doesn't resolve the same issue experienced in topic typeahead in the topic recipient box, namely that only full words can be autocompleted.