### PR TITLE
tools: Use isort multi-line style '3' for smaller diffs.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,8 +11,8 @@ filterwarnings =
 addopts = -rxXs --cov=zulipterminal
 
 [tool:isort]
-# For compatibility with 'black', we'd want this to be 3
-multi_line_output=5
+# These isort rules should be compatible with black, if we ever wish to use it
+multi_line_output=3
 include_trailing_comma=True
 force_grid_wrap=0
 use_parentheses=True

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -4,7 +4,11 @@ import os
 import pytest
 
 from zulipterminal.cli.run import (
-    THEMES, get_login_id, in_color, main, parse_args,
+    THEMES,
+    get_login_id,
+    in_color,
+    main,
+    parse_args,
 )
 from zulipterminal.model import ServerConnectionFailure
 from zulipterminal.version import ZT_VERSION

--- a/tests/config/test_themes.py
+++ b/tests/config/test_themes.py
@@ -1,7 +1,10 @@
 import pytest
 
 from zulipterminal.config.themes import (
-    THEMES, all_themes, complete_and_incomplete_themes, required_styles,
+    THEMES,
+    all_themes,
+    complete_and_incomplete_themes,
+    required_styles,
     theme_with_monochrome_added,
 )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,8 @@ from zulipterminal.helper import initial_index as helper_initial_index
 from zulipterminal.ui_tools.boxes import MessageBox
 from zulipterminal.ui_tools.buttons import StreamButton, UserButton
 from zulipterminal.version import (
-    MINIMUM_SUPPORTED_SERVER_VERSION, SUPPORTED_SERVER_VERSIONS,
+    MINIMUM_SUPPORTED_SERVER_VERSION,
+    SUPPORTED_SERVER_VERSIONS,
 )
 
 

--- a/tests/helper/test_helper.py
+++ b/tests/helper/test_helper.py
@@ -2,8 +2,14 @@ import pytest
 
 import zulipterminal.helper
 from zulipterminal.helper import (
-    canonicalize_color, classify_unread_counts, display_error_if_present,
-    get_unused_fence, hash_util_decode, index_messages, notify, powerset,
+    canonicalize_color,
+    classify_unread_counts,
+    display_error_if_present,
+    get_unused_fence,
+    hash_util_decode,
+    index_messages,
+    notify,
+    powerset,
 )
 
 

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -9,17 +9,29 @@ from urwid import Columns, Divider, Padding, Text
 
 from zulipterminal.config.keys import keys_for_command
 from zulipterminal.config.symbols import (
-    QUOTED_TEXT_MARKER, STATUS_ACTIVE, STREAM_TOPIC_SEPARATOR,
+    QUOTED_TEXT_MARKER,
+    STATUS_ACTIVE,
+    STREAM_TOPIC_SEPARATOR,
     TIME_MENTION_MARKER,
 )
 from zulipterminal.helper import powerset
 from zulipterminal.ui_tools.boxes import MessageBox
 from zulipterminal.ui_tools.buttons import (
-    StreamButton, TopButton, TopicButton, UserButton,
+    StreamButton,
+    TopButton,
+    TopicButton,
+    UserButton,
 )
 from zulipterminal.ui_tools.views import (
-    LeftColumnView, MessageView, MiddleColumnView, ModListWalker,
-    RightColumnView, StreamsView, StreamsViewDivider, TopicsView, UsersView,
+    LeftColumnView,
+    MessageView,
+    MiddleColumnView,
+    ModListWalker,
+    RightColumnView,
+    StreamsView,
+    StreamsViewDivider,
+    TopicsView,
+    UsersView,
 )
 
 

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -3,7 +3,9 @@ from pytest import param
 
 from zulipterminal.config.keys import keys_for_command, primary_key_for_command
 from zulipterminal.config.symbols import (
-    STREAM_MARKER_INVALID, STREAM_MARKER_PRIVATE, STREAM_MARKER_PUBLIC,
+    STREAM_MARKER_INVALID,
+    STREAM_MARKER_PRIVATE,
+    STREAM_MARKER_PUBLIC,
 )
 from zulipterminal.ui_tools.boxes import PanelSearchBox, WriteBox
 

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -5,8 +5,15 @@ from urwid import Columns, Text
 
 from zulipterminal.config.keys import is_command_key, keys_for_command
 from zulipterminal.ui_tools.views import (
-    AboutView, EditHistoryView, EditModeView, HelpView, MsgInfoView,
-    PopUpConfirmationView, PopUpView, StreamInfoView, StreamMembersView,
+    AboutView,
+    EditHistoryView,
+    EditModeView,
+    HelpView,
+    MsgInfoView,
+    PopUpConfirmationView,
+    PopUpView,
+    StreamInfoView,
+    StreamMembersView,
 )
 from zulipterminal.version import MINIMUM_SUPPORTED_SERVER_VERSION, ZT_VERSION
 

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -10,7 +10,10 @@ import requests
 from urwid import display_common, set_encoding
 
 from zulipterminal.config.themes import (
-    THEMES, aliased_themes, all_themes, complete_and_incomplete_themes,
+    THEMES,
+    aliased_themes,
+    all_themes,
+    complete_and_incomplete_themes,
     theme_with_monochrome_added,
 )
 from zulipterminal.core import Controller

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -18,8 +18,15 @@ from zulipterminal.model import Model
 from zulipterminal.ui import Screen, View
 from zulipterminal.ui_tools.utils import create_msg_box_list
 from zulipterminal.ui_tools.views import (
-    AboutView, EditHistoryView, EditModeView, HelpView, MsgInfoView,
-    NoticeView, PopUpConfirmationView, StreamInfoView, StreamMembersView,
+    AboutView,
+    EditHistoryView,
+    EditModeView,
+    HelpView,
+    MsgInfoView,
+    NoticeView,
+    PopUpConfirmationView,
+    StreamInfoView,
+    StreamMembersView,
 )
 from zulipterminal.version import ZT_VERSION
 

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -8,8 +8,17 @@ from itertools import chain, combinations
 from re import ASCII, MULTILINE, findall, match
 from threading import Thread
 from typing import (
-    Any, Callable, DefaultDict, Dict, FrozenSet, Iterable, List, Set, Tuple,
-    TypeVar, Union,
+    Any,
+    Callable,
+    DefaultDict,
+    Dict,
+    FrozenSet,
+    Iterable,
+    List,
+    Set,
+    Tuple,
+    TypeVar,
+    Union,
 )
 from urllib.parse import unquote
 

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -4,8 +4,18 @@ from collections import OrderedDict, defaultdict
 from concurrent.futures import Future, ThreadPoolExecutor, wait
 from copy import deepcopy
 from typing import (
-    Any, Callable, DefaultDict, Dict, FrozenSet, Iterable, List, Optional, Set,
-    Tuple, Union, cast,
+    Any,
+    Callable,
+    DefaultDict,
+    Dict,
+    FrozenSet,
+    Iterable,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+    cast,
 )
 from urllib.parse import urlparse
 
@@ -15,9 +25,17 @@ from typing_extensions import Literal, TypedDict
 from zulipterminal import unicode_emojis
 from zulipterminal.config.keys import primary_key_for_command
 from zulipterminal.helper import (
-    Message, NamedEmojiData, StreamData, asynch, canonicalize_color,
-    classify_unread_counts, display_error_if_present, index_messages,
-    initial_index, notify, set_count,
+    Message,
+    NamedEmojiData,
+    StreamData,
+    asynch,
+    canonicalize_color,
+    classify_unread_counts,
+    display_error_if_present,
+    index_messages,
+    initial_index,
+    notify,
+    set_count,
 )
 from zulipterminal.ui_tools.utils import create_msg_box_list
 

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -7,12 +7,15 @@ import urwid
 
 from zulipterminal.config.keys import commands_for_random_tips, is_command_key
 from zulipterminal.config.symbols import (
-    APPLICATION_TITLE_BAR_LINE, LIST_TITLE_BAR_LINE,
+    APPLICATION_TITLE_BAR_LINE,
+    LIST_TITLE_BAR_LINE,
 )
 from zulipterminal.helper import WSL, asynch
 from zulipterminal.ui_tools.boxes import SearchBox, WriteBox
 from zulipterminal.ui_tools.views import (
-    LeftColumnView, MiddleColumnView, RightColumnView,
+    LeftColumnView,
+    MiddleColumnView,
+    RightColumnView,
 )
 
 

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -15,16 +15,30 @@ from tzlocal import get_localzone
 from urwid_readline import ReadlineEdit
 
 from zulipterminal.config.keys import (
-    is_command_key, keys_for_command, primary_key_for_command,
+    is_command_key,
+    keys_for_command,
+    primary_key_for_command,
 )
 from zulipterminal.config.symbols import (
-    MESSAGE_CONTENT_MARKER, MESSAGE_HEADER_DIVIDER, QUOTED_TEXT_MARKER,
-    STREAM_MARKER_INVALID, STREAM_MARKER_PRIVATE, STREAM_MARKER_PUBLIC,
-    STREAM_TOPIC_SEPARATOR, TIME_MENTION_MARKER,
+    MESSAGE_CONTENT_MARKER,
+    MESSAGE_HEADER_DIVIDER,
+    QUOTED_TEXT_MARKER,
+    STREAM_MARKER_INVALID,
+    STREAM_MARKER_PRIVATE,
+    STREAM_MARKER_PUBLIC,
+    STREAM_TOPIC_SEPARATOR,
+    TIME_MENTION_MARKER,
 )
 from zulipterminal.helper import (
-    Message, asynch, format_string, get_unused_fence, match_emoji, match_group,
-    match_stream, match_topics, match_user,
+    Message,
+    asynch,
+    format_string,
+    get_unused_fence,
+    match_emoji,
+    match_group,
+    match_stream,
+    match_topics,
+    match_user,
 )
 from zulipterminal.server_url import near_message_url
 from zulipterminal.ui_tools.buttons import EditModeButton

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -7,10 +7,14 @@ from typing_extensions import TypedDict
 
 from zulipterminal.config.keys import is_command_key, primary_key_for_command
 from zulipterminal.config.symbols import (
-    MUTE_MARKER, STREAM_MARKER_PRIVATE, STREAM_MARKER_PUBLIC,
+    MUTE_MARKER,
+    STREAM_MARKER_PRIVATE,
+    STREAM_MARKER_PUBLIC,
 )
 from zulipterminal.helper import (
-    StreamData, edit_mode_captions, hash_util_decode,
+    StreamData,
+    edit_mode_captions,
+    hash_util_decode,
 )
 from zulipterminal.urwid_types import urwid_Size
 

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -7,20 +7,40 @@ import urwid
 from typing_extensions import Literal
 
 from zulipterminal.config.keys import (
-    HELP_CATEGORIES, KEY_BINDINGS, is_command_key, keys_for_command,
+    HELP_CATEGORIES,
+    KEY_BINDINGS,
+    is_command_key,
+    keys_for_command,
 )
 from zulipterminal.config.symbols import (
-    CHECK_MARK, LIST_TITLE_BAR_LINE, PINNED_STREAMS_DIVIDER, STATUS_ACTIVE,
-    STATUS_IDLE, STATUS_INACTIVE, STATUS_OFFLINE, STREAM_MARKER_PRIVATE,
+    CHECK_MARK,
+    LIST_TITLE_BAR_LINE,
+    PINNED_STREAMS_DIVIDER,
+    STATUS_ACTIVE,
+    STATUS_IDLE,
+    STATUS_INACTIVE,
+    STATUS_OFFLINE,
+    STREAM_MARKER_PRIVATE,
     STREAM_MARKER_PUBLIC,
 )
 from zulipterminal.helper import (
-    Message, asynch, edit_mode_captions, match_stream, match_user,
+    Message,
+    asynch,
+    edit_mode_captions,
+    match_stream,
+    match_user,
 )
 from zulipterminal.ui_tools.boxes import PanelSearchBox
 from zulipterminal.ui_tools.buttons import (
-    HomeButton, MentionedButton, MessageLinkButton, PMButton, StarredButton,
-    StreamButton, TopicButton, UnreadPMButton, UserButton,
+    HomeButton,
+    MentionedButton,
+    MessageLinkButton,
+    PMButton,
+    StarredButton,
+    StreamButton,
+    TopicButton,
+    UnreadPMButton,
+    UserButton,
 )
 from zulipterminal.ui_tools.utils import create_msg_box_list
 from zulipterminal.urwid_types import urwid_Size


### PR DESCRIPTION
This also will enable compatibility with black, if we move to that tool in the future.