### PR TITLE
[WIP] Toggle showing only unread streams

### DIFF
--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -154,6 +154,11 @@ KEY_BINDINGS = OrderedDict([
         'help_text': 'Toggle topics in a stream',
         'key_category': 'stream_list',
     }),
+    ('TOGGLE_UNREAD_ONLY', {
+        'keys': ['U'],
+        'help_text': 'Toggle showing only unread streams or topics',
+        'key_category': 'stream_list',
+    }),
     ('ALL_MESSAGES', {
         'keys': ['a', 'esc'],
         'help_text': 'Narrow to all messages',

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -177,7 +177,7 @@ def _set_count_in_view(controller: Any, new_count: int,
         additionally set the current count in the model and make use of the
         same in the UI.
     """
-    stream_buttons_log = controller.view.stream_w.log
+    stream_buttons_log = controller.view.stream_w.streams_btn_list
     is_open_topic_view = controller.view.left_panel.is_in_topic_view
     if is_open_topic_view:
         topic_buttons_log = controller.view.topic_w.log

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -150,6 +150,8 @@ class StreamButton(TopButton):
         is_private = properties['invite_only']
         self.description = properties['description']
 
+        self._is_muted = False
+
         self.model = controller.model
         self.count = count
         self.view = view
@@ -174,14 +176,22 @@ class StreamButton(TopButton):
 
         # Mark muted streams 'M' during button creation.
         if self.model.is_muted_stream(self.stream_id):
+            # Use mark_muted here?
+            self._is_muted = True
             self.update_widget(('unread_count', 'M'))
 
+    @property
+    def is_muted(self) -> bool:
+        return self._is_muted
+
     def mark_muted(self) -> None:
+        self._is_muted = True
         self.update_widget(('unread_count', 'M'))
         self.view.home_button.update_count(
             self.model.unread_counts['all_msg'])
 
     def mark_unmuted(self, unread_count: int) -> None:
+        self._is_muted = False
         self.update_count(unread_count)
         self.view.home_button.update_count(
             self.model.unread_counts['all_msg'])

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -364,6 +364,8 @@ class StreamsView(urwid.Frame):
         if is_command_key('SEARCH_STREAMS', key):
             self.set_focus('header')
             return key
+        elif is_command_key('TOGGLE_UNREAD_ONLY', key):
+            self._toggle_unread_only()
         elif is_command_key('GO_BACK', key):
             self.stream_search_box.reset_search_text()
             self.log.clear()

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -283,6 +283,8 @@ class StreamsView(urwid.Frame):
                                                 'SEARCH_STREAMS',
                                                 self.update_streams)
 
+        self._show_unread_only = False
+
         title = urwid.Text("Streams", align="center")
         self._header = urwid.Pile([
             urwid.Columns([
@@ -296,6 +298,12 @@ class StreamsView(urwid.Frame):
         self.search_lock = threading.Lock()
 
         super().__init__(list_box, header=self._header)
+
+    def _set_title(self, text: str) -> None:
+        self._header[0].contents[1] = (
+            urwid.Text(text, align="center"),
+            urwid.Columns.options(width_type="pack")
+        )
 
     @asynch
     def update_streams(self, search_box: Any, new_text: str) -> None:
@@ -332,6 +340,14 @@ class StreamsView(urwid.Frame):
             self.log.clear()
             self.log.extend(streams_display)
             self.view.controller.update_screen()
+
+    def _toggle_unread_only(self) -> None:
+        self._show_unread_only = not self._show_unread_only
+
+        if self._show_unread_only:
+            self._set_title("Streams [Unread]")
+        else:
+            self._set_title("Streams")
 
     def mouse_event(self, size: urwid_Size, event: str, button: int, col: int,
                     row: int, focus: bool) -> bool:

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -282,12 +282,20 @@ class StreamsView(urwid.Frame):
         self.stream_search_box = PanelSearchBox(self,
                                                 'SEARCH_STREAMS',
                                                 self.update_streams)
-        super().__init__(list_box, header=urwid.LineBox(
-            self.stream_search_box, tlcorner='─', tline='', lline='',
-            trcorner='─', blcorner='─', rline='',
-            bline='─', brcorner='─'
-        ))
+
+        title = urwid.Text("Streams", align="center")
+        self._header = urwid.Pile([
+            urwid.Columns([
+                urwid.Divider(LIST_TITLE_BAR_LINE),
+                ("pack", title),
+                urwid.Divider(LIST_TITLE_BAR_LINE),
+            ], dividechars=1),
+            self.stream_search_box,
+            urwid.Divider("─"),
+        ])
         self.search_lock = threading.Lock()
+
+        super().__init__(list_box, header=self._header)
 
     @asynch
     def update_streams(self, search_box: Any, new_text: str) -> None:
@@ -775,15 +783,7 @@ class LeftColumnView(urwid.Pile):
                                          if hasattr(stream, 'stream_id')}
 
         self.view.stream_w = StreamsView(streams_btn_list, self.view)
-        w = urwid.LineBox(
-            self.view.stream_w, title="Streams",
-            tlcorner=LIST_TITLE_BAR_LINE,
-            tline=LIST_TITLE_BAR_LINE,
-            trcorner=LIST_TITLE_BAR_LINE,
-            blcorner='', rline='', lline='',
-            bline='', brcorner='─'
-            )
-        return w
+        return self.view.stream_w
 
     def topics_view(self, stream_button: Any) -> Any:
         stream_id = stream_button.stream_id

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -341,6 +341,11 @@ class StreamsView(urwid.Frame):
             self.log.extend(streams_display)
             self.view.controller.update_screen()
 
+    def _reset_stream_list(self) -> None:
+        self.log.clear()
+        self.log.extend(self.streams_btn_list)
+        self.log.set_focus(self.focus_index_before_search)
+
     def _toggle_unread_only(self) -> None:
         self._show_unread_only = not self._show_unread_only
 
@@ -368,11 +373,8 @@ class StreamsView(urwid.Frame):
             self._toggle_unread_only()
         elif is_command_key('GO_BACK', key):
             self.stream_search_box.reset_search_text()
-            self.log.clear()
-            self.log.extend(self.streams_btn_list)
+            self._reset_stream_list()
             self.set_focus('body')
-            self.log.set_focus(self.focus_index_before_search)
-            self.view.controller.update_screen()
             return key
         return_value = super().keypress(size, key)
         _, self.focus_index_before_search = self.log.get_focus()


### PR DESCRIPTION
This is a draft approach to filter the visible streams, leading to a result a little like the unreads view in the mobile app.

While this is a WIP, this is pretty useful already; next I'll likely look at filtering topics in a similar way.

Some outstanding points to consider:
* Position is saved and restored when toggling, but we don't take into account eg. no unread streams (or no subscribed!)
* Should the unread 'filter' state be different for topics and streams, and maybe even between each set of topics (ie. stream) - possibly easier for us and users to just have one setting?
* I left search looking over all streams (even if previously in unreads-only view), but this can leave a strange situation where deleting the search text gives a different view from the unread stream list, so I'm reconsidering this
* Muted streams are excluded from the unreads - this seems reasonable?
* Unlike the mobile app (?), "emptied" unread streams (ie. initially with unreads, but then up to date) are not updated, except with a `UU` ie. toggle to all and back to only unreads to re-filter
* Unread counts **mostly** just work - but I just noticed an exception that if messages arrive in currently not-shown (read) streams then they are not counted.
* The setting is not saved between sessions right now