### PR TITLE
Minor typing adjustments to reach Zulip's client expectations

### DIFF
--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -2089,6 +2089,7 @@ class TestModel:
         mocker.patch("zulipterminal.ui.View.set_footer_text")
         model.narrow = narrow
         model.user_dict = {"hamlet@zulip.com": {"full_name": "hamlet"}}
+        TYPING_STARTED_EXPIRY_PERIOD = 15
 
         if narrow and "pm_with" in narrow[0]:
             sender_full_name = model.user_dict[event["sender"]["email"]]["full_name"]
@@ -2101,6 +2102,7 @@ class TestModel:
             if event["op"] == "start":
                 model.controller.view.set_footer_text.assert_called_once_with(
                     [" ", ("footer_contrast", sender_full_name), " is typing..."],
+                    TYPING_STARTED_EXPIRY_PERIOD,
                 )
             elif event["op"] == "stop":
                 model.controller.view.set_footer_text.assert_called_once_with()

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -2090,9 +2090,20 @@ class TestModel:
         model.narrow = narrow
         model.user_dict = {"hamlet@zulip.com": {"full_name": "hamlet"}}
 
+        if narrow and "pm_with" in narrow[0]:
+            sender_full_name = model.user_dict[event["sender"]["email"]]["full_name"]
+
         model._handle_typing_event(event)
 
         assert model.controller.view.set_footer_text.called == called
+
+        if called:
+            if event["op"] == "start":
+                model.controller.view.set_footer_text.assert_called_once_with(
+                    [" ", ("footer_contrast", sender_full_name), " is typing..."],
+                )
+            elif event["op"] == "stop":
+                model.controller.view.set_footer_text.assert_called_once_with()
 
     @pytest.mark.parametrize(
         "event, final_muted_streams, ",

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -52,6 +52,7 @@ class TestWriteBox:
         assert write_box.model == self.view.model
         assert write_box.view == self.view
         assert write_box.msg_edit_state is None
+        assert not write_box.sent_start_typing_status
 
     def test_not_calling_typing_method_without_recipients(self, mocker, write_box):
         write_box.model.send_typing_status_by_user_ids = mocker.Mock()

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1001,6 +1001,9 @@ class Model:
         Handle typing notifications (in private messages)
         """
         assert event["type"] == "typing"
+
+        TYPING_STARTED_EXPIRY_PERIOD = 15
+
         if hasattr(self.controller, "view"):
             # If the user is in pm narrow with the person typing
             narrow = self.narrow
@@ -1012,7 +1015,11 @@ class Model:
                 if event["op"] == "start":
                     user = self.user_dict[event["sender"]["email"]]
                     self.controller.view.set_footer_text(
-                        [" ", ("footer_contrast", user["full_name"]), " is typing..."]
+                        [" ", ("footer_contrast", user["full_name"]), " is typing..."],
+                        # Restore the footer if there hasn't been a corresponding
+                        # typing 'stop' event after a 'start' event for greater
+                        # than 15 seconds.
+                        TYPING_STARTED_EXPIRY_PERIOD,
                     )
                 elif event["op"] == "stop":
                     self.controller.view.set_footer_text()

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -88,6 +88,7 @@ class WriteBox(urwid.Pile):
         self.send_next_typing_update = datetime.now()
         self.last_key_update = datetime.now()
         self.idle_status_tracking = False
+        self.sent_start_typing_status = False
 
         # Constant indices into self.contents
         # (CONTAINER=vertical, HEADER/MESSAGE=horizontal)
@@ -113,13 +114,19 @@ class WriteBox(urwid.Pile):
         self.view.controller.enter_editor_mode_with(self)
 
     def send_stop_typing_status(self) -> None:
-        # Send 'stop' updates only for PM narrows.
-        if self.to_write_box and self.recipient_user_ids:
+        # Send 'stop' updates only for PM narrows, when there are recipients
+        # to send to and a prior 'start' status has already been sent.
+        if (
+            self.to_write_box
+            and self.recipient_user_ids
+            and self.sent_start_typing_status
+        ):
             self.model.send_typing_status_by_user_ids(
                 self.recipient_user_ids, status="stop"
             )
             self.send_next_typing_update = datetime.now()
             self.idle_status_tracking = False
+            self.sent_start_typing_status = False
 
     def private_box_view(
         self,
@@ -201,6 +208,7 @@ class WriteBox(urwid.Pile):
                         self.recipient_user_ids, status="start"
                     )
                     self.send_next_typing_update += start_period_delta
+                    self.sent_start_typing_status = True
                     # Initiate tracker function only if it isn't already
                     # initiated.
                     if not self.idle_status_tracking:


### PR DESCRIPTION
- The first commit adds a 'state' boolean that indicates whether a typing `start` event has been sent, so as to avoid sending unnecessary `stop` events.
- The second commit adds assertions within the `_handle_typing_event()` tests, to assert on the message being passed to the footer call based on the `op`.
- The third commit adds a duration of 15 seconds to the `set_footer_text()` function call so that the footer doesn't get stuck displaying the 'is typing...' status when it doesn't receive a `stop` event.
 
Fixes #885.