### PR TITLE
bugfix: Ensure subscription status checked before muting status.

### DIFF
--- a/tests/ui/test_utils.py
+++ b/tests/ui/test_utils.py
@@ -144,9 +144,13 @@ def test_create_msg_box_list(mocker, narrow, messages, focus_msg_id,
     msg_box = mocker.patch('zulipterminal.ui_tools.utils.MessageBox')
     mocker.patch('zulipterminal.ui_tools.utils.urwid.AttrMap',
                  return_value='MSG')
-    mocker.patch('zulipterminal.ui_tools.utils.is_muted', return_value=muted)
+    mock_muted = mocker.patch('zulipterminal.ui_tools.utils.is_muted',
+                              return_value=muted)
     mocker.patch('zulipterminal.ui_tools.utils.is_unsubscribed_message',
                  return_value=unsubscribed)
+
     return_value = create_msg_box_list(model, messages,
                                        focus_msg_id=focus_msg_id)
+
     assert len(return_value) == len_w_list
+    assert mock_muted.called is not unsubscribed

--- a/zulipterminal/ui_tools/utils.py
+++ b/zulipterminal/ui_tools/utils.py
@@ -23,13 +23,13 @@ def create_msg_box_list(model: Any, messages: Union[None, Iterable[Any]]=None,
     last_msg = last_message
     muted_msgs = 0  # No of messages that are muted.
     for msg in message_list:
+        if is_unsubscribed_message(msg, model):
+            continue
         # Remove messages of muted topics / streams.
         if is_muted(msg, model):
             muted_msgs += 1
             if model.narrow == []:  # Don't show in 'All messages'.
                 continue
-        if is_unsubscribed_message(msg, model):
-            continue
         msg_flag = 'unread'  # type: Union[str, None]
         flags = msg.get('flags')
         # update_messages sends messages with no flags


### PR DESCRIPTION
This causes a traceback for me when I do a specific search, since checking muted topic status assumes the stream is subscribed.

The test is updated but is rather implementation-specific.

I'd like to refactor the code further, so this is a bugfix which would benefit from being addressed better in future.