### PR TITLE
Adjust subscription op=peer_* events for ZFL35+

### DIFF
--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -1634,10 +1634,8 @@ class TestModel:
         model.controller.update_screen.assert_called_once_with()
 
     @pytest.mark.parametrize('event, expected_subscribers', [
-        ({'type': 'subscription', 'op': 'peer_add',
-          'stream_id': 99, 'user_id': 12}, [1001, 11, 12]),
-        ({'type': 'subscription', 'op': 'peer_remove',
-          'stream_id': 2, 'user_id': 12}, [1001, 11]),
+        ({'op': 'peer_add', 'stream_id': 99, 'user_id': 12}, [1001, 11, 12]),
+        ({'op': 'peer_remove', 'stream_id': 2, 'user_id': 12}, [1001, 11]),
     ], ids=[
         'user_subscribed_to_stream',
         'user_unsubscribed_from_stream',
@@ -1645,6 +1643,8 @@ class TestModel:
     def test__handle_subscription_event_subscribers(self, model, mocker,
                                                     stream_dict, event,
                                                     expected_subscribers):
+        event['type'] = 'subscription'
+
         model.stream_dict = stream_dict
 
         model._handle_subscription_event(event)
@@ -1653,16 +1653,16 @@ class TestModel:
         assert new_subscribers == expected_subscribers
 
     @pytest.mark.parametrize('event', [
-        ({'type': 'subscription', 'op': 'peer_add',
-          'stream_id': 462, 'user_id': 12}),
-        ({'type': 'subscription', 'op': 'peer_remove',
-          'stream_id': 462, 'user_id': 12}),
+        ({'op': 'peer_add', 'stream_id': 462, 'user_id': 12}),
+        ({'op': 'peer_remove', 'stream_id': 462, 'user_id': 12}),
     ], ids=[
         'peer_subscribed_to_stream_that_user_is_unsubscribed_to',
         'peer_unsubscribed_from_stream_that_user_is_unsubscribed_to',
     ])
     def test__handle_subscription_event_subscribers_to_unsubscribed_streams(
                             self, model, mocker, stream_dict, event):
+        event['type'] = 'subscription'
+
         model.stream_dict = deepcopy(stream_dict)
 
         model._handle_subscription_event(event)

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -783,14 +783,17 @@ class Model:
                     sort_streams(self.pinned_streams)
                     self.controller.view.left_panel.update_stream_view()
                     self.controller.update_screen()
-        elif (event['op'] in ('peer_add', 'peer_remove')
-              and self.is_user_subscribed_to_stream(event['stream_id'])):
-            subscribers = self.stream_dict[event['stream_id']]['subscribers']
-            user_id = event['user_id']
-            if event['op'] == 'peer_add':
-                subscribers.append(user_id)
-            else:
-                subscribers.remove(user_id)
+        elif event['op'] in ('peer_add', 'peer_remove'):
+            stream_ids = [event['stream_id']]
+            user_ids = [event['user_id']]
+            for stream_id in stream_ids:
+                if self.is_user_subscribed_to_stream(stream_id):
+                    subscribers = self.stream_dict[stream_id]['subscribers']
+                    if event['op'] == 'peer_add':
+                        subscribers.extend(user_ids)
+                    else:
+                        for user_id in user_ids:
+                            subscribers.remove(user_id)
 
     def _handle_typing_event(self, event: Event) -> None:
         """

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -49,7 +49,9 @@ Event = TypedDict('Event', {
     # subscription:
     'property': str,
     'user_id': int,  # Present when a streams subscribers are updated.
+    'user_ids': List[int],  # NOTE: replaces 'user_id' in ZFL 35
     'stream_id': int,
+    'stream_ids': List[int],  # NOTE: replaces 'stream_id' in ZFL 35 for peer*
     'value': bool,
     'message_ids': List[int]  # Present when subject of msg(s) is updated
 }, total=False)  # Each Event will only have a subset of these
@@ -784,8 +786,15 @@ class Model:
                     self.controller.view.left_panel.update_stream_view()
                     self.controller.update_screen()
         elif event['op'] in ('peer_add', 'peer_remove'):
-            stream_ids = [event['stream_id']]
-            user_ids = [event['user_id']]
+            # NOTE: ZFL 35 commit was not atomic with API change
+            #       (ZFL >=35 can use new plural style)
+            if 'stream_ids' not in event or 'user_ids' not in event:
+                stream_ids = [event['stream_id']]
+                user_ids = [event['user_id']]
+            else:
+                stream_ids = event['stream_ids']
+                user_ids = event['user_ids']
+
             for stream_id in stream_ids:
                 if self.is_user_subscribed_to_stream(stream_id):
                     subscribers = self.stream_dict[stream_id]['subscribers']

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -783,14 +783,14 @@ class Model:
                     sort_streams(self.pinned_streams)
                     self.controller.view.left_panel.update_stream_view()
                     self.controller.update_screen()
-        elif (event['op'] == 'peer_add'
+        elif (event['op'] in ('peer_add', 'peer_remove')
               and self.is_user_subscribed_to_stream(event['stream_id'])):
             subscribers = self.stream_dict[event['stream_id']]['subscribers']
-            subscribers.append(event['user_id'])
-        elif (event['op'] == 'peer_remove'
-              and self.is_user_subscribed_to_stream(event['stream_id'])):
-            subscribers = self.stream_dict[event['stream_id']]['subscribers']
-            subscribers.remove(event['user_id'])
+            user_id = event['user_id']
+            if event['op'] == 'peer_add':
+                subscribers.append(user_id)
+            else:
+                subscribers.remove(user_id)
 
     def _handle_typing_event(self, event: Event) -> None:
         """


### PR DESCRIPTION
Previously these events contained single stream and user ids, but now instead contain lists of each to reduce the numbers of events required for cases where users join or leave large numbers of streams.

This is already merged into master as of https://github.com/zulip/zulip/commit/7ff3859136638defff01abafcaa8db51a2e2eb54, so pending zulip/zulip#16628, this should limit breakage for those using czo.