### PR TITLE
Clarify StreamComposition and apply to message-sending 

### DIFF
--- a/zulipterminal/api_types.py
+++ b/zulipterminal/api_types.py
@@ -17,7 +17,6 @@ class StreamComposition(TypedDict):
     content: str
     to: str  # stream name  # TODO: Migrate to using int (stream id)
     subject: str  # TODO: Migrate to using topic
-    stream_id: int  # FIXME: Not type of API; use until migrate to stream id
 
 
 Composition = Union[PrivateComposition, StreamComposition]

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -24,7 +24,13 @@ import zulip
 from typing_extensions import Literal
 
 from zulipterminal import unicode_emojis
-from zulipterminal.api_types import Composition, EditPropagateMode, Event
+from zulipterminal.api_types import (
+    Composition,
+    EditPropagateMode,
+    Event,
+    PrivateComposition,
+    StreamComposition,
+)
 from zulipterminal.config.keys import primary_key_for_command
 from zulipterminal.helper import (
     Message,
@@ -378,12 +384,12 @@ class Model:
     def send_private_message(self, recipients: List[str],
                              content: str) -> bool:
         if recipients:
-            request = {
-                'type': 'private',
-                'to': recipients,
-                'content': content,
-            }
-            response = self.client.send_message(request)
+            composition = PrivateComposition(
+                type='private',
+                to=recipients,
+                content=content,
+            )
+            response = self.client.send_message(composition)
             display_error_if_present(response, self.controller)
             return response['result'] == 'success'
         else:
@@ -391,13 +397,13 @@ class Model:
 
     def send_stream_message(self, stream: str, topic: str,
                             content: str) -> bool:
-        request = {
-            'type': 'stream',
-            'to': stream,
-            'subject': topic,
-            'content': content,
-        }
-        response = self.client.send_message(request)
+        composition = StreamComposition(
+            type='stream',
+            to=stream,
+            subject=topic,
+            content=content,
+        )
+        response = self.client.send_message(composition)
         display_error_if_present(response, self.controller)
         return response['result'] == 'success'
 

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -223,10 +223,13 @@ class View(urwid.WidgetWrap):
             saved_draft = self.model.session_draft_message()
             if saved_draft:
                 if saved_draft['type'] == 'stream':
+                    stream_id = self.model.stream_id_from_name(
+                        saved_draft['to']
+                    )
                     self.write_box.stream_box_view(
                         caption=saved_draft['to'],
                         title=saved_draft['subject'],
-                        stream_id=saved_draft['stream_id'],
+                        stream_id=stream_id,
                     )
                 elif saved_draft['type'] == 'private':
                     email_list = saved_draft['to']

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -559,7 +559,6 @@ class WriteBox(urwid.Pile):
                         to=self.stream_write_box.edit_text,
                         content=self.msg_write_box.edit_text,
                         subject=self.title_write_box.edit_text,
-                        stream_id=self.stream_id,  # FIXME Migrate to ids
                     )
                 saved_draft = self.model.session_draft_message()
                 if not saved_draft:


### PR DESCRIPTION
This removes the non-API stream_id field from StreamComposition, allowing it to be used more widely.