### PR TITLE
refactor: Clarify draft types & naming

### DIFF
--- a/zulipterminal/api_types.py
+++ b/zulipterminal/api_types.py
@@ -6,6 +6,23 @@ from typing_extensions import Literal, TypedDict
 EditPropagateMode = Literal['change_one', 'change_all', 'change_later']
 
 
+class PrivateComposition(TypedDict):
+    type: Literal['private']
+    content: str
+    to: List[str]  # emails  # TODO: Migrate to using List[int] (user ids)
+
+
+class StreamComposition(TypedDict):
+    type: Literal['stream']
+    content: str
+    to: str  # stream name  # TODO: Migrate to using int (stream id)
+    subject: str  # TODO: Migrate to using topic
+    stream_id: int  # FIXME: Not type of API; use until migrate to stream id
+
+
+Composition = Union[PrivateComposition, StreamComposition]
+
+
 class Message(TypedDict, total=False):
     id: int
     sender_id: int

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -12,7 +12,7 @@ import urwid
 import zulip
 from typing_extensions import Literal
 
-from zulipterminal.api_types import Message
+from zulipterminal.api_types import Composition, Message
 from zulipterminal.config.themes import ThemeSpec
 from zulipterminal.helper import asynch
 from zulipterminal.model import Model
@@ -262,10 +262,10 @@ class Controller:
         if 0 <= focus_position < len(w_list):
             self.view.message_view.set_focus(focus_position)
 
-    def save_draft_confirmation_popup(self, message: Message) -> None:
+    def save_draft_confirmation_popup(self, draft: Composition) -> None:
         question = urwid.Text('Save this message as a draft?'
                               ' (This will overwrite the existing draft.)')
-        save_draft = partial(self.model.save_draft, message)
+        save_draft = partial(self.model.save_draft, draft)
         self.loop.widget = PopUpConfirmationView(self, question, save_draft)
 
     def stream_muting_confirmation_popup(self, button: Any) -> None:

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -24,7 +24,7 @@ import zulip
 from typing_extensions import Literal
 
 from zulipterminal import unicode_emojis
-from zulipterminal.api_types import EditPropagateMode, Event
+from zulipterminal.api_types import Composition, EditPropagateMode, Event
 from zulipterminal.config.keys import primary_key_for_command
 from zulipterminal.helper import (
     Message,
@@ -127,7 +127,7 @@ class Model:
 
         self.unread_counts = classify_unread_counts(self)
 
-        self._draft: Optional[Message] = None
+        self._draft: Optional[Composition] = None
         unicode_emoji_data = unicode_emojis.EMOJI_DATA
         for name, data in unicode_emoji_data.items():
             data['type'] = 'unicode_emoji'
@@ -333,11 +333,11 @@ class Model:
             response = self.client.add_reaction(reaction_to_toggle_spec)
         display_error_if_present(response, self.controller)
 
-    def session_draft_message(self) -> Optional[Message]:
+    def session_draft_message(self) -> Optional[Composition]:
         return deepcopy(self._draft)
 
-    def save_draft(self, message: Message) -> None:
-        self._draft = deepcopy(message)
+    def save_draft(self, draft: Composition) -> None:
+        self._draft = deepcopy(draft)
         self.controller.view.set_footer_text("Saved message as draft", 3)
 
     @asynch

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -224,12 +224,12 @@ class View(urwid.WidgetWrap):
             if saved_draft:
                 if saved_draft['type'] == 'stream':
                     self.write_box.stream_box_view(
-                        caption=saved_draft['display_recipient'],
+                        caption=saved_draft['to'],
                         title=saved_draft['subject'],
                         stream_id=saved_draft['stream_id'],
                     )
                 elif saved_draft['type'] == 'private':
-                    email_list = saved_draft['display_recipient']
+                    email_list = saved_draft['to']
                     recipient_user_ids = [
                         self.model.user_dict[email.strip()]['user_id']
                         for email in email_list


### PR DESCRIPTION
Previously a draft was a Message, which is a much more complex data
structure received from the server with differently-named fields. The
draft system only requires the data which is subsequently sent via
the send_message API call, so a simpler API-specific set of data
structures are created and used for drafts named ~ Composition.

Other than typing, the new data structures allow space to define where
we wish to move to use newer API forms (ids vs strings) in future. An
extra 'stream_id' field is present in StreamComposition, not present in
the API, until we migrate to use IDs.

To emphasize the message/draft distinction and migration, variable names
are also updated to match.