### PR TITLE
Feature: Add user info view

### DIFF
--- a/docs/hotkeys.md
+++ b/docs/hotkeys.md
@@ -11,6 +11,7 @@
 |Open draft message saved in this session|<kbd>d</kbd>|
 |Redraw screen|<kbd>ctrl</kbd> + <kbd>l</kbd>|
 |Quit|<kbd>ctrl</kbd> + <kbd>c</kbd>|
+|View user information (From Users list)|<kbd>i</kbd>|
 
 ## Navigation
 |Command|Key Combination|

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -141,6 +141,22 @@ def users_fixture(logged_on_user):
 
 
 @pytest.fixture
+def tidied_user_info_response():
+    # FIXME: Refactor this to use a more generic user?
+    return {
+        "full_name": "Human 2",
+        "email": "person2@example.com",
+        "date_joined": "",
+        "timezone": "",
+        "is_bot": False,
+        "role": 400,
+        "bot_type": None,
+        "bot_owner_name": "",
+        "last_active": "",
+    }
+
+
+@pytest.fixture
 def _all_users_by_id(initial_data):
     return {
         user["user_id"]: user

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -971,8 +971,12 @@ class TestModel:
             ({"role": 300}, "role", 300),
             ({"role": 600}, "role", 600),
             ({}, "role", 400),
+            ({"is_owner": True}, "role", 100),
+            ({"is_admin": True}, "role", 200),
+            ({"is_guest": True}, "role", 600),
             ({"is_bot": True}, "is_bot", True),
             ({"bot_owner_id": 12}, "bot_owner_name", "Human 2"),
+            ({"bot_owner": "person2@example.com"}, "bot_owner_name", "Human 2"),
             ({}, "bot_owner_name", ""),
         ],
         ids=[
@@ -991,8 +995,12 @@ class TestModel:
             "user_is_moderator:Zulip_4.0+_ZFL60",
             "user_is_guest:Zulip_4.0+_ZFL59",
             "user_is_member",
+            "user_is_owner:Zulip_3.0+",
+            "user_is_admin:preZulip_4.0",
+            "user_is_guest:preZulip_4.0",
             "user_is_bot",
             "user_bot_has_owner:Zulip_3.0+_ZFL1",
+            "user_bot_has_owner:preZulip_3.0",
             "user_bot_has_no_owner",
         ],
     )
@@ -1001,12 +1009,14 @@ class TestModel:
         model,
         mocker,
         _all_users_by_id,
+        user_dict,
         to_vary_in_each_user,
         key,
         expected_value,
     ):
         _all_users_by_id[11] = dict({"user_id": 11}, **to_vary_in_each_user)
         model._all_users_by_id = _all_users_by_id
+        model.user_dict = user_dict
 
         assert model.get_user_info(11)[key] == expected_value
 

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -949,6 +949,76 @@ class TestModel:
         }
         assert user_group_names == ["Group 1", "Group 2", "Group 3", "Group 4"]
 
+    @pytest.mark.parametrize(
+        ["to_vary_in_each_user", "key", "expected_value"],
+        [
+            ({"full_name": "Test User"}, "full_name", "Test User"),
+            ({}, "full_name", "(No name)"),
+            ({"email": "person1@example.com"}, "email", "person1@example.com"),
+            ({}, "email", ""),
+            (
+                {"date_joined": "2021-02-28T19:58:29.035543+00:00"},
+                "date_joined",
+                "2021-02-28T19:58:29.035543+00:00",
+            ),
+            ({}, "date_joined", ""),
+            ({"timezone": "Asia/Kolkata"}, "timezone", "Asia/Kolkata"),
+            ({}, "timezone", ""),
+            ({"bot_type": 1}, "bot_type", 1),
+            ({}, "bot_type", 0),
+            ({"role": 100}, "role", 100),
+            ({"role": 200}, "role", 200),
+            ({"role": 300}, "role", 300),
+            ({"role": 600}, "role", 600),
+            ({}, "role", 400),
+            ({"is_bot": True}, "is_bot", True),
+            ({"bot_owner_id": 12}, "bot_owner_name", "Human 2"),
+            ({}, "bot_owner_name", ""),
+        ],
+        ids=[
+            "user_full_name",
+            "user_empty_full_name",
+            "user_email",
+            "user_empty_email",
+            "user_date_joined",
+            "user_empty_date_joined",
+            "user_timezone",
+            "user_empty_timezone",
+            "user_bot_type",
+            "user_empty_bot_type",
+            "user_is_owner:Zulip_4.0+_ZFL59",
+            "user_is_admin:Zulip_4.0+_ZFL59",
+            "user_is_moderator:Zulip_4.0+_ZFL60",
+            "user_is_guest:Zulip_4.0+_ZFL59",
+            "user_is_member",
+            "user_is_bot",
+            "user_bot_has_owner:Zulip_3.0+_ZFL1",
+            "user_bot_has_no_owner",
+        ],
+    )
+    def test_get_user_info(
+        self,
+        model,
+        mocker,
+        _all_users_by_id,
+        to_vary_in_each_user,
+        key,
+        expected_value,
+    ):
+        _all_users_by_id[11] = dict({"user_id": 11}, **to_vary_in_each_user)
+        model._all_users_by_id = _all_users_by_id
+
+        assert model.get_user_info(11)[key] == expected_value
+
+    def test_get_user_info_USER_NOT_FOUND(self, model):
+        assert model.get_user_info(-1) is None
+
+    def test_get_user_info_sample_response(
+        self, model, _all_users_by_id, tidied_user_info_response
+    ):
+        model._all_users_by_id = _all_users_by_id
+        assert model.get_user_info(12) == tidied_user_info_response
+
     def test_get_all_users(self, mocker, initial_data, user_list, user_dict, user_id):
         mocker.patch(MODEL + ".get_messages", return_value="")
         self.client.register.return_value = initial_data

--- a/tests/ui_tools/test_buttons.py
+++ b/tests/ui_tools/test_buttons.py
@@ -328,6 +328,15 @@ class TestUserButton:
 
         assert activate.call_count == 1
 
+    @pytest.mark.parametrize("key", keys_for_command("USER_INFO"))
+    def test_keypress_USER_INFO(self, mocker, user_button, key, widget_size):
+        size = widget_size(user_button)
+        pop_up = mocker.patch("zulipterminal.core.Controller.show_user_info")
+
+        user_button.keypress(size, key)
+
+        pop_up.assert_called_once_with(user_button.user_id)
+
 
 class TestTopicButton:
     @pytest.mark.parametrize(

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -264,6 +264,11 @@ KEY_BINDINGS: 'OrderedDict[str, KeyBinding]' = OrderedDict([
         'help_text': 'Quit',
         'key_category': 'general',
     }),
+    ('USER_INFO', {
+        'keys': ['i'],
+        'help_text': 'View user information (From Users list)',
+        'key_category': 'general',
+    }),
     ('BEGINNING_OF_LINE', {
         'keys': ['ctrl a'],
         'help_text': 'Jump to the beginning of line',

--- a/zulipterminal/config/themes.py
+++ b/zulipterminal/config/themes.py
@@ -63,6 +63,7 @@ REQUIRED_STYLES = {
     'area:msg'        : 'standout',
     'area:stream'     : 'standout',
     'area:error'      : 'standout',
+    'area:user'       : 'standout',
     'search_error'    : 'standout',
     'task:success'    : 'standout',
     'task:error'      : 'standout',

--- a/zulipterminal/config/ui_mappings.py
+++ b/zulipterminal/config/ui_mappings.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, Optional
 
 from zulipterminal.api_types import EditPropagateMode
 from zulipterminal.config.symbols import (
@@ -22,4 +22,21 @@ STATE_ICON = {
     "idle": STATUS_IDLE,
     "offline": STATUS_OFFLINE,
     "inactive": STATUS_INACTIVE,
+}
+
+
+BOT_TYPE_BY_ID = {
+    1: "Generic Bot",
+    2: "Incoming Webhook Bot",
+    3: "Outgoing Webhook Bot",
+    4: "Embedded Bot",
+}
+
+
+ROLE_BY_ID: Dict[Optional[int], Dict[str, str]] = {
+    100: {"bool": "is_owner", "name": "Owner"},
+    200: {"bool": "is_admin", "name": "Administrator"},
+    300: {"bool": "is_moderator", "name": "Moderator"},
+    400: {"bool": "", "name": "Member"},
+    600: {"bool": "is_guest", "name": "Guest"},
 }

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -29,6 +29,7 @@ from zulipterminal.ui_tools.views import (
     PopUpConfirmationView,
     StreamInfoView,
     StreamMembersView,
+    UserInfoView,
 )
 from zulipterminal.version import ZT_VERSION
 
@@ -284,6 +285,12 @@ class Controller:
                 maximum_footlinks=self.maximum_footlinks,
             ),
             "area:help",
+        )
+
+    def show_user_info(self, user_id: int) -> None:
+        self.show_pop_up(
+            UserInfoView(self, user_id, "User Information (up/down scrolls)"),
+            "area:user",
         )
 
     def show_edit_history(

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -17,6 +17,7 @@ from typing import (
     Iterable,
     Iterator,
     List,
+    Optional,
     Set,
     Tuple,
     TypeVar,
@@ -49,6 +50,20 @@ class EmojiData(TypedDict):
 
 
 NamedEmojiData = Dict[str, EmojiData]
+
+
+class TidiedUserInfo(TypedDict):
+    full_name: str
+    email: str
+    date_joined: str
+    timezone: str
+    role: Optional[int]
+    last_active: str
+
+    is_bot: bool
+    # Below fields are only meaningful if is_bot == True
+    bot_type: int
+    bot_owner_name: str
 
 
 class Index(TypedDict):

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -35,6 +35,7 @@ from zulipterminal.api_types import (
     Subscription,
 )
 from zulipterminal.config.keys import primary_key_for_command
+from zulipterminal.config.ui_mappings import ROLE_BY_ID
 from zulipterminal.helper import (
     Message,
     NamedEmojiData,
@@ -732,10 +733,19 @@ class Model:
             # Default role is member
             user_info["role"] = 400
 
-        bot_owner: Optional[RealmUser] = None
+            # Ensure backwards compatibility for role parameters (e.g., `is_admin`)
+            for role_id, role in ROLE_BY_ID.items():
+                if api_user_data.get(role["bool"], None):
+                    user_info["role"] = role_id
+                    break
+
+        bot_owner: Optional[Union[RealmUser, Dict[str, Any]]] = None
 
         if api_user_data.get("bot_owner_id", None):
             bot_owner = self._all_users_by_id.get(api_user_data["bot_owner_id"], None)
+        # Ensure backwards compatibility for `bot_owner` (which is email of owner)
+        elif api_user_data.get("bot_owner", None):
+            bot_owner = self.user_dict.get(api_user_data["bot_owner"], None)
 
         user_info["bot_owner_name"] = bot_owner["full_name"] if bot_owner else ""
 

--- a/zulipterminal/themes/gruvbox.py
+++ b/zulipterminal/themes/gruvbox.py
@@ -83,6 +83,7 @@ STYLES = {
     'area:msg'         : (Color.DARK0_HARD,            Color.BRIGHT_RED),
     'area:stream'      : (Color.DARK0_HARD,            Color.BRIGHT_BLUE),
     'area:error'       : (Color.LIGHT2,                Color.FADED_RED),
+    'area:user'        : (Color.LIGHT2,                Color.FADED_BLUE),
     'search_error'     : (Color.BRIGHT_RED,            Color.DARK0_HARD),
     'task:success'     : (Color.DARK0_HARD,            Color.BRIGHT_GREEN),
     'task:error'       : (Color.LIGHT2,                Color.FADED_RED),

--- a/zulipterminal/themes/zt_blue.py
+++ b/zulipterminal/themes/zt_blue.py
@@ -57,6 +57,7 @@ STYLES = {
     'area:stream'     : (Color.WHITE,               Color.DARK_CYAN),
     'area:msg'        : (Color.WHITE,               Color.BROWN),
     'area:error'      : (Color.WHITE,               Color.DARK_RED),
+    'area:user'       : (Color.WHITE,               Color.DARK_BLUE),
     'search_error'    : (Color.LIGHT_RED,           Color.LIGHT_BLUE),
     'task:success'    : (Color.WHITE,               Color.DARK_GREEN),
     'task:error'      : (Color.WHITE,               Color.DARK_RED),

--- a/zulipterminal/themes/zt_dark.py
+++ b/zulipterminal/themes/zt_dark.py
@@ -57,6 +57,7 @@ STYLES = {
     'area:msg'        : (Color.WHITE,               Color.BROWN),
     'area:stream'     : (Color.WHITE,               Color.DARK_CYAN),
     'area:error'      : (Color.WHITE,               Color.DARK_RED),
+    'area:user'       : (Color.WHITE,               Color.DARK_BLUE),
     'search_error'    : (Color.LIGHT_RED,           Color.BLACK),
     'task:success'    : (Color.WHITE,               Color.DARK_GREEN),
     'task:error'      : (Color.WHITE,               Color.DARK_RED),

--- a/zulipterminal/themes/zt_light.py
+++ b/zulipterminal/themes/zt_light.py
@@ -57,6 +57,7 @@ STYLES = {
     'area:stream'     : (Color.BLACK,               Color.LIGHT_BLUE),
     'area:msg'        : (Color.BLACK,               Color.YELLOW),
     'area:error'      : (Color.BLACK,               Color.LIGHT_RED),
+    'area:user'       : (Color.WHITE,               Color.DARK_BLUE),
     'search_error'    : (Color.LIGHT_RED,           Color.WHITE),
     'task:success'    : (Color.BLACK,               Color.DARK_GREEN),
     'task:error'      : (Color.WHITE,               Color.DARK_RED),

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -255,6 +255,7 @@ class UserButton(TopButton):
         self.email = user["email"]
         self.user_id = user["user_id"]
 
+        self.controller = controller
         self._view = view  # Used in _narrow_with_compose
 
         # FIXME Is this still needed?
@@ -282,6 +283,11 @@ class UserButton(TopButton):
         self._view.write_box.private_box_view(
             emails=[self.email], recipient_user_ids=[self.user_id]
         )
+
+    def keypress(self, size: urwid_Size, key: str) -> Optional[str]:
+        if is_command_key("USER_INFO", key):
+            self.controller.show_user_info(self.user_id)
+        return super().keypress(size, key)
 
 
 class TopicButton(TopButton):


### PR DESCRIPTION
**What does this PR do?!**
- Adds a basic interpolable user info view from web app.
- Custom fields omitted for now.
- Press `i` in the users list to see user info.

**Commit flow**
1. Create UI <=> API mappings for a realm user.
2. Adds a method to return tidied user info, so that it becomes displayable.
3. Support backward compatibility of API user response.
4. Adds hotkey `i` to trigger the popup.
5. Structures the user info popup to be shown.
6. Adds UI elements for toggling the popup.
7. Adds keypress events to trigger the popup.

Fixes #511

**Screenshots/GIF**
![Screenshot from 2021-04-27 19-58-50](https://user-images.githubusercontent.com/55916430/116259136-2a801400-a793-11eb-9613-568e7e569f04.png)
