### PR TITLE
docker: fix locale setting in Debian Buster Dockerfile.

### DIFF
--- a/docker/Dockerfile.buster
+++ b/docker/Dockerfile.buster
@@ -14,6 +14,7 @@ FROM python:3.7-slim-buster
 RUN useradd --user-group --create-home zulip
 COPY --from=builder --chown=zulip:zulip /home/zulip /home/zulip
 USER zulip
+ENV LC_ALL=C
 WORKDIR /home/zulip
 ENTRYPOINT ["/home/zulip/zulip-terminal-venv/bin/zulip-term"]
 CMD ["--config-file", "/.zulip/zuliprc"]


### PR DESCRIPTION
Fixes the locale issue mentioned in https://github.com/zulip/zulip-terminal/issues/797#issue-707661389.