### PR TITLE
Display and autocomplete PM recipients name along with their emails

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1318,7 +1318,7 @@ class TestMessageBox:
         mocker.patch.object(MessageBox, 'main_view')
         msg_box = MessageBox(message, self.model, None)
 
-        assert msg_box.recipients_emails == 'foo@zulip.com'
+        assert msg_box.recipients_emails == ['foo@zulip.com']
         msg_box._is_private_message_to_self.assert_called_once_with()
 
     @pytest.mark.parametrize('content, markup', [

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1318,7 +1318,7 @@ class TestMessageBox:
         mocker.patch.object(MessageBox, 'main_view')
         msg_box = MessageBox(message, self.model, None)
 
-        assert msg_box.recipients_emails == ['foo@zulip.com']
+        assert msg_box.recipient_emails == ['foo@zulip.com']
         msg_box._is_private_message_to_self.assert_called_once_with()
 
     @pytest.mark.parametrize('content, markup', [

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -621,7 +621,7 @@ class TestWriteBox:
         elif msg_type == 'stream_edit':
             write_box.stream_box_edit_view(1000)
         else:
-            write_box.private_box_view(email='foo@gmail.com',
+            write_box.private_box_view(emails=['feedback@zulip.com'],
                                        recipient_user_ids=[1])
 
         assert len(write_box.header_write_box.widget_list) == expected_box_size

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -21,10 +21,11 @@ class TestWriteBox:
 
     @pytest.fixture()
     def write_box(self, mocker, users_fixture, user_groups_fixture,
-                  streams_fixture, unicode_emojis):
+                  streams_fixture, unicode_emojis, user_dict):
         self.view.model.active_emoji_data = unicode_emojis
         write_box = WriteBox(self.view)
         write_box.view.users = users_fixture
+        write_box.model.user_dict = user_dict
         write_box.model.user_group_names = [
             groups['name'] for groups in user_groups_fixture]
 

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -287,6 +287,90 @@ class TestWriteBox:
         typeahead_string = write_box.generic_autocomplete(text, state)
         assert typeahead_string == required_typeahead
 
+    @pytest.mark.parametrize(['text', 'matching_users',
+                              'matching_users_info'], [
+        ('', [
+            'Human Myself',
+            'Human 1',
+            'Human 2'
+        ], [
+            'Human Myself <FOOBOO@gmail.com>',
+            'Human 1 <person1@example.com>',
+            'Human 2 <person2@example.com>'
+        ]),
+        ('My', ['Human Myself'],
+         ['Human Myself <FOOBOO@gmail.com>']),
+    ], ids=[
+        'no_search_text',
+        'single_word_search_text',
+    ])
+    def test__to_box_autocomplete(self, mocker, write_box, text,
+                                  users_fixture, matching_users,
+                                  matching_users_info, state=1):
+        _process_typeaheads = mocker.patch(BOXES
+                                           + '.WriteBox._process_typeaheads')
+
+        write_box._to_box_autocomplete(text, state)
+
+        _process_typeaheads.assert_called_once_with(matching_users_info, state,
+                                                    matching_users)
+
+    @pytest.mark.parametrize('text, expected_text', [
+        ('Hu', 'Human Myself <FOOBOO@gmail.com>'),
+        ('Human M', 'Human Myself <FOOBOO@gmail.com>'),
+        ('Human Myself <FOOBOO', 'Human Myself <FOOBOO@gmail.com>')
+    ])
+    def test__to_box_autocomplete_with_spaces(self, write_box, text,
+                                              expected_text, widget_size):
+        write_box.private_box_view(emails=['feedback@zulip.com'],
+                                   recipient_user_ids=[1])
+        write_box.to_write_box.set_edit_text(text)
+        write_box.to_write_box.set_edit_pos(len(text))
+        write_box.focus_position = write_box.FOCUS_CONTAINER_HEADER
+        size = widget_size(write_box)
+
+        write_box.keypress(size, primary_key_for_command('AUTOCOMPLETE'))
+
+        assert (write_box.to_write_box.edit_text
+                == expected_text)
+
+    @pytest.mark.parametrize(['text', 'matching_users',
+                              'matching_users_info'], [
+        ('Welcome Bot <welcome-bot@zulip.com>, Human', [
+            'Human Myself',
+            'Human 1',
+            'Human 2'
+        ], [
+            'Welcome Bot <welcome-bot@zulip.com>, '
+            'Human Myself <FOOBOO@gmail.com>',
+            'Welcome Bot <welcome-bot@zulip.com>, '
+            'Human 1 <person1@example.com>',
+            'Welcome Bot <welcome-bot@zulip.com>, '
+            'Human 2 <person2@example.com>'
+        ]),
+        ('Welcome Bot <welcome-bot@zulip.com>, Notification Bot '
+         '<notification-bot@zulip.com>, person2',
+         ['Human 2'],
+         ['Welcome Bot <welcome-bot@zulip.com>, Notification Bot '
+          '<notification-bot@zulip.com>, Human 2 <person2@example.com>'])
+    ], ids=[
+        'name_search_text',
+        'email_search_text',
+    ])
+    def test__to_box_autocomplete_with_multiple_recipients(self, mocker,
+                                                           write_box, text,
+                                                           users_fixture,
+                                                           matching_users,
+                                                           matching_users_info,
+                                                           state=1):
+        _process_typeaheads = mocker.patch(BOXES
+                                           + '.WriteBox._process_typeaheads')
+
+        write_box._to_box_autocomplete(text, state)
+
+        _process_typeaheads.assert_called_once_with(matching_users_info, state,
+                                                    matching_users)
+
     @pytest.mark.parametrize(['text', 'state', 'to_pin', 'matching_streams'], [
         ('', 1, [], ['Secret stream', 'Some general stream',
                      'Stream 1', 'Stream 2']),

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -512,6 +512,23 @@ def match_user(user: Any, text: str) -> bool:
     return False
 
 
+def match_user_name_and_email(user: Any, text: str) -> bool:
+    """
+    Matches if the user's full name, last name, email or a combination
+    in the form of "name <email>" matches with `text`.
+    """
+    full_name = user['full_name'].lower()
+    email = user['email'].lower()
+    keywords = full_name.split()
+    keywords.append(full_name)
+    keywords.append(email)
+    keywords.append(f"{full_name} <{email}>")
+    for keyword in keywords:
+        if keyword.startswith(text.lower()):
+            return True
+    return False
+
+
 def match_emoji(emoji: str, text: str) -> bool:
     """
     True if the emoji matches with `text` (case insensitive),

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -230,13 +230,13 @@ class View(urwid.WidgetWrap):
                         stream_id=saved_draft['stream_id'],
                     )
                 elif saved_draft['type'] == 'private':
-                    email_txt = saved_draft['display_recipient']
+                    email_list = saved_draft['display_recipient']
                     recipient_user_ids = [
                         self.model.user_dict[email.strip()]['user_id']
-                        for email in email_txt.split(",")
+                        for email in email_list
                     ]
                     self.write_box.private_box_view(
-                        email=email_txt,
+                        emails=email_list,
                         recipient_user_ids=recipient_user_ids,
                     )
                 content = saved_draft['content']

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -121,17 +121,20 @@ class WriteBox(urwid.Pile):
                 or (emails is None and recipient_user_ids is None))
 
         self.set_editor_mode()
-        email_text = ''
+        recipient_info = ''
         if recipient_user_ids and emails:
             self.recipient_user_ids = recipient_user_ids
-            for email in emails:
-                email_text += (', ' if email_text else '')
-                email_text += email
+            self.recipient_emails = emails
+            for email in self.recipient_emails:
+                recipient_name = self.model.user_dict[email]['full_name']
+                recipient_info += (', ' if recipient_info else '')
+                recipient_info += f"{recipient_name} <{email}>"
         else:
             self.recipient_user_ids = []
+            self.recipient_emails = []
 
         self.send_next_typing_update = datetime.now()
-        self.to_write_box = ReadlineEdit("To: ", edit_text=email_text)
+        self.to_write_box = ReadlineEdit("To: ", edit_text=recipient_info)
         self.msg_write_box = ReadlineEdit(multiline=True)
         self.msg_write_box.enable_autocomplete(
             func=self.generic_autocomplete,
@@ -183,6 +186,12 @@ class WriteBox(urwid.Pile):
             self.send_stop_typing_status()
 
         urwid.connect_signal(self.msg_write_box, 'change', on_type_send_status)
+
+    def update_recipient_emails(self, write_box: ReadlineEdit) -> None:
+        self.recipient_emails = re.findall(
+            r'[\w\.-]+@[\w\.-]+',
+            write_box.edit_text
+        )
 
     def stream_box_view(self, stream_id: int, caption: str='', title: str='',
                         ) -> None:
@@ -475,10 +484,9 @@ class WriteBox(urwid.Pile):
                         msg_id=self.msg_edit_id,
                     )
                 else:
-                    recipient_emails = [email.strip() for email in
-                                        self.to_write_box.edit_text.split(',')]
+                    self.update_recipient_emails(self.to_write_box)
                     success = self.model.send_private_message(
-                        recipients=recipient_emails,
+                        recipients=self.recipient_emails,
                         content=self.msg_write_box.edit_text
                     )
             if success:
@@ -496,10 +504,9 @@ class WriteBox(urwid.Pile):
         elif is_command_key('SAVE_AS_DRAFT', key):
             if not self.msg_edit_id:
                 if self.to_write_box:
-                    recipient_emails = [email.strip() for email in
-                                        self.to_write_box.edit_text.split(',')]
+                    self.update_recipient_emails(self.to_write_box)
                     message = Message(
-                            display_recipient=recipient_emails,
+                            display_recipient=self.recipient_emails,
                             content=self.msg_write_box.edit_text,
                             type='private',
                     )
@@ -562,11 +569,10 @@ class WriteBox(urwid.Pile):
                     else:
                         header.focus_col = self.FOCUS_HEADER_BOX_STREAM
                 else:
-                    recipient_box = header[self.FOCUS_HEADER_BOX_RECIPIENT]
-                    recipient_emails = [email.strip() for email in
-                                        recipient_box.edit_text.split(',')]
+                    self.update_recipient_emails(self.to_write_box)
                     invalid_emails = self.model.get_invalid_recipient_emails(
-                                                              recipient_emails)
+                        self.recipient_emails
+                    )
                     if invalid_emails:
                         invalid_emails_error = ('Invalid recipient(s) - '
                                                 + ', '.join(invalid_emails))
@@ -574,7 +580,8 @@ class WriteBox(urwid.Pile):
                         return key
                     users = self.model.user_dict
                     self.recipient_user_ids = [users[email]['user_id']
-                                               for email in recipient_emails]
+                                               for email in
+                                               self.recipient_emails]
 
             if not self.msg_body_edit_enabled:
                 return key
@@ -625,7 +632,7 @@ class MessageBox(urwid.Pile):
             if self._is_private_message_to_self():
                 recipient = self.message['display_recipient'][0]
                 self.recipients_names = recipient['full_name']
-                self.recipients_emails = [self.model.user_email]
+                self.recipient_emails = [self.model.user_email]
                 self.recipient_ids = [self.model.user_id]
             else:
                 self.recipients_names = ', '.join(list(
@@ -633,10 +640,10 @@ class MessageBox(urwid.Pile):
                             for recipient in self.message['display_recipient']
                             if recipient['email'] != self.model.user_email
                         ))
-                self.recipients_emails = [recipient['email'] for recipient in
-                                          self.message['display_recipient']
-                                          if recipient['email']
-                                          != self.model.user_email]
+                self.recipient_emails = [recipient['email'] for recipient in
+                                         self.message['display_recipient']
+                                         if recipient['email']
+                                         != self.model.user_email]
                 self.recipient_ids = [recipient['id'] for recipient
                                       in self.message['display_recipient']
                                       if recipient['id'] != self.model.user_id]
@@ -1264,7 +1271,7 @@ class MessageBox(urwid.Pile):
         if is_command_key('ENTER', key):
             if self.message['type'] == 'private':
                 self.model.controller.view.write_box.private_box_view(
-                    emails=self.recipients_emails,
+                    emails=self.recipient_emails,
                     recipient_user_ids=self.recipient_ids,
                 )
             elif self.message['type'] == 'stream':
@@ -1276,7 +1283,7 @@ class MessageBox(urwid.Pile):
         elif is_command_key('STREAM_MESSAGE', key):
             if self.message['type'] == 'private':
                 self.model.controller.view.write_box.private_box_view(
-                    emails=self.recipients_emails,
+                    emails=self.recipient_emails,
                     recipient_user_ids=self.recipient_ids,
                 )
             elif self.message['type'] == 'stream':

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -40,6 +40,7 @@ from zulipterminal.helper import (
     match_stream,
     match_topics,
     match_user,
+    match_user_name_and_email,
 )
 from zulipterminal.server_url import near_message_url
 from zulipterminal.ui_tools.buttons import EditModeButton
@@ -73,8 +74,9 @@ class WriteBox(urwid.Pile):
         # * updates server on PM typing events
         self.recipient_user_ids = []  # type: List[int]
 
-        # Private message recipient text entry
-        self.to_write_box = None  # None if stream-box or not initialized
+        # Private message recipient text entry, None if stream-box
+        # or not initialized
+        self.to_write_box = None  # type: Optional[ReadlineEdit]
 
         # For tracking sending typing status updates
         self.send_next_typing_update = datetime.now()
@@ -135,6 +137,13 @@ class WriteBox(urwid.Pile):
 
         self.send_next_typing_update = datetime.now()
         self.to_write_box = ReadlineEdit("To: ", edit_text=recipient_info)
+        self.to_write_box.enable_autocomplete(
+            func=self._to_box_autocomplete,
+            key=primary_key_for_command('AUTOCOMPLETE'),
+            key_reverse=primary_key_for_command('AUTOCOMPLETE_REVERSE')
+        )
+        self.to_write_box.set_completer_delims("")
+
         self.msg_write_box = ReadlineEdit(multiline=True)
         self.msg_write_box.enable_autocomplete(
             func=self.generic_autocomplete,
@@ -271,6 +280,30 @@ class WriteBox(urwid.Pile):
             color = stream['color']
         (self.header_write_box[self.FOCUS_HEADER_PREFIX_STREAM]
          .set_text((color, stream_marker)))
+
+    def _to_box_autocomplete(self, text: str, state: Optional[int]
+                             ) -> Optional[str]:
+        users_list = self.view.users
+        recipients = text.rsplit(', ', 1)
+
+        # Use the most recent recipient for autocomplete.
+        previous_recipients = (recipients[0] + ', ' if len(recipients) > 1
+                               else '')
+        latest_text = recipients[-1]
+        matching_users = [user
+                          for user in users_list
+                          if match_user_name_and_email(user, latest_text)]
+
+        # Append the potential autocompleted recipients to the string
+        # containing the previous recipients.
+        updated_recipients = [(previous_recipients
+                              + f"{user['full_name']} <{user['email']}>")
+                              for user in matching_users]
+
+        user_names = [user['full_name'] for user in matching_users]
+
+        return self._process_typeaheads(updated_recipients, state,
+                                        user_names)
 
     def _topic_box_autocomplete(self, text: str, state: Optional[int]
                                 ) -> Optional[str]:

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -114,20 +114,24 @@ class WriteBox(urwid.Pile):
             self.send_next_typing_update = datetime.now()
             self.idle_status_tracking = False
 
-    def private_box_view(self, *, email: str='',
+    def private_box_view(self, *, emails: Optional[List[str]]=None,
                          recipient_user_ids: Optional[List[int]]=None) -> None:
         # Neither or both arguments should be set
-        assert ((email != '' and recipient_user_ids is not None)
-                or (email == '' and recipient_user_ids is None))
+        assert ((emails is not None and recipient_user_ids is not None)
+                or (emails is None and recipient_user_ids is None))
 
         self.set_editor_mode()
-        if recipient_user_ids:
+        email_text = ''
+        if recipient_user_ids and emails:
             self.recipient_user_ids = recipient_user_ids
+            for email in emails:
+                email_text += (', ' if email_text else '')
+                email_text += email
         else:
             self.recipient_user_ids = []
 
         self.send_next_typing_update = datetime.now()
-        self.to_write_box = ReadlineEdit("To: ", edit_text=email)
+        self.to_write_box = ReadlineEdit("To: ", edit_text=email_text)
         self.msg_write_box = ReadlineEdit(multiline=True)
         self.msg_write_box.enable_autocomplete(
             func=self.generic_autocomplete,
@@ -492,8 +496,10 @@ class WriteBox(urwid.Pile):
         elif is_command_key('SAVE_AS_DRAFT', key):
             if not self.msg_edit_id:
                 if self.to_write_box:
+                    recipient_emails = [email.strip() for email in
+                                        self.to_write_box.edit_text.split(',')]
                     message = Message(
-                            display_recipient=self.to_write_box.edit_text,
+                            display_recipient=recipient_emails,
                             content=self.msg_write_box.edit_text,
                             type='private',
                     )
@@ -619,7 +625,7 @@ class MessageBox(urwid.Pile):
             if self._is_private_message_to_self():
                 recipient = self.message['display_recipient'][0]
                 self.recipients_names = recipient['full_name']
-                self.recipients_emails = self.model.user_email
+                self.recipients_emails = [self.model.user_email]
                 self.recipient_ids = [self.model.user_id]
             else:
                 self.recipients_names = ', '.join(list(
@@ -627,11 +633,10 @@ class MessageBox(urwid.Pile):
                             for recipient in self.message['display_recipient']
                             if recipient['email'] != self.model.user_email
                         ))
-                self.recipients_emails = ', '.join(list(
-                            recipient['email']
-                            for recipient in self.message['display_recipient']
-                            if recipient['email'] != self.model.user_email
-                        ))
+                self.recipients_emails = [recipient['email'] for recipient in
+                                          self.message['display_recipient']
+                                          if recipient['email']
+                                          != self.model.user_email]
                 self.recipient_ids = [recipient['id'] for recipient
                                       in self.message['display_recipient']
                                       if recipient['id'] != self.model.user_id]
@@ -1259,7 +1264,7 @@ class MessageBox(urwid.Pile):
         if is_command_key('ENTER', key):
             if self.message['type'] == 'private':
                 self.model.controller.view.write_box.private_box_view(
-                    email=self.recipients_emails,
+                    emails=self.recipients_emails,
                     recipient_user_ids=self.recipient_ids,
                 )
             elif self.message['type'] == 'stream':
@@ -1271,7 +1276,7 @@ class MessageBox(urwid.Pile):
         elif is_command_key('STREAM_MESSAGE', key):
             if self.message['type'] == 'private':
                 self.model.controller.view.write_box.private_box_view(
-                    email=self.recipients_emails,
+                    emails=self.recipients_emails,
                     recipient_user_ids=self.recipient_ids,
                 )
             elif self.message['type'] == 'stream':
@@ -1309,7 +1314,7 @@ class MessageBox(urwid.Pile):
         elif is_command_key('REPLY_AUTHOR', key):
             # All subscribers from recipient_ids are not needed here.
             self.model.controller.view.write_box.private_box_view(
-                email=self.message['sender_email'],
+                emails=[self.message['sender_email']],
                 recipient_user_ids=[self.message['sender_id']],
             )
         elif is_command_key('MENTION_REPLY', key):

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -240,7 +240,7 @@ class UserButton(TopButton):
         self.controller.narrow_to_user(self)
         self._view.body.focus.original_widget.set_focus('footer')
         self._view.write_box.private_box_view(
-            email=self.email,
+            emails=[self.email],
             recipient_user_ids=[self.user_id]
         )
 


### PR DESCRIPTION
Modified the display to use names along with delivery emails, and enabled the autocomplete for the `to_write_box`.
The commits do the following (in order):
- Type the `emails` parameter of the `private_box_view()` as `List[str]`.
- Display the name of the user along with the email to make it more user-friendly.
- Add a helper function to match users, considering matches in name, email, or a combination of both in the `name <email>` format.
- Enable autocomplete for the users' names.