### PR TITLE
boxes: Disable cycling using arrow keys if recipient is invalid.

### DIFF
--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -177,8 +177,7 @@ class TestWriteBox:
         write_box.to_write_box.edit_text = raw_recipients
         write_box.to_write_box.set_edit_pos(len(raw_recipients))
         expected_lines = [
-            "Invalid recipient(s) - " + invalid_recipients,
-            " - Use ",
+            "Invalid recipient(s) - " + invalid_recipients + ". Use ",
             ("footer_contrast", primary_key_for_command("AUTOCOMPLETE")),
             " or ",
             ("footer_contrast", primary_key_for_command("AUTOCOMPLETE_REVERSE")),

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -1044,6 +1044,7 @@ class TestWriteBox:
             "box_type",
             "msg_body_edit_enabled",
             "message_being_edited",
+            "key",
             "expected_focus_name",
             "expected_focus_col_name",
         ],
@@ -1054,9 +1055,10 @@ class TestWriteBox:
                 "stream",
                 True,
                 False,
+                "tab_key",
                 "CONTAINER_HEADER",
                 "HEADER_BOX_TOPIC",
-                id="stream_name_to_topic_box",
+                id="stream_name_to_topic_box_tab",
             ),
             case(
                 "CONTAINER_HEADER",
@@ -1064,9 +1066,10 @@ class TestWriteBox:
                 "stream",
                 True,
                 False,
+                "tab_key",
                 "CONTAINER_MESSAGE",
                 "MESSAGE_BOX_BODY",
-                id="topic_to_message_box",
+                id="topic_to_message_box_tab",
             ),
             case(
                 "CONTAINER_HEADER",
@@ -1074,9 +1077,10 @@ class TestWriteBox:
                 "stream",
                 False,
                 True,
+                "tab_key",
                 "CONTAINER_HEADER",
                 "HEADER_BOX_EDIT",
-                id="topic_edit_only-topic_to_edit_mode_box",
+                id="topic_edit_only-topic_to_edit_mode_box_tab",
             ),
             case(
                 "CONTAINER_HEADER",
@@ -1084,9 +1088,10 @@ class TestWriteBox:
                 "stream",
                 False,
                 True,
+                "tab_key",
                 "CONTAINER_HEADER",
                 "HEADER_BOX_TOPIC",
-                id="topic_edit_only-edit_mode_to_topic_box",
+                id="topic_edit_only-edit_mode_to_topic_box_tab",
             ),
             case(
                 "CONTAINER_MESSAGE",
@@ -1094,9 +1099,10 @@ class TestWriteBox:
                 "stream",
                 True,
                 False,
+                "tab_key",
                 "CONTAINER_HEADER",
                 "HEADER_BOX_STREAM",
-                id="message_to_stream_name_box",
+                id="message_to_stream_name_box_tab",
             ),
             case(
                 "CONTAINER_HEADER",
@@ -1104,9 +1110,10 @@ class TestWriteBox:
                 "stream",
                 True,
                 True,
+                "tab_key",
                 "CONTAINER_HEADER",
                 "HEADER_BOX_TOPIC",
-                id="edit_box-stream_name_to_topic_box",
+                id="edit_box-stream_name_to_topic_box_tab",
             ),
             case(
                 "CONTAINER_HEADER",
@@ -1114,9 +1121,10 @@ class TestWriteBox:
                 "stream",
                 True,
                 True,
+                "tab_key",
                 "CONTAINER_HEADER",
                 "HEADER_BOX_EDIT",
-                id="edit_box-topic_to_edit_mode_box",
+                id="edit_box-topic_to_edit_mode_box_tab",
             ),
             case(
                 "CONTAINER_HEADER",
@@ -1124,9 +1132,10 @@ class TestWriteBox:
                 "stream",
                 True,
                 True,
+                "tab_key",
                 "CONTAINER_MESSAGE",
                 "MESSAGE_BOX_BODY",
-                id="edit_box-edit_mode_to_message_box",
+                id="edit_box-edit_mode_to_message_box_tab",
             ),
             case(
                 "CONTAINER_MESSAGE",
@@ -1134,9 +1143,10 @@ class TestWriteBox:
                 "stream",
                 True,
                 True,
+                "tab_key",
                 "CONTAINER_HEADER",
                 "HEADER_BOX_STREAM",
-                id="edit_box-message_to_stream_name_box",
+                id="edit_box-message_to_stream_name_box_tab",
             ),
             case(
                 "CONTAINER_HEADER",
@@ -1144,9 +1154,10 @@ class TestWriteBox:
                 "private",
                 True,
                 False,
+                "tab_key",
                 "CONTAINER_MESSAGE",
                 "MESSAGE_BOX_BODY",
-                id="recipient_to_message_box",
+                id="recipient_to_message_box_tab",
             ),
             case(
                 "CONTAINER_MESSAGE",
@@ -1154,17 +1165,115 @@ class TestWriteBox:
                 "private",
                 True,
                 False,
+                "tab_key",
                 "CONTAINER_HEADER",
                 "HEADER_BOX_RECIPIENT",
-                id="message_to_recipient_box",
+                id="message_to_recipient_box_tab",
+            ),
+            case(
+                "CONTAINER_HEADER",
+                "HEADER_BOX_STREAM",
+                "stream",
+                True,
+                False,
+                "right",
+                "CONTAINER_HEADER",
+                "HEADER_BOX_TOPIC",
+                id="stream_name_to_topic_box_right",
+            ),
+            case(
+                "CONTAINER_HEADER",
+                "HEADER_BOX_TOPIC",
+                "stream",
+                True,
+                True,
+                "right",
+                "CONTAINER_HEADER",
+                "HEADER_BOX_EDIT",
+                id="topic_edit_only-topic_to_edit_mode_box_right",
+            ),
+            case(
+                "CONTAINER_HEADER",
+                "HEADER_BOX_EDIT",
+                "stream",
+                False,
+                True,
+                "up",
+                "CONTAINER_HEADER",
+                "HEADER_BOX_EDIT",
+                id="topic_edit_only-edit_mode_to_edit_box_up",
+            ),
+            case(
+                "CONTAINER_HEADER",
+                "HEADER_BOX_STREAM",
+                "stream",
+                True,
+                True,
+                "left",
+                "CONTAINER_HEADER",
+                "HEADER_BOX_STREAM",
+                id="edit_box-stream_name_to_stream_box_left",
+            ),
+            case(
+                "CONTAINER_HEADER",
+                "HEADER_BOX_TOPIC",
+                "stream",
+                True,
+                True,
+                "right",
+                "CONTAINER_HEADER",
+                "HEADER_BOX_EDIT",
+                id="edit_box-topic_to_edit_mode_box_right",
+            ),
+            case(
+                "CONTAINER_HEADER",
+                "HEADER_BOX_TOPIC",
+                "stream",
+                True,
+                False,
+                "down",
+                "CONTAINER_MESSAGE",
+                "MESSAGE_BOX_BODY",
+                id="topic_box_to_message_box_down",
+            ),
+            case(
+                "CONTAINER_HEADER",
+                "HEADER_BOX_RECIPIENT",
+                "private",
+                True,
+                False,
+                "right",
+                "CONTAINER_HEADER",
+                "HEADER_BOX_RECIPIENT",
+                id="recipient_to_recipient_box_right",
+            ),
+            case(
+                "CONTAINER_HEADER",
+                "HEADER_BOX_RECIPIENT",
+                "private",
+                True,
+                False,
+                "down",
+                "CONTAINER_MESSAGE",
+                "MESSAGE_BOX_BODY",
+                id="recipient_to_message_box_down",
+            ),
+            case(
+                "CONTAINER_MESSAGE",
+                "MESSAGE_BOX_BODY",
+                "private",
+                True,
+                False,
+                "right",
+                "CONTAINER_MESSAGE",
+                "MESSAGE_BOX_BODY",
+                id="message_to_message_box_private_right",
             ),
         ],
     )
-    @pytest.mark.parametrize("tab_key", keys_for_command("CYCLE_COMPOSE_FOCUS"))
-    def test_keypress_CYCLE_COMPOSE_FOCUS(
+    def test_keypress_CHANGE_COMPOSE_FOCUS(
         self,
         write_box,
-        tab_key,
         initial_focus_name,
         expected_focus_name,
         initial_focus_col_name,
@@ -1172,12 +1281,15 @@ class TestWriteBox:
         box_type,
         msg_body_edit_enabled,
         message_being_edited,
+        key,
         widget_size,
         mocker,
         stream_id=10,
     ):
         mocker.patch(BOXES + ".WriteBox._set_stream_write_box_style")
 
+        if key == "tab_key":
+            key = primary_key_for_command("CYCLE_COMPOSE_FOCUS")
         if box_type == "stream":
             if message_being_edited:
                 mocker.patch(BOXES + ".EditModeButton")
@@ -1189,7 +1301,8 @@ class TestWriteBox:
                 write_box.stream_box_view(stream_id)
         else:
             write_box.private_box_view()
-        size = widget_size(write_box)
+        # FIXME: Use widget_size(), instead of hard-coded size.
+        size = (20,)
 
         def focus_val(x: str) -> int:
             return getattr(write_box, "FOCUS_" + x)
@@ -1201,7 +1314,7 @@ class TestWriteBox:
         write_box.model.get_invalid_recipient_emails.return_value = []
         write_box.model.user_dict = mocker.MagicMock()
 
-        write_box.keypress(size, tab_key)
+        write_box.keypress(size, key)
 
         assert write_box.focus_position == focus_val(expected_focus_name)
         # FIXME: Needs refactoring?

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -252,18 +252,8 @@ class WriteBox(urwid.Pile):
         write_box.edit_pos = len(write_box.edit_text)
 
         if invalid_recipients:
-            invalid_recipients_error = [
-                "Invalid recipient(s) - " + ", ".join(invalid_recipients),
-                " - Use ",
-                ("footer_contrast", primary_key_for_command("AUTOCOMPLETE")),
-                " or ",
-                (
-                    "footer_contrast",
-                    primary_key_for_command("AUTOCOMPLETE_REVERSE"),
-                ),
-                " to autocomplete.",
-            ]
-            self.view.controller.report_error(invalid_recipients_error)
+            error_message = "Invalid recipient(s) - " + ", ".join(invalid_recipients)
+            self.footer_notify_invalid_recipient(error_message)
             return False
 
         return True
@@ -572,6 +562,16 @@ class WriteBox(urwid.Pile):
 
         return emoji_typeahead, emojis
 
+    def footer_notify_invalid_recipient(self, error_message: str) -> None:
+        footer_message = [
+            error_message + ". Use ",
+            ("footer_contrast", primary_key_for_command("AUTOCOMPLETE")),
+            " or ",
+            ("footer_contrast", primary_key_for_command("AUTOCOMPLETE_REVERSE")),
+            " to autocomplete.",
+        ]
+        self.view.controller.report_error(footer_message)
+
     def keypress(self, size: urwid_Size, key: str) -> Optional[str]:
         if self.is_in_typeahead_mode:
             if not (
@@ -686,14 +686,7 @@ class WriteBox(urwid.Pile):
                     if header.focus_col == self.FOCUS_HEADER_BOX_STREAM:
                         stream_name = header[self.FOCUS_HEADER_BOX_STREAM].edit_text
                         if not self.model.is_valid_stream(stream_name):
-                            invalid_stream_error = (
-                                "Invalid stream name."
-                                " Use {} or {} to autocomplete.".format(
-                                    primary_key_for_command("AUTOCOMPLETE"),
-                                    primary_key_for_command("AUTOCOMPLETE_REVERSE"),
-                                )
-                            )
-                            self.view.controller.report_error(invalid_stream_error)
+                            self.footer_notify_invalid_recipient("Invalid stream name")
                             return key
                         user_ids = self.model.get_other_subscribers_in_stream(
                             stream_name=stream_name


### PR DESCRIPTION
This PR disables cycling from the recipient box to any other box inside the `WriteBox` view using arrow keys, if the recipient name is invalid. This is very similar to `CYCLE_COMPOSE_FOCUS` using <kbd>Tab</kbd> key. Tests have also been updated and amended.

This PR fixes #779.
