### PR TITLE
Handle internal PM links

### DIFF
--- a/tests/ui_tools/test_buttons.py
+++ b/tests/ui_tools/test_buttons.py
@@ -439,36 +439,40 @@ class TestMessageLinkButton:
     @pytest.mark.parametrize(
         "link, expected_parsed_link",
         [
-            (
+            case(
                 SERVER_URL + "/#narrow/stream/1-Stream-1",
                 ParsedNarrowLink(
                     narrow="stream", stream=DecodedStream(stream_id=1, stream_name=None)
                 ),
+                id="modern_stream_narrow_link",
             ),
-            (
+            case(
                 SERVER_URL + "/#narrow/stream/Stream.201",
                 ParsedNarrowLink(
                     narrow="stream",
                     stream=DecodedStream(stream_id=None, stream_name="Stream 1"),
                 ),
+                id="deprecated_stream_narrow_link",
             ),
-            (
+            case(
                 SERVER_URL + "/#narrow/stream/1-Stream-1/topic/foo.20bar",
                 ParsedNarrowLink(
                     narrow="stream:topic",
                     topic_name="foo bar",
                     stream=DecodedStream(stream_id=1, stream_name=None),
                 ),
+                id="topic_narrow_link",
             ),
-            (
+            case(
                 SERVER_URL + "/#narrow/stream/1-Stream-1/near/1",
                 ParsedNarrowLink(
                     narrow="stream:near",
                     message_id=1,
                     stream=DecodedStream(stream_id=1, stream_name=None),
                 ),
+                id="stream_near_narrow_link",
             ),
-            (
+            case(
                 SERVER_URL + "/#narrow/stream/1-Stream-1/topic/foo/near/1",
                 ParsedNarrowLink(
                     narrow="stream:topic:near",
@@ -476,27 +480,33 @@ class TestMessageLinkButton:
                     message_id=1,
                     stream=DecodedStream(stream_id=1, stream_name=None),
                 ),
+                id="topic_near_narrow_link",
             ),
-            (SERVER_URL + "/#narrow/foo", ParsedNarrowLink()),
-            (SERVER_URL + "/#narrow/stream/", ParsedNarrowLink()),
-            (SERVER_URL + "/#narrow/stream/1-Stream-1/topic/", ParsedNarrowLink()),
-            (SERVER_URL + "/#narrow/stream/1-Stream-1//near/", ParsedNarrowLink()),
-            (
+            case(
+                SERVER_URL + "/#narrow/foo",
+                ParsedNarrowLink(),
+                id="invalid_narrow_link_1",
+            ),
+            case(
+                SERVER_URL + "/#narrow/stream/",
+                ParsedNarrowLink(),
+                id="invalid_narrow_link_2",
+            ),
+            case(
+                SERVER_URL + "/#narrow/stream/1-Stream-1/topic/",
+                ParsedNarrowLink(),
+                id="invalid_narrow_link_3",
+            ),
+            case(
+                SERVER_URL + "/#narrow/stream/1-Stream-1//near/",
+                ParsedNarrowLink(),
+                id="invalid_narrow_link_4",
+            ),
+            case(
                 SERVER_URL + "/#narrow/stream/1-Stream-1/topic/foo/near/",
                 ParsedNarrowLink(),
+                id="invalid_narrow_link_5",
             ),
-        ],
-        ids=[
-            "modern_stream_narrow_link",
-            "deprecated_stream_narrow_link",
-            "topic_narrow_link",
-            "stream_near_narrow_link",
-            "topic_near_narrow_link",
-            "invalid_narrow_link_1",
-            "invalid_narrow_link_2",
-            "invalid_narrow_link_3",
-            "invalid_narrow_link_4",
-            "invalid_narrow_link_5",
         ],
     )
     def test__parse_narrow_link(
@@ -755,15 +765,16 @@ class TestMessageLinkButton:
     @pytest.mark.parametrize(
         "parsed_link, narrow_to_stream_called, narrow_to_topic_called",
         [
-            (
+            case(
                 ParsedNarrowLink(
                     narrow="stream",
                     stream=DecodedStream(stream_id=1, stream_name="Stream 1"),
                 ),
                 True,
                 False,
+                id="stream_narrow",
             ),
-            (
+            case(
                 ParsedNarrowLink(
                     narrow="stream:topic",
                     topic_name="Foo",
@@ -771,8 +782,9 @@ class TestMessageLinkButton:
                 ),
                 False,
                 True,
+                id="topic_narrow",
             ),
-            (
+            case(
                 ParsedNarrowLink(
                     narrow="stream:near",
                     message_id=1,
@@ -780,8 +792,9 @@ class TestMessageLinkButton:
                 ),
                 True,
                 False,
+                id="stream_near_narrow",
             ),
-            (
+            case(
                 ParsedNarrowLink(
                     narrow="stream:topic:near",
                     topic_name="Foo",
@@ -790,13 +803,8 @@ class TestMessageLinkButton:
                 ),
                 False,
                 True,
+                id="topic_near_narrow",
             ),
-        ],
-        ids=[
-            "stream_narrow",
-            "topic_narrow",
-            "stream_near_narrow",
-            "topic_near_narrow",
         ],
     )
     def test__switch_narrow_to(

--- a/tests/ui_tools/test_buttons.py
+++ b/tests/ui_tools/test_buttons.py
@@ -7,6 +7,7 @@ from urwid import AttrMap, Overlay, Widget
 
 from zulipterminal.config.keys import keys_for_command
 from zulipterminal.ui_tools.buttons import (
+    DecodedPM,
     DecodedStream,
     MessageLinkButton,
     ParsedNarrowLink,
@@ -419,6 +420,58 @@ class TestMessageLinkButton:
         self, stream_data: str, expected_response: DecodedStream
     ) -> None:
         return_value = MessageLinkButton._decode_stream_data(stream_data)
+
+        assert return_value == expected_response
+
+    @pytest.mark.parametrize(
+        "pm_data, expected_response",
+        [
+            case(
+                "1001,12-pm",
+                dict(type=None, recipient_ids=[1001, 12], recipient_emails=None),
+                id="pm_with_two_recipients",
+            ),
+            case(
+                "1001,12-group",
+                dict(type=None, recipient_ids=[1001, 12], recipient_emails=None),
+                id="group_pm_with_two_recipients",
+            ),
+            case(
+                "1001,11,12-pm",
+                dict(type=None, recipient_ids=[1001, 11, 12], recipient_emails=None),
+                id="pm_with_more_than_two_recipients",
+            ),
+            case(
+                "1001,11,12-group",
+                dict(type=None, recipient_ids=[1001, 11, 12], recipient_emails=None),
+                id="group_pm_with_more_than_two_recipients",
+            ),
+            case(
+                "11-user11",
+                dict(type=None, recipient_ids=[11], recipient_emails=None),
+                id="pm_exposed_format_1_ordinary",
+            ),
+            case(
+                "11-user2",
+                dict(type=None, recipient_ids=[11], recipient_emails=None),
+                id="pm_exposed_format_1_ambigous",
+            ),
+            case(
+                "5-bot-name",
+                dict(type=None, recipient_ids=[5], recipient_emails=None),
+                id="pm_with_bot_exposed_format_1_ordinary",
+            ),
+            case(
+                "5-bot;name",
+                dict(type=None, recipient_ids=[5], recipient_emails=None),
+                id="pm_with_bot_exposed_format_1_ambigous",
+            ),
+        ],
+    )
+    def test__decode_pm_data(
+        self, mocker: MockerFixture, pm_data: str, expected_response: DecodedPM
+    ) -> None:
+        return_value = MessageLinkButton._decode_pm_data(pm_data)
 
         assert return_value == expected_response
 

--- a/tests/ui_tools/test_buttons.py
+++ b/tests/ui_tools/test_buttons.py
@@ -676,91 +676,48 @@ class TestMessageLinkButton:
     @pytest.mark.parametrize(
         [
             "parsed_link",
-            "is_user_subscribed_to_stream",
-            "is_valid_stream",
             "stream_id_from_name_return_value",
             "expected_parsed_link",
-            "expected_error",
         ],
         [
-            (
+            case(
                 ParsedNarrowLink(
                     stream=DecodedStream(stream_id=1, stream_name=None)
                 ),  # ...
-                True,
-                None,
                 None,
                 ParsedNarrowLink(
                     stream=DecodedStream(stream_id=1, stream_name="Stream 1")
                 ),
-                "",
+                id="stream_data_with_stream_id",
             ),
-            (
-                ParsedNarrowLink(
-                    stream=DecodedStream(stream_id=462, stream_name=None)
-                ),  # ...
-                False,
-                None,
-                None,
-                ParsedNarrowLink(stream=DecodedStream(stream_id=462, stream_name=None)),
-                "The stream seems to be either unknown or unsubscribed",
-            ),
-            (
+            case(
                 ParsedNarrowLink(
                     stream=DecodedStream(stream_id=None, stream_name="Stream 1")
                 ),  # ...
-                None,
-                True,
                 1,
                 ParsedNarrowLink(
                     stream=DecodedStream(stream_id=1, stream_name="Stream 1")
                 ),
-                "",
+                id="stream_data_with_stream_name",
             ),
-            (
-                ParsedNarrowLink(
-                    stream=DecodedStream(stream_id=None, stream_name="foo")
-                ),  # ...
-                None,
-                False,
-                None,
-                ParsedNarrowLink(
-                    stream=DecodedStream(stream_id=None, stream_name="foo")
-                ),
-                "The stream seems to be either unknown or unsubscribed",
-            ),
-        ],
-        ids=[
-            "valid_stream_data_with_stream_id",
-            "invalid_stream_data_with_stream_id",
-            "valid_stream_data_with_stream_name",
-            "invalid_stream_data_with_stream_name",
         ],
     )
-    def test__validate_and_patch_stream_data(
+    def test__patch_narrow_link(
         self,
         stream_dict: Dict[int, Any],
         parsed_link: ParsedNarrowLink,
-        is_user_subscribed_to_stream: Optional[bool],
-        is_valid_stream: Optional[bool],
         stream_id_from_name_return_value: Optional[int],
         expected_parsed_link: ParsedNarrowLink,
-        expected_error: str,
     ) -> None:
         self.controller.model.stream_dict = stream_dict
         self.controller.model.stream_id_from_name.return_value = (
             stream_id_from_name_return_value
         )
-        self.controller.model.is_user_subscribed_to_stream.return_value = (
-            is_user_subscribed_to_stream
-        )
-        self.controller.model.is_valid_stream.return_value = is_valid_stream
         mocked_button = self.message_link_button()
 
-        error = mocked_button._validate_and_patch_stream_data(parsed_link)
+        mocked_button._patch_narrow_link(parsed_link)
 
         assert parsed_link == expected_parsed_link
-        assert error == expected_error
 
     @pytest.mark.parametrize(
         "parsed_link, narrow_to_stream_called, narrow_to_topic_called",

--- a/tests/ui_tools/test_buttons.py
+++ b/tests/ui_tools/test_buttons.py
@@ -612,6 +612,7 @@ class TestMessageLinkButton:
         [
             "parsed_link",
             "is_user_subscribed_to_stream",
+            "is_valid_private_recipient",
             "is_valid_stream",
             "topics_in_stream",
             "expected_error",
@@ -622,6 +623,7 @@ class TestMessageLinkButton:
                     narrow="stream", stream=DecodedStream(stream_id=1, stream_name=None)
                 ),
                 True,
+                None,
                 None,
                 None,
                 "",
@@ -635,6 +637,7 @@ class TestMessageLinkButton:
                 False,
                 None,
                 None,
+                None,
                 "The stream seems to be either unknown or unsubscribed",
                 id="invalid_modern_stream_narrow_parsed_link",
             ),
@@ -643,6 +646,7 @@ class TestMessageLinkButton:
                     narrow="stream",
                     stream=DecodedStream(stream_id=None, stream_name="Stream 1"),
                 ),
+                None,
                 None,
                 True,
                 None,
@@ -654,6 +658,7 @@ class TestMessageLinkButton:
                     narrow="stream",
                     stream=DecodedStream(stream_id=None, stream_name="foo"),
                 ),
+                None,
                 None,
                 False,
                 None,
@@ -668,6 +673,7 @@ class TestMessageLinkButton:
                 ),
                 True,
                 None,
+                None,
                 ["Valid"],
                 "",
                 id="valid_topic_narrow_parsed_link",
@@ -679,6 +685,7 @@ class TestMessageLinkButton:
                     stream=DecodedStream(stream_id=1, stream_name=None),
                 ),
                 True,
+                None,
                 None,
                 [],
                 "Invalid topic name",
@@ -693,6 +700,7 @@ class TestMessageLinkButton:
                 True,
                 None,
                 None,
+                None,
                 "",
                 id="valid_stream_near_narrow_parsed_link",
             ),
@@ -703,6 +711,7 @@ class TestMessageLinkButton:
                     stream=DecodedStream(stream_id=1, stream_name=None),
                 ),
                 True,
+                None,
                 None,
                 None,
                 "Invalid message ID",
@@ -717,6 +726,7 @@ class TestMessageLinkButton:
                 ),
                 True,
                 None,
+                None,
                 ["Valid"],
                 "",
                 id="valid_topic_near_narrow_parsed_link",
@@ -730,6 +740,7 @@ class TestMessageLinkButton:
                 ),
                 True,
                 None,
+                None,
                 ["Valid"],
                 "Invalid message ID",
                 id="invalid_topic_near_narrow_parsed_link",
@@ -739,8 +750,98 @@ class TestMessageLinkButton:
                 None,
                 None,
                 None,
+                None,
                 "The narrow link seems to be either broken or unsupported",
                 id="invalid_narrow_link",
+            ),
+            case(
+                ParsedNarrowLink(
+                    narrow="stream", stream=DecodedStream(stream_id=1, stream_name=None)
+                ),  # ...
+                True,
+                None,
+                None,
+                None,
+                "",
+                id="valid_stream_data_with_stream_id",
+            ),
+            case(
+                ParsedNarrowLink(
+                    narrow="stream",
+                    stream=DecodedStream(stream_id=462, stream_name=None),
+                ),  # ...
+                False,
+                None,
+                None,
+                None,
+                "The stream seems to be either unknown or unsubscribed",
+                id="invalid_stream_data_with_stream_id",
+            ),
+            case(
+                ParsedNarrowLink(
+                    narrow="stream",
+                    stream=DecodedStream(stream_id=None, stream_name="Stream 1"),
+                ),  # ...
+                None,
+                None,
+                True,
+                None,
+                "",
+                id="valid_stream_data_with_stream_name",
+            ),
+            case(
+                ParsedNarrowLink(
+                    narrow="stream",
+                    stream=DecodedStream(stream_id=None, stream_name="foo"),
+                ),  # ...
+                None,
+                None,
+                False,
+                None,
+                "The stream seems to be either unknown or unsubscribed",
+                id="invalid_stream_data_with_stream_name",
+            ),
+            case(
+                ParsedNarrowLink(
+                    narrow="pm_with",
+                    pm_with=DecodedPM(
+                        type=None, recipient_ids=[1001, 11], recipient_emails=None
+                    ),
+                ),  # ...
+                None,
+                True,
+                None,
+                None,
+                "",
+                id="valid_pm_data",
+            ),
+            case(
+                ParsedNarrowLink(
+                    narrow="pm_with",
+                    pm_with=DecodedPM(
+                        type=None, recipient_ids=[1001, 11, 12], recipient_emails=None
+                    ),
+                ),  # ...
+                None,
+                True,
+                None,
+                None,
+                "",
+                id="valid_group_pm_data",
+            ),
+            case(
+                ParsedNarrowLink(
+                    narrow="pm_with",
+                    pm_with=DecodedPM(
+                        type=None, recipient_ids=[1001, -1], recipient_emails=None
+                    ),
+                ),  # ...
+                None,
+                False,
+                None,
+                None,
+                "The PM has one or more invalid recipient(s)",
+                id="invalid_recipient",
             ),
         ],
     )
@@ -749,6 +850,7 @@ class TestMessageLinkButton:
         stream_dict: Dict[int, Any],
         parsed_link: ParsedNarrowLink,
         is_user_subscribed_to_stream: Optional[bool],
+        is_valid_private_recipient: Optional[bool],
         is_valid_stream: Optional[bool],
         topics_in_stream: Optional[List[str]],
         expected_error: str,
@@ -756,6 +858,9 @@ class TestMessageLinkButton:
         self.controller.model.stream_dict = stream_dict
         self.controller.model.is_user_subscribed_to_stream.return_value = (
             is_user_subscribed_to_stream
+        )
+        self.controller.model.is_valid_private_recipient.return_value = (
+            is_valid_private_recipient
         )
         self.controller.model.is_valid_stream.return_value = is_valid_stream
         self.controller.model.topics_in_stream.return_value = topics_in_stream

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -505,6 +505,23 @@ class MessageLinkButton(urwid.Button):
 
         return ""
 
+    def _validate_pm_data(self, parsed_link: ParsedNarrowLink) -> str:
+        """
+        Validates PM data and returns either an empty string for a successful
+        validation or an appropriate validation error.
+        """
+        recipient_ids = parsed_link["pm_with"]["recipient_ids"]
+
+        for recipient_id in recipient_ids:
+            user = self.model._all_users_by_id.get(recipient_id, None)
+            email = user["email"] if user else ""
+            name = user["full_name"] if user else ""
+
+            if not self.model.is_valid_private_recipient(email, name):
+                return "The PM has one or more invalid recipient(s)"
+
+        return ""
+
     def _validate_narrow_link(self, parsed_link: ParsedNarrowLink) -> str:
         """
         Returns either an empty string for a successful validation or an
@@ -516,6 +533,12 @@ class MessageLinkButton(urwid.Button):
         # Validate stream data.
         if "stream" in parsed_link:
             error = self._validate_stream_data(parsed_link)
+            if error:
+                return error
+
+        # Validate PM data.
+        if "pm_with" in parsed_link:
+            error = self._validate_pm_data(parsed_link)
             if error:
                 return error
 


### PR DESCRIPTION
This is a follow-up PR from #708. It adds support for handling internal PM links.

I highly appreciate the work of @preetmishra in #708, by which it became simpler and cleaner to work with the helper functions in general :)

Partially fixes #764.