### PR TITLE
Time format setting

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1,4 +1,5 @@
 import datetime
+import itertools
 from collections import OrderedDict, defaultdict
 from typing import Any, Dict
 
@@ -1778,10 +1779,6 @@ class TestMessageBox:
             'timestamp': 1532103879,
         }
     ])
-    @pytest.mark.parametrize('current_year', [2018, 2019, 2050],
-                             ids=['now_2018', 'now_2019', 'now_2050'])
-    @pytest.mark.parametrize('starred_msg', ['this', 'last', 'neither'],
-                             ids=['this_starred', 'last_starred', 'no_stars'])
     @pytest.mark.parametrize('expected_header, to_vary_in_last_message', [
         (['alice', ' ', 'DAYDATETIME'], {'sender_full_name': 'bob'}),
         ([' ', ' ', 'DAYDATETIME'], {'timestamp': 1532103779}),
@@ -1789,6 +1786,10 @@ class TestMessageBox:
     ], ids=['show_author_as_authors_different',
             'merge_messages_as_only_slightly_earlier_message',
             'dont_merge_messages_as_much_earlier_message'])
+    @pytest.mark.parametrize('current_year', [2018, 2019, 2050],
+                             ids=['now_2018', 'now_2019', 'now_2050'])
+    @pytest.mark.parametrize('starred_msg', ['this', 'last', 'neither'],
+                             ids=['this_starred', 'last_starred', 'no_stars'])
     def test_main_view_content_header_without_header(self, mocker, message,
                                                      expected_header,
                                                      current_year,
@@ -1804,7 +1805,9 @@ class TestMessageBox:
         all_to_vary = dict(to_vary_in_last_message, **stars['last'])
         last_msg = dict(message, **all_to_vary)
         msg_box = MessageBox(this_msg, self.model, last_msg)
-        expected_header[1] = msg_box._time_for_message(message)
+        self.model.formatted_local_time.side_effect = itertools.cycle(
+                                ["Fri Jul 20 21:54", " ", "Thu Jan 01 05:30"])
+        expected_header[1] = "Fri Jul 20 21:54"
         if current_year > 2018:
             expected_header[1] = '2018 - ' + expected_header[1]
         expected_header[2] = '*' if starred_msg == 'this' else ' '

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -432,6 +432,8 @@ class TestMsgInfoView:
         self.controller.model.initial_data = {
             'realm_allow_edit_history': False,
         }
+        self.controller.model.formatted_local_time.side_effect = [
+           "Tue Mar 13 10:55:22", "Tue Mar 13 10:55:37", "Tue Mar 13 10:55:36"]
         self.msg_info_view = MsgInfoView(self.controller, message_fixture,
                                          'Message Information', OrderedDict(),
                                          list())

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import time
 from collections import OrderedDict, defaultdict
@@ -1126,6 +1127,14 @@ class Model:
         if operation == 'add' and flag_to_change == 'read':
             set_count(list(message_ids_to_mark & indexed_message_ids),
                       self.controller, -1)
+
+    def formatted_local_time(self, timestamp: int,
+                             *, show_seconds: bool) -> str:
+        local_time = datetime.datetime.fromtimestamp(timestamp)
+        if show_seconds:
+            return local_time.strftime('%a %b %d %H:%M:%S')
+        else:
+            return local_time.strftime('%a %b %d %H:%M')
 
     def _update_rendered_view(self, msg_id: int) -> None:
         """

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -3,7 +3,7 @@ import unicodedata
 from collections import OrderedDict, defaultdict
 from datetime import date, datetime, timedelta
 from sys import platform
-from time import ctime, sleep, time
+from time import sleep, time
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 from urllib.parse import urljoin, urlparse
 
@@ -622,9 +622,6 @@ class MessageBox(urwid.Pile):
 
         super().__init__(self.main_view())
 
-    def _time_for_message(self, message: Message) -> str:
-        return ctime(message['timestamp'])[:-8]
-
     def need_recipient_header(self) -> bool:
         # Prevent redundant information in recipient bar
         if (len(self.model.narrow) == 1
@@ -1055,7 +1052,8 @@ class MessageBox(urwid.Pile):
                 'is_starred': 'starred' in msg['flags'],
                 'author': (msg['sender_full_name']
                            if 'sender_full_name' in msg else None),
-                'time': (self._time_for_message(msg)
+                'time': (str(self.model.formatted_local_time(
+                                        msg['timestamp'], show_seconds=False))
                          if 'timestamp' in msg else None),
                 'datetime': (datetime.fromtimestamp(msg['timestamp'])
                              if 'timestamp' in msg else None),

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1,5 +1,4 @@
 import threading
-import time
 from collections import OrderedDict
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
@@ -1177,9 +1176,11 @@ class MsgInfoView(PopUpView):
         self.msg = msg
         self.message_links = message_links
         self.time_mentions = time_mentions
+        date_and_time = controller.model.formatted_local_time(
+                                        msg['timestamp'], show_seconds=True)
 
         msg_info = [
-            ('', [('Date & Time', time.ctime(msg['timestamp'])[:-5]),
+            ('', [('Date & Time', (date_and_time)),
                   ('Sender', msg['sender_full_name']),
                   ('Sender\'s Email ID', msg['sender_email'])]),
         ]
@@ -1190,7 +1191,7 @@ class MsgInfoView(PopUpView):
         )
         if self.show_edit_history_label:
             msg_info[0][1][0] = (
-                'Date & Time (Original)', time.ctime(msg['timestamp'])[:-5]
+                'Date & Time (Original)', (date_and_time)
             )
 
             keys = ', '.join(map(repr, keys_for_command('EDIT_HISTORY')))
@@ -1333,7 +1334,8 @@ class EditHistoryView(PopUpView):
                          tag: EditHistoryTag) -> Any:
         content = snapshot['content']
         topic = snapshot['topic']
-        timestamp = time.ctime(snapshot['timestamp'])[:-5]
+        date_and_time = self.controller.model.formatted_local_time(
+                                    snapshot['timestamp'], show_seconds=True)
 
         user_id = snapshot.get('user_id')
         if user_id:
@@ -1351,7 +1353,7 @@ class EditHistoryView(PopUpView):
         subheader = [
             urwid.Text(('edit_author', author)),
             # 19 = len(timestamp).
-            (19, urwid.Text(('edit_time', timestamp), align='right')),
+            (19, urwid.Text(('edit_time', str(date_and_time)), align='right')),
         ]
 
         edit_block = [


### PR DESCRIPTION
Initial time format settings are fetched during initial register call.
Event handler enables update of this setting as events are recieved
from the server.

Fixes #770

