### PR TITLE
keymapping: Add new 'a' key for all messages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ source ~/.zshenv
 | Scroll up                                             | <kbd>PgUp</kbd> / <kbd>K</kbd>                |
 | Scroll down                                           | <kbd>PgDn</kbd> / <kbd>J</kbd>                |
 | Go to the last message                                | <kbd>G</kbd> / <kbd>end</kbd>                 |
+| Narrow to all messages                                | <kbd>a</kbd> / <kbd>esc</kbd>                 |
 | Narrow to all private messages                        | <kbd>P</kbd>                                  |
 | Narrow to all starred messages                        | <kbd>f</kbd>                                  |
 | Narrow to messages in which you're mentioned          | <kbd>#</kbd>                                  |

--- a/tests/config/test_keys.py
+++ b/tests/config/test_keys.py
@@ -23,7 +23,7 @@ def invalid_command(request):
 
 
 def test_keys_for_command(valid_command):
-    assert (keys.KEY_BINDINGS[valid_command]['keys']
+    assert (sorted(keys.KEY_BINDINGS[valid_command]['keys'])
             == keys.keys_for_command(valid_command))
 
 
@@ -35,8 +35,8 @@ def test_keys_for_command_invalid_command(invalid_command):
 def test_keys_for_command_identity(valid_command):
     """
     Ensures that each call to keys_for_command returns the original keys in a
-    new set which validates that the original keys don't get altered elsewhere
-    unintentionally.
+    new sorted list which validates that the original keys don't get altered
+    elsewhere unintentionally.
     """
     assert id(keys.KEY_BINDINGS[valid_command]['keys']) \
         != id(keys.keys_for_command(valid_command))
@@ -48,7 +48,7 @@ def test_is_command_key_matching_keys(valid_command):
 
 
 def test_is_command_key_nonmatching_keys(valid_command):
-    keys_to_test = USED_KEYS - keys.keys_for_command(valid_command)
+    keys_to_test = USED_KEYS - set(keys.keys_for_command(valid_command))
     for key in keys_to_test:
         assert not keys.is_command_key(valid_command, key)
 

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -324,12 +324,12 @@ def is_command_key(command: str, key: str) -> bool:
         raise InvalidCommand(command)
 
 
-def keys_for_command(command: str) -> Set[str]:
+def keys_for_command(command: str) -> List[str]:
     """
     Returns the actual keys for a given mapped command
     """
     try:
-        return set(KEY_BINDINGS[command]['keys'])
+        return sorted(KEY_BINDINGS[command]['keys'])
     except KeyError as exception:
         raise InvalidCommand(command)
 

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -151,6 +151,11 @@ KEY_BINDINGS = OrderedDict([
         'help_text': 'Toggle topics in a stream',
         'key_category': 'stream_list',
     }),
+    ('ALL_MESSAGES', {
+        'keys': {'a', 'esc'},
+        'help_text': 'Narrow to all messages',
+        'key_category': 'navigation',
+    }),
     ('ALL_PM', {
         'keys': {'P'},
         'help_text': 'Narrow to all private messages',

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -1160,7 +1160,7 @@ class MessageBox(urwid.Pile):
                 self.model.controller.narrow_to_user(self)
             elif self.message['type'] == 'stream':
                 self.model.controller.narrow_to_topic(self)
-        elif is_command_key('GO_BACK', key):
+        elif is_command_key('ALL_MESSAGES', key):
             self.model.controller.show_all_messages(self)
         elif is_command_key('REPLY_AUTHOR', key):
             # All subscribers from recipient_ids are not needed here.

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -94,8 +94,8 @@ class TopButton(urwid.Button):
 
 class HomeButton(TopButton):
     def __init__(self, controller: Any, width: int, count: int=0) -> None:
-        button_text = ("All messages   ["
-                       + keys_for_command("GO_BACK").pop()  # FIXME
+        button_text = ("All messages     ["
+                       + keys_for_command("ALL_MESSAGES").pop(0)
                        + "]")
         super().__init__(controller, button_text,
                          controller.show_all_messages, count=count,


### PR DESCRIPTION
A New Keymapping 'ALL_MESSAGES' is added.
This maps to 'a' key.

This replaces the 'GO_BACK' ('ESC') key currently
being used for displaying all messages.

Currently both 'GO_BACK' and 'ALL_MESSAGES' work.

Fixes #804

Signed-off-by: Adwait Thattey <coderdude1999@gmail.com>

Screenshot: 
![Screenshot_20201005_103853](https://user-images.githubusercontent.com/33225124/95042288-ffe74480-06f6-11eb-9603-732a86b41079.png)
