### PR TITLE
Add Python 3.9 to CI/installation (& other travis adjustments)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ jobs:
     - python: 3.8
       name: "Install & pytest - CPython 3.8 (default linux)"
     - python: pypy3.6-7.3.1
+      # Bumped from xenial for openssl
+      dist: bionic
       # Use PyPy3 7.3.1, which fixes a typing_extensions.TypedDict bug
       name: "Install & pytest - PyPy 3.6 v7.3.1 (default linux)"
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: python
+os: linux
+dist: xenial
 git:
   depth: 20
 cache:
   pip: true
-matrix:
+jobs:
   include:
     - python: 3.7
       name: "Linting - type consistency (mypy)"
@@ -34,7 +36,6 @@ matrix:
       cache:
       - $HOME/Library/Caches/pip
       osx_image: xcode10
-      sudo: required
       language: generic
 install:
   - pip3 install . && pip3 install .[testing]

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,8 @@ jobs:
       name: "Install & pytest - CPython 3.7 (default linux)"
     - python: 3.8
       name: "Install & pytest - CPython 3.8 (default linux)"
+    - python: 3.9
+      name: "Install & pytest - CPython 3.9 (default linux)"
     - python: pypy3.6-7.3.1
       # Bumped from xenial for openssl
       dist: bionic

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
@@ -89,7 +90,7 @@ setup(
         'Issues':
             'https://github.com/zulip/zulip-terminal/issues',
     },
-    python_requires='>=3.5, <3.9',
+    python_requires='>=3.5, <3.10',
     keywords='',
     packages=find_packages(exclude=['tests', 'tests.*']),
     zip_safe=True,


### PR DESCRIPTION
The main enhancement is the support for testing/installation on py3.9.

However, this also fixes a few other issues:
* PyPy now indirectly appears to require a later openssl build, so dist is set to bionic
* Update the travis config generally to be more explicit and resolve the config warnings during travis builds