### PR TITLE
Remove space to split recipients by ','.

### DIFF
--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -351,10 +351,29 @@ class TestWriteBox:
          '<notification-bot@zulip.com>, person2',
          ['Human 2'],
          ['Welcome Bot <welcome-bot@zulip.com>, Notification Bot '
+          '<notification-bot@zulip.com>, Human 2 <person2@example.com>']),
+        ('Email Gateway <emailgateway@zulip.com>,Human', [
+            'Human Myself',
+            'Human 1',
+            'Human 2'
+        ], [
+            'Email Gateway <emailgateway@zulip.com>, '
+            'Human Myself <FOOBOO@gmail.com>',
+            'Email Gateway <emailgateway@zulip.com>, '
+            'Human 1 <person1@example.com>',
+            'Email Gateway <emailgateway@zulip.com>, '
+            'Human 2 <person2@example.com>'
+        ]),
+        ('Human 1 <person1@example.com>, Notification Bot '
+         '<notification-bot@zulip.com>,person2',
+         ['Human 2'],
+         ['Human 1 <person1@example.com>, Notification Bot '
           '<notification-bot@zulip.com>, Human 2 <person2@example.com>'])
     ], ids=[
-        'name_search_text',
-        'email_search_text',
+        'name_search_text_with_space_after_separator',
+        'email_search_text_with_space_after_separator',
+        'name_search_text_without_space_after_separator',
+        'email_search_text_without_space_after_separator'
     ])
     def test__to_box_autocomplete_with_multiple_recipients(self, mocker,
                                                            write_box, text,

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -285,13 +285,13 @@ class WriteBox(urwid.Pile):
     def _to_box_autocomplete(self, text: str, state: Optional[int]
                              ) -> Optional[str]:
         users_list = self.view.users
-        recipients = text.rsplit(', ', 1)
+        recipients = text.rsplit(',', 1)
 
         # Use the most recent recipient for autocomplete.
         previous_recipients = (
             f"{recipients[0]}, " if len(recipients) > 1 else ""
         )
-        latest_text = recipients[-1]
+        latest_text = recipients[-1].strip()
 
         matching_users = [
             user


### PR DESCRIPTION
Autocomplete now splits on just `','` instead of `', '`.
The users would only have to use a `,` and continue with typing the next recipient and receive suggestions through autocomplete, without having to worry about adding a space.