### PR TITLE
docs: Developer documentation updated and cleaned

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,10 @@ A simple tutorial for implementing the `typing` indicator is available
 in the [wiki](https://github.com/zulip/zulip-terminal/wiki/Developer-Documentation). Follow
 it to understand the how to implement a new feature for zulip-terminal.
 
+### Urwid
+
+Zulip Terminal uses [urwid](http://urwid.org/) to render the UI components in terminal. Urwid is an awesome library through which you can render a decent terminal UI just using python. [Urwid's Tutorial](http://urwid.org/tutorial/index.html) is a great place to start for new contributors.
+
 ### Setting up a development environment
 
 Various options are available; we are exploring the benefits of each and would appreciate feedback on which you use or feel works best.

--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -1,0 +1,23 @@
+## Overview
+
+Zulip Terminal uses [Zulip's API](https://zulip.com/api/) to store and retrieve all the information it displays. It has an [MVC structure](https://en.wikipedia.org/wiki/Model%E2%80%93view%E2%80%93controller) overall. Here is a description of some of its files:
+
+| Folder                 | File                | Description                                                                                            |
+| ---------------------- | ------------------- | ------------------------------------------------------------------------------------------------------ |
+| zulipterminal/         | core.py             | Defines the `Controller`, which sets up the `model`, `view`, and coordinates the application           |
+|                        | emoji_names.py      | Stores valid emoji names                                                                               |
+|                        | helper.py           | Helper functions used in multiple places                                                               |
+|                        | model.py            | Defines the `Model`, fetching and storing data retrieved from the Zulip server                         |
+|                        | ui.py               | Defines the `View`, and controls where each component is displayed                                     |
+|                        | version.py          | Keeps track of the version of the current code                                                         |
+|                        |                     |                                                                                                        |
+| zulipterminal/cli      | run.py              | Marks the entry point into the application                                                             |
+|                        |                     |                                                                                                        |
+| zulipterminal/config   | keys.py             | Stores keybindings and their helper functions                                                          |
+|                        | themes.py           | Stores styles and their colour mappings in each theme, with helper functions                           |
+|                        |                     |                                                                                                        |
+| zulipterminal/ui_tools | boxes.py            | UI boxes for displaying messages and entering text, such as `MessageBox`, `SearchBox`, `WriteBox`, etc.|
+|                        | buttons.py          | UI buttons for 'narrowing' and showing unread counts, such as Stream, PM, Topic, Home, Starred, etc    |
+|                        | tables.py           | Helper functions which render tables in the UI                                                         |
+|                        | utils.py            | The `MessageBox` for every message displayed is created here                                           |
+|                        | views.py            | UI views for larger elements such as Streams, Messages, Topics, Help, etc                              |

--- a/docs/developer-add-feature-tutorial.md
+++ b/docs/developer-add-feature-tutorial.md
@@ -1,29 +1,5 @@
 **Zulip Terminal** is a light and fast terminal client for [Zulip](https://zulip.com). It's written in python and :snake: only.
 
-## Overview
-
-Zulip Terminal uses [Zulip's API](https://zulip.com/api/) to store and retrieve all the information it displays. It has an [MVC structure](https://en.wikipedia.org/wiki/Model%E2%80%93view%E2%80%93controller) overall. Here is a description of some of its files:
-
-| Folder                 | File                | Description                                                                                            |
-| ---------------------- | ------------------- | ------------------------------------------------------------------------------------------------------ |
-| zulipterminal/         | core.py             | Defines the `Controller`, which sets up the `model`, `view`, and coordinates the application           |
-|                        | emoji_names.py      | Stores valid emoji names                                                                               |
-|                        | helper.py           | Helper functions used in multiple places                                                               |
-|                        | model.py            | Defines the `Model`, fetching and storing data retrieved from the Zulip server                         |
-|                        | ui.py               | Defines the `View`, and controls where each component is displayed                                     |
-|                        | version.py          | Keeps track of the version of the current code                                                         |
-|                        |                     |                                                                                                        |
-| zulipterminal/cli      | run.py              | Marks the entry point into the application                                                             |
-|                        |                     |                                                                                                        |
-| zulipterminal/config   | keys.py             | Stores keybindings and their helper functions                                                          |
-|                        | themes.py           | Stores styles and their colour mappings in each theme, with helper functions                           |
-|                        |                     |                                                                                                        |
-| zulipterminal/ui_tools | boxes.py            | UI boxes for displaying messages and entering text, such as `MessageBox`, `SearchBox`, `WriteBox`, etc.|
-|                        | buttons.py          | UI buttons for 'narrowing' and showing unread counts, such as Stream, PM, Topic, Home, Starred, etc    |
-|                        | tables.py           | Helper functions which render tables in the UI                                                         |
-|                        | utils.py            | The `MessageBox` for every message displayed is created here                                           |
-|                        | views.py            | UI views for larger elements such as Streams, Messages, Topics, Help, etc                              |
-
 
 ## Tutorial - Adding typing indicator
 

--- a/docs/developer-documentation.md
+++ b/docs/developer-documentation.md
@@ -24,13 +24,6 @@ Zulip Terminal uses [Zulip's API](https://zulip.com/api/) to store and retrieve 
 |                        | utils.py            | The `MessageBox` for every message displayed is created here                                           |
 |                        | views.py            | UI views for larger elements such as Streams, Messages, Topics, Help, etc                              |
 
-Zulip Terminal uses [urwid](http://urwid.org/) to render the UI components in terminal. Urwid is an awesome library through which you can render a decent terminal UI just using python. [Urwid's Tutorial](http://urwid.org/tutorial/index.html) is a great place to start for new contributors.
-
-
-## Tests
-
-Tests for zulip-terminal are written using [pytest](https://pytest.org/). You can read the tests in `/tests` folder to learn about writing tests for a new class/function. If you are new to pytest, reading its documentation is definitely recommended.
-
 
 ## Tutorial - Adding typing indicator
 


### PR DESCRIPTION
This PR aims:
- To remove duplicate Pytest information in developer docs.
- To mention Urwid related info in general README.md
- To split Overview and Tutorial (as tutorial covers a bulkier portion of developer-documentation).

Fixes an early issue #27