### PR TITLE
bugfix: boxes: Call typing status method only when recipients exist.

### DIFF
--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -41,6 +41,18 @@ class TestWriteBox:
         assert write_box.view == self.view
         assert write_box.msg_edit_id is None
 
+    def test_not_calling_typing_method_without_recipients(self, mocker,
+                                                          write_box):
+        write_box.model.send_typing_status_by_user_ids = mocker.Mock()
+        write_box.private_box_view(emails=[], recipient_user_ids=[])
+        # Set idle_status_tracking to True to avoid setting off the
+        # idleness tracker function.
+        write_box.idle_status_tracking = True
+        # Changing the edit_text triggers on_type_send_status.
+        write_box.msg_write_box.edit_text = "random text"
+
+        assert not write_box.model.send_typing_status_by_user_ids.called
+
     @pytest.mark.parametrize('text, state', [
         ('Plain Text', 0),
         ('Plain Text', 1),

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -179,7 +179,7 @@ class WriteBox(urwid.Pile):
         stop_period_delta = timedelta(seconds=TYPING_STOPPED_WAIT_PERIOD)
 
         def on_type_send_status(edit: object, new_edit_text: str) -> None:
-            if new_edit_text:
+            if new_edit_text and self.recipient_user_ids:
                 self.last_key_update = datetime.now()
                 if self.last_key_update > self.send_next_typing_update:
                     self.model.send_typing_status_by_user_ids(


### PR DESCRIPTION
This PR adds a commit that prevents calling `model`'s `send_typing_status_by_user_ids` method without recipients specified.
I've also added a test for the same.