### PR TITLE
Extract api types & split Event

### DIFF
--- a/docs/developer-file-overview.md
+++ b/docs/developer-file-overview.md
@@ -4,7 +4,8 @@ Zulip Terminal uses [Zulip's API](https://zulip.com/api/) to store and retrieve 
 
 | Folder                 | File                | Description                                                                                            |
 | ---------------------- | ------------------- | ------------------------------------------------------------------------------------------------------ |
-| zulipterminal/         | core.py             | Defines the `Controller`, which sets up the `model`, `view`, and coordinates the application           |
+| zulipterminal/         | api_types.py        | Preliminary Zulip API types defined in python, to allow type checking                                  |
+|                        | core.py             | Defines the `Controller`, which sets up the `model`, `view`, and coordinates the application           |
 |                        | helper.py           | Helper functions used in multiple places                                                               |
 |                        | model.py            | Defines the `Model`, fetching and storing data retrieved from the Zulip server                         |
 |                        | server_url.py       | Constructs and encodes server_url of messages.                                                         |

--- a/zulipterminal/api_types.py
+++ b/zulipterminal/api_types.py
@@ -1,0 +1,66 @@
+from typing import Any, Dict, List
+
+from typing_extensions import Literal, TypedDict
+
+
+EditPropagateMode = Literal['change_one', 'change_all', 'change_later']
+
+
+class Message(TypedDict, total=False):
+    id: int
+    sender_id: int
+    content: str
+    recipient_id: int
+    timestamp: int
+    client: str
+    subject: str  # Only for stream msgs.
+    topic_links: List[str]
+    is_me_message: bool
+    reactions: List[Dict[str, Any]]
+    submessages: List[Dict[str, Any]]
+    flags: List[str]
+    sender_full_name: str
+    sender_short_name: str
+    sender_email: str
+    sender_realm_str: str
+    display_recipient: Any
+    type: str
+    stream_id: int  # Only for stream msgs.
+    avatar_url: str
+    content_type: str
+    match_content: str  # If keyword search specified in narrow params.
+    match_subject: str  # If keyword search specified in narrow params.
+
+
+class Event(TypedDict, total=False):  # Each Event will only have a subset
+    type: str
+    # typing:
+    sender: Dict[str, Any]  # 'email', ...
+    # typing & reaction:
+    op: str
+    # reaction:
+    user: Dict[str, Any]  # 'email', 'user_id', 'full_name'
+    reaction_type: str
+    emoji_code: str
+    emoji_name: str
+    # reaction & update_message:
+    message_id: int
+    # update_message:
+    rendered_content: str
+    # update_message_flags:
+    messages: List[int]
+    operation: str  # NOTE: deprecated in Zulip 4.0 / ZFL 32 -> 'op'
+    flag: str
+    all: bool
+    # message:
+    message: Message
+    flags: List[str]
+    subject: str
+    # subscription:
+    property: str
+    user_id: int  # Present when a streams subscribers are updated.
+    user_ids: List[int]  # NOTE: replaces 'user_id' in ZFL 35
+    stream_id: int
+    stream_ids: List[int]  # NOTE: replaces 'stream_id' in ZFL 35 for peer*
+    value: bool
+    message_ids: List[int]  # Present when subject of msg(s) is updated

--- a/zulipterminal/api_types.py
+++ b/zulipterminal/api_types.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Union
 
 from typing_extensions import Literal, TypedDict
 
@@ -32,35 +32,69 @@ class Message(TypedDict, total=False):
     match_subject: str  # If keyword search specified in narrow params.
 
 
-class Event(TypedDict, total=False):  # Each Event will only have a subset
-    type: str
-    # typing:
-    sender: Dict[str, Any]  # 'email', ...
-    # typing & reaction:
+class MessageEvent(TypedDict):
+    type: Literal['message']
+    message: Message
+    flags: List[str]
+
+
+class UpdateMessageEvent(TypedDict):
+    type: Literal['update_message']
+    message_id: int
+    # FIXME: These groups of types are not always present
+    # A: Content needs re-rendering
+    rendered_content: str
+    # B: Subject of these message ids needs updating?
+    message_ids: List[int]
+    subject: str
+    stream_id: int
+
+
+class ReactionEvent(TypedDict):
+    type: Literal['reaction']
     op: str
-    # reaction:
     user: Dict[str, Any]  # 'email', 'user_id', 'full_name'
     reaction_type: str
     emoji_code: str
     emoji_name: str
-    # reaction & update_message:
     message_id: int
-    # update_message:
-    rendered_content: str
-    # update_message_flags:
-    messages: List[int]
-    operation: str  # NOTE: deprecated in Zulip 4.0 / ZFL 32 -> 'op'
-    flag: str
-    all: bool
-    # message:
-    message: Message
-    flags: List[str]
-    subject: str
-    # subscription:
+
+
+class SubscriptionEvent(TypedDict):
+    type: Literal['subscription']
+    op: str
     property: str
+
     user_id: int  # Present when a streams subscribers are updated.
     user_ids: List[int]  # NOTE: replaces 'user_id' in ZFL 35
+
     stream_id: int
     stream_ids: List[int]  # NOTE: replaces 'stream_id' in ZFL 35 for peer*
+
     value: bool
     message_ids: List[int]  # Present when subject of msg(s) is updated
+
+
+class TypingEvent(TypedDict):
+    type: Literal['typing']
+    sender: Dict[str, Any]  # 'email', ...
+    op: str
+
+
+class UpdateMessageFlagsEvent(TypedDict):
+    type: Literal['update_message_flags']
+    messages: List[int]
+    operation: str  # NOTE: deprecated in Zulip 4.0 / ZFL 32 -> 'op'
+    op: str
+    flag: str
+    all: bool
+
+
+Event = Union[
+    MessageEvent,
+    UpdateMessageEvent,
+    ReactionEvent,
+    SubscriptionEvent,
+    TypingEvent,
+    UpdateMessageFlagsEvent,
+]

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -12,8 +12,9 @@ import urwid
 import zulip
 from typing_extensions import Literal
 
+from zulipterminal.api_types import Message
 from zulipterminal.config.themes import ThemeSpec
-from zulipterminal.helper import Message, asynch
+from zulipterminal.helper import asynch
 from zulipterminal.model import Model
 from zulipterminal.ui import Screen, View
 from zulipterminal.ui_tools.utils import create_msg_box_list

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -25,6 +25,8 @@ from urllib.parse import unquote
 import lxml.html
 from typing_extensions import Literal, TypedDict
 
+from zulipterminal.api_types import Message
+
 
 MACOS = platform.system() == "Darwin"
 LINUX = platform.system() == "Linux"
@@ -45,32 +47,6 @@ class EmojiData(TypedDict):
 
 
 NamedEmojiData = Dict[str, EmojiData]
-
-
-class Message(TypedDict, total=False):
-    id: int
-    sender_id: int
-    content: str
-    recipient_id: int
-    timestamp: int
-    client: str
-    subject: str  # Only for stream msgs.
-    topic_links: List[str]
-    is_me_message: bool
-    reactions: List[Dict[str, Any]]
-    submessages: List[Dict[str, Any]]
-    flags: List[str]
-    sender_full_name: str
-    sender_short_name: str
-    sender_email: str
-    sender_realm_str: str
-    display_recipient: Any
-    type: str
-    stream_id: int  # Only for stream msgs.
-    avatar_url: str
-    content_type: str
-    match_content: str  # If keyword search specified in narrow params.
-    match_subject: str  # If keyword search specified in narrow params.
 
 
 class Index(TypedDict):

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -782,6 +782,7 @@ class Model:
         Handle changes in subscription (eg. muting/unmuting,
                                         pinning/unpinning streams)
         """
+        assert event['type'] == "subscription"
         def get_stream_by_id(streams: List[StreamData], stream_id: int
                              ) -> StreamData:
             for stream in streams:
@@ -856,6 +857,7 @@ class Model:
         """
         Handle typing notifications (in private messages)
         """
+        assert event['type'] == "typing"
         if hasattr(self.controller, 'view'):
             # If the user is in pm narrow with the person typing
             narrow = self.narrow
@@ -924,6 +926,7 @@ class Model:
         """
         Handle new messages (eg. add message to the end of the view)
         """
+        assert event['type'] == "message"
         message = event['message']
         # sometimes `flags` are missing in `event` so initialize
         # an empty list of flags in that case.
@@ -1016,6 +1019,7 @@ class Model:
         """
         Handle updated (edited) messages (changed content/subject)
         """
+        assert event['type'] == "update_message"
         # Update edited message status from single message id
         # NOTE: If all messages in topic have topic edited,
         #       they are not all marked as edited, as per server optimization
@@ -1063,6 +1067,7 @@ class Model:
         """
         Handle change to reactions on a message
         """
+        assert event['type'] == "reaction"
         message_id = event['message_id']
         # If the message is indexed
         if self.index['messages'][message_id] != {}:
@@ -1092,6 +1097,7 @@ class Model:
         """
         Handle change to message flags (eg. starred, read)
         """
+        assert event['type'] == "update_message_flags"
         if (self.server_feature_level is None
                 or self.server_feature_level < 32):
             operation = event['operation']

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -20,9 +20,10 @@ from typing import (
 from urllib.parse import urlparse
 
 import zulip
-from typing_extensions import Literal, TypedDict
+from typing_extensions import Literal
 
 from zulipterminal import unicode_emojis
+from zulipterminal.api_types import EditPropagateMode, Event
 from zulipterminal.config.keys import primary_key_for_command
 from zulipterminal.helper import (
     Message,
@@ -39,42 +40,6 @@ from zulipterminal.helper import (
 )
 from zulipterminal.ui_tools.utils import create_msg_box_list
 
-
-class Event(TypedDict, total=False):  # Each Event will only have a subset
-    type: str
-    # typing:
-    sender: Dict[str, Any]  # 'email', ...
-    # typing & reaction:
-    op: str
-    # reaction:
-    user: Dict[str, Any]  # 'email', 'user_id', 'full_name'
-    reaction_type: str
-    emoji_code: str
-    emoji_name: str
-    # reaction & update_message:
-    message_id: int
-    # update_message:
-    rendered_content: str
-    # update_message_flags:
-    messages: List[int]
-    operation: str  # NOTE: deprecated in Zulip 4.0 / ZFL 32 -> 'op'
-    flag: str
-    all: bool
-    # message:
-    message: Message
-    flags: List[str]
-    subject: str
-    # subscription:
-    property: str
-    user_id: int  # Present when a streams subscribers are updated.
-    user_ids: List[int]  # NOTE: replaces 'user_id' in ZFL 35
-    stream_id: int
-    stream_ids: List[int]  # NOTE: replaces 'stream_id' in ZFL 35 for peer*
-    value: bool
-    message_ids: List[int]  # Present when subject of msg(s) is updated
-
-
-EditPropagateMode = Literal['change_one', 'change_all', 'change_later']
 
 OFFLINE_THRESHOLD_SECS = 140
 

--- a/zulipterminal/server_url.py
+++ b/zulipterminal/server_url.py
@@ -1,6 +1,6 @@
 import urllib.parse
 
-from zulipterminal.helper import Message
+from zulipterminal.api_types import Message
 
 
 def hash_util_encode(string: str) -> str:

--- a/zulipterminal/ui_tools/utils.py
+++ b/zulipterminal/ui_tools/utils.py
@@ -2,7 +2,7 @@ from typing import Any, Iterable, List, Optional, Union
 
 import urwid
 
-from zulipterminal.helper import Message
+from zulipterminal.api_types import Message
 from zulipterminal.ui_tools.boxes import MessageBox
 
 


### PR DESCRIPTION
This PR combines:
* extracting types that should match the Zulip API into a separate file, reducing coupling and making it clear they are not related to the implementation
* splitting the existing Event type from a large TypedDict which may not contain every element into multiple TypedDicts which must contain all elements

I was working on the latter last year, but the python3.6 changes make this much neater.