### PR TITLE
bugfixes: Improve first/last message handling

### DIFF
--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -176,6 +176,9 @@ class Model:
         self.new_user_input = True
         self._start_presence_updates()
 
+    def have_last_message_in_current_narrow(self) -> bool:
+        return self._have_last_message.get(repr(self.narrow), False)
+
     def get_focus_in_current_narrow(self) -> Union[int, Set[None]]:
         """
         Returns the focus in the current narrow.

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -101,6 +101,7 @@ class Model:
 
         self.narrow = []  # type: List[Any]
         self._have_last_message = {}  # type: Dict[str, bool]
+        self._have_first_message = {}  # type: Dict[str, bool]
         self.stream_id = -1
         self.recipients = frozenset()  # type: FrozenSet[Any]
         self.index = initial_index
@@ -178,6 +179,9 @@ class Model:
 
     def have_last_message_in_current_narrow(self) -> bool:
         return self._have_last_message.get(repr(self.narrow), False)
+
+    def have_first_message_in_current_narrow(self) -> bool:
+        return self._have_first_message.get(repr(self.narrow), False)
 
     def get_focus_in_current_narrow(self) -> Union[int, Set[None]]:
         """
@@ -460,6 +464,12 @@ class Model:
             had_last_msg = self._have_last_message.get(narrow_str, False)
             self._have_last_message[narrow_str] = (
                 had_last_msg or just_found_last_msg
+            )
+
+            just_found_first_msg = response.get('found_oldest', False)
+            had_first_msg = self._have_first_message.get(narrow_str, False)
+            self._have_first_message[narrow_str] = (
+                had_first_msg or just_found_first_msg
             )
 
             return ""

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -447,13 +447,18 @@ class Model:
             if first_anchor and response['anchor'] != 10000000000000000:
                 self.index['pointer'][narrow_str] = response['anchor']
             if 'found_newest' in response:
-                self._have_last_message[narrow_str] = response['found_newest']
+                just_found_last_msg = response['found_newest']
             else:
                 # Older versions of the server does not contain the
                 # 'found_newest' flag. Instead, we use this logic:
                 query_range = num_after + num_before + 1
-                self._have_last_message[narrow_str] = (
-                    len(response['messages']) < query_range)
+                just_found_last_msg = len(response['messages']) < query_range
+
+            had_last_msg = self._have_last_message.get(narrow_str, False)
+            self._have_last_message[narrow_str] = (
+                had_last_msg or just_found_last_msg
+            )
+
             return ""
         display_error_if_present(response, self.controller)
         return response['msg']
@@ -963,7 +968,7 @@ class Model:
             set_count([message['id']], self.controller, 1)
 
         if (hasattr(self.controller, 'view')
-                and self._have_last_message[repr(self.narrow)]):
+                and self._have_last_message.get(repr(self.narrow), False)):
             msg_log = self.controller.view.message_view.log
             if msg_log:
                 last_message = msg_log[-1].original_widget.message

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -177,9 +177,10 @@ class MessageView(urwid.ListBox):
 
                 return key
             except Exception:
-                if self.focus:
-                    id = self.focus.original_widget.message['id']
-                    self.load_new_messages(id)
+                if not self.model.have_last_message_in_current_narrow():
+                    if self.focus:
+                        id = self.focus.original_widget.message['id']
+                        self.load_new_messages(id)
                 return key
 
         elif is_command_key('GO_UP', key) and not self.old_loading:

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -190,12 +190,13 @@ class MessageView(urwid.ListBox):
                 self.set_focus_valign('middle')
                 return key
             except Exception:
-                if self.focus:
-                    id = self.focus.original_widget.message['id']
-                    self.load_old_messages(id)
-                else:
-                    self.load_old_messages()
-                return key
+                if not self.model.have_first_message_in_current_narrow():
+                    if self.focus:
+                        id = self.focus.original_widget.message['id']
+                        self.load_old_messages(id)
+                    else:
+                        self.load_old_messages()
+                    return key
 
         elif is_command_key('SCROLL_UP', key) and not self.old_loading:
             if (self.focus is not None


### PR DESCRIPTION
This is the result of exploring seeing intermittent cases where the `_have_last_message` dict had a `KeyError` in event handling via the new Notice popup.

This PR:
* improves the handling of this dict so that the logic is more consistent and expected
* uses the first/last message tracking to avoid hitting the API on trying to scroll beyond the start/end of the message view

This is a partial fix of #428, in particular https://github.com/zulip/zulip-terminal/issues/428#issuecomment-627187932.