### PR TITLE
footlinks: Add threshold configuration for footlinks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,13 @@ theme=default
 # Autohide defaults to 'no_autohide', but can be set to 'autohide' to hide the left & right panels except when focused.
 autohide=autohide
 # Footlinks default to 'enabled', but can be set to 'disabled' to hide footlinks.
+# disabled won't show any footlinks.
+# enabled would show the first 3.
 footlinks=disabled
+# If you need more flexibility, use maximum-footlinks.
+# Maximum footlinks to be shown, defaults to 3, but can be set to any value>=0.
+# Cannot be used along with footlinks, use either of them.
+maximum-footlinks=3
 # Notify defaults to 'disabled', but can be set to 'enabled' to display notifications (see next section).
 notify=enabled
 # Color depth defaults to 256, but can be set to 1 (for monochrome) or 16.

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -35,10 +35,11 @@ class TestController:
         self.in_explore_mode = False
         self.autohide = True  # FIXME Add tests for no-autohide
         self.notify_enabled = False
-        self.footlinks_enabled = True
-        result = Controller(self.config_file, self.theme_name, self.theme, 256,
+        self.maximum_footlinks = 3
+        result = Controller(self.config_file, self.maximum_footlinks,
+                            self.theme_name, self.theme, 256,
                             self.in_explore_mode, self.autohide,
-                            self.notify_enabled, self.footlinks_enabled)
+                            self.notify_enabled)
         result.view.message_view = mocker.Mock()  # set in View.__init__
         return result
 
@@ -51,7 +52,7 @@ class TestController:
         self.view.assert_called_once_with(controller)
         self.poll_for_events.assert_called_once_with()
         assert controller.theme == self.theme
-
+        assert controller.maximum_footlinks == self.maximum_footlinks
         assert self.main_loop.call_count == 1
         controller.loop.watch_pipe.assert_has_calls([
             mocker.call(controller._draw_screen),

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -2073,7 +2073,7 @@ class TestMessageBox:
     )
     def test_footlinks_view(self, message_fixture, message_links,
                             expected_text, expected_attrib):
-        self.model.controller.footlinks_enabled = True
+        self.model.controller.maximum_footlinks = 3
         msg_box = MessageBox(message_fixture, self.model, None)
 
         footlinks = msg_box.footlinks_view(message_links)
@@ -2085,16 +2085,17 @@ class TestMessageBox:
             assert footlinks is None
             assert not hasattr(footlinks, 'original_widget')
 
-    @pytest.mark.parametrize('footlinks_enabled, expected_instance', [
-        (False, type(None)),
-        (True, Padding),
+    @pytest.mark.parametrize('maximum_footlinks, expected_instance', [
+        (0, type(None)),
+        (1, Padding),
+        (3, Padding),
     ])
-    def test_footlinks_enabled(self, message_fixture, footlinks_enabled,
-                               expected_instance):
+    def test_footlinks_limit(self, message_fixture, maximum_footlinks,
+                             expected_instance):
         message_links = OrderedDict([
             ('https://github.com/zulip/zulip-terminal', ('ZT', 1, True)),
         ])
-        self.model.controller.footlinks_enabled = footlinks_enabled
+        self.model.controller.maximum_footlinks = maximum_footlinks
         msg_box = MessageBox(message_fixture, self.model, None)
 
         footlinks = msg_box.footlinks_view(message_links)

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -141,7 +141,7 @@ class TestAboutView:
                                     theme_name='zt_dark',
                                     color_depth=256,
                                     autohide_enabled=False,
-                                    footlink_enabled=True)
+                                    maximum_footlinks=3)
 
     @pytest.mark.parametrize('key', {*keys_for_command('GO_BACK'),
                                      *keys_for_command('ABOUT')})
@@ -177,7 +177,7 @@ class TestAboutView:
                                theme_name='zt_dark',
                                color_depth=256,
                                autohide_enabled=False,
-                               footlink_enabled=True)
+                               maximum_footlinks=3)
 
         assert len(about_view.feature_level_content) == (
             1 if server_feature_level else 0

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -25,6 +25,8 @@ from zulipterminal.version import ZT_VERSION
 
 TRACEBACK_LOG_FILENAME = 'zulip-terminal-tracebacks.log'
 API_CALL_LOG_FILENAME = 'zulip-terminal-API-requests.log'
+ZULIPRC_CONFIG = 'in zuliprc file'
+NO_CONFIG = 'with no config'
 
 # Create a logger for this application
 zt_logger = logging.getLogger(__name__)
@@ -46,6 +48,7 @@ DEFAULT_SETTINGS = {
     'notify': 'disabled',
     'footlinks': 'enabled',
     'color-depth': '256',
+    'maximum-footlinks': '3'
 }
 
 
@@ -271,7 +274,6 @@ def parse_zuliprc(zuliprc_str: str) -> Dict[str, Any]:
 
     if 'zterm' in zuliprc:
         config = zuliprc['zterm']
-        ZULIPRC_CONFIG = 'in zuliprc file'
         for conf in config:
             settings[conf] = (config[conf], ZULIPRC_CONFIG)
 
@@ -339,6 +341,27 @@ def main(options: Optional[List[str]]=None) -> None:
         else:
             theme_to_use = zterm['theme']
 
+        if (zterm['footlinks'][1] == ZULIPRC_CONFIG
+           and zterm['maximum-footlinks'][1] == ZULIPRC_CONFIG):
+            exit_with_error(
+                error_message='Footlinks property is not allowed '
+                'alongside maximum-footlinks')
+
+        if (zterm['maximum-footlinks'][1] == ZULIPRC_CONFIG
+           and int(zterm['maximum-footlinks'][0]) < 0):
+            exit_with_error(
+                error_message='Minimum value allowed '
+                'for maximum-footlinks is 0')
+
+        if zterm['footlinks'][1] == ZULIPRC_CONFIG:
+            if zterm['footlinks'][0] == DEFAULT_SETTINGS['footlinks']:
+                maximum_footlinks = 3
+            else:
+                maximum_footlinks = 0
+
+        else:
+            maximum_footlinks = int(zterm['maximum-footlinks'][0])
+
         available_themes = all_themes()
         theme_aliases = aliased_themes()
         is_valid_theme = (
@@ -374,8 +397,14 @@ def main(options: Optional[List[str]]=None) -> None:
                            format(", ".join(complete))))
         print("   autohide setting '{}' specified {}."
               .format(*zterm['autohide']))
-        print("   footlinks setting '{}' specified {}."
-              .format(*zterm['footlinks']))
+        if zterm['footlinks'][1] == ZULIPRC_CONFIG:
+            print(
+                "   maximum footlinks value '{}' specified {} from footlinks."
+                .format(maximum_footlinks, zterm['footlinks'][1]))
+        else:
+            print(
+                "   maximum footlinks value '{}' specified {}."
+                .format(*zterm['maximum-footlinks']))
         print("   color depth setting '{}' specified {}."
               .format(*zterm['color-depth']))
         # For binary settings
@@ -383,7 +412,6 @@ def main(options: Optional[List[str]]=None) -> None:
         valid_settings = {
             'autohide': ['autohide', 'no_autohide'],
             'notify': ['enabled', 'disabled'],
-            'footlinks': ['enabled', 'disabled'],
             'color-depth': ['1', '16', '256']
         }
         boolean_settings = dict()  # type: Dict[str, bool]
@@ -407,6 +435,7 @@ def main(options: Optional[List[str]]=None) -> None:
             theme_data = THEMES[theme_to_use[0]]
 
         Controller(zuliprc_path,
+                   maximum_footlinks,
                    theme_to_use[0],
                    theme_data,
                    color_depth,

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -40,16 +40,16 @@ class Controller:
     the application.
     """
 
-    def __init__(self, config_file: str, theme_name: str, theme: ThemeSpec,
-                 color_depth: int, in_explore_mode: bool,
-                 autohide: bool, notify: bool, footlinks: bool) -> None:
+    def __init__(self, config_file: str, maximum_footlinks: int,
+                 theme_name: str, theme: ThemeSpec, color_depth: int,
+                 in_explore_mode: bool, autohide: bool, notify: bool) -> None:
         self.theme_name = theme_name
         self.theme = theme
         self.color_depth = color_depth
         self.in_explore_mode = in_explore_mode
         self.autohide = autohide
         self.notify_enabled = notify
-        self.footlinks_enabled = footlinks
+        self.maximum_footlinks = maximum_footlinks
 
         self._editor = None  # type: Optional[Any]
 
@@ -231,7 +231,7 @@ class Controller:
                       server_feature_level=self.model.server_feature_level,
                       theme_name=self.theme_name, color_depth=self.color_depth,
                       autohide_enabled=self.autohide,
-                      footlink_enabled=self.footlinks_enabled),
+                      maximum_footlinks=self.maximum_footlinks),
             'area:help'
         )
 

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -802,14 +802,18 @@ class MessageBox(urwid.Pile):
         self, message_links: 'OrderedDict[str, Tuple[str, int, bool]]',
     ) -> Any:
         # Return if footlinks are disabled by the user.
-        if not self.model.controller.footlinks_enabled:
+        if self.model.controller.maximum_footlinks == 0:
             return None
 
         footlinks = []
+        counter = 0
         for link, (text, index, show_footlink) in message_links.items():
+            if counter == self.model.controller.maximum_footlinks:
+                break
             if not show_footlink:
                 continue
 
+            counter += 1
             footlinks.extend([
                 ('msg_link_index', f"{index}:"),
                 ' ',

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1014,7 +1014,7 @@ class AboutView(PopUpView):
                  server_version: str,
                  server_feature_level: Optional[int],
                  theme_name: str, color_depth: int,
-                 autohide_enabled: bool, footlink_enabled: bool) -> None:
+                 autohide_enabled: bool, maximum_footlinks: int) -> None:
         self.feature_level_content = (
             [('Feature level', str(server_feature_level))]
             if server_feature_level else []
@@ -1026,7 +1026,7 @@ class AboutView(PopUpView):
             ('Application Configuration', [
                 ('Theme', theme_name),
                 ('Autohide', 'enabled' if autohide_enabled else 'disabled'),
-                ('Footlink', 'enabled' if footlink_enabled else 'disabled'),
+                ('Maximum footlinks', str(maximum_footlinks)),
                 ('Color depth', str(color_depth))])
         ]
 


### PR DESCRIPTION
This enables user to configure footlinks threshold settings
using footlinks_threshold in zuliprc, retiring the previous
footlinks. Tests have been updated to reflect the change.
Fixes #773.