### PR TITLE
README: Add About section (including feature status notes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,22 @@
 
 ![Screenshot 2020-05-19 at 9 56 49 AM](https://user-images.githubusercontent.com/56690786/82285402-0760b800-99b9-11ea-9a86-9d3765ea9177.png)
 
+## About
 
-## Supported platforms
+Zulip Terminal is the official terminal client for Zulip, providing a [text-based user interface (TUI)](https://en.wikipedia.org/wiki/Text-based_user_interface).
+
+Specific aims include:
+* Providing a broadly similar user experience to the Zulip web client, ultimately supporting all of its features
+* Enabling all actions to be achieved through the keyboard (see [Hot keys](#hot-keys))
+* Exploring alternative user interface designs suited to the display and input constraints
+* Supporting a wide range of platforms and terminal emulators
+
+### Supported platforms
 - Linux
 - OSX
 - WSL (On Windows)
 
-## Supported Server Versions
+### Supported Server Versions
 
 The minimum server version that Zulip Terminal supports is [`2.1.0`](https://zulip.readthedocs.io/en/latest/overview/changelog.html#id7). It may still work with earlier versions.
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,21 @@ Specific aims include:
 * Exploring alternative user interface designs suited to the display and input constraints
 * Supporting a wide range of platforms and terminal emulators
 
+### Feature status
+
+We consider the client to already provide a fairly stable moderately-featureful everyday-user experience.
+
+The current development focus is on improving aspects of everyday usage which are more commonly used - to reduce the need for users to temporarily switch to another client for a particular feature.
+
+Current limitations which we expect to only resolve over the long term include support for:
+* All operations performed by users with extra privileges (owners/admins)
+* Accessing and updating all settings
+* Using a mouse/pointer to achieve all actions
+* An internationalized UI
+
+For queries on missing feature support please take a look at the [Frequently Asked Questions (FAQs)](https://github.com/zulip/zulip-terminal/blob/master/docs/FAQ.md),
+our open [Issues](https://github.com/zulip/zulip-terminal/issues/), or sign up on https://chat.zulip.org and chat with users and developers in the [#zulip-terminal](https://chat.zulip.org/#narrow/stream/206-zulip-terminal) stream!
+
 ### Supported platforms
 - Linux
 - OSX


### PR DESCRIPTION
Following up on my comment in #859, this hopefully clarifies the keyboard-centric aspect, as well as starting to clarify the focus of the project and some limited caveats which could provide some scope to link to a document supporting #731 later.