### PR TITLE
Support inter-thread exception handling

### DIFF
--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -53,8 +53,10 @@ class TestController:
         assert controller.theme == self.theme
 
         assert self.main_loop.call_count == 1
-        controller.loop.watch_pipe.assert_called_once_with(
-            controller.draw_screen)
+        controller.loop.watch_pipe.assert_has_calls([
+            mocker.call(controller.draw_screen),
+            mocker.call(controller._raise_exception)
+        ])
 
     def test_initial_editor_mode(self, controller):
         assert not controller.is_in_editor_mode()

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -54,7 +54,7 @@ class TestController:
 
         assert self.main_loop.call_count == 1
         controller.loop.watch_pipe.assert_has_calls([
-            mocker.call(controller.draw_screen),
+            mocker.call(controller._draw_screen),
             mocker.call(controller._raise_exception)
         ])
 

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1203,4 +1203,9 @@ class Model:
             for event in response['events']:
                 last_event_id = max(last_event_id, int(event['id']))
                 if event['type'] in self.event_actions:
-                    self.event_actions[event['type']](event)
+                    try:
+                        self.event_actions[event['type']](event)
+                    except Exception:
+                        import sys
+                        (self.controller.
+                         raise_exception_in_main_thread(sys.exc_info()))

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1208,4 +1208,5 @@ class Model:
                     except Exception:
                         import sys
                         (self.controller.
-                         raise_exception_in_main_thread(sys.exc_info()))
+                         raise_exception_in_main_thread(sys.exc_info(),
+                                                        critical=False))


### PR DESCRIPTION
This extends an approach originally in a commit by @amanagr some time ago to use an urwid pipe to allow exceptions to be passed across threads. This is a more general form which I've had in a branch for some time.

While this doesn't yet take this approach as far as it could go, this has some rather important benefits already, most noticeably if an exception occurs during event handling:
* the event loop keeps running
* the exception is logged to a file
* a notice window is shown indicating an error occurred, where to report it and where the report is logged 

The limitations in this PR right now are:
* lack of explicit tests; this has been manually tested and appear to work fine
* perhaps configuring the exception output to use a standard logger from run.py?