### PR TITLE
[WIP] boxes: Notify time left to edit message.

### DIFF
--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -1221,6 +1221,18 @@ class MessageBox(urwid.Pile):
                             " Time Limit for editing the message body has"
                             " been exceeded.", 3)
                     msg_body_edit_enabled = False
+            else:
+                seconds_left = edit_time_limit - time_since_msg_sent
+                edit_countdown_min = seconds_left // 60
+                edit_countdown_sec = seconds_left % 60
+                if edit_countdown_min > 0:
+                    self.model.controller.view.set_footer_text(
+                        "{} minutes to edit".format(int(edit_countdown_min)), 5
+                    )
+                else:
+                    self.model.controller.view.set_footer_text(
+                        "{} seconds to edit".format(int(edit_countdown_sec)), 5
+                    )
 
             if self.message['type'] == 'private':
                 self.keypress(size, 'enter')


### PR DESCRIPTION
This PR alerts the user of the time left to edit a sent message. Presently, the mode of informing is through a `Footer notifications` that shows the time in minutes and seconds(when time left is below a min) until the user can edit his sent message. This is currently the v1 of this PR and there might still be a few things to discuss and improve upon.

This PR may fix #727.