### PR TITLE
Displays unread message counts of muted streams and topics.

### DIFF
--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -86,6 +86,7 @@ class Model:
         self.stream_id = -1
         self.recipients = frozenset()  # type: FrozenSet[Any]
         self.index = initial_index
+        self.add_to_counts = True
 
         self.user_id = -1
         self.user_email = ""
@@ -754,11 +755,13 @@ class Model:
                     unread_count = self.unread_counts['streams'][stream_id]
                     if event['value']:  # Unmuting streams
                         self.muted_streams.remove(stream_id)
-                        self.unread_counts['all_msg'] += unread_count
+                        if self.add_to_counts:
+                            self.unread_counts['all_msg'] += unread_count
                         stream_button.mark_unmuted(unread_count)
                     else:  # Muting streams
                         self.muted_streams.add(stream_id)
-                        self.unread_counts['all_msg'] -= unread_count
+                        if self.add_to_counts:
+                            self.unread_counts['all_msg'] -= unread_count
                         stream_button.mark_muted()
                     self.controller.update_screen()
                 elif event.get('property', None) == 'pin_to_top':

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -6,7 +6,6 @@ import urwid
 from typing_extensions import TypedDict
 
 from zulipterminal.config.keys import is_command_key, primary_key_for_command
-from zulipterminal.config.symbols import MUTE_MARKER
 from zulipterminal.helper import (
     StreamData, edit_mode_captions, hash_util_decode,
 )
@@ -49,7 +48,8 @@ class TopButton(urwid.Button):
         self.controller = controller
         urwid.connect_signal(self, 'click', self.activate)
 
-    def update_count(self, count: int, text_color: Optional[str]=None) -> None:
+    def update_count(self, count: int, text_color: Optional[str]=None,
+                     unread_count_color: str='unread_count') -> None:
         new_color = self.original_color if text_color is None else text_color
 
         self.count = count
@@ -57,7 +57,7 @@ class TopButton(urwid.Button):
             count_text = ''
         else:
             count_text = str(count)
-        self.update_widget(('unread_count', count_text), new_color)
+        self.update_widget((unread_count_color, count_text), new_color)
 
     def update_widget(self, count_text: Tuple[str, str],
                       text_color: Optional[str]) -> Any:
@@ -181,7 +181,7 @@ class StreamButton(TopButton):
             self.mark_muted()
 
     def mark_muted(self) -> None:
-        self.update_widget(('muted', MUTE_MARKER), 'muted')
+        self.update_count(self.count, 'muted', 'muted')
         self.view.home_button.update_count(
             self.model.unread_counts['all_msg'])
 
@@ -252,7 +252,7 @@ class TopicButton(TopButton):
             self.mark_muted()
 
     def mark_muted(self) -> None:
-        self.update_widget(('muted',  MUTE_MARKER), 'muted')
+        self.update_count(self.count, 'muted', 'muted')
     # TODO: Handle event-based approach for topic-muting.
 
 


### PR DESCRIPTION
This PR displays unread message count of muted streams and topics.
Names of muted streams and topics are displayed in a different color instead of 'M'.

Fixes #209