### PR TITLE
gitignore: Add zulip-terminal-thread-exceptions.log.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,12 +6,10 @@ cov_html/*
 .mypy_cache
 Pipfile.lock
 zulipterminal.egg-info
-debug.log
 dist/*
 build/*
 zulip_term.egg-info
-zulip-terminal-tracebacks.log
-zulip-terminal-API-requests.log
+*.log
 zt_venv/*
 zulip-terminal-venv/*
 


### PR DESCRIPTION
Added `zulip-terminal-thread-exceptions.log` to the `.gitignore`.