### PR TITLE
Scrollable large single msg view

### DIFF
--- a/docs/hotkeys.md
+++ b/docs/hotkeys.md
@@ -58,6 +58,7 @@
 |Show/hide edit history (from message information)|<kbd>e</kbd>|
 |View current message in browser (from message information)|<kbd>v</kbd>|
 |Show/hide full rendered message (from message information)|<kbd>f</kbd>|
+|Show/hide full raw message (from message information)|<kbd>r</kbd>|
 
 ## Stream list actions
 |Command|Key Combination|

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -853,6 +853,46 @@ class TestModel:
             model = Model(self.controller)
 
     @pytest.mark.parametrize(
+        "response, expected_raw_content, display_error_called",
+        [
+            (
+                {
+                    "result": "success",
+                    "msg": "",
+                    "raw_content": "Feels **great** to be back!",
+                },
+                "Feels **great** to be back!",
+                False,
+            ),
+            (
+                {
+                    "result": "error",
+                    "msg": "Invalid message(s)",
+                    "code": "BAD_REQUEST",
+                },
+                None,
+                True,
+            ),
+        ],
+    )
+    def test_fetch_raw_message_content(
+        self,
+        mocker,
+        model,
+        expected_raw_content,
+        response,
+        display_error_called,
+        message_id=1,
+    ):
+        self.client.get_raw_message.return_value = response
+
+        return_value = model.fetch_raw_message_content(message_id)
+
+        self.client.get_raw_message.assert_called_once_with(message_id)
+        assert self.display_error_if_present.called == display_error_called
+        assert return_value == expected_raw_content
+
+    @pytest.mark.parametrize(
         "initial_muted_streams, value",
         [
             ({315}, True),

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -2334,9 +2334,7 @@ class TestMessageBox:
             "realm_allow_message_editing": realm_editing_allowed,
             "realm_message_content_edit_limit_seconds": msg_body_edit_limit,
         }
-        msg_box.model.client.get_raw_message.return_value = {
-            "raw_content": "Edit this message"
-        }
+        msg_box.model.fetch_raw_message_content.return_value = "Edit this message"
         write_box = msg_box.model.controller.view.write_box
         write_box.msg_edit_state = None
         write_box.msg_body_edit_enabled = None

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -899,6 +899,27 @@ class TestMsgInfoView:
             time_mentions=list(),
         )
 
+    @pytest.mark.parametrize("key", keys_for_command("FULL_RAW_MESSAGE"))
+    def test_keypress_full_raw_message(self, message_fixture, key, widget_size):
+        msg_info_view = MsgInfoView(
+            self.controller,
+            message_fixture,
+            title="Message Information",
+            topic_links=OrderedDict(),
+            message_links=OrderedDict(),
+            time_mentions=list(),
+        )
+        size = widget_size(msg_info_view)
+
+        msg_info_view.keypress(size, key)
+
+        self.controller.show_full_raw_message.assert_called_once_with(
+            message=message_fixture,
+            topic_links=OrderedDict(),
+            message_links=OrderedDict(),
+            time_mentions=list(),
+        )
+
     @pytest.mark.parametrize(
         "key", {*keys_for_command("GO_BACK"), *keys_for_command("MSG_INFO")}
     )
@@ -918,10 +939,11 @@ class TestMsgInfoView:
         assert self.controller.open_in_browser.called
 
     def test_height_noreactions(self):
-        expected_height = 5
-        # 5 = 1 (date & time) +1 (sender's name) +1 (sender's email)
+        expected_height = 6
+        # 6 = 1 (date & time) +1 (sender's name) +1 (sender's email)
         # +1 (view message in browser)
         # +1 (full rendered message)
+        # +1 (full raw message)
         assert self.msg_info_view.height == expected_height
 
     # FIXME This is the same parametrize as MessageBox:test_reactions_view
@@ -984,9 +1006,9 @@ class TestMsgInfoView:
             OrderedDict(),
             list(),
         )
-        # 11 = 5 labels + 1 blank line + 1 'Reactions' (category)
+        # 12 = 6 labels + 1 blank line + 1 'Reactions' (category)
         # + 4 reactions (excluding 'Message Links').
-        expected_height = 11
+        expected_height = 12
         assert self.msg_info_view.height == expected_height
 
     @pytest.mark.parametrize(

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -10,6 +10,7 @@ from zulipterminal.ui_tools.views import (
     AboutView,
     EditHistoryView,
     EditModeView,
+    FullRawMsgView,
     FullRenderedMsgView,
     HelpView,
     MsgInfoView,
@@ -420,6 +421,87 @@ class TestFullRenderedMsgView:
         super_keypress = mocker.patch(MODULE + ".urwid.Frame.keypress")
 
         self.full_rendered_message.keypress(size, key)
+
+        super_keypress.assert_called_once_with(size, expected_key)
+
+
+class TestFullRawMsgView:
+    @pytest.fixture(autouse=True)
+    def mock_external_classes(self, mocker, msg_box, initial_index):
+        self.controller = mocker.Mock()
+        mocker.patch.object(
+            self.controller, "maximum_popup_dimensions", return_value=(64, 64)
+        )
+        self.controller.model.fetch_raw_message_content = mocker.Mock(
+            return_value="This is a `raw` message content :+1:"
+        )
+        mocker.patch(MODULE + ".MessageBox", return_value=msg_box)
+        # NOTE: Given that the FullRawMsgView just uses the message ID from
+        # the message data currently, message_fixture is not used to avoid
+        # adding extra test runs unnecessarily.
+        self.message = {"id": 1}
+        self.full_raw_message = FullRawMsgView(
+            controller=self.controller,
+            message=self.message,
+            topic_links=OrderedDict(),
+            message_links=OrderedDict(),
+            time_mentions=list(),
+            title="Full Raw Message",
+        )
+
+    def test_init(self, mocker, msg_box):
+        assert self.full_raw_message.title == "Full Raw Message"
+        assert self.full_raw_message.controller == self.controller
+        assert self.full_raw_message.message == self.message
+        assert self.full_raw_message.topic_links == OrderedDict()
+        assert self.full_raw_message.message_links == OrderedDict()
+        assert self.full_raw_message.time_mentions == list()
+        assert self.full_raw_message.header.widget_list == msg_box.header
+        assert self.full_raw_message.footer.widget_list == msg_box.footer
+
+    @pytest.mark.parametrize("key", keys_for_command("MSG_INFO"))
+    def test_keypress_exit_popup(self, key, widget_size):
+        size = widget_size(self.full_raw_message)
+
+        self.full_raw_message.keypress(size, key)
+
+        assert self.controller.exit_popup.called
+
+    def test_keypress_exit_popup_invalid_key(self, widget_size):
+        size = widget_size(self.full_raw_message)
+        key = "a"
+
+        self.full_raw_message.keypress(size, key)
+
+        assert not self.controller.exit_popup.called
+
+    @pytest.mark.parametrize(
+        "key",
+        {
+            *keys_for_command("FULL_RAW_MESSAGE"),
+            *keys_for_command("GO_BACK"),
+        },
+    )
+    def test_keypress_show_msg_info(self, key, widget_size):
+        size = widget_size(self.full_raw_message)
+
+        self.full_raw_message.keypress(size, key)
+
+        self.controller.show_msg_info.assert_called_once_with(
+            msg=self.message,
+            topic_links=OrderedDict(),
+            message_links=OrderedDict(),
+            time_mentions=list(),
+        )
+
+    def test_keypress_navigation(
+        self, mocker, widget_size, navigation_key_expected_key_pair
+    ):
+        size = widget_size(self.full_raw_message)
+        key, expected_key = navigation_key_expected_key_pair
+        super_keypress = mocker.patch(MODULE + ".urwid.Frame.keypress")
+
+        self.full_raw_message.keypress(size, key)
 
         super_keypress.assert_called_once_with(size, expected_key)
 

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -349,6 +349,11 @@ KEY_BINDINGS: 'OrderedDict[str, KeyBinding]' = OrderedDict([
         'help_text': 'Show/hide full rendered message (from message information)',
         'key_category': 'msg_actions',
     }),
+    ('FULL_RAW_MESSAGE', {
+        'keys': ['r'],
+        'help_text': 'Show/hide full raw message (from message information)',
+        'key_category': 'msg_actions',
+    }),
 ])
 # fmt: on
 

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -23,6 +23,7 @@ from zulipterminal.ui_tools.views import (
     AboutView,
     EditHistoryView,
     EditModeView,
+    FullRawMsgView,
     FullRenderedMsgView,
     HelpView,
     MsgInfoView,
@@ -309,6 +310,25 @@ class Controller:
                 message_links,
                 time_mentions,
                 "Full rendered message (up/down scrolls)",
+            ),
+            "area:msg",
+        )
+
+    def show_full_raw_message(
+        self,
+        message: Message,
+        topic_links: "OrderedDict[str, Tuple[str, int, bool]]",
+        message_links: "OrderedDict[str, Tuple[str, int, bool]]",
+        time_mentions: List[Tuple[str, str]],
+    ) -> None:
+        self.show_pop_up(
+            FullRawMsgView(
+                self,
+                message,
+                topic_links,
+                message_links,
+                time_mentions,
+                "Full raw message (up/down scrolls)",
             ),
             "area:msg",
         )

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -609,6 +609,17 @@ class Model:
         display_error_if_present(response, self.controller)
         return list()
 
+    def fetch_raw_message_content(self, message_id: int) -> Optional[str]:
+        """
+        Fetches raw message content of a message using its ID.
+        """
+        response = self.client.get_raw_message(message_id)
+        if response["result"] == "success":
+            return response["raw_content"]
+        display_error_if_present(response, self.controller)
+
+        return None
+
     def _fetch_topics_in_streams(self, stream_list: Iterable[int]) -> str:
         """
         Fetch all topics with specified stream_id's and

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -1669,9 +1669,8 @@ class MessageBox(urwid.Pile):
             # To correctly quote a message that contains quote/code-blocks,
             # we need to fence quoted message containing ``` with ````,
             # ```` with ````` and so on.
-            message_raw_content = self.model.client.get_raw_message(self.message["id"])[
-                "raw_content"
-            ]
+            response = self.model.fetch_raw_message_content(self.message["id"])
+            message_raw_content = response if response is not None else ""
             fence = get_unused_fence(message_raw_content)
 
             absolute_url = near_message_url(self.model.server_url[:-1], self.message)
@@ -1734,7 +1733,8 @@ class MessageBox(urwid.Pile):
                     title=self.message["subject"],
                 )
             msg_id = self.message["id"]
-            msg = self.model.client.get_raw_message(msg_id)["raw_content"]
+            response = self.model.fetch_raw_message_content(msg_id)
+            msg = response if response is not None else ""
             write_box = self.model.controller.view.write_box
             write_box.msg_edit_state = _MessageEditState(
                 message_id=msg_id, old_topic=self.message["subject"]

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1422,6 +1422,9 @@ class MsgInfoView(PopUpView):
         full_rendered_message_keys = ", ".join(
             map(repr, keys_for_command("FULL_RENDERED_MESSAGE"))
         )
+        full_raw_message_keys = ", ".join(
+            map(repr, keys_for_command("FULL_RAW_MESSAGE"))
+        )
         msg_info = [
             (
                 "",
@@ -1436,6 +1439,10 @@ class MsgInfoView(PopUpView):
                     (
                         "Full rendered message",
                         f"Press {full_rendered_message_keys} to view",
+                    ),
+                    (
+                        "Full raw message",
+                        f"Press {full_raw_message_keys} to view",
                     ),
                 ],
             ),
@@ -1544,6 +1551,14 @@ class MsgInfoView(PopUpView):
             self.controller.open_in_browser(url)
         elif is_command_key("FULL_RENDERED_MESSAGE", key):
             self.controller.show_full_rendered_message(
+                message=self.msg,
+                topic_links=self.topic_links,
+                message_links=self.message_links,
+                time_mentions=self.time_mentions,
+            )
+            return key
+        elif is_command_key("FULL_RAW_MESSAGE", key):
+            self.controller.show_full_raw_message(
                 message=self.msg,
                 topic_links=self.topic_links,
                 message_links=self.message_links,

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1749,3 +1749,53 @@ class FullRenderedMsgView(PopUpView):
             )
             return key
         return super().keypress(size, key)
+
+
+class FullRawMsgView(PopUpView):
+    def __init__(
+        self,
+        controller: Any,
+        message: Message,
+        topic_links: "OrderedDict[str, Tuple[str, int, bool]]",
+        message_links: "OrderedDict[str, Tuple[str, int, bool]]",
+        time_mentions: List[Tuple[str, str]],
+        title: str,
+    ) -> None:
+        self.controller = controller
+        self.message = message
+        self.topic_links = topic_links
+        self.message_links = message_links
+        self.time_mentions = time_mentions
+        max_cols, max_rows = controller.maximum_popup_dimensions()
+
+        # Get rendered message header and footer
+        msg_box = MessageBox(message, controller.model, None)
+
+        # Get raw message content widget list
+        response = controller.model.fetch_raw_message_content(message["id"])
+
+        if response is None:
+            return
+
+        body_list = [urwid.Text(response)]
+
+        super().__init__(
+            controller,
+            body_list,
+            "MSG_INFO",
+            max_cols,
+            title,
+            urwid.Pile(msg_box.header),
+            urwid.Pile(msg_box.footer),
+        )
+
+    def keypress(self, size: urwid_Size, key: str) -> str:
+        if is_command_key("GO_BACK", key) or is_command_key("FULL_RAW_MESSAGE", key):
+            self.controller.show_msg_info(
+                msg=self.message,
+                topic_links=self.topic_links,
+                message_links=self.message_links,
+                time_mentions=self.time_mentions,
+            )
+            return key
+        return super().keypress(size, key)


### PR DESCRIPTION
**What does the PR do?!** :

 - Allows scrolling for large single messages 
   **Note: currently true for every message**
 - Provides raw and rendered message view to users.

**Commit flow:**
- refactor: views: Use urwid.Frame for PopUpView.
- boxes: Add members to MessageBox to fetch header, content, footer.
- hotkeys/keys: Add f hotkey for full rendered message popup.
- views: Structure FullRenderedMsgView class.
- core: Add controller helper to show full rendered message on toggle.
- views: Add keypress events for showing/hiding full rendered message.
- model: Add support for fetching a raw message.
- refactor: boxes: Use new model method to fetch a raw message.
- hotkeys/keys: Add r hotkey for full raw message popup view.
- views: Structure FullRawMsgView class.
- core: Add controller helper to show full raw message on toggle.
- views: Add keypress events for showing/hiding full raw message.

Further discussions [here](https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/Full.20message.20source.20scrollable.20view.20.23T543) on czo :)

Fixes #543.

**Screenshots/GIFs:**
*Full Rendered Message View*
![rendered_view](https://user-images.githubusercontent.com/55916430/125608064-95177600-cf49-451f-8482-309f175541c4.png)
*Full Raw Message View*
![raw_message_view](https://user-images.githubusercontent.com/55916430/125608220-88216961-ce62-4ea1-9d43-309a309c76af.gif)
