### PR TITLE
Handle topic links in message info view

### DIFF
--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -600,6 +600,34 @@ class TestModel:
             assert model.index['pointer'][repr(model.narrow)] == anchor
         assert model._have_last_message[repr(model.narrow)] is True
 
+    @pytest.mark.parametrize('messages, expected_messages_response', [(
+        {'topic_links':   [{'url': 'www.foo.com', 'text': 'Bar'}]},
+        {'topic_links':   [{'url': 'www.foo.com', 'text': 'Bar'}]},
+    ), (
+        {'topic_links':   ['www.foo1.com']},
+        {'topic_links':   [{'url': 'www.foo1.com', 'text': ''}]},
+    ), (
+        {'topic_links': []},
+        {'topic_links': []},
+    ), (
+        {'subject_links':   ['www.foo2.com']},
+        {'topic_links':     [{'url': 'www.foo2.com', 'text': ''}]},
+    ), (
+        {'subject_links': []},
+        {'topic_links':   []},
+    )], ids=[
+        'Zulip_4.0+_ZFL46_response_with_topic_links',
+        'Zulip_3.0+_ZFL1_response_with_topic_links',
+        'Zulip_3.0+_ZFL1_response_empty_topic_links',
+        'Zulip_2.1+_response_with_subject_links',
+        'Zulip_2.1+_response_empty_subject_links',
+    ])
+    def test_modernize_message_response(self, model, messages,
+                                        expected_messages_response):
+
+        assert (model.modernize_message_response(messages)
+                == expected_messages_response)
+
     def test_get_message_false_first_anchor(
             self, mocker, messages_successful_response, index_all_messages,
             initial_data, num_before=30, num_after=10

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1292,6 +1292,8 @@ class TestMessageBox:
         assert msg_box.last_message == defaultdict(dict)
         for field, invalid_default in set_fields:
             assert getattr(msg_box, field) != invalid_default
+        if message_type == 'stream':
+            assert msg_box.topic_links == OrderedDict()
         assert msg_box.message_links == OrderedDict()
         assert msg_box.time_mentions == list()
 

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -568,6 +568,36 @@ class TestMsgInfoView:
         expected_height = 9
         assert self.msg_info_view.height == expected_height
 
+    @pytest.mark.parametrize([
+            'initial_link',
+            'expected_text',
+            'expected_attr_map',
+            'expected_focus_map',
+            'expected_link_width'
+        ], [(
+            OrderedDict([('https://bar.com', ('Foo', 1, True))]),
+            '1: Foo\nhttps://bar.com',
+            {None: 'popup_contrast'},
+            {None: 'selected'},
+            15,
+        )],
+    )
+    def test_create_link_buttons(self, initial_link, expected_text,
+                                 expected_attr_map, expected_focus_map,
+                                 expected_link_width):
+        [link_w], link_width = self.msg_info_view.create_link_buttons(
+            self.controller, initial_link,
+        )
+
+        assert [link_w.link] == list(initial_link)
+        assert (link_w._wrapped_widget.original_widget.text
+                == expected_text)
+        assert (link_w._wrapped_widget.focus_map
+                == expected_focus_map)
+        assert (link_w._wrapped_widget.attr_map
+                == expected_attr_map)
+        assert link_width == expected_link_width
+
     def test_keypress_navigation(self, mocker, widget_size,
                                  navigation_key_expected_key_pair):
         key, expected_key = navigation_key_expected_key_pair

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -580,7 +580,16 @@ class TestMsgInfoView:
             {None: 'popup_contrast'},
             {None: 'selected'},
             15,
-        )],
+        ), (
+            OrderedDict([('https://foo.com', ('', 1, True))]),
+            '1: https://foo.com',
+            {None: 'popup_contrast'},
+            {None: 'selected'},
+            18,
+        )], ids=[
+            'link_with_link_text',
+            'link_without_link_text',
+        ]
     )
     def test_create_link_buttons(self, initial_link, expected_text,
                                  expected_attr_map, expected_focus_map,

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -207,6 +207,7 @@ class TestEditHistoryView:
         self.edit_history_view = EditHistoryView(
             controller=self.controller,
             message=self.message,
+            topic_links=OrderedDict(),
             message_links=OrderedDict(),
             time_mentions=list(),
             title='Edit History',
@@ -215,6 +216,7 @@ class TestEditHistoryView:
     def test_init(self):
         assert self.edit_history_view.controller == self.controller
         assert self.edit_history_view.message == self.message
+        assert self.edit_history_view.topic_links == OrderedDict()
         assert self.edit_history_view.message_links == OrderedDict()
         assert self.edit_history_view.time_mentions == list()
         self.controller.model.fetch_message_history.assert_called_once_with(
@@ -246,6 +248,7 @@ class TestEditHistoryView:
 
         self.controller.show_msg_info.assert_called_once_with(
             msg=self.message,
+            topic_links=OrderedDict(),
             message_links=OrderedDict(),
             time_mentions=list(),
         )
@@ -450,7 +453,13 @@ class TestMsgInfoView:
         ]
         self.msg_info_view = MsgInfoView(self.controller, message_fixture,
                                          'Message Information', OrderedDict(),
-                                         list())
+                                         OrderedDict(), list())
+
+    def test_init(self, message_fixture):
+        assert self.msg_info_view.msg == message_fixture
+        assert self.msg_info_view.topic_links == OrderedDict()
+        assert self.msg_info_view.message_links == OrderedDict()
+        assert self.msg_info_view.time_mentions == list()
 
     def test_keypress_any_key(self, widget_size):
         key = "a"
@@ -482,6 +491,7 @@ class TestMsgInfoView:
         }
         msg_info_view = MsgInfoView(self.controller, message_fixture,
                                     title='Message Information',
+                                    topic_links=OrderedDict(),
                                     message_links=OrderedDict(),
                                     time_mentions=list())
         size = widget_size(msg_info_view)
@@ -491,6 +501,7 @@ class TestMsgInfoView:
         if msg_info_view.show_edit_history_label:
             self.controller.show_edit_history.assert_called_once_with(
                 message=message_fixture,
+                topic_links=OrderedDict(),
                 message_links=OrderedDict(),
                 time_mentions=list(),
             )
@@ -552,7 +563,7 @@ class TestMsgInfoView:
         varied_message = dict(message_fixture, **to_vary_in_each_message)
         self.msg_info_view = MsgInfoView(self.controller, varied_message,
                                          'Message Information', OrderedDict(),
-                                         list())
+                                         OrderedDict(), list())
         # 9 = 3 labels + 1 blank line + 1 'Reactions' (category) + 4 reactions.
         expected_height = 9
         assert self.msg_info_view.height == expected_height

--- a/zulipterminal/api_types.py
+++ b/zulipterminal/api_types.py
@@ -30,7 +30,12 @@ class Message(TypedDict, total=False):
     timestamp: int
     client: str
     subject: str  # Only for stream msgs.
-    topic_links: List[str]
+    # NOTE: new in Zulip 3.0 / ZFL 1
+    # NOTE: API response format of `topic_links` new in Zulip 4.0 / ZFL 46
+    topic_links: List[Any]
+    # NOTE: `subject_links` new in Zulip 2.1;
+    # Deprecated from Zulip 3.0 / ZFL 1
+    subject_links: List[str]
     is_me_message: bool
     reactions: List[Dict[str, Any]]
     submessages: List[Dict[str, Any]]

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -205,12 +205,13 @@ class Controller:
         self.show_pop_up(EditModeView(self, button), 'area:msg')
 
     def show_msg_info(self, msg: Message,
+                      topic_links: 'OrderedDict[str, Tuple[str, int, bool]]',
                       message_links: 'OrderedDict[str, Tuple[str, int, bool]]',
                       time_mentions: List[Tuple[str, str]],
                       ) -> None:
         msg_info_view = MsgInfoView(self, msg,
                                     "Message Information (up/down scrolls)",
-                                    message_links, time_mentions)
+                                    topic_links, message_links, time_mentions)
         self.show_pop_up(msg_info_view, 'area:msg')
 
     def show_stream_info(self, stream_id: int) -> None:
@@ -241,11 +242,13 @@ class Controller:
 
     def show_edit_history(
         self, message: Message,
+        topic_links: 'OrderedDict[str, Tuple[str, int, bool]]',
         message_links: 'OrderedDict[str, Tuple[str, int, bool]]',
         time_mentions: List[Tuple[str, str]],
     ) -> None:
         self.show_pop_up(
-            EditHistoryView(self, message, message_links, time_mentions,
+            EditHistoryView(self, message, topic_links,
+                            message_links, time_mentions,
                             'Edit History (up/down scrolls)'),
             'area:msg'
         )

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -661,6 +661,9 @@ class MessageBox(urwid.Pile):
         self.message_links: 'OrderedDict[str, Tuple[str, int, bool]]' = (
             OrderedDict()
         )
+        self.topic_links: 'OrderedDict[str, Tuple[str, int, bool]]' = (
+            OrderedDict()
+        )
         self.time_mentions: List[Tuple[str, str]] = list()
         self.last_message = last_message
         # if this is the first message
@@ -668,6 +671,13 @@ class MessageBox(urwid.Pile):
             self.last_message = defaultdict(dict)
 
         if self.message['type'] == 'stream':
+            # Set `topic_links` if present
+            for link in self.message.get('topic_links', []):
+                # Modernized response
+                self.topic_links[link['url']] = (
+                    link['text'], len(self.topic_links) + 1, True
+                )
+
             self.stream_name = self.message['display_recipient']
             self.stream_id = self.message['stream_id']
             self.topic_name = self.message['subject']
@@ -1549,6 +1559,7 @@ class MessageBox(urwid.Pile):
             self.model.controller.view.middle_column.set_focus('footer')
         elif is_command_key('MSG_INFO', key):
             self.model.controller.show_msg_info(self.message,
+                                                self.topic_links,
                                                 self.message_links,
                                                 self.time_mentions)
         return key

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1251,6 +1251,8 @@ class MsgInfoView(PopUpView):
                 ('Edit History', f"Press {keys} to view")
             )
         # Render the category using the existing table methods if links exist.
+        if topic_links:
+            msg_info.append(('Topic Links', []))
         if message_links:
             msg_info.append(('Message Links', []))
         if time_mentions:
@@ -1275,6 +1277,21 @@ class MsgInfoView(PopUpView):
         # To keep track of buttons (e.g., button links) and to facilitate
         # computing their slice indexes
         button_widgets = []  # type: List[Any]
+
+        if topic_links:
+            topic_link_widgets, topic_link_width = (
+                self.create_link_buttons(controller, topic_links)
+            )
+
+            # slice_index = Number of labels before topic links + 1 newline
+            #               + 1 'Topic Links' category label.
+            slice_index = len(msg_info[0][1]) + 2
+            slice_index += sum([len(w) + 2 for w in button_widgets])
+            button_widgets.append(topic_links)
+
+            widgets = (widgets[:slice_index] + topic_link_widgets
+                       + widgets[slice_index:])
+            popup_width = max(popup_width, topic_link_width)
 
         if message_links:
             message_link_widgets, message_link_width = (
@@ -1303,7 +1320,10 @@ class MsgInfoView(PopUpView):
 
         for index, link in enumerate(links):
             text, link_index, _ = links[link]
-            caption = f"{link_index}: {text}\n{link}"
+            if text:
+                caption = f"{link_index}: {text}\n{link}"
+            else:
+                caption = f"{link_index}: {link}"
             link_width = max(
                 link_width,
                 len(max(caption.split('\n'), key=len))

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1219,10 +1219,12 @@ class StreamMembersView(PopUpView):
 
 class MsgInfoView(PopUpView):
     def __init__(self, controller: Any, msg: Message, title: str,
+                 topic_links: 'OrderedDict[str, Tuple[str, int, bool]]',
                  message_links: 'OrderedDict[str, Tuple[str, int, bool]]',
                  time_mentions: List[Tuple[str, str]],
                  ) -> None:
         self.msg = msg
+        self.topic_links = topic_links
         self.message_links = message_links
         self.time_mentions = time_mentions
         date_and_time = controller.model.formatted_local_time(
@@ -1300,6 +1302,7 @@ class MsgInfoView(PopUpView):
                 and self.show_edit_history_label):
             self.controller.show_edit_history(
                 message=self.msg,
+                topic_links=self.topic_links,
                 message_links=self.message_links,
                 time_mentions=self.time_mentions,
             )
@@ -1345,11 +1348,13 @@ EditHistoryTag = Literal['(Current Version)', '(Original Version)', '']
 
 class EditHistoryView(PopUpView):
     def __init__(self, controller: Any, message: Message,
+                 topic_links: 'OrderedDict[str, Tuple[str, int, bool]]',
                  message_links: 'OrderedDict[str, Tuple[str, int, bool]]',
                  time_mentions: List[Tuple[str, str]],
                  title: str) -> None:
         self.controller = controller
         self.message = message
+        self.topic_links = topic_links
         self.message_links = message_links
         self.time_mentions = time_mentions
         width = 64
@@ -1446,6 +1451,7 @@ class EditHistoryView(PopUpView):
                 or is_command_key('EDIT_HISTORY', key)):
             self.controller.show_msg_info(
                 msg=self.message,
+                topic_links=self.topic_links,
                 message_links=self.message_links,
                 time_mentions=self.time_mentions,
             )


### PR DESCRIPTION
This PR is a headstart in handling Topic links in a stream topic.

**Commit flow:**
- Generate link buttons in message info view via a static method (Refactor).
- Add API return types for new and old topic links' responses.
- Convert message responses to support modern formats (in general) via a model helper (Refactor).
- Topic links stored by parsing into `OrderedDict` (like message links).
- Topic links appended in the message info view.

Fixes #709.

View:
![Topic links](https://user-images.githubusercontent.com/55916430/104996384-d0620b00-5a4d-11eb-9b70-49aada9de3f5.png)
