### PR TITLE
[WIP] Avoid inserting topics into topic search list unless relevant

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -602,7 +602,7 @@ class TestTopicsView:
         assert topic_view.view == self.view
         assert topic_view.topic_search_box
         self.topic_search_box.assert_called_once_with(
-            topic_view, 'SEARCH_TOPICS', topic_view.update_topics)
+            topic_view, 'SEARCH_TOPICS', topic_view.filter_topics)
         self.header_list.assert_called_once_with([topic_view.stream_button,
                                                   self.divider('─'),
                                                   topic_view.topic_search_box])
@@ -628,7 +628,7 @@ class TestTopicsView:
             mocker.Mock(topic_name=topic_name)
             for topic_name in topic_names
         ]
-        topic_view.update_topics(search_box, new_text)
+        topic_view.filter_topics(search_box, new_text)
         assert [topic.topic_name for topic in topic_view.log
                 ] == expected_log
         self.view.controller.update_screen.assert_called_once_with()

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -915,12 +915,13 @@ class Model:
             if hasattr(self.controller, 'view'):
                 view = self.controller.view
                 if view.left_panel.is_in_topic_view_with_stream_id(stream_id):
-                    sender_id = message['sender_id']
+                    sent_by_me = message['sender_id'] == self.user_id
                     if is_new_topic:
                         view.topic_w.add_new_top_topic(stream_id, topic,
-                                                       sender_id)
+                                                       sent_by_me)
                     else:
-                        view.topic_w.try_to_move_topic_to_top(topic, sender_id)
+                        view.topic_w.try_to_move_topic_to_top(topic,
+                                                              sent_by_me)
                     self.controller.update_screen()
 
         # We can notify user regardless of whether UI is rendered or not,

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -901,23 +901,23 @@ class Model:
         message['flags'] = event.get('flags', [])
         # We need to update the topic order in index, unconditionally.
         if message['type'] == 'stream':
+            stream_id = message['stream_id']
+            topic = message['subject']
             # NOTE: The subsequent helper only updates the topic index based
             # on the message event not the UI (the UI is updated in a
             # consecutive block independently). However, it is critical to keep
             # the topics index synchronized as it used whenever the topics list
             # view is reconstructed later.
-            self._update_topic_index(message['stream_id'],
-                                     message['subject'])
+            self._update_topic_index(stream_id, topic)
             # If the topic view is toggled for incoming message's
             # recipient stream, then we re-arrange topic buttons
             # with most recent at the top.
             if hasattr(self.controller, 'view'):
                 view = self.controller.view
-                if (view.left_panel.is_in_topic_view_with_stream_id(
-                        message['stream_id'])):
+                if view.left_panel.is_in_topic_view_with_stream_id(stream_id):
                     view.topic_w.update_topics_list(
-                        message['stream_id'], message['subject'],
-                        message['sender_id'])
+                        stream_id, topic, message['sender_id']
+                    )
                     self.controller.update_screen()
 
         # We can notify user regardless of whether UI is rendered or not,

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -394,10 +394,8 @@ class TopicsView(urwid.Frame):
             self.log.extend(topics_to_display)
             self.view.controller.update_screen()
 
-    def update_topics_list(self, stream_id: int, topic_name: str,
-                           sender_id: int) -> None:
-        # More recent topics are found towards the beginning
-        # of the list.
+    def try_to_move_topic_to_top(self, topic_name: str,
+                                 sender_id: int) -> None:
         for topic_iterator, topic_button in enumerate(self.log):
             if topic_button.topic_name == topic_name:
                 self.log.insert(0, self.log.pop(topic_iterator))
@@ -405,8 +403,10 @@ class TopicsView(urwid.Frame):
                 if sender_id == self.view.model.user_id:
                     self.list_box.set_focus(0)
                 return
-        # No previous topics with same topic names are found
-        # hence we create a new topic button for it.
+        # Reaching here is not necesarily an error, as we may be searching
+
+    def add_new_top_topic(self, stream_id: int, topic_name: str,
+                          sender_id: int) -> None:
         new_topic_button = TopicButton(stream_id,
                                        topic_name,
                                        self.view.controller,

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -394,14 +394,18 @@ class TopicsView(urwid.Frame):
             self.log.extend(topics_to_display)
             self.view.controller.update_screen()
 
+    def _insert_topic_at_top(self, button: Any, is_current_user: bool) -> None:
+        self.log.insert(0, button)
+        self.list_box.set_focus_valign('bottom')
+        if is_current_user:
+            self.list_box.set_focus(0)
+
     def try_to_move_topic_to_top(self, topic_name: str,
                                  is_current_user: bool) -> None:
         for topic_iterator, topic_button in enumerate(self.log):
             if topic_button.topic_name == topic_name:
-                self.log.insert(0, self.log.pop(topic_iterator))
-                self.list_box.set_focus_valign('bottom')
-                if is_current_user:
-                    self.list_box.set_focus(0)
+                button_to_move = self.log.pop(topic_iterator)
+                self._insert_topic_at_top(button_to_move, is_current_user)
                 return
         # Reaching here is not necesarily an error, as we may be searching
 
@@ -412,10 +416,7 @@ class TopicsView(urwid.Frame):
                                        self.view.controller,
                                        self.view.LEFT_WIDTH,
                                        0)
-        self.log.insert(0, new_topic_button)
-        self.list_box.set_focus_valign('bottom')
-        if is_current_user:
-            self.list_box.set_focus(0)
+        self._insert_topic_at_top(new_topic_button, is_current_user)
 
     def mouse_event(self, size: urwid_Size, event: str, button: int, col: int,
                     row: int, focus: bool) -> bool:

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -395,18 +395,18 @@ class TopicsView(urwid.Frame):
             self.view.controller.update_screen()
 
     def try_to_move_topic_to_top(self, topic_name: str,
-                                 sender_id: int) -> None:
+                                 is_current_user: bool) -> None:
         for topic_iterator, topic_button in enumerate(self.log):
             if topic_button.topic_name == topic_name:
                 self.log.insert(0, self.log.pop(topic_iterator))
                 self.list_box.set_focus_valign('bottom')
-                if sender_id == self.view.model.user_id:
+                if is_current_user:
                     self.list_box.set_focus(0)
                 return
         # Reaching here is not necesarily an error, as we may be searching
 
     def add_new_top_topic(self, stream_id: int, topic_name: str,
-                          sender_id: int) -> None:
+                          is_current_user: bool) -> None:
         new_topic_button = TopicButton(stream_id,
                                        topic_name,
                                        self.view.controller,
@@ -414,7 +414,7 @@ class TopicsView(urwid.Frame):
                                        0)
         self.log.insert(0, new_topic_button)
         self.list_box.set_focus_valign('bottom')
-        if sender_id == self.view.model.user_id:
+        if is_current_user:
             self.list_box.set_focus(0)
 
     def mouse_event(self, size: urwid_Size, event: str, button: int, col: int,

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -366,7 +366,7 @@ class TopicsView(urwid.Frame):
         self.list_box = urwid.ListBox(self.log)
         self.topic_search_box = PanelSearchBox(self,
                                                'SEARCH_TOPICS',
-                                               self.update_topics)
+                                               self.filter_topics)
         self.header_list = urwid.Pile([self.stream_button,
                                        urwid.Divider('─'),
                                        self.topic_search_box])
@@ -378,7 +378,7 @@ class TopicsView(urwid.Frame):
         self.search_lock = threading.Lock()
 
     @asynch
-    def update_topics(self, search_box: Any, new_text: str) -> None:
+    def filter_topics(self, search_box: Any, new_text: str) -> None:
         if not self.view.controller.is_in_editor_mode():
             return
         # wait for any previously started search to finish to avoid


### PR DESCRIPTION
This refactors the view update (originally by @sumanthvrao) on pushing newer topics to the top of the topic list, making the logic cleaner.

The final commit fixes #661.

NOTES:
* The tests still need updating, which I'm leaving as pending until I'm more sure this is the right approach.
* I'm considering a further refactor or adjustment of the last commit to deduplicate the loop or use a lookup dict.

Feedback welcome