### PR TITLE
Model: Update view after message edit

### DIFF
--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -1209,12 +1209,16 @@ class TestModel:
         'msgbox_updated_in_all_messages_narrow',
     ])
     def test__update_rendered_view(self, mocker, model, subject, narrow,
-                                   new_log_len, msg_id=1):
+                                   new_log_len, msg_id=1,
+                                   sender_email='foo@gmail.com'):
         msg_w = mocker.Mock()
         other_msg_w = mocker.Mock()
-        msg_w.original_widget.message = {'id': msg_id, 'subject': subject}
+        msg_w.original_widget.message = {'id': msg_id, 'subject': subject,
+                                         'timestamp': 12,
+                                         'sender_email': sender_email}
         model.narrow = narrow
-        other_msg_w.original_widget.message = {'id': 2}
+        other_msg_w.original_widget.message = {'id': 2, 'timestamp': 13,
+                                               'sender_email': 'boo@gmail.com'}
         self.controller.view.message_view = (
             mocker.Mock(log=[msg_w, other_msg_w])
         )
@@ -1228,8 +1232,9 @@ class TestModel:
         # If there are 2 msgs and first one is updated, next one is updated too
         if new_log_len == 2:
             other_msg_w = new_msg_w
+
         assert (self.controller.view.message_view.log
-                == [new_msg_w, other_msg_w][-new_log_len:])
+                == [new_msg_w, other_msg_w][:new_log_len])
         assert model.controller.update_screen.called
 
     @pytest.mark.parametrize('subject, narrow, narrow_changed', [
@@ -1247,6 +1252,7 @@ class TestModel:
         msg_w = mocker.Mock()
         other_msg_w = mocker.Mock()
         msg_w.original_widget.message = {'id': msg_id, 'subject': subject}
+        msg_w.original_widget.last_message = {}
         model.narrow = narrow
         self.controller.view.message_view = mocker.Mock(log=[msg_w])
         # New msg widget generated after updating index.

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1019,7 +1019,7 @@ class Model:
         if 'subject' in event:
             new_subject = event['subject']
             stream_id = event['stream_id']
-
+            event['message_ids'].sort()
             # Update any indexed messages & re-render them
             for msg_id in event['message_ids']:
                 indexed_msg = self.index['messages'].get(msg_id)
@@ -1123,7 +1123,10 @@ class Model:
                 # narrow.
                 if (len(self.narrow) == 2
                         and msg_box.message['subject'] != self.narrow[1][1]):
+                    msg_pos = view.message_view.log.index(msg_w)
                     view.message_view.log.remove(msg_w)
+                    prev_msg_sender = msg_box.last_message['sender_email']
+                    edited_msg_sender = msg_box.message['sender_email']
                     # Change narrow if there are no messages left in the
                     # current narrow.
                     if not view.message_view.log:
@@ -1133,6 +1136,21 @@ class Model:
                         if msg_w_list:
                             self.controller.narrow_to_topic(
                                 msg_w_list[0].original_widget)
+                    # Creates message box of the message following the
+                    # edited message to display elided sender/datefields
+                    # of lower messages
+                    elif prev_msg_sender != edited_msg_sender:
+                        if len(view.message_view.log) >= (msg_pos + 1):
+                            next_msg_w = view.message_view.log[msg_pos]
+                            next_msg = next_msg_w.original_widget.message
+                            next_msg_sender = next_msg['sender_email']
+                            prev_msg = msg_box.last_message
+                            if next_msg_sender != prev_msg_sender:
+                                msg_w_list = create_msg_box_list(
+                                                self,
+                                                [next_msg['id']],
+                                                last_message=prev_msg)
+                                view.message_view.log[msg_pos] = msg_w_list[0]
                     self.controller.update_screen()
                     return
 

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1125,8 +1125,6 @@ class Model:
                         and msg_box.message['subject'] != self.narrow[1][1]):
                     msg_pos = view.message_view.log.index(msg_w)
                     view.message_view.log.remove(msg_w)
-                    prev_msg_sender = msg_box.last_message['sender_email']
-                    edited_msg_sender = msg_box.message['sender_email']
                     # Change narrow if there are no messages left in the
                     # current narrow.
                     if not view.message_view.log:
@@ -1139,18 +1137,31 @@ class Model:
                     # Creates message box of the message following the
                     # edited message to display elided sender/datefields
                     # of lower messages
-                    elif prev_msg_sender != edited_msg_sender:
-                        if len(view.message_view.log) >= (msg_pos + 1):
-                            next_msg_w = view.message_view.log[msg_pos]
-                            next_msg = next_msg_w.original_widget.message
-                            next_msg_sender = next_msg['sender_email']
-                            prev_msg = msg_box.last_message
-                            if next_msg_sender != prev_msg_sender:
-                                msg_w_list = create_msg_box_list(
-                                                self,
-                                                [next_msg['id']],
-                                                last_message=prev_msg)
-                                view.message_view.log[msg_pos] = msg_w_list[0]
+                    elif len(view.message_view.log) >= (msg_pos + 1):
+                        edited_msg_sender = msg_box.message['sender_email']
+                        edited_msg_time = msg_box.message['timestamp']
+                        next_msg_w = view.message_view.log[msg_pos]
+                        next_msg = next_msg_w.original_widget.message
+                        next_msg_sender = next_msg['sender_email']
+                        next_msg_time = next_msg['timestamp']
+                        prev_msg = msg_box.last_message
+                        prev_msg_time = prev_msg.get('timestamp', 0)
+                        prev_msg_sender = prev_msg.get('sender_email', "")
+                        if prev_msg_sender == "":
+                            msg_w_list = create_msg_box_list(
+                                            self,
+                                            [next_msg['id']])
+                            new_msg_w = msg_w_list[0]
+                            view.message_view.log[msg_pos] = next_msg_w
+
+                        elif (next_msg_sender != prev_msg_sender
+                                or next_msg_time != prev_msg_time):
+                            msg_w_list = create_msg_box_list(
+                                            self,
+                                            [next_msg['id']],
+                                            last_message=prev_msg)
+                            new_msg_w = msg_w_list[0]
+                            view.message_view.log[msg_pos] = new_msg_w
                     self.controller.update_screen()
                     return
 


### PR DESCRIPTION
This PR attempts to maintain UI design after message edit by user.
This has been achieved by handling the `hanlde_update_message` event in a better manner and updating UI by creating message box when required.

Fixes #833 