### PR TITLE
785 with refactors and extra bugfix

### DIFF
--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -967,7 +967,9 @@ class TestModel:
         model.notify_user(message_fixture)
         assert notify.called == is_notify_called
 
-    @pytest.mark.parametrize(['response', 'update_call_count', 'new_index',
+    @pytest.mark.parametrize(['event',
+                              'expected_times_messages_rerendered',
+                              'expected_index',
                               'topic_view_enabled'], [
         ({  # Only subject of 1 message is updated.
             'message_id': 1,
@@ -1040,7 +1042,7 @@ class TestModel:
             'subject': 'new subject',
             'stream_id': 10,
             'message_ids': [1],
-        }, 2, {
+        }, 2, {  # 2=update of subject & content
             'messages': {
                 1: {
                     'id': 1,
@@ -1121,13 +1123,20 @@ class TestModel:
                     'subject': 'old subject'
                 }},
             'edited_messages': {1},
-            # _fetch_topics_in_streams will update this.
-            'topics': {10: ['old subject']},
+            'topics': {10: ['new subject', 'old subject']},
         }, True),
+    ], ids=[
+        "Only subject of 1 message is updated",
+        "Subject of 2 messages is updated",
+        "Message content is updated",
+        "Both message content and subject is updated",
+        "Some new type of update which we don't handle yet",
+        "message_id not present in index",
+        "Message content is updated and topic view is enabled",
     ])
     def test__handle_update_message_event(self, mocker, model,
-                                          response, new_index,
-                                          update_call_count,
+                                          event, expected_index,
+                                          expected_times_messages_rerendered,
                                           topic_view_enabled):
         model.index = {
             'messages': {
@@ -1142,17 +1151,25 @@ class TestModel:
             'topics': {10: ['old subject']},
         }
         mocker.patch('zulipterminal.model.Model._update_rendered_view')
+
+        def _set_topics_to_old_and_new(event):
+            model.index['topics'][10] = ['new subject', 'old subject']
         fetch_topics = mocker.patch(
-                    'zulipterminal.model.Model._fetch_topics_in_streams')
+                    'zulipterminal.model.Model._fetch_topics_in_streams',
+                    side_effect=_set_topics_to_old_and_new)
+
         (model.controller.view.left_panel.is_in_topic_view_with_stream_id.
             return_value) = topic_view_enabled
 
-        model._handle_update_message_event(response)
+        model._handle_update_message_event(event)
 
-        assert model.index == new_index
-        assert model._update_rendered_view.call_count == update_call_count
+        assert model.index == expected_index
+
+        calls_to_update_messages = model._update_rendered_view.call_count
+        assert calls_to_update_messages == expected_times_messages_rerendered
+
         if topic_view_enabled:
-            fetch_topics.assert_called_once_with([response['stream_id']])
+            fetch_topics.assert_called_once_with([event['stream_id']])
             stream_button = model.controller.view.topic_w.stream_button
             (model.controller.view.left_panel.show_topic_view.
                 assert_called_once_with(stream_button))

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -967,79 +967,96 @@ class TestModel:
         model.notify_user(message_fixture)
         assert notify.called == is_notify_called
 
-    @pytest.mark.parametrize('response, update_call_count, new_index', [
+    @pytest.mark.parametrize(['response', 'update_call_count', 'new_index',
+                              'topic_view_enabled'], [
         ({  # Only subject of 1 message is updated.
             'message_id': 1,
             'subject': 'new subject',
+            'stream_id': 10,
             'message_ids': [1],
         }, 1, {
             'messages': {
                 1: {
                     'id': 1,
+                    'stream_id': 10,
                     'content': 'old content',
                     'subject': 'new subject'
                 },
                 2: {
                     'id': 2,
+                    'stream_id': 10,
                     'content': 'old content',
                     'subject': 'old subject'
                 }},
-            'edited_messages': {1}
-        }),
+            'edited_messages': {1},
+            'topics': {10: []},
+        }, False),
         ({  # Subject of 2 messages is updated
             'message_id': 1,
             'subject': 'new subject',
+            'stream_id': 10,
             'message_ids': [1, 2],
         }, 2, {
             'messages': {
                 1: {
                     'id': 1,
+                    'stream_id': 10,
                     'content': 'old content',
                     'subject': 'new subject'
                 },
                 2: {
                     'id': 2,
+                    'stream_id': 10,
                     'content': 'old content',
                     'subject': 'new subject'
                 }},
-            'edited_messages': {1}
-        }),
+            'edited_messages': {1},
+            'topics': {10: []},
+        }, False),
         ({  # Message content is updated
             'message_id': 1,
+            'stream_id': 10,
             'rendered_content': '<p>new content</p>',
         }, 1, {
             'messages': {
                 1: {
                     'id': 1,
+                    'stream_id': 10,
                     'content': '<p>new content</p>',
                     'subject': 'old subject'
                 },
                 2: {
                     'id': 2,
+                    'stream_id': 10,
                     'content': 'old content',
                     'subject': 'old subject'
                 }},
-            'edited_messages': {1}
-        }),
+            'edited_messages': {1},
+            'topics': {10: ['old subject']},
+        }, False),
         ({  # Both message content and subject is updated.
             'message_id': 1,
             'rendered_content': '<p>new content</p>',
             'subject': 'new subject',
+            'stream_id': 10,
             'message_ids': [1],
         }, 2, {
             'messages': {
                 1: {
                     'id': 1,
+                    'stream_id': 10,
                     'content': '<p>new content</p>',
                     'subject': 'new subject'
                 },
                 2: {
                     'id': 2,
+                    'stream_id': 10,
                     'content': 'old content',
                     'subject': 'old subject'
                 }},
-            'edited_messages': {1}
-        }),
+            'edited_messages': {1},
+            'topics': {10: []},
+        }, False),
         ({  # Some new type of update which we don't handle yet.
             'message_id': 1,
             'foo': 'boo',
@@ -1047,55 +1064,99 @@ class TestModel:
             'messages': {
                 1: {
                     'id': 1,
+                    'stream_id': 10,
                     'content': 'old content',
                     'subject': 'old subject'
                 },
                 2: {
                     'id': 2,
+                    'stream_id': 10,
                     'content': 'old content',
                     'subject': 'old subject'
                 }},
-            'edited_messages': {1}
-        }),
+            'edited_messages': {1},
+            'topics': {10: ['old subject']},
+        }, False),
         ({  # message_id not present in index.
             'message_id': 3,
             'rendered_content': '<p>new content</p>',
             'subject': 'new subject',
+            'stream_id': 10,
             'message_ids': [3],
         }, 0, {
             'messages': {
                 1: {
                     'id': 1,
+                    'stream_id': 10,
                     'content': 'old content',
                     'subject': 'old subject'
                 },
                 2: {
                     'id': 2,
+                    'stream_id': 10,
                     'content': 'old content',
                     'subject': 'old subject'
                 }},
-            'edited_messages': set()
-        }),
+            'edited_messages': set(),
+            'topics': {10: ['old subject']},
+        }, False),
+        ({  # Message content is updated and topic view is enabled.
+            'message_id': 1,
+            'rendered_content': '<p>new content</p>',
+            'subject': 'new subject',
+            'stream_id': 10,
+            'message_ids': [1],
+        }, 2, {
+            'messages': {
+                1: {
+                    'id': 1,
+                    'stream_id': 10,
+                    'content': '<p>new content</p>',
+                    'subject': 'new subject'
+                },
+                2: {
+                    'id': 2,
+                    'stream_id': 10,
+                    'content': 'old content',
+                    'subject': 'old subject'
+                }},
+            'edited_messages': {1},
+            # _fetch_topics_in_streams will update this.
+            'topics': {10: ['old subject']},
+        }, True),
     ])
     def test__handle_update_message_event(self, mocker, model,
                                           response, new_index,
-                                          update_call_count):
+                                          update_call_count,
+                                          topic_view_enabled):
         model.index = {
             'messages': {
                 message_id: {
                     'id': message_id,
+                    'stream_id': 10,
                     'content': 'old content',
                     'subject': 'old subject',
                 } for message_id in [1, 2]
             },
-            'edited_messages': set()
+            'edited_messages': set(),
+            'topics': {10: ['old subject']},
         }
         mocker.patch('zulipterminal.model.Model._update_rendered_view')
+        fetch_topics = mocker.patch(
+                    'zulipterminal.model.Model._fetch_topics_in_streams')
+        (model.controller.view.left_panel.is_in_topic_view_with_stream_id.
+            return_value) = topic_view_enabled
 
         model._handle_update_message_event(response)
 
         assert model.index == new_index
         assert model._update_rendered_view.call_count == update_call_count
+        if topic_view_enabled:
+            fetch_topics.assert_called_once_with([response['stream_id']])
+            stream_button = model.controller.view.topic_w.stream_button
+            (model.controller.view.left_panel.show_topic_view.
+                assert_called_once_with(stream_button))
+            model.controller.update_screen.assert_called_once_with()
 
     @pytest.mark.parametrize('subject, narrow, new_log_len', [
         ('foo', [['stream', 'boo'], ['topic', 'foo']], 2),

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -1079,7 +1079,7 @@ class TestModel:
             'edited_messages': {1},
             'topics': {10: ['old subject']},
         }, False),
-        ({  # message_id not present in index.
+        ({  # message_id not present in index, topic view closed.
             'message_id': 3,
             'rendered_content': '<p>new content</p>',
             'subject': 'new subject',
@@ -1100,8 +1100,31 @@ class TestModel:
                     'subject': 'old subject'
                 }},
             'edited_messages': set(),
-            'topics': {10: ['old subject']},
+            'topics': {10: []},  # This resets the cache
         }, False),
+        ({  # message_id not present in index, topic view is enabled.
+            'message_id': 3,
+            'rendered_content': '<p>new content</p>',
+            'subject': 'new subject',
+            'stream_id': 10,
+            'message_ids': [3],
+        }, 0, {
+            'messages': {
+                1: {
+                    'id': 1,
+                    'stream_id': 10,
+                    'content': 'old content',
+                    'subject': 'old subject'
+                },
+                2: {
+                    'id': 2,
+                    'stream_id': 10,
+                    'content': 'old content',
+                    'subject': 'old subject'
+                }},
+            'edited_messages': set(),
+            'topics': {10: ['new subject', 'old subject']},
+        }, True),
         ({  # Message content is updated and topic view is enabled.
             'message_id': 1,
             'rendered_content': '<p>new content</p>',
@@ -1131,7 +1154,8 @@ class TestModel:
         "Message content is updated",
         "Both message content and subject is updated",
         "Some new type of update which we don't handle yet",
-        "message_id not present in index",
+        "message_id not present in index, topic view closed",
+        "message_id not present in index, topic view is enabled",
         "Message content is updated and topic view is enabled",
     ])
     def test__handle_update_message_event(self, mocker, model,

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1012,9 +1012,22 @@ class Model:
             # the event didn't have a 'subject' update.
             if 'subject' in event:
                 new_subject = event['subject']
+                stream_id = event['stream_id']
                 for msg_id in event['message_ids']:
                     self.index['messages'][msg_id]['subject'] = new_subject
                     self._update_rendered_view(msg_id)
+                if stream_id in self.index['topics']:
+                    # If topic view is open, reload list else reset cache.
+                    if hasattr(self.controller, 'view'):
+                        view = self.controller.view
+                        if (view.left_panel.is_in_topic_view_with_stream_id(
+                                message['stream_id'])):
+                            self._fetch_topics_in_streams([stream_id])
+                            view.left_panel.show_topic_view(
+                                view.topic_w.stream_button)
+                            self.controller.update_screen()
+                        else:
+                            self.index['topics'][stream_id] = []
 
     def _handle_reaction_event(self, event: Event) -> None:
         """


### PR DESCRIPTION
This is the trailing commit of #785 with extra refactoring and a bugfix to ensure topic list update is independent of message indexing.

Closes #785 

@kaustubh-nair I've not touched your original commit; how does this look?