### PR TITLE
model: Fetch realm emoji using events

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -208,6 +208,13 @@ def unicode_emojis():
     ])
 
 
+@pytest.fixture
+def zulip_emoji():
+    return OrderedDict([
+        ('zulip', {'code': 'zulip', 'type': 'zulip_extra_emoji'})
+    ])
+
+
 stream_msg_template = {
     'id': 537286,
     'sender_full_name': 'Foo Foo',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -185,13 +185,44 @@ def streams_fixture():
 
 
 @pytest.fixture
-def custom_emojis():
+def realm_emojis():
+    # Omitting source_url, author_id (server version 3.0),
+    # author (server version < 3.0) since they are not used.
+    return {
+        "1": {
+            "deactivated": True,
+            "id": "1",
+            "name": "green_tick",
+        },
+        "202020": {
+            "deactivated": False,
+            "id": "202020",
+            "name": "joker",
+        },
+        "2": {
+            "deactivated": True,
+            "id": "2",
+            "name": "joy_cat",
+        },
+        "3": {
+            "deactivated": False,
+            "id": "3",
+            "name": "singing",
+        },
+        "4": {
+            "deactivated": False,
+            "id": "4",
+            "name": "zulip",
+        }
+    }
+
+
+@pytest.fixture
+def realm_emojis_data():
     return OrderedDict([
-        ('urwid', {'code': '100', 'type': 'realm_emoji'}),
-        ('dancing', {'code': '3', 'type': 'realm_emoji'}),
-        ('snape', {'code': '20', 'type': 'realm_emoji'}),
         ('joker', {'code': '202020', 'type': 'realm_emoji'}),
-        ('zulip', {'code': '12345', 'type': 'realm_emoji'}),
+        ('singing', {'code': '3', 'type': 'realm_emoji'}),
+        ('zulip', {'code': '4', 'type': 'realm_emoji'}),
     ])
 
 
@@ -395,7 +426,7 @@ def topics():
 
 
 @pytest.fixture
-def initial_data(logged_on_user, users_fixture, streams_fixture):
+def initial_data(logged_on_user, users_fixture, streams_fixture, realm_emojis):
     """
     Response from /register API request.
     """
@@ -547,6 +578,7 @@ def initial_data(logged_on_user, users_fixture, streams_fixture):
             }
         },
         'twenty_four_hour_time': True,
+        'realm_emoji': realm_emojis,
         'last_event_id': -1,
         'muted_topics': [],
         'realm_user_groups': [],

--- a/zulipterminal/api_types.py
+++ b/zulipterminal/api_types.py
@@ -148,9 +148,18 @@ class UpdateDisplaySettings(TypedDict):
     setting: bool
 
 
+class RealmEmojiData(TypedDict):
+    id: str
+    name: str
+    source_url: str
+    deactivated: bool
+    # Previous versions had an author object with an id field.
+    author_id: int  # NOTE: new in Zulip 3.0 / ZFL 7.
+
+
 class UpdateRealmEmojiEvent(TypedDict):
     type: Literal['realm_emoji']
-    realm_emoji: Dict[str, Any]
+    realm_emoji: Dict[str, RealmEmojiData]
 
 
 Event = Union[

--- a/zulipterminal/api_types.py
+++ b/zulipterminal/api_types.py
@@ -148,6 +148,11 @@ class UpdateDisplaySettings(TypedDict):
     setting: bool
 
 
+class UpdateRealmEmojiEvent(TypedDict):
+    type: Literal['realm_emoji']
+    realm_emoji: Dict[str, Any]
+
+
 Event = Union[
     MessageEvent,
     UpdateMessageEvent,
@@ -156,4 +161,5 @@ Event = Union[
     TypingEvent,
     UpdateMessageFlagsEvent,
     UpdateDisplaySettings,
+    UpdateRealmEmojiEvent,
 ]

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -125,6 +125,7 @@ class Model:
                  self._handle_update_message_flags_event),
                 ('update_display_settings',
                  self._handle_update_display_settings_event),
+                ('realm_emoji', self._handle_update_emoji_event),
             ])
         )
 
@@ -1271,6 +1272,17 @@ class Model:
             f"{'' if self.twenty_four_hr_format else ' %p'}"
         )
         return local_time.strftime(format_codes)
+
+    def _handle_update_emoji_event(self, event: Event) -> None:
+        """
+        Handle update of emoji
+        """
+        # Here, the event contains information of all realm emojis added
+        # by the users in the organisation along with a boolean value
+        # representing the active state of each emoji.
+        assert event['type'] == "realm_emoji"
+        self.active_emoji_data = self.generate_all_emoji_data(
+                                                    event['realm_emoji'])
 
     def _update_rendered_view(self, msg_id: int) -> None:
         """

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -165,21 +165,10 @@ class Model:
         self.unread_counts = classify_unread_counts(self)
 
         self._draft: Optional[Composition] = None
-        unicode_emoji_data = unicode_emojis.EMOJI_DATA
-        for name, data in unicode_emoji_data.items():
-            data['type'] = 'unicode_emoji'
-        typed_unicode_emoji_data = cast(NamedEmojiData, unicode_emoji_data)
-        custom_emoji_data = self.fetch_custom_emojis()
-        zulip_extra_emoji: NamedEmojiData = {
-                'zulip': {'code': 'zulip', 'type': 'zulip_extra_emoji'}
-        }
-        all_emoji_data = {**typed_unicode_emoji_data,
-                          **custom_emoji_data,
-                          **zulip_extra_emoji}.items()
-        self.active_emoji_data = OrderedDict(sorted(all_emoji_data,
-                                                    key=lambda e: e[0]))
 
         self._store_content_length_restrictions()
+
+        self.active_emoji_data = self.generate_all_emoji_data()
         self.twenty_four_hr_format = self.initial_data['twenty_four_hour_time']
         self.new_user_input = True
         self._start_presence_updates()
@@ -499,6 +488,22 @@ class Model:
         }
         display_error_if_present(response, self.controller)
         return custom_emojis
+
+    def generate_all_emoji_data(self) -> NamedEmojiData:
+        unicode_emoji_data = unicode_emojis.EMOJI_DATA
+        for name, data in unicode_emoji_data.items():
+            data['type'] = 'unicode_emoji'
+        typed_unicode_emoji_data = cast(NamedEmojiData, unicode_emoji_data)
+        custom_emoji_data: NamedEmojiData = self.fetch_custom_emojis()
+        zulip_extra_emoji: NamedEmojiData = {
+                'zulip': {'code': 'zulip', 'type': 'zulip_extra_emoji'}
+        }
+        all_emoji_data = {**typed_unicode_emoji_data,
+                          **custom_emoji_data,
+                          **zulip_extra_emoji}.items()
+        active_emoji_data = OrderedDict(sorted(all_emoji_data,
+                                               key=lambda e: e[0]))
+        return active_emoji_data
 
     def get_messages(self, *,
                      num_after: int, num_before: int,

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -29,6 +29,7 @@ from zulipterminal.api_types import (
     EditPropagateMode,
     Event,
     PrivateComposition,
+    RealmEmojiData,
     StreamComposition,
     Subscription,
 )
@@ -481,7 +482,7 @@ class Model:
         return response['result'] == 'success'
 
     def generate_all_emoji_data(self,
-                                custom_emoji: Dict[str, Any]
+                                custom_emoji: Dict[str, RealmEmojiData]
                                 ) -> NamedEmojiData:
         unicode_emoji_data = unicode_emojis.EMOJI_DATA
         for name, data in unicode_emoji_data.items():


### PR DESCRIPTION
Continues work on #825. 
Processed `initial_data['realm_emoji]` and set `custom_emoji_data` according to the schema given by `NamedEmojiData`.
Similar processing for `realm_emoji_update` before updating `active_emoji_data` in `_handle_update_emoji_event`.
Also, the deactivated realm emojis are removed from `active_emoji_data`.
