### PR TITLE
keymapping: replace pop with prime_key method

### DIFF
--- a/tests/config/test_keys.py
+++ b/tests/config/test_keys.py
@@ -23,7 +23,7 @@ def invalid_command(request):
 
 
 def test_keys_for_command(valid_command):
-    assert (sorted(keys.KEY_BINDINGS[valid_command]['keys'])
+    assert (keys.KEY_BINDINGS[valid_command]['keys']
             == keys.keys_for_command(valid_command))
 
 
@@ -35,7 +35,7 @@ def test_keys_for_command_invalid_command(invalid_command):
 def test_keys_for_command_identity(valid_command):
     """
     Ensures that each call to keys_for_command returns the original keys in a
-    new sorted list which validates that the original keys don't get altered
+    new list which validates that the original keys don't get altered
     elsewhere unintentionally.
     """
     assert id(keys.KEY_BINDINGS[valid_command]['keys']) \

--- a/tests/config/test_keys.py
+++ b/tests/config/test_keys.py
@@ -27,6 +27,11 @@ def test_keys_for_command(valid_command):
             == keys.keys_for_command(valid_command))
 
 
+def test_primary_key_for_command(valid_command):
+    assert (keys.KEY_BINDINGS[valid_command]['keys'][0]
+            == keys.primary_key_for_command(valid_command))
+
+
 def test_keys_for_command_invalid_command(invalid_command):
     with pytest.raises(keys.InvalidCommand):
         keys.keys_for_command(invalid_command)

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -1,7 +1,7 @@
 import pytest
 from pytest import param
 
-from zulipterminal.config.keys import keys_for_command
+from zulipterminal.config.keys import keys_for_command, primary_key_for_command
 from zulipterminal.ui_tools.boxes import PanelSearchBox, WriteBox
 
 
@@ -328,7 +328,7 @@ class TestWriteBox:
         write_box.contents[0][0].focus_col = 0
         size = widget_size(write_box)
 
-        write_box.keypress(size, keys_for_command('AUTOCOMPLETE').pop())
+        write_box.keypress(size, primary_key_for_command('AUTOCOMPLETE'))
 
         assert write_box.contents[0][0][0].edit_text == expected_text
 
@@ -367,7 +367,7 @@ class TestWriteBox:
         write_box.contents[0][0].focus_col = 1
         size = widget_size(write_box)
 
-        write_box.keypress(size, keys_for_command('AUTOCOMPLETE').pop())
+        write_box.keypress(size, primary_key_for_command('AUTOCOMPLETE'))
 
         assert write_box.contents[0][0][1].edit_text == expected_text
 
@@ -450,12 +450,12 @@ class TestWriteBox:
                               'expected_typeahead_mode',
                               'expect_footer_was_reset'], [
         # footer does not reset
-        (keys_for_command('AUTOCOMPLETE').pop(), False, False, False),
-        (keys_for_command('AUTOCOMPLETE_REVERSE').pop(), False, False, False),
-        (keys_for_command('AUTOCOMPLETE').pop(), True, True, False),
-        (keys_for_command('AUTOCOMPLETE_REVERSE').pop(), True, True, False),
+        (primary_key_for_command('AUTOCOMPLETE'), False, False, False),
+        (primary_key_for_command('AUTOCOMPLETE_REVERSE'), False, False, False),
+        (primary_key_for_command('AUTOCOMPLETE'), True, True, False),
+        (primary_key_for_command('AUTOCOMPLETE_REVERSE'), True, True, False),
         # footer resets
-        (keys_for_command('GO_BACK').pop(), True, False, True),
+        (primary_key_for_command('GO_BACK'), True, False, True),
         ('space', True, False, True),
         ('k', True, False, True),
     ])

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -1,11 +1,11 @@
 from collections import OrderedDict
-from typing import List, Set
+from typing import List
 
 from typing_extensions import TypedDict
 
 
 KeyBinding = TypedDict('KeyBinding', {
-    'keys': Set[str],
+    'keys': List[str],
     'help_text': str,
     'excluded_from_random_tips': bool,
     'key_category': str,
@@ -13,292 +13,292 @@ KeyBinding = TypedDict('KeyBinding', {
 
 KEY_BINDINGS = OrderedDict([
     ('HELP', {
-        'keys': {'?'},
+        'keys': ['?'],
         'help_text': 'Show/hide help menu',
         'excluded_from_random_tips': True,
         'key_category': 'general',
     }),
     ('ABOUT', {
-        'keys': {'meta ?'},
+        'keys': ['meta ?'],
         'help_text': 'Show/hide about menu',
         'key_category': 'general',
     }),
     ('GO_BACK', {
-        'keys': {'esc'},
+        'keys': ['esc'],
         'help_text': 'Go Back',
         'excluded_from_random_tips': False,
         'key_category': 'general',
     }),
     ('OPEN_DRAFT', {
-        'keys': {'d'},
+        'keys': ['d'],
         'help_text': 'Open draft message saved in this session',
         'key_category': 'general',
     }),
     ('GO_UP', {
-        'keys': {'k', 'up'},
+        'keys': ['k', 'up'],
         'help_text': 'Go up/Previous message',
         'key_category': 'navigation',
     }),
     ('GO_DOWN', {
-        'keys': {'j', 'down'},
+        'keys': ['j', 'down'],
         'help_text': 'Go down/Next message',
         'key_category': 'navigation',
     }),
     ('GO_LEFT', {
-        'keys': {'h', 'left'},
+        'keys': ['h', 'left'],
         'help_text': 'Go left',
         'key_category': 'navigation',
     }),
     ('GO_RIGHT', {
-        'keys': {'l', 'right'},
+        'keys': ['l', 'right'],
         'help_text': 'Go right',
         'key_category': 'navigation',
     }),
     ('SCROLL_UP', {
-        'keys': {'K', 'page up'},
+        'keys': ['K', 'page up'],
         'help_text': 'Scroll up',
         'key_category': 'navigation',
     }),
     ('SCROLL_DOWN', {
-        'keys': {'J', 'page down'},
+        'keys': ['J', 'page down'],
         'help_text': 'Scroll down',
         'key_category': 'navigation',
     }),
     ('GO_TO_BOTTOM', {
-        'keys': {'G', 'end'},
+        'keys': ['G', 'end'],
         'help_text': 'Go to bottom/last message in view',
         'key_category': 'navigation',
     }),
     ('REPLY_MESSAGE', {
-        'keys': {'r', 'enter'},
+        'keys': ['r', 'enter'],
         'help_text': 'Reply to the current message',
         'key_category': 'msg_actions',
     }),
     ('MENTION_REPLY', {
-        'keys': {'@'},
+        'keys': ['@'],
         'help_text': 'Reply mentioning the sender of the current message',
         'key_category': 'msg_actions',
     }),
     ('QUOTE_REPLY', {
-        'keys': {'>'},
+        'keys': ['>'],
         'help_text': 'Reply quoting the current message text',
         'key_category': 'msg_actions',
     }),
     ('REPLY_AUTHOR', {
-        'keys': {'R'},
+        'keys': ['R'],
         'help_text': 'Reply privately to the sender of the current message',
         'key_category': 'msg_actions',
     }),
     ('EDIT_MESSAGE', {
-        'keys': {'e'},
+        'keys': ['e'],
         'help_text': "Edit current message's text or topic",
         'key_category': 'msg_actions'
     }),
     ('STREAM_MESSAGE', {
-        'keys': {'c'},
+        'keys': ['c'],
         'help_text': 'New message to a stream',
         'key_category': 'msg_actions',
     }),
     ('PRIVATE_MESSAGE', {
-        'keys': {'x'},
+        'keys': ['x'],
         'help_text': 'New message to a person or group of people',
         'key_category': 'msg_actions',
     }),
     ('CYCLE_COMPOSE_FOCUS', {
-        'keys': {'tab'},
+        'keys': ['tab'],
         'help_text': 'Cycle through recipient and content boxes',
         'key_category': 'msg_compose',
     }),
     ('SEND_MESSAGE', {
-        'keys': {'meta enter', 'ctrl d'},
+        'keys': ['meta enter', 'ctrl d'],
         'help_text': 'Send a message',
         'key_category': 'msg_compose',
     }),
     ('SAVE_AS_DRAFT', {
-        'keys': {'meta s'},
+        'keys': ['meta s'],
         'help_text': 'Save current message as a draft',
         'key_category': 'msg_compose',
     }),
     ('AUTOCOMPLETE', {
-        'keys': {'ctrl f'},
+        'keys': ['ctrl f'],
         'help_text': ('Autocomplete @mentions, #stream_names, :emoji:'
                       ' and topics'),
         'key_category': 'msg_compose',
     }),
     ('AUTOCOMPLETE_REVERSE', {
-        'keys': {'ctrl r'},
+        'keys': ['ctrl r'],
         'help_text': 'Cycle through autocomplete suggestions in reverse',
         'key_category': 'msg_compose',
     }),
     ('STREAM_NARROW', {
-        'keys': {'s'},
+        'keys': ['s'],
         'help_text': 'Narrow to the stream of the current message',
         'key_category': 'msg_actions',
     }),
     ('TOPIC_NARROW', {
-        'keys': {'S'},
+        'keys': ['S'],
         'help_text': 'Narrow to the topic of the current message',
         'key_category': 'msg_actions',
     }),
     ('TOGGLE_NARROW', {
-        'keys': {'z'},
+        'keys': ['z'],
         'help_text':
             'Narrow to a topic/private-chat, or stream/all-private-messages',
         'key_category': 'msg_actions',
     }),
     ('TOGGLE_TOPIC', {
-        'keys': {'t'},
+        'keys': ['t'],
         'help_text': 'Toggle topics in a stream',
         'key_category': 'stream_list',
     }),
     ('ALL_MESSAGES', {
-        'keys': {'a', 'esc'},
+        'keys': ['a', 'esc'],
         'help_text': 'Narrow to all messages',
         'key_category': 'navigation',
     }),
     ('ALL_PM', {
-        'keys': {'P'},
+        'keys': ['P'],
         'help_text': 'Narrow to all private messages',
         'key_category': 'navigation',
     }),
     ('ALL_STARRED', {
-        'keys': {'f'},
+        'keys': ['f'],
         'help_text': 'Narrow to all starred messages',
         'key_category': 'navigation',
     }),
     ('ALL_MENTIONS', {
-        'keys': {'#'},
+        'keys': ['#'],
         'help_text': "Narrow to messages in which you're mentioned",
         'key_category': 'navigation',
     }),
     ('NEXT_UNREAD_TOPIC', {
-        'keys': {'n'},
+        'keys': ['n'],
         'help_text': 'Next unread topic',
         'key_category': 'navigation',
     }),
     ('NEXT_UNREAD_PM', {
-        'keys': {'p'},
+        'keys': ['p'],
         'help_text': 'Next unread private message',
         'key_category': 'navigation',
     }),
     ('SEARCH_PEOPLE', {
-        'keys': {'w'},
+        'keys': ['w'],
         'help_text': 'Search users',
         'key_category': 'searching',
     }),
     ('SEARCH_MESSAGES', {
-        'keys': {'/'},
+        'keys': ['/'],
         'help_text': 'Search Messages',
         'key_category': 'searching',
     }),
     ('SEARCH_STREAMS', {
-        'keys': {'q'},
+        'keys': ['q'],
         'help_text': 'Search Streams',
         'key_category': 'searching',
     }),
     ('SEARCH_TOPICS', {
-        'keys': {'q'},
+        'keys': ['q'],
         'help_text': 'Search topics in a stream',
         'key_category': 'searching',
     }),
     ('TOGGLE_MUTE_STREAM', {
-        'keys': {'m'},
+        'keys': ['m'],
         'help_text': 'Mute/unmute Streams',
         'key_category': 'stream_list',
     }),
     ('ENTER', {
-        'keys': {'enter'},
+        'keys': ['enter'],
         'help_text': 'Perform current action',
         'key_category': 'navigation',
     }),
     ('THUMBS_UP', {
-        'keys': {'+'},
+        'keys': ['+'],
         'help_text': 'Add/remove thumbs-up reaction to the current message',
         'key_category': 'msg_actions',
     }),
     ('TOGGLE_STAR_STATUS', {
-        'keys': {'ctrl s', '*'},
+        'keys': ['ctrl s', '*'],
         'help_text': 'Add/remove star status of the current message',
         'key_category': 'msg_actions',
     }),
     ('MSG_INFO', {
-        'keys': {'i'},
+        'keys': ['i'],
         'help_text': 'View message information',
         'key_category': 'msg_actions',
     }),
     ('EDIT_HISTORY', {
-        'keys': {'e'},
+        'keys': ['e'],
         'help_text': 'View edit history from message information box',
         'excluded_from_random_tips': True,
         'key_category': 'msg_actions',
     }),
     ('STREAM_DESC', {
-        'keys': {'i'},
+        'keys': ['i'],
         'help_text': 'View stream information & modify settings',
         'key_category': 'stream_list',
     }),
     ('REDRAW', {
-        'keys': {'ctrl l'},
+        'keys': ['ctrl l'],
         'help_text': 'Redraw screen',
         'key_category': 'general',
     }),
     ('QUIT', {
-        'keys': {'ctrl c'},
+        'keys': ['ctrl c'],
         'help_text': 'Quit',
         'key_category': 'general',
     }),
     ('BEGINNING_OF_LINE', {
-        'keys': {'ctrl a'},
+        'keys': ['ctrl a'],
         'help_text': 'Jump to the beginning of the line',
         'key_category': 'msg_compose',
     }),
     ('END_OF_LINE', {
-        'keys': {'ctrl e'},
+        'keys': ['ctrl e'],
         'help_text': 'Jump to the end of the line',
         'key_category': 'msg_compose',
     }),
     ('ONE_WORD_BACKWARD', {
-        'keys': {'meta b'},
+        'keys': ['meta b'],
         'help_text': 'Jump backward one word',
         'key_category': 'msg_compose',
     }),
     ('ONE_WORD_FORWARD', {
-        'keys': {'meta f'},
+        'keys': ['meta f'],
         'help_text': 'Jump forward one word',
         'key_category': 'msg_compose',
     }),
     ('CUT_TO_END_OF_LINE', {
-        'keys': {'ctrl k'},
+        'keys': ['ctrl k'],
         'help_text': 'Cut forward to the end of the line',
         'key_category': 'msg_compose',
     }),
     ('CUT_TO_START_OF_LINE', {
-        'keys': {'ctrl u'},
+        'keys': ['ctrl u'],
         'help_text': 'Cut backward to the start of the line',
         'key_category': 'msg_compose',
     }),
     ('CUT_TO_END_OF_WORD', {
-        'keys': {'meta d'},
+        'keys': ['meta d'],
         'help_text': 'Cut forward to the end of the current word',
         'key_category': 'msg_compose',
     }),
     ('CUT_TO_START_OF_WORD', {
-        'keys': {'ctrl w'},
+        'keys': ['ctrl w'],
         'help_text': 'Cut backward to the start of the current word',
         'key_category': 'msg_compose',
     }),
     ('PREV_LINE', {
-        'keys': {'ctrl p', 'up'},
+        'keys': ['ctrl p', 'up'],
         'help_text': 'Jump to the previous line',
         'key_category': 'msg_compose',
     }),
     ('NEXT_LINE', {
-        'keys': {'ctrl n', 'down'},
+        'keys': ['ctrl n', 'down'],
         'help_text': 'Jump to the next line',
         'key_category': 'msg_compose',
     }),
     ('CLEAR_MESSAGE', {
-        'keys': {'ctrl l'},
+        'keys': ['ctrl l'],
         'help_text': 'Clear compose screen',
         'key_category': 'msg_compose',
     }),
@@ -334,7 +334,7 @@ def keys_for_command(command: str) -> List[str]:
     Returns the actual keys for a given mapped command
     """
     try:
-        return sorted(KEY_BINDINGS[command]['keys'])
+        return list(KEY_BINDINGS[command]['keys'])
     except KeyError as exception:
         raise InvalidCommand(command)
 

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -12,6 +12,9 @@ KeyBinding = TypedDict('KeyBinding', {
 }, total=False)
 
 KEY_BINDINGS = OrderedDict([
+    # Key that is displayed in the UI is determined by the method
+    # primary_key_for_command. (Currently the first key in the list)
+
     ('HELP', {
         'keys': ['?'],
         'help_text': 'Show/hide help menu',
@@ -337,6 +340,14 @@ def keys_for_command(command: str) -> List[str]:
         return list(KEY_BINDINGS[command]['keys'])
     except KeyError as exception:
         raise InvalidCommand(command)
+
+
+def primary_key_for_command(command: str) -> str:
+    """
+    Primary Key is the key that will be displayed in
+    the UI
+    """
+    return keys_for_command(command).pop(0)
 
 
 def commands_for_random_tips() -> List[KeyBinding]:

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -12,7 +12,7 @@ from urllib.parse import urlparse
 import zulip
 from typing_extensions import Literal, TypedDict
 
-from zulipterminal.config.keys import keys_for_command
+from zulipterminal.config.keys import primary_key_for_command
 from zulipterminal.helper import (
     Message, StreamData, asynch, canonicalize_color, classify_unread_counts,
     display_error_if_present, index_messages, initial_index, notify, set_count,
@@ -882,7 +882,7 @@ class Model:
                 "Press '{}' to close this window."
             )
             notice = notice_template.format(failed_command,
-                                            keys_for_command("GO_BACK").pop())
+                                            primary_key_for_command("GO_BACK"))
             self.controller.popup_with_message(notice, width=50)
             self.controller.update_screen()
             self._notified_user_of_notification_failure = True

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -15,7 +15,9 @@ from tzlocal import get_localzone
 from urwid_readline import ReadlineEdit
 
 from zulipterminal import emoji_names
-from zulipterminal.config.keys import is_command_key, keys_for_command
+from zulipterminal.config.keys import (
+    is_command_key, keys_for_command, primary_key_for_command,
+)
 from zulipterminal.config.symbols import (
     MESSAGE_CONTENT_MARKER, MESSAGE_HEADER_DIVIDER, QUOTED_TEXT_MARKER,
     STREAM_TOPIC_SEPARATOR, TIME_MENTION_MARKER,
@@ -60,8 +62,8 @@ class WriteBox(urwid.Pile):
         self.msg_write_box = ReadlineEdit(multiline=True)
         self.msg_write_box.enable_autocomplete(
             func=self.generic_autocomplete,
-            key=keys_for_command('AUTOCOMPLETE').pop(),
-            key_reverse=keys_for_command('AUTOCOMPLETE_REVERSE').pop()
+            key=primary_key_for_command('AUTOCOMPLETE'),
+            key_reverse=primary_key_for_command('AUTOCOMPLETE_REVERSE')
         )
         self.header_write_box = urwid.LineBox(
             self.to_write_box, tlcorner='─', tline='─', lline='',
@@ -84,8 +86,8 @@ class WriteBox(urwid.Pile):
         self.msg_write_box = ReadlineEdit(multiline=True)
         self.msg_write_box.enable_autocomplete(
             func=self.generic_autocomplete,
-            key=keys_for_command('AUTOCOMPLETE').pop(),
-            key_reverse=keys_for_command('AUTOCOMPLETE_REVERSE').pop()
+            key=primary_key_for_command('AUTOCOMPLETE'),
+            key_reverse=primary_key_for_command('AUTOCOMPLETE_REVERSE')
         )
         self.stream_write_box = ReadlineEdit(
             caption="Stream:  ",
@@ -93,15 +95,15 @@ class WriteBox(urwid.Pile):
         )
         self.stream_write_box.enable_autocomplete(
             func=self._stream_box_autocomplete,
-            key=keys_for_command('AUTOCOMPLETE').pop(),
-            key_reverse=keys_for_command('AUTOCOMPLETE_REVERSE').pop()
+            key=primary_key_for_command('AUTOCOMPLETE'),
+            key_reverse=primary_key_for_command('AUTOCOMPLETE_REVERSE')
         )
         self.title_write_box = ReadlineEdit(caption="Topic:  ",
                                             edit_text=title)
         self.title_write_box.enable_autocomplete(
             func=self._topic_box_autocomplete,
-            key=keys_for_command('AUTOCOMPLETE').pop(),
-            key_reverse=keys_for_command('AUTOCOMPLETE_REVERSE').pop()
+            key=primary_key_for_command('AUTOCOMPLETE'),
+            key_reverse=primary_key_for_command('AUTOCOMPLETE_REVERSE')
         )
 
         self.header_write_box = urwid.Columns([
@@ -394,9 +396,13 @@ class WriteBox(urwid.Pile):
                             invalid_stream_error = (
                                 'Invalid stream name.'
                                 ' Use {} or {} to autocomplete.'
-                                .format(keys_for_command('AUTOCOMPLETE').pop(),
-                                        keys_for_command('AUTOCOMPLETE'
-                                                         '_REVERSE').pop())
+                                .format(primary_key_for_command(
+                                            'AUTOCOMPLETE'
+                                        ),
+                                        primary_key_for_command(
+                                            'AUTOCOMPLETE'
+                                            '_REVERSE'
+                                        ))
                             )
                             self.view.set_footer_text(invalid_stream_error, 3)
                             return key
@@ -1095,7 +1101,7 @@ class MessageBox(urwid.Pile):
             if button == 1:
                 if self.model.controller.is_in_editor_mode():
                     return True
-                self.keypress(size, keys_for_command('ENTER').pop())
+                self.keypress(size, primary_key_for_command('ENTER'))
                 return True
         elif event == 'mouse drag':
             selection_key = "Fn + Alt" if platform == "darwin" else "Shift"

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -5,7 +5,7 @@ from urllib.parse import urljoin, urlparse
 import urwid
 from typing_extensions import TypedDict
 
-from zulipterminal.config.keys import is_command_key, keys_for_command
+from zulipterminal.config.keys import is_command_key, primary_key_for_command
 from zulipterminal.helper import (
     StreamData, edit_mode_captions, hash_util_decode,
 )
@@ -95,7 +95,7 @@ class TopButton(urwid.Button):
 class HomeButton(TopButton):
     def __init__(self, controller: Any, width: int, count: int=0) -> None:
         button_text = ("All messages     ["
-                       + keys_for_command("ALL_MESSAGES").pop(0)
+                       + primary_key_for_command("ALL_MESSAGES")
                        + "]")
         super().__init__(controller, button_text,
                          controller.show_all_messages, count=count,
@@ -106,7 +106,7 @@ class HomeButton(TopButton):
 class PMButton(TopButton):
     def __init__(self, controller: Any, width: int, count: int=0) -> None:
         button_text = ("Private messages ["
-                       + keys_for_command("ALL_PM").pop()
+                       + primary_key_for_command("ALL_PM")
                        + "]")
         super().__init__(controller, button_text,
                          controller.show_all_pm, count=count,
@@ -117,7 +117,7 @@ class PMButton(TopButton):
 class MentionedButton(TopButton):
     def __init__(self, controller: Any, width: int, count: int=0) -> None:
         button_text = ("Mentions         ["
-                       + keys_for_command("ALL_MENTIONS").pop()
+                       + primary_key_for_command("ALL_MENTIONS")
                        + "]")
         super().__init__(controller, button_text,
                          controller.show_all_mentions,
@@ -129,7 +129,7 @@ class MentionedButton(TopButton):
 class StarredButton(TopButton):
     def __init__(self, controller: Any, width: int) -> None:
         button_text = ("Starred messages ["
-                       + keys_for_command("ALL_STARRED").pop()
+                       + primary_key_for_command("ALL_STARRED")
                        + "]")
         super().__init__(controller, button_text,
                          controller.show_all_starred,


### PR DESCRIPTION
keys_for_command currently returns a sorted_list
and pop is used to get the key that is to be displayed in the UI

A new method prime_key_for_command is introduced, that always
returns first element from the sorted list

pop is rpelaced everywhere with this new method

tests are also added to assert this behaviour

A followup to PR #805