### PR TITLE
WIP: Add Application config menu in About section.

### DIFF
--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -28,12 +28,13 @@ class TestController:
         mocker.patch(CORE + '.Controller.show_loading')
 
         self.config_file = 'path/to/zuliprc'
+        self.theme_name = 'zt_dark'
         self.theme = 'default'
         self.in_explore_mode = False
         self.autohide = True  # FIXME Add tests for no-autohide
         self.notify_enabled = False
         self.footlinks_enabled = True
-        result = Controller(self.config_file, self.theme, 256,
+        result = Controller(self.config_file, self.theme_name, self.theme, 256,
                             self.in_explore_mode, self.autohide,
                             self.notify_enabled, self.footlinks_enabled)
         result.view.message_view = mocker.Mock()  # set in View.__init__

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -126,10 +126,15 @@ class TestAboutView:
                             return_value=(64, 64))
         mocker.patch(VIEWS + '.urwid.SimpleFocusListWalker', return_value=[])
         server_version, server_feature_level = MINIMUM_SUPPORTED_SERVER_VERSION
+
         self.about_view = AboutView(self.controller, 'About',
                                     zt_version=ZT_VERSION,
                                     server_version=server_version,
-                                    server_feature_level=server_feature_level)
+                                    server_feature_level=server_feature_level,
+                                    theme_name='zt_dark',
+                                    color_depth=256,
+                                    autohide_enabled=False,
+                                    footlink_enabled=True)
 
     @pytest.mark.parametrize('key', {*keys_for_command('GO_BACK'),
                                      *keys_for_command('ABOUT')})
@@ -161,7 +166,11 @@ class TestAboutView:
 
         about_view = AboutView(self.controller, 'About', zt_version=ZT_VERSION,
                                server_version=server_version,
-                               server_feature_level=server_feature_level)
+                               server_feature_level=server_feature_level,
+                               theme_name='zt_dark',
+                               color_depth=256,
+                               autohide_enabled=False,
+                               footlink_enabled=True)
 
         assert len(about_view.feature_level_content) == (
             1 if server_feature_level else 0

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -352,6 +352,7 @@ def main(options: Optional[List[str]]=None) -> None:
             theme_data = THEMES[theme_to_use[0]]
 
         Controller(zuliprc_path,
+                   theme_to_use[0],
                    theme_data,
                    color_depth,
                    args.explore,

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -28,9 +28,10 @@ class Controller:
     the application.
     """
 
-    def __init__(self, config_file: str, theme: ThemeSpec,
+    def __init__(self, config_file: str, theme_name: str, theme: ThemeSpec,
                  color_depth: int, in_explore_mode: bool,
                  autohide: bool, notify: bool, footlinks: bool) -> None:
+        self.theme_name = theme_name
         self.theme = theme
         self.color_depth = color_depth
         self.in_explore_mode = in_explore_mode
@@ -160,7 +161,10 @@ class Controller:
         self.show_pop_up(
             AboutView(self, 'About', zt_version=ZT_VERSION,
                       server_version=self.model.server_version,
-                      server_feature_level=self.model.server_feature_level)
+                      server_feature_level=self.model.server_feature_level,
+                      theme_name=self.theme_name, color_depth=self.color_depth,
+                      autohide_enabled=self.autohide,
+                      footlink_enabled=self.footlinks_enabled)
         )
 
     def show_edit_history(

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -991,7 +991,9 @@ class NoticeView(PopUpView):
 class AboutView(PopUpView):
     def __init__(self, controller: Any, title: str, *, zt_version: str,
                  server_version: str,
-                 server_feature_level: Optional[int]) -> None:
+                 server_feature_level: Optional[int],
+                 theme_name: str, color_depth: int,
+                 autohide_enabled: bool, footlink_enabled: bool) -> None:
         self.feature_level_content = (
             [('Feature level', str(server_feature_level))]
             if server_feature_level else []
@@ -1000,6 +1002,11 @@ class AboutView(PopUpView):
             ('Application', [('Zulip Terminal', zt_version)]),
             ('Server', [('Version', server_version)]
              + self.feature_level_content),
+            ('Application Configuration', [
+                ('Theme', theme_name),
+                ('Autohide', 'enabled' if autohide_enabled else 'disabled'),
+                ('Footlink', 'enabled' if footlink_enabled else 'disabled'),
+                ('Color depth', str(color_depth))])
         ]
 
         popup_width, column_widths = self.calculate_table_widths(contents,


### PR DESCRIPTION
The about section has now an added menu `Application Configuration`, that lists the options that Zulip-terminal was loaded with. Here is the screenshot of the new `About` section:

![About-section-zt](https://user-images.githubusercontent.com/54993043/98072739-b8d2a780-1e8c-11eb-98b6-b26bbe0a2786.png)

Fixes #812 
