### PR TITLE
Use varying symbols for user status.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,7 +63,8 @@ def user_button(mocker, width=38):
         },
         width=width,
         controller=mocker.patch('zulipterminal.core.Controller'),
-        view=mocker.patch('zulipterminal.ui.View')
+        view=mocker.patch('zulipterminal.ui.View'),
+        state_marker="*",
     )
 
 

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -9,7 +9,8 @@ from urwid import Columns, Divider, Padding, Text
 
 from zulipterminal.config.keys import keys_for_command
 from zulipterminal.config.symbols import (
-    QUOTED_TEXT_MARKER, STREAM_TOPIC_SEPARATOR, TIME_MENTION_MARKER,
+    QUOTED_TEXT_MARKER, STATUS_ACTIVE, STREAM_TOPIC_SEPARATOR,
+    TIME_MENTION_MARKER,
 )
 from zulipterminal.helper import powerset
 from zulipterminal.ui_tools.boxes import MessageBox
@@ -1128,6 +1129,7 @@ class TestRightColumnView:
                 view=self.view,
                 width=width,
                 color='user_' + self.view.users[0]['status'],
+                state_marker=STATUS_ACTIVE,
                 count=1,
                 is_current_user=False
             )
@@ -2313,11 +2315,12 @@ class TestUserButton:
                                  view=mocker.Mock(),
                                  width=width,
                                  color=None,  # FIXME test elsewhere?
+                                 state_marker="*",
                                  count=count)
 
         text = user_button._w._original_widget.get_text()
         count_str = '' if count == 0 else str(count)
-        expected_text = ' \N{BULLET} {}{}{}'.format(
+        expected_text = ' * {}{}{}'.format(
                 short_text,
                 (width - 4 - len(short_text) - len(count_str)) * ' ',
                 count_str)
@@ -2342,6 +2345,7 @@ class TestUserButton:
                                  view=mocker.Mock(),
                                  width=width,
                                  color=mocker.Mock(),
+                                 state_marker="*",
                                  count=mocker.Mock())
         size = widget_size(user_button)
 

--- a/zulipterminal/config/symbols.py
+++ b/zulipterminal/config/symbols.py
@@ -11,3 +11,7 @@ LIST_TITLE_BAR_LINE = '━'
 # appears to overlap its subsequent text.
 TIME_MENTION_MARKER = '⏱ '  # Other tested options are: '⧗' and '⧖'.
 MUTE_MARKER = 'M'
+STATUS_ACTIVE = '●'
+STATUS_IDLE = '◒'
+STATUS_OFFLINE = '○'
+STATUS_INACTIVE = '•'

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -203,6 +203,7 @@ class StreamButton(TopButton):
 class UserButton(TopButton):
     def __init__(self, user: Dict[str, Any], controller: Any,
                  view: Any, width: int,
+                 state_marker: str,
                  color: Optional[str]=None, count: int=0,
                  is_current_user: bool=False) -> None:
         # Properties accessed externally
@@ -217,7 +218,7 @@ class UserButton(TopButton):
         super().__init__(controller,
                          caption=user['full_name'],
                          show_function=self._narrow_with_compose,
-                         prefix_character=(color, '\N{BULLET}'),
+                         prefix_character=(color, state_marker),
                          text_color=color,
                          width=width,
                          count=count)

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -10,7 +10,8 @@ from zulipterminal.config.keys import (
     HELP_CATEGORIES, KEY_BINDINGS, is_command_key, keys_for_command,
 )
 from zulipterminal.config.symbols import (
-    CHECK_MARK, LIST_TITLE_BAR_LINE, PINNED_STREAMS_DIVIDER,
+    CHECK_MARK, LIST_TITLE_BAR_LINE, PINNED_STREAMS_DIVIDER, STATUS_ACTIVE,
+    STATUS_IDLE, STATUS_INACTIVE, STATUS_OFFLINE,
 )
 from zulipterminal.helper import (
     Message, asynch, edit_mode_captions, match_stream, match_user,
@@ -651,10 +652,19 @@ class RightColumnView(urwid.Frame):
         if users is None:
             users = self.view.users.copy()
             reset_default_view_users = True
+
+        state_icon = {
+            'active': STATUS_ACTIVE,
+            'idle': STATUS_IDLE,
+            'offline': STATUS_OFFLINE,
+            'inactive': STATUS_INACTIVE,
+        }
+
         users_btn_list = list()
         for user in users:
+            status = user['status']
             # Only include `inactive` users in search result.
-            if (user['status'] == 'inactive'
+            if (status == 'inactive'
                     and not self.view.controller.is_in_editor_mode()):
                 continue
             unread_count = (self.view.model.unread_counts['unread_pms'].
@@ -666,7 +676,8 @@ class RightColumnView(urwid.Frame):
                     controller=self.view.controller,
                     view=self.view,
                     width=self.width,
-                    color='user_' + user['status'],
+                    state_marker=state_icon[status],
+                    color='user_' + status,
                     count=unread_count,
                     is_current_user=is_current_user
                 )


### PR DESCRIPTION
This moves from having a single small bullet to a style similar to the
webapp, with circles of varying degrees of fullness:
* filled (active)
* bottom-filled (idle)
* empty (offline)
* small (inactive)

Tests updated.

NOTE: I'll move the unicode to symbols.py before this is merged.