### PR TITLE
Wrap creation of zuliprc in try to catch PermissionError.

### DIFF
--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -160,12 +160,17 @@ def fetch_zuliprc(zuliprc_path: str) -> None:
         print(in_color('red', "\nIncorrect Email(or Username) or Password!\n"))
         res, login_id = get_api_key(realm_url)
 
-    with open(zuliprc_path, 'w') as f:
-        f.write('[api]'
-                + '\nemail=' + login_id
-                + '\nkey=' + str(res.json()['api_key'])
-                + '\nsite=' + realm_url)
-    print('Generated API key saved at ' + zuliprc_path)
+    try:
+        with open(zuliprc_path, 'w') as f:
+            f.write('[api]'
+                    + '\nemail=' + login_id
+                    + '\nkey=' + str(res.json()['api_key'])
+                    + '\nsite=' + realm_url)
+        print('Generated API key saved at ' + zuliprc_path)
+    except OSError as ex:
+        print(in_color('red', ex.__class__.__name__
+              + ": zuliprc could not be created at " + zuliprc_path))
+        sys.exit(1)
 
 
 def parse_zuliprc(zuliprc_str: str) -> Dict[str, Any]:


### PR DESCRIPTION
Previously PermissionErrors where caught in the outer try in the while loop in
parse_zuliprc. This resulted in a misleading error message about invalid
credentials. This patch catches PermissionError directly at the source, and
exits directly since there is no point to keep asking the user for credentials.
In particular, when running the default docker configuration, this happens
since the zulip user in the container does not have permission to create files
in the mapped host folder. Fixes #797.