### PR TITLE
[WIP] enhancement: Added a command-line option to list all the available color themes.

### DIFF
--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -60,6 +60,7 @@ def test_main_help(capsys, options):
         '--theme THEME, -t THEME',
         '-h, --help',
         '-d, --debug',
+        '--list-themes',
         '--profile',
         '--config-file CONFIG_FILE, -c CONFIG_FILE',
         '--autohide',

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -62,6 +62,9 @@ def parse_args(argv: List[str]) -> argparse.Namespace:
                              'organization.(e.g. ~/zuliprc)')
     parser.add_argument('--theme', '-t',
                         help='choose color theme. (e.g. blue, light)')
+    parser.add_argument('--list-themes',
+                        action="store_true",
+                        help='list all the color themes.')
     parser.add_argument('--color-depth',
                         choices=['1', '16', '256'], default=256,
                         help="Force the color depth (default 256).")
@@ -247,6 +250,11 @@ def main(options: Optional[List[str]]=None) -> None:
 
     if args.version:
         print('Zulip Terminal ' + ZT_VERSION)
+        sys.exit(0)
+
+    if args.list_themes:
+        print('Themes available:-',)
+        print('\n'.join(all_themes()))
         sys.exit(0)
 
     if args.config_file:

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -253,8 +253,10 @@ def main(options: Optional[List[str]]=None) -> None:
         sys.exit(0)
 
     if args.list_themes:
-        print('Themes available:-',)
-        print('\n'.join(all_themes()))
+        available_themes = all_themes()
+        print('Themes available:-')
+        for i in available_themes:
+            print('    {}'.format(i))
         sys.exit(0)
 
     if args.config_file:

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -257,37 +257,6 @@ def main(options: Optional[List[str]]=None) -> None:
     else:
         zuliprc_path = '~/zuliprc'
 
-    if args.list_themes:
-        zterm = parse_zuliprc(zuliprc_path)
-
-        if args.theme:
-            theme_to_be_used = (args.theme)
-        else:
-            theme_to_be_used = zterm['theme'][0]
-
-        available_themes = all_themes()
-        default_index = available_themes.index('zt_dark')
-        available_themes[default_index] += " [default theme]"
-        theme_aliases = aliased_themes()
-
-        print('Themes available:-')
-        for i in available_themes:
-            if theme_to_be_used in i:
-                index = available_themes.index(i)
-                available_themes[index] += " [user preference]"
-                i = available_themes[index]
-            print('    {}'.format(i))
-
-        print("")
-        print("You can change the theme temporarily using -t <theme>,")
-        print("or permanently by configuring the theme in zuliprc file:-")
-        print(in_color("yellow", "\n[zterm]"))
-        print(in_color("yellow", "theme=")
-              + in_color("cyan", "theme_name\n")
-              + "\n(where 'theme_name' is the name of the theme you want)")
-
-        sys.exit(0)
-
     try:
         zterm = parse_zuliprc(zuliprc_path)
 
@@ -321,6 +290,25 @@ def main(options: Optional[List[str]]=None) -> None:
                 real_theme_name,
                 "{} (by alias '{}')".format(theme_to_use[1], theme_to_use[0])
             )
+
+        if args.list_themes:
+            print('Themes available:-')
+            for theme in available_themes:
+                suffix = ""
+                if theme == "zt_dark":
+                    suffix += " [default theme]"
+                if theme_to_use[0] in theme:
+                    suffix += " [user preference]"
+                print('  ', theme, suffix)
+
+            print("You can change the theme temporarily using -t <theme>,")
+            print("or permanently by configuring the theme in zuliprc file:-")
+            print(in_color("yellow", "\n[zterm]"))
+            print(in_color("yellow", "theme=")
+                  + in_color("cyan", "theme_name\n")
+                  + "\n(where 'theme_name' is the name of the theme you want)")
+
+            sys.exit(0)
 
         print("Loading with:")
         print("   theme '{}' specified {}.".format(*theme_to_use))

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -274,15 +274,23 @@ def main(options: Optional[List[str]]=None) -> None:
             theme_to_use[0] in available_themes
             or theme_to_use[0] in theme_aliases
         )
-        if not is_valid_theme:
-            print("Invalid theme '{}' was specified {}."
-                  .format(*theme_to_use))
+        if not is_valid_theme or args.list_themes:
+            exit_code = 0
+            if not is_valid_theme:
+                print("Invalid theme '{}' was specified {}."
+                      .format(*theme_to_use))
+                exit_code = 1
             print("The following themes are available:")
             for theme in available_themes:
-                print("  ", theme)
+                suffix = ""
+                if theme == "zt_dark":
+                    suffix += "[default theme]"
+                if theme_to_use[0] == theme:
+                    suffix += "[user preference]"
+                print("  ", theme, suffix)
             print("Specify theme in zuliprc file or override "
                   "using -t/--theme options on command line.")
-            sys.exit(1)
+            sys.exit(exit_code)
         if theme_to_use[0] not in available_themes:
             # theme must be an alias, as it is valid
             real_theme_name = theme_aliases[theme_to_use[0]]
@@ -290,25 +298,6 @@ def main(options: Optional[List[str]]=None) -> None:
                 real_theme_name,
                 "{} (by alias '{}')".format(theme_to_use[1], theme_to_use[0])
             )
-
-        if args.list_themes:
-            print('Themes available:-')
-            for theme in available_themes:
-                suffix = ""
-                if theme == "zt_dark":
-                    suffix += " [default theme]"
-                if theme_to_use[0] in theme:
-                    suffix += " [user preference]"
-                print('  ', theme, suffix)
-
-            print("You can change the theme temporarily using -t <theme>,")
-            print("or permanently by configuring the theme in zuliprc file:-")
-            print(in_color("yellow", "\n[zterm]"))
-            print(in_color("yellow", "theme=")
-                  + in_color("cyan", "theme_name\n")
-                  + "\n(where 'theme_name' is the name of the theme you want)")
-
-            sys.exit(0)
 
         print("Loading with:")
         print("   theme '{}' specified {}.".format(*theme_to_use))

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -252,17 +252,41 @@ def main(options: Optional[List[str]]=None) -> None:
         print('Zulip Terminal ' + ZT_VERSION)
         sys.exit(0)
 
-    if args.list_themes:
-        available_themes = all_themes()
-        print('Themes available:-')
-        for i in available_themes:
-            print('    {}'.format(i))
-        sys.exit(0)
-
     if args.config_file:
         zuliprc_path = args.config_file
     else:
         zuliprc_path = '~/zuliprc'
+
+    if args.list_themes:
+        zterm = parse_zuliprc(zuliprc_path)
+
+        if args.theme:
+            theme_to_be_used = (args.theme)
+        else:
+            theme_to_be_used = zterm['theme'][0]
+
+        available_themes = all_themes()
+        default_index = available_themes.index('zt_dark')
+        available_themes[default_index] += " [default theme]"
+        theme_aliases = aliased_themes()
+
+        print('Themes available:-')
+        for i in available_themes:
+            if theme_to_be_used in i:
+                index = available_themes.index(i)
+                available_themes[index] += " [user preference]"
+                i = available_themes[index]
+            print('    {}'.format(i))
+
+        print("")
+        print("You can change the theme temporarily using -t <theme>,")
+        print("or permanently by configuring the theme in zuliprc file:-")
+        print(in_color("yellow", "\n[zterm]"))
+        print(in_color("yellow", "theme=")
+              + in_color("cyan", "theme_name\n")
+              + "\n(where 'theme_name' is the name of the theme you want)")
+
+        sys.exit(0)
 
     try:
         zterm = parse_zuliprc(zuliprc_path)


### PR DESCRIPTION
This PR adds the `--list-themes` command-line option to zulip-term which list all the available color themes. 

Fixes #613 