### PR TITLE
Display '(you)' beside logged-in-user in user list.

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1128,7 +1128,8 @@ class TestRightColumnView:
                 view=self.view,
                 width=width,
                 color='user_' + self.view.users[0]['status'],
-                count=1
+                count=1,
+                is_current_user=False
             )
         users_view.assert_called_once_with(self.view.controller,
                                            right_col_view.users_btn_list)

--- a/zulipterminal/config/themes.py
+++ b/zulipterminal/config/themes.py
@@ -53,6 +53,7 @@ DEF_base = dict(
     dark_blue='#24a',
     dark_cyan='#088',
     dark_gray='#666',
+    light_gray='#ccc',
     light_red='#f00',
     light_green='#0f0',
     dark_green='#080',
@@ -166,6 +167,8 @@ THEMES = {
          None,             DEF['yellow'],             DEF['black']),
         ('edit_time',      'light blue',              'black',
          None,             DEF['light_blue'],         DEF['black']),
+        ('current_user',   'white',                   'black',
+         None,             DEF['white'],              DEF['black']),
     ],
     'gruvbox_dark': [
         # default colorscheme on 16 colors, gruvbox colorscheme
@@ -242,6 +245,8 @@ THEMES = {
          None,             YELLOW,            BLACK),
         ('edit_time',      'light blue',      'black',
          None,             LIGHTBLUE,         BLACK),
+        ('current_user',   'white',           'black',
+         None,             WHITE,             BLACK),
     ],
     'zt_light': [
         (None,             'black',           'white'),
@@ -280,6 +285,7 @@ THEMES = {
         ('edit_tag',       'white',           'dark gray'),
         ('edit_author',    'dark green',      'white'),
         ('edit_time',      'dark blue',       'white'),
+        ('current_user',   'dark gray',       'white'),
     ],
     'zt_blue': [
         (None,             'black',           'light blue'),
@@ -318,6 +324,7 @@ THEMES = {
         ('edit_tag',       'white',           'dark blue'),
         ('edit_author',    'dark gray',       'light blue'),
         ('edit_time',      'dark blue',       'light blue'),
+        ('current_user',   'light gray',      'light blue'),
     ]
 }  # type: Dict[str, ThemeSpec]
 

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -199,8 +199,8 @@ class StreamButton(TopButton):
 class UserButton(TopButton):
     def __init__(self, user: Dict[str, Any], controller: Any,
                  view: Any, width: int,
-                 color: Optional[str]=None, count: int=0
-                 ) -> None:
+                 color: Optional[str]=None, count: int=0,
+                 is_current_user: bool=False) -> None:
         # Properties accessed externally
         self.email = user['email']
         self.user_id = user['user_id']
@@ -217,6 +217,8 @@ class UserButton(TopButton):
                          text_color=color,
                          width=width,
                          count=count)
+        if is_current_user:
+            self.update_widget(('current_user', '(you)'))
 
     def _narrow_with_compose(self, button: Any) -> None:
         # Switches directly to composing with user

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -54,19 +54,19 @@ class TopButton(urwid.Button):
             count_text = ''
         else:
             count_text = str(count)
-        self.update_widget(count_text)
+        self.update_widget(('unread_count', count_text))
 
-    def update_widget(self, count_text: str) -> Any:
+    def update_widget(self, count_text: Tuple[str, str]) -> Any:
         # Note that we don't modify self._caption
         max_caption_length = (self.width_for_text_and_count
-                              - len(count_text))
+                              - len(count_text[1]))
         if len(self._caption) > max_caption_length:
             caption = (self._caption[:max_caption_length - 1]
                        + '\N{HORIZONTAL ELLIPSIS}')
         else:
             caption = self._caption
         num_extra_spaces = (
-            self.width_for_text_and_count - len(count_text) - len(caption)
+            self.width_for_text_and_count - len(count_text[1]) - len(caption)
         )
 
         # NOTE: Generated text does not include space at end
@@ -174,10 +174,10 @@ class StreamButton(TopButton):
 
         # Mark muted streams 'M' during button creation.
         if self.model.is_muted_stream(self.stream_id):
-            self.update_widget('M')
+            self.update_widget(('unread_count', 'M'))
 
     def mark_muted(self) -> None:
-        self.update_widget('M')
+        self.update_widget(('unread_count', 'M'))
         self.view.home_button.update_count(
             self.model.unread_counts['all_msg'])
 
@@ -199,7 +199,8 @@ class StreamButton(TopButton):
 class UserButton(TopButton):
     def __init__(self, user: Dict[str, Any], controller: Any,
                  view: Any, width: int,
-                 color: Optional[str]=None, count: int=0) -> None:
+                 color: Optional[str]=None, count: int=0
+                 ) -> None:
         # Properties accessed externally
         self.email = user['email']
         self.user_id = user['user_id']
@@ -244,7 +245,7 @@ class TopicButton(TopButton):
             self.mark_muted()
 
     def mark_muted(self) -> None:
-        self.update_widget('M')
+        self.update_widget(('unread_count', 'M'))
     # TODO: Handle event-based approach for topic-muting.
 
 

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -659,6 +659,7 @@ class RightColumnView(urwid.Frame):
                 continue
             unread_count = (self.view.model.unread_counts['unread_pms'].
                             get(user['user_id'], 0))
+            is_current_user = (user['user_id'] == self.view.model.user_id)
             users_btn_list.append(
                 UserButton(
                     user,
@@ -666,7 +667,8 @@ class RightColumnView(urwid.Frame):
                     view=self.view,
                     width=self.width,
                     color='user_' + user['status'],
-                    count=unread_count
+                    count=unread_count,
+                    is_current_user=is_current_user
                 )
             )
         user_w = UsersView(self.view.controller, users_btn_list)


### PR DESCRIPTION
Fixes #437 
This PR displays '(you)' in white color beside the current user's username in user list.