### PR TITLE
views: Updated Stream Info.

### DIFF
--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -6,7 +6,7 @@ from urwid import Columns, Text
 from zulipterminal.config.keys import is_command_key, keys_for_command
 from zulipterminal.ui_tools.views import (
     AboutView, EditHistoryView, EditModeView, HelpView, MsgInfoView,
-    PopUpConfirmationView, PopUpView, StreamInfoView,
+    PopUpConfirmationView, PopUpView, StreamInfoView, StreamMembersView,
 )
 from zulipterminal.version import MINIMUM_SUPPORTED_SERVER_VERSION, ZT_VERSION
 
@@ -562,8 +562,37 @@ class TestStreamInfoView:
         stream_id = 10
         self.controller.model.stream_dict = {stream_id: {'name': 'books',
                                                          'invite_only': False,
-                                                         'description': 'hey'}}
+                                                         'description': 'hey',
+                                                         'subscribers': []}}
         self.stream_info_view = StreamInfoView(self.controller, stream_id)
+
+    def test_keypress_any_key(self, widget_size):
+        key = "a"
+        size = widget_size(self.stream_info_view)
+        self.stream_info_view.keypress(size, key)
+        assert not self.controller.exit_popup.called
+
+    @pytest.mark.parametrize('key', keys_for_command('STREAM_MEMBERS'))
+    def test_keypress_stream_members(self, mocker, key, widget_size):
+        self.controller = mocker.Mock()
+        mocker.patch.object(self.controller, 'maximum_popup_dimensions',
+                            return_value=(64, 64))
+        self.controller.model.is_muted_stream.return_value = False
+        self.controller.model.is_pinned_stream.return_value = False
+        mocker.patch(VIEWS + ".urwid.SimpleFocusListWalker", return_value=[])
+        stream_id = self.stream_info_view.stream_id
+        self.controller.model.stream_dict = {stream_id: {'name': 'books',
+                                                         'description': 'hey',
+                                                         'subscribers': []}}
+
+        stream_info_view = StreamInfoView(self.controller, stream_id)
+        size = widget_size(stream_info_view)
+
+        stream_info_view.keypress(size, key)
+
+        self.controller.show_stream_members.assert_called_once_with(
+            stream_id=stream_id,
+        )
 
     @pytest.mark.parametrize('key', {*keys_for_command('GO_BACK'),
                                      *keys_for_command('STREAM_DESC')})
@@ -582,7 +611,7 @@ class TestStreamInfoView:
 
     @pytest.mark.parametrize('key', (*keys_for_command('ENTER'), ' '))
     def test_checkbox_toggle_mute_stream(self, mocker, key, widget_size):
-        mute_checkbox = self.stream_info_view.widgets[3]
+        mute_checkbox = self.stream_info_view.widgets[6]
         toggle_mute_status = self.controller.model.toggle_stream_muted_status
         stream_id = self.stream_info_view.stream_id
         size = widget_size(mute_checkbox)
@@ -593,7 +622,7 @@ class TestStreamInfoView:
 
     @pytest.mark.parametrize('key', (*keys_for_command('ENTER'), ' '))
     def test_checkbox_toggle_pin_stream(self, mocker, key, widget_size):
-        pin_checkbox = self.stream_info_view.widgets[4]
+        pin_checkbox = self.stream_info_view.widgets[7]
         toggle_pin_status = self.controller.model.toggle_stream_pinned_status
         stream_id = self.stream_info_view.stream_id
         size = widget_size(pin_checkbox)
@@ -601,3 +630,35 @@ class TestStreamInfoView:
         pin_checkbox.keypress(size, key)
 
         toggle_pin_status.assert_called_once_with(stream_id)
+
+
+class TestStreamMembersView:
+    @pytest.fixture(autouse=True)
+    def mock_external_classes(self, mocker, monkeypatch):
+        self.controller = mocker.Mock()
+        mocker.patch.object(self.controller, 'maximum_popup_dimensions',
+                            return_value=(64, 64))
+        self.controller.model.get_other_subscribers_in_stream.return_value = []
+        self.controller.model.user_full_name = ''
+        mocker.patch(VIEWS + ".urwid.SimpleFocusListWalker", return_value=[])
+        stream_id = 10
+        self.stream_members_view = StreamMembersView(
+            self.controller, stream_id)
+
+    @pytest.mark.parametrize('key', {*keys_for_command('GO_BACK'),
+                                     *keys_for_command('STREAM_MEMBERS')})
+    def test_keypress_exit_popup(self, key, widget_size):
+        stream_id = self.stream_members_view.stream_id
+        size = widget_size(self.stream_members_view)
+        self.stream_members_view.keypress(size, key)
+        self.controller.show_stream_info.assert_called_once_with(
+            stream_id=stream_id,
+        )
+
+    def test_keypress_navigation(self, mocker, widget_size,
+                                 navigation_key_expected_key_pair):
+        key, expected_key = navigation_key_expected_key_pair
+        size = widget_size(self.stream_members_view)
+        super_keypress = mocker.patch(VIEWS + '.urwid.ListBox.keypress')
+        self.stream_members_view.keypress(size, key)
+        super_keypress.assert_called_once_with(size, expected_key)

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -560,10 +560,12 @@ class TestStreamInfoView:
         self.controller.model.is_pinned_stream.return_value = False
         mocker.patch(VIEWS + ".urwid.SimpleFocusListWalker", return_value=[])
         stream_id = 10
-        self.controller.model.stream_dict = {stream_id: {'name': 'books',
-                                                         'invite_only': False,
-                                                         'description': 'hey',
-                                                         'subscribers': []}}
+        self.controller.model.stream_dict = {stream_id:
+                                             {'name': 'books',
+                                              'subscribers': [],
+                                              'description': 'hey',
+                                              'invite_only': False,
+                                              'stream_weekly_traffic': 123}}
         self.stream_info_view = StreamInfoView(self.controller, stream_id)
 
     def test_keypress_any_key(self, widget_size):
@@ -581,9 +583,12 @@ class TestStreamInfoView:
         self.controller.model.is_pinned_stream.return_value = False
         mocker.patch(VIEWS + ".urwid.SimpleFocusListWalker", return_value=[])
         stream_id = self.stream_info_view.stream_id
-        self.controller.model.stream_dict = {stream_id: {'name': 'books',
-                                                         'description': 'hey',
-                                                         'subscribers': []}}
+        self.controller.model.stream_dict = {stream_id:
+                                             {'name': 'books',
+                                              'subscribers': [],
+                                              'description': 'hey',
+                                              'invite_only': False,
+                                              'stream_weekly_traffic': 123}}
 
         stream_info_view = StreamInfoView(self.controller, stream_id)
         size = widget_size(stream_info_view)
@@ -611,7 +616,7 @@ class TestStreamInfoView:
 
     @pytest.mark.parametrize('key', (*keys_for_command('ENTER'), ' '))
     def test_checkbox_toggle_mute_stream(self, mocker, key, widget_size):
-        mute_checkbox = self.stream_info_view.widgets[6]
+        mute_checkbox = self.stream_info_view.widgets[7]
         toggle_mute_status = self.controller.model.toggle_stream_muted_status
         stream_id = self.stream_info_view.stream_id
         size = widget_size(mute_checkbox)
@@ -622,7 +627,7 @@ class TestStreamInfoView:
 
     @pytest.mark.parametrize('key', (*keys_for_command('ENTER'), ' '))
     def test_checkbox_toggle_pin_stream(self, mocker, key, widget_size):
-        pin_checkbox = self.stream_info_view.widgets[7]
+        pin_checkbox = self.stream_info_view.widgets[8]
         toggle_pin_status = self.controller.model.toggle_stream_pinned_status
         stream_id = self.stream_info_view.stream_id
         size = widget_size(pin_checkbox)

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -240,6 +240,12 @@ KEY_BINDINGS = OrderedDict([
         'help_text': 'View stream information & modify settings',
         'key_category': 'stream_list',
     }),
+    ('STREAM_MEMBERS', {
+        'keys': ['m'],
+        'help_text': 'View subscribed stream members from stream info',
+        'excluded_from_random_tips': True,
+        'key_category': 'stream_list',
+    }),
     ('REDRAW', {
         'keys': ['ctrl l'],
         'help_text': 'Redraw screen',

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -19,7 +19,7 @@ from zulipterminal.ui import Screen, View
 from zulipterminal.ui_tools.utils import create_msg_box_list
 from zulipterminal.ui_tools.views import (
     AboutView, EditHistoryView, EditModeView, HelpView, MsgInfoView,
-    NoticeView, PopUpConfirmationView, StreamInfoView,
+    NoticeView, PopUpConfirmationView, StreamInfoView, StreamMembersView,
 )
 from zulipterminal.version import ZT_VERSION
 
@@ -208,6 +208,10 @@ class Controller:
     def show_stream_info(self, stream_id: int) -> None:
         show_stream_view = StreamInfoView(self, stream_id)
         self.show_pop_up(show_stream_view, 'area:stream')
+
+    def show_stream_members(self, stream_id: int) -> None:
+        stream_members_view = StreamMembersView(self, stream_id)
+        self.show_pop_up(stream_members_view, 'area:stream')
 
     def popup_with_message(self, text: str, width: int) -> None:
         self.show_pop_up(NoticeView(self, text, width, "NOTICE"),

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1082,10 +1082,13 @@ class StreamInfoView(PopUpView):
                          else STREAM_MARKER_PUBLIC)
         title = '{} {}'.format(stream_marker, stream['name'])
         total_members = len(stream['subscribers'])
+        weekly_msg_count = stream['stream_weekly_traffic']
         keys = ', '.join(map(repr, keys_for_command('STREAM_MEMBERS')))
         desc = stream['description']
         stream_info_content = [('', [desc]),
                                ('Stream Details', [
+                                   ('Weekly Message Count',
+                                    str(weekly_msg_count)),
                                    ('Stream Members',
                                     '[{}] Press {} to view'.format(
                                         total_members, keys))


### PR DESCRIPTION
This PR is divided into two parts:
- Show Stream Members in Stream Info view - The First commit leading this PR adds the feature to view Members subscribed to a stream from inside the Stream info view on pressing `m` key.
- Show estimated messages per week for streams - The Second commit will add another submenu inside Stream info which will show the Estimated messages per week gathered inside that stream.

Tests amended.
This PR fixes #753.