### PR TITLE
feature: Capture screenshots in ZT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ zulip_term.egg-info
 *.log
 zt_venv/*
 zulip-terminal-venv/*
+screenshots/*
 
 ## Config files
 zuliprc

--- a/docs/hotkeys.md
+++ b/docs/hotkeys.md
@@ -13,6 +13,7 @@
 |Redraw screen|<kbd>ctrl</kbd> + <kbd>l</kbd>|
 |Quit|<kbd>ctrl</kbd> + <kbd>c</kbd>|
 |View user information (From Users list)|<kbd>i</kbd>|
+|Capture screenshot of the window|<kbd>meta</kbd> + <kbd>c</kbd>|
 
 ## Navigation
 |Command|Key Combination|

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,8 @@ dev_helper_deps = [
     "gitlint>=0.10",
     "autopep8~=1.5.4",
     "autoflake~=1.3.1",
+    "pyscreenshot>=2.3",
+    "Pillow>=8.1.2",
 ]
 
 setup(

--- a/tools/capture_screenshot.py
+++ b/tools/capture_screenshot.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+
+# Script to capture screenshot, and save them to screenshots/
+
+import os
+from datetime import datetime
+
+import pyscreenshot as ImageGrab
+
+
+DIR = "screenshots"
+
+
+def stdout(cmd: str) -> str:
+    output = str(os.popen(cmd).read())
+    # Truncate the output string (original: '<output>\n')
+    return output[:-1]
+
+
+def capture_curr_screen() -> None:
+    # Getting the active window id
+    win_id = stdout("xprop -root 32x '\t$0' _NET_ACTIVE_WINDOW | cut -f 2")
+    win_info = f"xwininfo -id {win_id} | grep "
+
+    # Get window dimensions
+    left_x = int(stdout(f"{win_info}'Absolute upper-left X'")[26:])
+    top_y = int(stdout(f"{win_info}'Absolute upper-left Y'")[26:])
+    right_x = int(stdout(f"{win_info}Width")[9:]) + left_x
+    bottom_y = int(stdout(f"{win_info}Height")[9:]) + top_y
+
+    dimensions = (left_x, top_y, right_x, bottom_y)
+
+    # If the directory doesn't exists, create it
+    if not os.path.isdir(DIR):
+        os.mkdir(DIR)
+
+    # Set filename as the timestamp of capture
+    date = datetime.now().replace(microsecond=0)
+    path = f"{DIR}/Screenshot from {date}.png"
+
+    # Capture and save the screenshot
+    ImageGrab.grab(bbox=dimensions).save(path)
+
+
+if __name__ == "__main__":
+    capture_curr_screen()

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -387,6 +387,11 @@ KEY_BINDINGS: 'OrderedDict[str, KeyBinding]' = OrderedDict([
         'help_text': 'Show/hide full raw message (from message information)',
         'key_category': 'msg_actions',
     }),
+    ('CAPTURE_SCREEN', {
+        'keys': ['meta c'],
+        'help_text': 'Capture screenshot of the window',
+        'key_category': 'general',
+    }),
 ])
 # fmt: on
 

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -15,6 +15,7 @@ import urwid
 import zulip
 from typing_extensions import Literal
 
+from tools.capture_screenshot import capture_curr_screen
 from zulipterminal.api_types import Composition, Message
 from zulipterminal.config.themes import ThemeSpec
 from zulipterminal.helper import asynch, suppress_output
@@ -153,6 +154,9 @@ class Controller:
             sys.stdout.write("\b" * len(next_spinner))
 
         self.capture_stdout()
+
+    def capture_screen(self) -> None:
+        capture_curr_screen()
 
     def capture_stdout(self) -> None:
         if hasattr(self, "_stdout"):

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -302,6 +302,10 @@ class View(urwid.WidgetWrap):
         elif is_command_key("ABOUT", key):
             self.controller.show_about()
             return key
+        elif is_command_key("CAPTURE_SCREEN", key):
+            self.controller.capture_screen()
+            self.set_footer_text("Screenshot saved successfully!", 3)
+            return key
         elif is_command_key("HELP", key):
             # Show help menu
             self.controller.show_help()


### PR DESCRIPTION
This PR adds a feature to capture the screen of ZT using the hotkey `meta c`.
The screenshots are saved locally in `screenshots/` (format: `png`)

This PR could also potentially be an initial step in automating screenshots update in docs :)