### PR TITLE
model/boxes: Add functionality to send typing event to server for PMs.

### DIFF
--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -434,6 +434,32 @@ class TestModel:
         with pytest.raises(AssertionError):
             model.react_to_message(dict(), 'x')
 
+    @pytest.mark.parametrize('recipient_user_ids', [[5140], [5140, 5179]])
+    @pytest.mark.parametrize('status', ['start', 'stop'])
+    def test_send_typing_status_by_user_ids(self, mocker, model, status,
+                                            recipient_user_ids):
+        response = mocker.Mock()
+        mock_api_query = mocker.patch('zulipterminal.core.Controller'
+                                      '.client.set_typing_status',
+                                      return_value=response)
+
+        model.send_typing_status_by_user_ids(recipient_user_ids,
+                                             status=status)
+
+        mock_api_query.assert_called_once_with(
+            {'to': recipient_user_ids, 'op': status},
+        )
+
+        self.display_error_if_present.assert_called_once_with(response,
+                                                              self.controller)
+
+    @pytest.mark.parametrize('status', ['start', 'stop'])
+    def test_send_typing_status_with_no_recipients(self, model, status,
+                                                   recipient_user_ids=[]):
+        with pytest.raises(RuntimeError):
+            model.send_typing_status_by_user_ids(recipient_user_ids,
+                                                 status=status)
+
     @pytest.mark.parametrize('response, return_value', [
         ({'result': 'success'}, True),
         ({'result': 'some_failure'}, False),

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -32,6 +32,8 @@ class TestWriteBox:
             {'name': stream['name']} for stream in
             streams_fixture], key=lambda stream: stream['name'].lower())
 
+        write_box.to_write_box = None
+
         return write_box
 
     def test_init(self, write_box):

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -333,6 +333,20 @@ class Model:
         })
         display_error_if_present(response, self.controller)
 
+    @asynch
+    def send_typing_status_by_user_ids(self, recipient_user_ids: List[int],
+                                       *, status: Literal['start', 'stop']
+                                       ) -> None:
+        if recipient_user_ids:
+            request = {
+                'to': recipient_user_ids,
+                'op': status
+            }
+            response = self.client.set_typing_status(request)
+            display_error_if_present(response, self.controller)
+        else:
+            raise RuntimeError('Empty recipient list.')
+
     def send_private_message(self, recipients: List[str],
                              content: str) -> bool:
         if recipients:

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -233,7 +233,10 @@ class UserButton(TopButton):
         # FIXME should we just narrow?
         self.controller.narrow_to_user(self)
         self._view.body.focus.original_widget.set_focus('footer')
-        self._view.write_box.private_box_view(self)
+        self._view.write_box.private_box_view(
+            self,
+            recipient_user_ids=[self.user_id]
+        )
 
 
 class TopicButton(TopButton):


### PR DESCRIPTION
Added a function that enables ZT to be sending typing events to the server. 
This function is asynchronous to avoid the lag that occurs before the key is displayed on the screen, which is generated by the client making the API call to send the event.

Configured `private_box_view` to use the function to send the event. 
Fixes #593.