### PR TITLE
model: Add footer notification for messages.

### DIFF
--- a/zulipterminal/api_types.py
+++ b/zulipterminal/api_types.py
@@ -12,7 +12,7 @@ class PrivateComposition(TypedDict):
     to: List[str]  # emails  # TODO: Migrate to using List[int] (user ids)
 
 
-class StreamComposition(TypedDict):
+class StreamComposition(TypedDict, total=False):
     type: Literal['stream']
     content: str
     to: str  # stream name  # TODO: Migrate to using int (stream id)

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -651,6 +651,31 @@ def display_error_if_present(response: Dict[str, Any], controller: Any
         controller.view.set_footer_text(response['msg'], 3)
 
 
+def check_narrow_and_notify(outer_narrow: List[Any],
+                            inner_narrow: List[Any],
+                            controller: Any) -> None:
+    current_narrow = controller.model.narrow
+
+    if (current_narrow != [] and current_narrow != outer_narrow
+            and current_narrow != inner_narrow):
+        controller.view.set_footer_text(
+            'Message is sent outside of current narrow.', 3)
+
+
+def notify_if_message_sent_outside_narrow(message: Dict[str, Any],
+                                          controller: Any) -> None:
+    current_narrow = controller.model.narrow
+
+    if message['type'] == 'stream':
+        stream_narrow = [['stream', message['to']]]
+        topic_narrow = stream_narrow + [['topic', message['subject']]]
+        check_narrow_and_notify(stream_narrow, topic_narrow, controller)
+    elif message['type'] == 'private':
+        pm_narrow = [['is', 'private']]
+        pm_with_narrow = [['pm_with', ",".join(message['to'])]]
+        check_narrow_and_notify(pm_narrow, pm_with_narrow, controller)
+
+
 def hash_util_decode(string: str) -> str:
     """
     Returns a decoded string given a hash_util_encode() [present in

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -25,7 +25,7 @@ from urllib.parse import unquote
 import lxml.html
 from typing_extensions import Literal, TypedDict
 
-from zulipterminal.api_types import Message
+from zulipterminal.api_types import Composition, Message
 
 
 MACOS = platform.system() == "Darwin"
@@ -662,7 +662,7 @@ def check_narrow_and_notify(outer_narrow: List[Any],
             'Message is sent outside of current narrow.', 3)
 
 
-def notify_if_message_sent_outside_narrow(message: Dict[str, Any],
+def notify_if_message_sent_outside_narrow(message: Composition,
                                           controller: Any) -> None:
     current_narrow = controller.model.narrow
 

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -24,7 +24,13 @@ import zulip
 from typing_extensions import Literal
 
 from zulipterminal import unicode_emojis
-from zulipterminal.api_types import Composition, EditPropagateMode, Event
+from zulipterminal.api_types import (
+    Composition,
+    EditPropagateMode,
+    Event,
+    PrivateComposition,
+    StreamComposition,
+)
 from zulipterminal.config.keys import primary_key_for_command
 from zulipterminal.helper import (
     Message,
@@ -379,7 +385,7 @@ class Model:
     def send_private_message(self, recipients: List[str],
                              content: str) -> bool:
         if recipients:
-            request = {
+            request: PrivateComposition = {
                 'type': 'private',
                 'to': recipients,
                 'content': content,
@@ -395,7 +401,7 @@ class Model:
 
     def send_stream_message(self, stream: str, topic: str,
                             content: str) -> bool:
-        request = {
+        request: StreamComposition = {
             'type': 'stream',
             'to': stream,
             'subject': topic,


### PR DESCRIPTION
This will set a footer text notifying the user everytime
he sends or edits a message that is outside the current
narrow. This will give the user a pointer as to why the
message disappeared from the screen.

Fixes #781.