### PR TITLE
feature: Add Reactions to messages.

### DIFF
--- a/docs/hotkeys.md
+++ b/docs/hotkeys.md
@@ -39,6 +39,7 @@
 |Search Messages|<kbd>/</kbd>|
 |Search Streams|<kbd>q</kbd>|
 |Search topics in a stream|<kbd>q</kbd>|
+|Search emojis from Emoji-picker popup|<kbd>p</kbd>|
 
 ## Message actions
 |Command|Key Combination|
@@ -50,6 +51,7 @@
 |Edit message's content or topic|<kbd>e</kbd>|
 |New message to a stream|<kbd>c</kbd>|
 |New message to a person or group of people|<kbd>x</kbd>|
+|Show/hide Emoji picker popup for current message|<kbd>:</kbd>|
 |Narrow to the stream of the current message|<kbd>s</kbd>|
 |Narrow to the topic of the current message|<kbd>S</kbd>|
 |Narrow to a topic/private-chat, or stream/all-private-messages|<kbd>z</kbd>|

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -1515,6 +1515,7 @@ class TestPanelSearchBox:
     def test_keypress_GO_BACK(self, panel_search_box, back_key, widget_size):
         size = widget_size(panel_search_box)
         panel_search_box.panel_view.view.controller.is_in_editor_mode = lambda: True
+        panel_search_box.panel_view.view.controller.is_any_popup_open = lambda: False
         panel_search_box.set_caption(self.search_caption)
         panel_search_box.edit_text = "key words"
 

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -1316,6 +1316,51 @@ class TestEmojiPickerView:
             self.view,
         )
 
+    @pytest.mark.parametrize(
+        "emoji_units",
+        [
+            (
+                ("action", "1f3ac", []),
+                ("alien", "1f47d", ["ufo"]),
+                ("angel", "1f47c", []),
+                ("anger", "1f4a2", ["bam", "pow"]),
+                ("angry", "1f620", []),
+                ("eight", "0038-20e3", []),
+                ("email", "2709", ["envelope", "mail"]),
+                ("eye", "1f441", []),
+                ("ball", "26f9", ["sports"]),
+                ("cat", "1f408", ["meow"]),
+                ("heart", "2764", ["love", "love_you"]),
+                ("lightning", "1f329", ["lightning_storm"]),
+                ("smile", "1f642", []),
+                ("smiley", "1f603", []),
+                ("smirk", "1f60f", ["smug"]),
+                ("smoking", "1f6ac", []),
+            )
+        ],
+    )
+    @pytest.mark.parametrize(
+        ["search_string", "assert_list"],
+        [
+            ("e", ["eight", "email", "eye"]),
+            ("sm", ["smile", "smiley", "smirk", "smoking"]),
+            ("ang", ["angel", "anger", "angry"]),
+            ("abc", []),
+            ("q", []),
+        ],
+    )
+    def test_update_emoji_list(self, emoji_units, search_string, assert_list):
+        self.emoji_picker_view.emoji_buttons = (
+            self.emoji_picker_view.generate_emoji_buttons(emoji_units)
+        )
+
+        self.emoji_picker_view.update_emoji_list("SEARCH_EMOJIS", search_string)
+        self.emojis_display = self.emoji_picker_view.emojis_display
+        emojis_display_name = [emoji.emoji_name for emoji in self.emojis_display]
+
+        assert emojis_display_name == assert_list
+        assert self.emoji_picker_view.get_focus() == "header"
+
     @pytest.mark.parametrize("key", keys_for_command("SEARCH_EMOJIS"))
     def test_keypress_search_emoji(self, key, widget_size):
         size = widget_size(self.emoji_picker_view)

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -1361,6 +1361,20 @@ class TestEmojiPickerView:
         assert emojis_display_name == assert_list
         assert self.emoji_picker_view.get_focus() == "header"
 
+    @pytest.mark.parametrize(
+        "event, button, keypress",
+        [
+            ("mouse press", 4, "up"),
+            ("mouse press", 5, "down"),
+        ],
+    )
+    def test_mouse_event(self, mocker, widget_size, event, button, keypress):
+        emoji_picker = self.emoji_picker_view
+        mocker.patch.object(emoji_picker, "keypress")
+        size = widget_size(emoji_picker)
+        emoji_picker.mouse_event(size, event, button, 0, 0, mocker.Mock())
+        emoji_picker.keypress.assert_called_once_with(size, keypress)
+
     @pytest.mark.parametrize("key", keys_for_command("SEARCH_EMOJIS"))
     def test_keypress_search_emoji(self, key, widget_size):
         size = widget_size(self.emoji_picker_view)

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -149,6 +149,11 @@ KEY_BINDINGS: 'OrderedDict[str, KeyBinding]' = OrderedDict([
         'help_text': 'Cycle through autocomplete suggestions in reverse',
         'key_category': 'msg_compose',
     }),
+    ('ADD_REACTION', {
+        'keys': [':'],
+        'help_text': 'Show/hide Emoji picker popup for current message',
+        'key_category': 'msg_actions',
+    }),
     ('STREAM_NARROW', {
         'keys': ['s'],
         'help_text': 'Narrow to the stream of the current message',
@@ -218,6 +223,12 @@ KEY_BINDINGS: 'OrderedDict[str, KeyBinding]' = OrderedDict([
     ('SEARCH_TOPICS', {
         'keys': ['q'],
         'help_text': 'Search topics in a stream',
+        'key_category': 'searching',
+    }),
+    ('SEARCH_EMOJIS', {
+        'keys': ['p'],
+        'help_text': 'Search emojis from Emoji-picker popup',
+        'excluded_from_random_tips': True,
         'key_category': 'searching',
     }),
     ('TOGGLE_MUTE_STREAM', {

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -277,12 +277,12 @@ class Controller:
         self.show_pop_up(msg_info_view, "area:msg")
 
     def show_emoji_picker(self, message: Message) -> None:
+        all_emoji_units = [
+            (emoji_name, emoji["code"], emoji["aliases"])
+            for emoji_name, emoji in self.model.active_emoji_data.items()
+        ]
         emoji_picker_view = EmojiPickerView(
-            self,
-            "Add/Remove Emojis",
-            [("+1", "1f44d", ["thumbs_up", "like"])],
-            message,
-            self.view,
+            self, "Add/Remove Emojis", all_emoji_units, message, self.view
         )
         self.show_pop_up(emoji_picker_view, "area:msg")
 

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -26,6 +26,7 @@ from zulipterminal.ui_tools.views import (
     AboutView,
     EditHistoryView,
     EditModeView,
+    EmojiPickerView,
     FullRawMsgView,
     FullRenderedMsgView,
     HelpView,
@@ -274,6 +275,16 @@ class Controller:
             time_mentions,
         )
         self.show_pop_up(msg_info_view, "area:msg")
+
+    def show_emoji_picker(self, message: Message) -> None:
+        emoji_picker_view = EmojiPickerView(
+            self,
+            "Add/Remove Emojis",
+            [("+1", "1f44d", ["thumbs_up", "like"])],
+            message,
+            self.view,
+        )
+        self.show_pop_up(emoji_picker_view, "area:msg")
 
     def show_stream_info(self, stream_id: int) -> None:
         show_stream_view = StreamInfoView(self, stream_id)

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -1920,6 +1920,8 @@ class MessageBox(urwid.Pile):
             self.model.controller.show_msg_info(
                 self.message, self.topic_links, self.message_links, self.time_mentions
             )
+        elif is_command_key("ADD_REACTION", key):
+            self.model.controller.show_emoji_picker(self.message)
         return key
 
 
@@ -2017,7 +2019,9 @@ class PanelSearchBox(urwid.Edit):
             self.panel_view.view.controller.exit_editor_mode()
             self.reset_search_text()
             self.panel_view.set_focus("body")
-            self.panel_view.keypress(size, primary_key_for_command("GO_BACK"))
+            # Don't call 'Esc' when inside a popup search-box.
+            if not self.panel_view.view.controller.is_any_popup_open():
+                self.panel_view.keypress(size, primary_key_for_command("GO_BACK"))
         elif is_command_key("ENTER", key) and not self.panel_view.empty_search:
             self.panel_view.view.controller.exit_editor_mode()
             self.set_caption([("filter_results", " Search Results "), " "])

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -360,6 +360,15 @@ class EmojiButton(TopButton):
         reacted_check_mark = CHECK_MARK if user_reacted else ""
         return f" {reacted_check_mark} {count_text} "
 
+    def mouse_event(
+        self, size: urwid_Size, event: str, button: int, col: int, row: int, focus: int
+    ) -> bool:
+        if event == "mouse press":
+            if button == 1:
+                self.keypress(size, primary_key_for_command("ENTER"))
+                return True
+        return super().mouse_event(size, event, button, col, row, focus)
+
     def update_emoji_button(self) -> None:
         self.toggle_selection(self.emoji_code, self.emoji_name)
         is_reaction_added = self._has_user_reacted_to_msg() != self.is_selected(

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -40,6 +40,7 @@ from zulipterminal.helper import (
 from zulipterminal.server_url import near_message_url
 from zulipterminal.ui_tools.boxes import MessageBox, PanelSearchBox
 from zulipterminal.ui_tools.buttons import (
+    EmojiButton,
     HomeButton,
     MentionedButton,
     MessageLinkButton,
@@ -1900,5 +1901,103 @@ class FullRawMsgView(PopUpView):
                 message_links=self.message_links,
                 time_mentions=self.time_mentions,
             )
+            return key
+        return super().keypress(size, key)
+
+
+class EmojiPickerView(PopUpView):
+    """
+    Displays Emoji Picker view for messages.
+    """
+
+    def __init__(
+        self,
+        controller: Any,
+        title: str,
+        emoji_units: List[Tuple[str, str, List[str]]],
+        message: Message,
+        view: Any,
+    ) -> None:
+        self.view = view
+        self.message = message
+        self.controller = controller
+        self.selected_emojis: Dict[str, str] = {}
+        emoji_buttons = self.generate_emoji_buttons(emoji_units)
+        width = max(len(button.label) for button in emoji_buttons)
+        max_cols, max_rows = controller.maximum_popup_dimensions()
+        popup_width = min(max_cols, width)
+        self.emoji_search = PanelSearchBox(
+            self, "SEARCH_EMOJIS", self.update_emoji_list
+        )
+        search_box = urwid.LineBox(
+            self.emoji_search,
+            tlcorner="─",
+            tline="",
+            lline="",
+            trcorner="─",
+            blcorner="─",
+            rline="",
+            bline="─",
+            brcorner="─",
+        )
+        self.empty_search = False
+        super().__init__(
+            controller,
+            emoji_buttons,
+            "ADD_REACTION",
+            popup_width,
+            title,
+            header=search_box,
+        )
+        self.set_focus("header")
+        self.controller.enter_editor_mode_with(self.emoji_search)
+
+    @asynch
+    def update_emoji_list(
+        self,
+        search_box: Any = None,
+        new_text: Optional[str] = None,
+        emoji_list: Any = None,
+    ) -> None:
+        pass
+
+    def is_selected_emoji(self, emoji_name: str) -> bool:
+        return emoji_name in self.selected_emojis.values()
+
+    def add_or_remove_selected_emoji(self, emoji_code: str, emoji_name: str) -> None:
+        if emoji_name in self.selected_emojis.values():
+            self.selected_emojis.pop(emoji_code, None)
+        else:
+            self.selected_emojis.update({emoji_code: emoji_name})
+
+    def generate_emoji_buttons(
+        self, emoji_units: List[Tuple[str, str, List[str]]]
+    ) -> List[EmojiButton]:
+        return [
+            EmojiButton(
+                controller=self.controller,
+                emoji_unit=emoji_unit,
+                message=self.message,
+                is_selected=self.is_selected_emoji,
+                toggle_selection=self.add_or_remove_selected_emoji,
+            )
+            for emoji_unit in emoji_units
+        ]
+
+    def keypress(self, size: urwid_Size, key: str) -> str:
+        if (
+            is_command_key("SEARCH_EMOJIS", key)
+            and not self.controller.is_in_editor_mode()
+        ):
+            self.set_focus("header")
+            self.emoji_search.set_caption(" ")
+            self.controller.enter_editor_mode_with(self.emoji_search)
+            return key
+        elif is_command_key("GO_BACK", key) or is_command_key("ADD_REACTION", key):
+            for emoji_code, emoji_name in self.selected_emojis.items():
+                self.controller.model.toggle_message_reaction(self.message, emoji_name)
+            self.emoji_search.reset_search_text()
+            self.controller.exit_editor_mode()
+            self.controller.exit_popup()
             return key
         return super().keypress(size, key)

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -2008,19 +2008,31 @@ class EmojiPickerView(PopUpView):
         else:
             self.selected_emojis.update({emoji_code: emoji_name})
 
+    def count_reactions(self, emoji_code: str) -> int:
+        num_reacts = 0
+        for reaction in self.message["reactions"]:
+            if reaction["emoji_code"] == emoji_code:
+                num_reacts += 1
+        return num_reacts
+
     def generate_emoji_buttons(
         self, emoji_units: List[Tuple[str, str, List[str]]]
     ) -> List[EmojiButton]:
-        return [
+        emoji_buttons = [
             EmojiButton(
                 controller=self.controller,
                 emoji_unit=emoji_unit,
                 message=self.message,
+                reaction_count=self.count_reactions(emoji_unit[1]),
                 is_selected=self.is_selected_emoji,
                 toggle_selection=self.add_or_remove_selected_emoji,
             )
             for emoji_unit in emoji_units
         ]
+        sorted_emoji_buttons = sorted(
+            emoji_buttons, key=lambda button: button.reaction_count, reverse=True
+        )
+        return sorted_emoji_buttons
 
     def keypress(self, size: urwid_Size, key: str) -> str:
         if (

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -2034,6 +2034,21 @@ class EmojiPickerView(PopUpView):
         )
         return sorted_emoji_buttons
 
+    def mouse_event(
+        self, size: urwid_Size, event: str, button: int, col: int, row: int, focus: int
+    ) -> bool:
+        if event == "mouse press":
+            if button == 1 and self.controller.is_in_editor_mode():
+                super().keypress(size, "enter")
+                return True
+            if button == 4:
+                self.keypress(size, "up")
+                return True
+            elif button == 5:
+                self.keypress(size, "down")
+                return True
+        return super().mouse_event(size, event, button, col, row, focus)
+
     def keypress(self, size: urwid_Size, key: str) -> str:
         if (
             is_command_key("SEARCH_EMOJIS", key)


### PR DESCRIPTION
This PR packs a critical feature, that supports adding general reactions to messages. Few highlights of this feature:
- A new `EmojiPicker` popup that activates from <kbd>:</kbd> hotkey.
- Search for any emoji in the list through <kbd>p</kbd> hotkey.
- A reaction count beside emoji's that users have reacted with.
- Emoji list sorted in decreasing order of reaction count, and ascending order of emoji names(if reaction count is same).
- A `CHECK_MARK` that indicates emoji's that the current user has reacted with.
- Mouse support allows toggling reactions and scrolling through mouse events.

**Working:**

<img src="https://user-images.githubusercontent.com/54993043/110815551-8dcfe880-82b0-11eb-8ee4-135976efa44a.gif" width="250" height="500"/>


Thanks to @kaustubh-nair for his initial work in #707. I was able to pull some of his changes here, which simplified my work.
