### PR TITLE
Migrate popup tests out of general ui_tools file

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -18,8 +18,7 @@ from zulipterminal.ui_tools.buttons import (
 )
 from zulipterminal.ui_tools.views import (
     LeftColumnView, MessageView, MiddleColumnView, ModListWalker,
-    PopUpConfirmationView, RightColumnView, StreamsView, StreamsViewDivider,
-    TopicsView, UsersView,
+    RightColumnView, StreamsView, StreamsViewDivider, TopicsView, UsersView,
 )
 
 
@@ -1250,48 +1249,6 @@ class TestLeftColumnView:
                         count=count)
             for topic, count in zip(topic_list, unread_count_list)
         ])
-
-
-class TestPopUpConfirmationView:
-    @pytest.fixture
-    def popup_view(self, mocker, stream_button):
-        self.controller = mocker.Mock()
-        self.controller.view.LEFT_WIDTH = 27
-        self.callback = mocker.Mock()
-        self.list_walker = mocker.patch(VIEWS + ".urwid.SimpleFocusListWalker",
-                                        return_value=[])
-        self.divider = mocker.patch(VIEWS + '.urwid.Divider')
-        self.text = mocker.patch(VIEWS + '.urwid.Text')
-        self.wrapper_w = mocker.patch(VIEWS + '.urwid.WidgetWrap')
-        return PopUpConfirmationView(
-            self.controller,
-            self.text,
-            self.callback,
-        )
-
-    def test_init(self, popup_view):
-        assert popup_view.controller == self.controller
-        assert popup_view.success_callback == self.callback
-        self.divider.assert_called_once_with()
-        self.list_walker.assert_called_once_with(
-            [self.text, self.divider(), self.wrapper_w()])
-
-    def test_exit_popup_yes(self, mocker, popup_view):
-        popup_view.exit_popup_yes(mocker.Mock())
-        self.callback.assert_called_once_with()
-        assert self.controller.exit_popup.called
-
-    def test_exit_popup_no(self, mocker, popup_view):
-        popup_view.exit_popup_no(mocker.Mock())
-        self.callback.assert_not_called()
-        assert self.controller.exit_popup.called
-
-    @pytest.mark.parametrize('key', keys_for_command('GO_BACK'))
-    def test_exit_popup_GO_BACK(self, mocker, popup_view, key, widget_size):
-        size = widget_size(popup_view)
-        popup_view.keypress(size, key)
-        self.callback.assert_not_called()
-        assert self.controller.exit_popup.called
 
 
 class TestMessageBox:

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -18,8 +18,8 @@ from zulipterminal.ui_tools.buttons import (
 )
 from zulipterminal.ui_tools.views import (
     EditModeView, LeftColumnView, MessageView, MiddleColumnView, ModListWalker,
-    PopUpConfirmationView, PopUpView, RightColumnView, StreamInfoView,
-    StreamsView, StreamsViewDivider, TopicsView, UsersView,
+    PopUpConfirmationView, PopUpView, RightColumnView, StreamsView,
+    StreamsViewDivider, TopicsView, UsersView,
 )
 
 
@@ -1375,58 +1375,6 @@ class TestEditModeView:
 
         mode_button = edit_mode_view.edit_mode_button
         mode_button.set_selected_mode.assert_called_once_with(mode)
-
-
-class TestStreamInfoView:
-    @pytest.fixture(autouse=True)
-    def mock_external_classes(self, mocker, monkeypatch):
-        self.controller = mocker.Mock()
-        mocker.patch.object(self.controller, 'maximum_popup_dimensions',
-                            return_value=(64, 64))
-        self.controller.model.is_muted_stream.return_value = False
-        self.controller.model.is_pinned_stream.return_value = False
-        mocker.patch(VIEWS + ".urwid.SimpleFocusListWalker", return_value=[])
-        stream_id = 10
-        self.controller.model.stream_dict = {stream_id: {'name': 'books',
-                                                         'description': 'hey'}}
-        self.stream_info_view = StreamInfoView(self.controller, stream_id)
-
-    @pytest.mark.parametrize('key', {*keys_for_command('GO_BACK'),
-                                     *keys_for_command('STREAM_DESC')})
-    def test_keypress_exit_popup(self, key, widget_size):
-        size = widget_size(self.stream_info_view)
-        self.stream_info_view.keypress(size, key)
-        assert self.controller.exit_popup.called
-
-    def test_keypress_navigation(self, mocker, widget_size,
-                                 navigation_key_expected_key_pair):
-        key, expected_key = navigation_key_expected_key_pair
-        size = widget_size(self.stream_info_view)
-        super_keypress = mocker.patch(VIEWS + '.urwid.ListBox.keypress')
-        self.stream_info_view.keypress(size, key)
-        super_keypress.assert_called_once_with(size, expected_key)
-
-    @pytest.mark.parametrize('key', (*keys_for_command('ENTER'), ' '))
-    def test_checkbox_toggle_mute_stream(self, mocker, key, widget_size):
-        mute_checkbox = self.stream_info_view.widgets[3]
-        toggle_mute_status = self.controller.model.toggle_stream_muted_status
-        stream_id = self.stream_info_view.stream_id
-        size = widget_size(mute_checkbox)
-
-        mute_checkbox.keypress(size, key)
-
-        toggle_mute_status.assert_called_once_with(stream_id)
-
-    @pytest.mark.parametrize('key', (*keys_for_command('ENTER'), ' '))
-    def test_checkbox_toggle_pin_stream(self, mocker, key, widget_size):
-        pin_checkbox = self.stream_info_view.widgets[4]
-        toggle_pin_status = self.controller.model.toggle_stream_pinned_status
-        stream_id = self.stream_info_view.stream_id
-        size = widget_size(pin_checkbox)
-
-        pin_checkbox.keypress(size, key)
-
-        toggle_pin_status.assert_called_once_with(stream_id)
 
 
 class TestMessageBox:

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -17,12 +17,11 @@ from zulipterminal.ui_tools.buttons import (
     StreamButton, TopButton, TopicButton, UserButton,
 )
 from zulipterminal.ui_tools.views import (
-    AboutView, EditModeView, HelpView, LeftColumnView, MessageView,
-    MiddleColumnView, ModListWalker, MsgInfoView, PopUpConfirmationView,
-    PopUpView, RightColumnView, StreamInfoView, StreamsView,
-    StreamsViewDivider, TopicsView, UsersView,
+    EditModeView, HelpView, LeftColumnView, MessageView, MiddleColumnView,
+    ModListWalker, MsgInfoView, PopUpConfirmationView, PopUpView,
+    RightColumnView, StreamInfoView, StreamsView, StreamsViewDivider,
+    TopicsView, UsersView,
 )
-from zulipterminal.version import MINIMUM_SUPPORTED_SERVER_VERSION, ZT_VERSION
 
 
 VIEWS = "zulipterminal.ui_tools.views"
@@ -1340,56 +1339,6 @@ class TestHelpMenu:
         super_keypress = mocker.patch(VIEWS + '.urwid.ListBox.keypress')
         self.help_view.keypress(size, key)
         super_keypress.assert_called_once_with(size, expected_key)
-
-
-class TestAboutView:
-    @pytest.fixture(autouse=True)
-    def mock_external_classes(self, mocker):
-        self.controller = mocker.Mock()
-        mocker.patch.object(self.controller, 'maximum_popup_dimensions',
-                            return_value=(64, 64))
-        mocker.patch(VIEWS + '.urwid.SimpleFocusListWalker', return_value=[])
-        server_version, server_feature_level = MINIMUM_SUPPORTED_SERVER_VERSION
-        self.about_view = AboutView(self.controller, 'About',
-                                    zt_version=ZT_VERSION,
-                                    server_version=server_version,
-                                    server_feature_level=server_feature_level)
-
-    @pytest.mark.parametrize('key', {*keys_for_command('GO_BACK'),
-                                     *keys_for_command('ABOUT')})
-    def test_keypress_exit_popup(self, key, widget_size):
-        size = widget_size(self.about_view)
-        self.about_view.keypress(size, key)
-        assert self.controller.exit_popup.called
-
-    def test_keypress_exit_popup_invalid_key(self, widget_size):
-        key = 'a'
-        size = widget_size(self.about_view)
-        self.about_view.keypress(size, key)
-        assert not self.controller.exit_popup.called
-
-    def test_keypress_navigation(self, mocker, widget_size,
-                                 navigation_key_expected_key_pair):
-        key, expected_key = navigation_key_expected_key_pair
-        size = widget_size(self.about_view)
-        super_keypress = mocker.patch(VIEWS + '.urwid.ListBox.keypress')
-        self.about_view.keypress(size, key)
-        super_keypress.assert_called_once_with(size, expected_key)
-
-    def test_feature_level_content(self, mocker, zulip_version):
-        self.controller = mocker.Mock()
-        mocker.patch.object(self.controller, 'maximum_popup_dimensions',
-                            return_value=(64, 64))
-        mocker.patch(VIEWS + '.urwid.SimpleFocusListWalker', return_value=[])
-        server_version, server_feature_level = zulip_version
-
-        about_view = AboutView(self.controller, 'About', zt_version=ZT_VERSION,
-                               server_version=server_version,
-                               server_feature_level=server_feature_level)
-
-        assert len(about_view.feature_level_content) == (
-            1 if server_feature_level else 0
-        )
 
 
 class TestPopUpConfirmationView:

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -17,10 +17,9 @@ from zulipterminal.ui_tools.buttons import (
     StreamButton, TopButton, TopicButton, UserButton,
 )
 from zulipterminal.ui_tools.views import (
-    EditModeView, HelpView, LeftColumnView, MessageView, MiddleColumnView,
-    ModListWalker, MsgInfoView, PopUpConfirmationView, PopUpView,
-    RightColumnView, StreamInfoView, StreamsView, StreamsViewDivider,
-    TopicsView, UsersView,
+    EditModeView, LeftColumnView, MessageView, MiddleColumnView, ModListWalker,
+    MsgInfoView, PopUpConfirmationView, PopUpView, RightColumnView,
+    StreamInfoView, StreamsView, StreamsViewDivider, TopicsView, UsersView,
 )
 
 
@@ -1308,37 +1307,6 @@ class TestPopUpView:
         ))
         self.pop_up_view.keypress(size, key)
         self.super_keypress.assert_called_once_with(size, expected_key)
-
-
-class TestHelpMenu:
-    @pytest.fixture(autouse=True)
-    def mock_external_classes(self, mocker, monkeypatch):
-        self.controller = mocker.Mock()
-        mocker.patch.object(self.controller, 'maximum_popup_dimensions',
-                            return_value=(64, 64))
-        mocker.patch(VIEWS + ".urwid.SimpleFocusListWalker", return_value=[])
-        self.help_view = HelpView(self.controller, 'Help Menu')
-
-    def test_keypress_any_key(self, widget_size):
-        key = "a"
-        size = widget_size(self.help_view)
-        self.help_view.keypress(size, key)
-        assert not self.controller.exit_popup.called
-
-    @pytest.mark.parametrize('key', {*keys_for_command('GO_BACK'),
-                                     *keys_for_command('HELP')})
-    def test_keypress_exit_popup(self, key, widget_size):
-        size = widget_size(self.help_view)
-        self.help_view.keypress(size, key)
-        assert self.controller.exit_popup.called
-
-    def test_keypress_navigation(self, mocker, widget_size,
-                                 navigation_key_expected_key_pair):
-        key, expected_key = navigation_key_expected_key_pair
-        size = widget_size(self.help_view)
-        super_keypress = mocker.patch(VIEWS + '.urwid.ListBox.keypress')
-        self.help_view.keypress(size, key)
-        super_keypress.assert_called_once_with(size, expected_key)
 
 
 class TestPopUpConfirmationView:

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -17,7 +17,7 @@ from zulipterminal.ui_tools.buttons import (
     StreamButton, TopButton, TopicButton, UserButton,
 )
 from zulipterminal.ui_tools.views import (
-    EditModeView, LeftColumnView, MessageView, MiddleColumnView, ModListWalker,
+    LeftColumnView, MessageView, MiddleColumnView, ModListWalker,
     PopUpConfirmationView, PopUpView, RightColumnView, StreamsView,
     StreamsViewDivider, TopicsView, UsersView,
 )
@@ -1349,32 +1349,6 @@ class TestPopUpConfirmationView:
         popup_view.keypress(size, key)
         self.callback.assert_not_called()
         assert self.controller.exit_popup.called
-
-
-class TestEditModeView:
-    @pytest.fixture()
-    def edit_mode_view(self, mocker):
-        controller = mocker.Mock()
-        controller.maximum_popup_dimensions.return_value = (64, 64)
-        mocker.patch(VIEWS + ".urwid.SimpleFocusListWalker", return_value=[])
-        button = mocker.Mock()
-        return EditModeView(controller, button)
-
-    @pytest.mark.parametrize(['index_in_widgets', 'mode'], [
-        (0, 'change_one'),
-        (1, 'change_later'),
-        (2, 'change_all'),
-    ])
-    @pytest.mark.parametrize('key', keys_for_command('ENTER'))
-    def test_select_edit_mode(self, mocker, edit_mode_view, widget_size,
-                              index_in_widgets, mode, key):
-        radio_button = edit_mode_view.widgets[index_in_widgets]
-        size = widget_size(radio_button)
-
-        radio_button.keypress(size, key)
-
-        mode_button = edit_mode_view.edit_mode_button
-        mode_button.set_selected_mode.assert_called_once_with(mode)
 
 
 class TestMessageBox:

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -5,7 +5,8 @@ from urwid import Columns, Text
 
 from zulipterminal.config.keys import keys_for_command
 from zulipterminal.ui_tools.views import (
-    AboutView, EditHistoryView, HelpView, MsgInfoView, StreamInfoView,
+    AboutView, EditHistoryView, EditModeView, HelpView, MsgInfoView,
+    StreamInfoView,
 )
 from zulipterminal.version import MINIMUM_SUPPORTED_SERVER_VERSION, ZT_VERSION
 
@@ -246,6 +247,32 @@ class TestEditHistoryView:
         return_value = EditHistoryView._get_author_prefix(snapshot, tag)
 
         assert return_value == expected_author_prefix
+
+
+class TestEditModeView:
+    @pytest.fixture()
+    def edit_mode_view(self, mocker):
+        controller = mocker.Mock()
+        controller.maximum_popup_dimensions.return_value = (64, 64)
+        mocker.patch(VIEWS + ".urwid.SimpleFocusListWalker", return_value=[])
+        button = mocker.Mock()
+        return EditModeView(controller, button)
+
+    @pytest.mark.parametrize(['index_in_widgets', 'mode'], [
+        (0, 'change_one'),
+        (1, 'change_later'),
+        (2, 'change_all'),
+    ])
+    @pytest.mark.parametrize('key', keys_for_command('ENTER'))
+    def test_select_edit_mode(self, mocker, edit_mode_view, widget_size,
+                              index_in_widgets, mode, key):
+        radio_button = edit_mode_view.widgets[index_in_widgets]
+        size = widget_size(radio_button)
+
+        radio_button.keypress(size, key)
+
+        mode_button = edit_mode_view.edit_mode_button
+        mode_button.set_selected_mode.assert_called_once_with(mode)
 
 
 class TestHelpView:

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -4,7 +4,9 @@ import pytest
 from urwid import Columns, Text
 
 from zulipterminal.config.keys import keys_for_command
-from zulipterminal.ui_tools.views import AboutView, EditHistoryView, HelpView
+from zulipterminal.ui_tools.views import (
+    AboutView, EditHistoryView, HelpView, MsgInfoView,
+)
 from zulipterminal.version import MINIMUM_SUPPORTED_SERVER_VERSION, ZT_VERSION
 
 
@@ -274,4 +276,135 @@ class TestHelpView:
         size = widget_size(self.help_view)
         super_keypress = mocker.patch(VIEWS + '.urwid.ListBox.keypress')
         self.help_view.keypress(size, key)
+        super_keypress.assert_called_once_with(size, expected_key)
+
+
+class TestMsgInfoView:
+    @pytest.fixture(autouse=True)
+    def mock_external_classes(self, mocker, monkeypatch, message_fixture):
+        self.controller = mocker.Mock()
+        mocker.patch.object(self.controller, 'maximum_popup_dimensions',
+                            return_value=(64, 64))
+        mocker.patch(VIEWS + ".urwid.SimpleFocusListWalker", return_value=[])
+        # The subsequent patches (index and initial_data) set
+        # show_edit_history_label to False for this autoused fixture.
+        self.controller.model.index = {'edited_messages': set()}
+        self.controller.model.initial_data = {
+            'realm_allow_edit_history': False,
+        }
+        self.msg_info_view = MsgInfoView(self.controller, message_fixture,
+                                         'Message Information', OrderedDict(),
+                                         list())
+
+    def test_keypress_any_key(self, widget_size):
+        key = "a"
+        size = widget_size(self.msg_info_view)
+        self.msg_info_view.keypress(size, key)
+        assert not self.controller.exit_popup.called
+
+    @pytest.mark.parametrize('key', keys_for_command('EDIT_HISTORY'))
+    @pytest.mark.parametrize('realm_allow_edit_history', [True, False])
+    @pytest.mark.parametrize('edited_message_id', [
+            537286,
+            537287,
+            537288,
+        ],
+        ids=[
+            'stream_message_id',
+            'pm_message_id',
+            'group_pm_message_id',
+        ]
+    )
+    def test_keypress_edit_history(self, message_fixture, key, widget_size,
+                                   realm_allow_edit_history,
+                                   edited_message_id):
+        self.controller.model.index = {
+            'edited_messages': set([edited_message_id]),
+        }
+        self.controller.model.initial_data = {
+            'realm_allow_edit_history': realm_allow_edit_history,
+        }
+        msg_info_view = MsgInfoView(self.controller, message_fixture,
+                                    title='Message Information',
+                                    message_links=OrderedDict(),
+                                    time_mentions=list())
+        size = widget_size(msg_info_view)
+
+        msg_info_view.keypress(size, key)
+
+        if msg_info_view.show_edit_history_label:
+            self.controller.show_edit_history.assert_called_once_with(
+                message=message_fixture,
+                message_links=OrderedDict(),
+                time_mentions=list(),
+            )
+        else:
+            self.controller.show_edit_history.assert_not_called()
+
+    @pytest.mark.parametrize('key', {*keys_for_command('GO_BACK'),
+                                     *keys_for_command('MSG_INFO')})
+    def test_keypress_exit_popup(self, key, widget_size):
+        size = widget_size(self.msg_info_view)
+        self.msg_info_view.keypress(size, key)
+        assert self.controller.exit_popup.called
+
+    def test_height_noreactions(self):
+        expected_height = 3
+        assert self.msg_info_view.height == expected_height
+
+    # FIXME This is the same parametrize as MessageBox:test_reactions_view
+    @pytest.mark.parametrize('to_vary_in_each_message', [
+        {'reactions': [{
+                'emoji_name': 'thumbs_up',
+                'emoji_code': '1f44d',
+                'user': {
+                    'email': 'iago@zulip.com',
+                    'full_name': 'Iago',
+                    'id': 5,
+                },
+                'reaction_type': 'unicode_emoji'
+            }, {
+                'emoji_name': 'zulip',
+                'emoji_code': 'zulip',
+                'user': {
+                    'email': 'iago@zulip.com',
+                    'full_name': 'Iago',
+                    'id': 5,
+                },
+                'reaction_type': 'zulip_extra_emoji'
+            }, {
+                'emoji_name': 'zulip',
+                'emoji_code': 'zulip',
+                'user': {
+                    'email': 'AARON@zulip.com',
+                    'full_name': 'aaron',
+                    'id': 1,
+                },
+                'reaction_type': 'zulip_extra_emoji'
+            }, {
+                'emoji_name': 'heart',
+                'emoji_code': '2764',
+                'user': {
+                    'email': 'iago@zulip.com',
+                    'full_name': 'Iago',
+                    'id': 5,
+                },
+                'reaction_type': 'unicode_emoji'
+            }]}
+        ])
+    def test_height_reactions(self, message_fixture, to_vary_in_each_message):
+        varied_message = dict(message_fixture, **to_vary_in_each_message)
+        self.msg_info_view = MsgInfoView(self.controller, varied_message,
+                                         'Message Information', OrderedDict(),
+                                         list())
+        # 9 = 3 labels + 1 blank line + 1 'Reactions' (category) + 4 reactions.
+        expected_height = 9
+        assert self.msg_info_view.height == expected_height
+
+    def test_keypress_navigation(self, mocker, widget_size,
+                                 navigation_key_expected_key_pair):
+        key, expected_key = navigation_key_expected_key_pair
+        size = widget_size(self.msg_info_view)
+        super_keypress = mocker.patch(VIEWS + '.urwid.ListBox.keypress')
+        self.msg_info_view.keypress(size, key)
         super_keypress.assert_called_once_with(size, expected_key)

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -3,15 +3,72 @@ from collections import OrderedDict
 import pytest
 from urwid import Columns, Text
 
-from zulipterminal.config.keys import keys_for_command
+from zulipterminal.config.keys import is_command_key, keys_for_command
 from zulipterminal.ui_tools.views import (
-    AboutView, EditHistoryView, EditModeView, HelpView, MsgInfoView,
+    AboutView, EditHistoryView, EditModeView, HelpView, MsgInfoView, PopUpView,
     StreamInfoView,
 )
 from zulipterminal.version import MINIMUM_SUPPORTED_SERVER_VERSION, ZT_VERSION
 
 
 VIEWS = "zulipterminal.ui_tools.views"
+
+
+class TestPopUpView:
+    @pytest.fixture(autouse=True)
+    def pop_up_view(self, mocker):
+        self.controller = mocker.Mock()
+        mocker.patch.object(self.controller, 'maximum_popup_dimensions',
+                            return_value=(64, 64))
+        self.command = 'COMMAND'
+        self.title = 'Generic title'
+        self.width = 16
+        self.widget = mocker.Mock()
+        mocker.patch.object(self.widget, 'rows', return_value=1)
+        self.widgets = [self.widget, ]
+        self.list_walker = mocker.patch(VIEWS + '.urwid.SimpleFocusListWalker',
+                                        return_value=[])
+        self.super_init = mocker.patch(VIEWS + '.urwid.ListBox.__init__')
+        self.super_keypress = mocker.patch(VIEWS + '.urwid.ListBox.keypress')
+        self.pop_up_view = PopUpView(self.controller, self.widgets,
+                                     self.command, self.width, self.title)
+
+    def test_init(self):
+        assert self.pop_up_view.controller == self.controller
+        assert self.pop_up_view.command == self.command
+        assert self.pop_up_view.title == self.title
+        assert self.pop_up_view.width == self.width
+        self.list_walker.assert_called_once_with(self.widgets)
+        self.super_init.assert_called_once_with(self.pop_up_view.log)
+
+    @pytest.mark.parametrize('key', keys_for_command('GO_BACK'))
+    def test_keypress_GO_BACK(self, key, widget_size):
+        size = widget_size(self.pop_up_view)
+        self.pop_up_view.keypress(size, key)
+        assert self.controller.exit_popup.called
+
+    def test_keypress_command_key(self, mocker, widget_size):
+        size = widget_size(self.pop_up_view)
+        mocker.patch(VIEWS + '.is_command_key', side_effect=(
+            lambda command, key: command == self.command
+        ))
+        self.pop_up_view.keypress(size, 'cmd_key')
+        assert self.controller.exit_popup.called
+
+    def test_keypress_navigation(self, mocker, widget_size,
+                                 navigation_key_expected_key_pair):
+        key, expected_key = navigation_key_expected_key_pair
+        size = widget_size(self.pop_up_view)
+        # Patch `is_command_key` to not raise an 'Invalid Command' exception
+        # when its parameters are (self.command, key) as there is no
+        # self.command='COMMAND' command in keys.py.
+        mocker.patch(VIEWS + '.is_command_key', side_effect=(
+            lambda command, key:
+            False if command == self.command
+            else is_command_key(command, key)
+        ))
+        self.pop_up_view.keypress(size, key)
+        self.super_keypress.assert_called_once_with(size, expected_key)
 
 
 class TestAboutView:


### PR DESCRIPTION
We discussed this in the past in #**zulip-terminal>Splitting UI tests** - now seems a good time to make this change.

This moves all popup-related tests, resulting in ~400 lines moved, making the general test file change from ~2.8klines to ~2.4klines - and simplifying imports.

**I'm not sure we have particular open PRs which should be impacted by this, but please let me know if there are specific ones you know are impacted.**