### PR TITLE
Autocomplete with exact matches in stream & topic compose boxes

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,7 +6,7 @@ name = "pypi"
 [packages]
 urwid = "~=2.1.2"
 zulip = ">=0.7.0"
-urwid-readline = ">=0.11"
+urwid-readline = ">=0.12"
 beautifulsoup4 = ">=4.9.0"
 lxml = ">=4.5.2"
 typing_extensions = ">=3.7"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,11 @@
 urwid~=2.1.2
 zulip>=0.7.0
+urwid_readline>=0.11
+beautifulsoup4>=4.9.0
+lxml>=4.5.2
 typing_extensions>=3.7
+python-dateutil>=2.8.1
+tzlocal>=2.1
 
 pytest==5.3.5
 pytest-cov==2.5.1
@@ -13,11 +18,6 @@ snakeviz==0.4.2
 gitlint==0.10.0
 mypy==0.782
 isort==4.3.21
-urwid_readline>=0.11
-beautifulsoup4>=4.9.0
-lxml>=4.5.2
-python-dateutil>=2.8.1
-tzlocal>=2.1
 autopep8~=1.5.4
 autoflake~=1.3.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 urwid~=2.1.2
 zulip>=0.7.0
-urwid_readline>=0.11
+urwid_readline>=0.12
 beautifulsoup4>=4.9.0
 lxml>=4.5.2
 typing_extensions>=3.7

--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,7 @@ setup(
     install_requires=[
         'urwid~=2.1.2',
         'zulip>=0.7.0',
-        'urwid_readline>=0.11',
+        'urwid_readline>=0.12',
         'beautifulsoup4>=4.9.0',
         'lxml>=4.5.2',
         'typing_extensions>=3.7',

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -313,9 +313,7 @@ class TestWriteBox:
 
     @pytest.mark.parametrize('text, expected_text', [
         ('Som', 'Some general stream'),
-        pytest.param('Some gen', 'Some general stream',
-                     marks=pytest.mark.xfail(
-                         reason="Lacking urwid-readline support")),
+        ('Some gen', 'Some general stream'),
     ])
     def test__stream_box_autocomplete_with_spaces(self, mocker, write_box,
                                                   widget_size,
@@ -351,8 +349,7 @@ class TestWriteBox:
 
     @pytest.mark.parametrize('text, expected_text', [
         ('Th', 'This is a topic'),
-        pytest.param('This i', 'This is a topic', marks=pytest.mark.xfail(
-                             reason="Lacking urwid-readline support")),
+        ('This i', 'This is a topic'),
     ])
     def test__topic_box_autocomplete_with_spaces(self, mocker, write_box,
                                                  widget_size,

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -97,6 +97,8 @@ class WriteBox(urwid.Pile):
             key=primary_key_for_command('AUTOCOMPLETE'),
             key_reverse=primary_key_for_command('AUTOCOMPLETE_REVERSE')
         )
+        self.stream_write_box.set_completer_delims("")
+
         self.title_write_box = ReadlineEdit(caption="Topic:  ",
                                             edit_text=title)
         self.title_write_box.enable_autocomplete(
@@ -104,6 +106,7 @@ class WriteBox(urwid.Pile):
             key=primary_key_for_command('AUTOCOMPLETE'),
             key_reverse=primary_key_for_command('AUTOCOMPLETE_REVERSE')
         )
+        self.title_write_box.set_completer_delims("")
 
         self.header_write_box = urwid.Columns([
             urwid.LineBox(


### PR DESCRIPTION
This should partially or fully fix #776, but is pending on https://github.com/rr-/urwid_readline/pull/16 and assumes there will be a release of urwid-readline. For now my branch can be used to test this behavior; this allows 2 xfail-ing tests to be set to act normally.