### PR TITLE
search_box: Improved search box query handler.

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ source ~/.zshenv
 | Command                                               | Key Combination                               |
 | ----------------------------------------------------- | --------------------------------------------- |
 | Search users                                          | <kbd>w</kbd>                                  |
-| Search messages                                       | <kbd>/</kbd>                                  |
+| Search messages                                       | <kbd>/</kbd> / <kbd>alt /</kbd>               |
 | Search streams                                        | <kbd>q</kbd>                                  |
 | Search topics in a stream                             | <kbd>q</kbd>                                  |
 

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -190,7 +190,7 @@ KEY_BINDINGS = OrderedDict([
         'key_category': 'searching',
     }),
     ('SEARCH_MESSAGES', {
-        'keys': ['/'],
+        'keys': ['/', 'meta /'],
         'help_text': 'Search Messages',
         'key_category': 'searching',
     }),

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -39,6 +39,7 @@ class Controller:
         self.footlinks_enabled = footlinks
         self.message_search = None
         self.stream_button = None
+        self.sticky_search = False
 
         self._editor = None  # type: Optional[Any]
 
@@ -241,10 +242,12 @@ class Controller:
         else:
             self.view.message_view.log.extend(w_list)
 
-        if self.message_search is not None:
-            self.view.search_box.text_box.set_edit_text(self.message_search)
-        else:
-            self.view.search_box.text_box.set_edit_text('')
+        if self.sticky_search:
+            if self.message_search is not None:
+                self.view.search_box.text_box.set_edit_text(
+                    self.message_search)
+            else:
+                self.view.search_box.text_box.set_edit_text('')
 
         self.exit_editor_mode()
 

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -37,6 +37,8 @@ class Controller:
         self.autohide = autohide
         self.notify_enabled = notify
         self.footlinks_enabled = footlinks
+        self.message_search = None
+        self.stream_button = None
 
         self._editor = None  # type: Optional[Any]
 
@@ -239,6 +241,11 @@ class Controller:
         else:
             self.view.message_view.log.extend(w_list)
 
+        if self.message_search is not None:
+            self.view.search_box.text_box.set_edit_text(self.message_search)
+        else:
+            self.view.search_box.text_box.set_edit_text('')
+
         self.exit_editor_mode()
 
     def narrow_to_stream(self, button: Any) -> None:
@@ -247,6 +254,7 @@ class Controller:
         else:
             anchor = None
 
+        self.stream_button = button
         self._narrow_to(button,
                         anchor=anchor,
                         stream=button.stream_name)
@@ -256,7 +264,6 @@ class Controller:
             anchor = button.message['id']
         else:
             anchor = None
-
         self._narrow_to(button,
                         anchor=anchor,
                         stream=button.stream_name,
@@ -299,6 +306,13 @@ class Controller:
         self._narrow_to(button,
                         anchor=None,
                         starred=True)
+
+    def _activate(self) -> None:
+        self.view.show_left_panel(visible=False)
+        self.view.show_right_panel(visible=False)
+        self.view.body.focus_col = 1
+        if self.stream_button is not None:
+            self.narrow_to_stream(self.stream_button)
 
     def show_all_mentions(self, button: Any) -> None:
         # NOTE: Should we ensure we maintain anchor focus here?

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -1277,12 +1277,15 @@ class SearchBox(urwid.Pile):
                 or is_command_key('GO_BACK', key)):
             self.text_box.set_edit_text("")
             self.controller.exit_editor_mode()
+            self.controller.message_search = None
             self.controller.view.middle_column.set_focus('body')
+            self.controller._activate()
             return key
 
         elif is_command_key('ENTER', key):
             self.controller.exit_editor_mode()
             self.controller.search_messages(self.text_box.edit_text)
+            self.controller.message_search = self.text_box.edit_text
             self.controller.view.middle_column.set_focus('body')
             return key
 

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -91,7 +91,7 @@ class TopButton(urwid.Button):
     def keypress(self, size: urwid_Size, key: str) -> Optional[str]:
         if is_command_key('ENTER', key):
             self.activate(key)
-            if self.controller.message_search is not None:
+            if self.controller.sticky_search and self.controller.message_search is not None:
                 self.controller.exit_editor_mode()
                 self.controller.search_messages(self.controller.message_search)
                 self.controller.view.middle_column.set_focus('body')

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -91,6 +91,10 @@ class TopButton(urwid.Button):
     def keypress(self, size: urwid_Size, key: str) -> Optional[str]:
         if is_command_key('ENTER', key):
             self.activate(key)
+            if self.controller.message_search is not None:
+                self.controller.exit_editor_mode()
+                self.controller.search_messages(self.controller.message_search)
+                self.controller.view.middle_column.set_focus('body')
             return None
         else:  # This is in the else clause, to avoid multiple activation
             return super().keypress(size, key)

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -329,6 +329,10 @@ class StreamsView(urwid.Frame):
     def mouse_event(self, size: urwid_Size, event: str, button: int, col: int,
                     row: int, focus: bool) -> bool:
         if event == 'mouse press':
+            if button == 1:
+                self.view.search_box.text_box.set_edit_text('')
+                self.view.controller.message_search = None
+                return super().mouse_event(size, event, button, col, row, focus)
             if button == 4:
                 self.keypress(size, 'up')
                 return True

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -530,6 +530,7 @@ class MiddleColumnView(urwid.Frame):
             return super().keypress(size, key)
 
         elif is_command_key('SEARCH_MESSAGES', key):
+            self.controller.sticky_search = True if key == 'meta /' else False
             self.controller.enter_editor_mode_with(self.search_box)
             self.set_focus('header')
             return key


### PR DESCRIPTION
Earlier , The query typed in search box is erased when the user navigates to a new stream .
As suggested by @neiljp <a href = 'https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/Sticky.20message.20search.20.23T822/near/1058839'>here</a> , Added a extra keybinding of <code>meta /</code>( <code>alt /</code>) which retains the search query and carries it forward whenever the user changes narrows .

It includes : 
<ul>
<li>If the user wants to perform a <code>non-sticky</code> search across narrows , the usual keybinding of <code>/</code> would make the job done .</li>
<li>But , if user prefers for a <code>sticky-search</code> , activating the searchbox with <code>meta /</code> is useful.</li>
</ul>

<strong>Non-Sticky Search : </strong>(<code>/</code>)

![2](https://user-images.githubusercontent.com/53977614/98515886-cc697e00-2291-11eb-83f0-547492ee014b.gif)

<strong>Sticky Search :</strong>(<code>meta /</code>)

![3](https://user-images.githubusercontent.com/53977614/98515993-eb681000-2291-11eb-8161-0c165dcc7ff0.gif)

<br/>
Would love an review @neiljp .

