### PR TITLE
bugfix: model: Fix incorrect condition in update_message_event.

### DIFF
--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -1009,6 +1009,7 @@ class TestModel:
         ({  # Only subject of 1 message is updated.
             'message_id': 1,
             'subject': 'new subject',
+            'orig_subject': 'old subject',
             'stream_id': 10,
             'message_ids': [1],
         }, 1, {
@@ -1031,6 +1032,7 @@ class TestModel:
         ({  # Subject of 2 messages is updated
             'message_id': 1,
             'subject': 'new subject',
+            'orig_subject': 'old topic',
             'stream_id': 10,
             'message_ids': [1, 2],
         }, 2, {
@@ -1052,6 +1054,8 @@ class TestModel:
         }, False),
         ({  # Message content is updated
             'message_id': 1,
+            'subject': 'same topic',
+            'orig_subject': 'same topic',
             'stream_id': 10,
             'rendered_content': '<p>new content</p>',
         }, 1, {
@@ -1075,6 +1079,7 @@ class TestModel:
             'message_id': 1,
             'rendered_content': '<p>new content</p>',
             'subject': 'new subject',
+            'orig_subject': 'old subject',
             'stream_id': 10,
             'message_ids': [1],
         }, 2, {  # 2=update of subject & content
@@ -1097,6 +1102,8 @@ class TestModel:
         ({  # Some new type of update which we don't handle yet.
             'message_id': 1,
             'foo': 'boo',
+            'subject': 'old subject',
+            'orig_subject': 'old subject',
         }, 0, {
             'messages': {
                 1: {
@@ -1118,6 +1125,7 @@ class TestModel:
             'message_id': 3,
             'rendered_content': '<p>new content</p>',
             'subject': 'new subject',
+            'orig_subject': 'old subject',
             'stream_id': 10,
             'message_ids': [3],
         }, 0, {
@@ -1141,6 +1149,7 @@ class TestModel:
             'message_id': 3,
             'rendered_content': '<p>new content</p>',
             'subject': 'new subject',
+            'orig_subject': 'old subject',
             'stream_id': 10,
             'message_ids': [3],
         }, 0, {
@@ -1164,6 +1173,7 @@ class TestModel:
             'message_id': 1,
             'rendered_content': '<p>new content</p>',
             'subject': 'new subject',
+            'orig_subject': 'still old subject',
             'stream_id': 10,
             'message_ids': [1],
         }, 2, {

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -64,6 +64,7 @@ class Event(TypedDict, total=False):  # Each Event will only have a subset
     message: Message
     flags: List[str]
     subject: str
+    orig_subject: str
     # subscription:
     property: str
     user_id: int  # Present when a streams subscribers are updated.
@@ -1046,10 +1047,11 @@ class Model:
             self._update_rendered_view(message_id)
 
         # NOTE: This is independent of messages being indexed
-        # Previous assertion:
-        # * 'subject' is not present in update event if
-        #   the event didn't have a 'subject' update.
-        if 'subject' in event:
+        # 'subject' will be present in event even if the message
+        #  was not edited. In this case 'orig_subject' and 'subject'
+        #  will have the same value. We can exploit this fact to check
+        # if a message's subject/topic was edited.
+        if event['subject'] != event['orig_subject']:
             new_subject = event['subject']
             stream_id = event['stream_id']
 


### PR DESCRIPTION
Fixed an inaccurate condition in `handle_update_message_event` that assumed `subject` will only be present in event list if the message had a topic/subject edit.
