### PR TITLE
Codecov improvements

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -65,5 +65,7 @@ jobs:
         run: pip install .[testing]
       - name: Run tests with pytest
         run: pytest 
-      - name: Run codecov
-        run: pip3 install codecov && codecov
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+        # We avoid extra work by just running codecov on one python version
+        if: matrix.test-python-version == 3.9

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Python Versions](https://img.shields.io/pypi/pyversions/zulip-term.svg)](https://pypi.python.org/pypi/zulip-term)
 [![Travis Build Status](https://travis-ci.com/zulip/zulip-terminal.svg?branch=master)](https://travis-ci.com/github/zulip/zulip-terminal)
 [![GitHub Actions - Linting & tests](https://github.com/zulip/zulip-terminal/workflows/Linting%20%26%20tests/badge.svg?branch=master)](https://github.com/zulip/zulip-terminal/actions?query=workflow%3A%22Linting+%26+tests%22+branch%3Amaster)
-[![Coverage status](https://img.shields.io/codecov/c/github/zulip/zulip-terminal/master.svg)](https://codecov.io/gh/zulip/zulip-terminal)
+[![Coverage status](https://img.shields.io/codecov/c/github/zulip/zulip-terminal/master.svg)](https://app.codecov.io/gh/zulip/zulip-terminal/branch/master)
 [![Checked with mypy](http://www.mypy-lang.org/static/mypy_badge.svg)](http://mypy-lang.org/)
 
 ![Screenshot 2020-05-19 at 9 56 49 AM](https://user-images.githubusercontent.com/56690786/82285402-0760b800-99b9-11ea-9a86-9d3765ea9177.png)


### PR DESCRIPTION
@sumanthvrao This is a follow-up to the discussion we had in #831 - it doesn't make much difference to the runtime, but this now just runs codecov when running the tests under one version of python - 3.9 (we could pick some fixed element in the python version array instead if we could determine the appropriate syntax).

I also noticed that we can filter the default view to the master branch on the badge and get an improved UI using the `app.` website for Codecov (going back further than 6 months, for example).

@rht Thanks for pointing out the github action for codecov in the API repo PR :)