### PR TITLE
Enhance validation and check for bad/no recipients in PMs

### DIFF
--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -122,8 +122,13 @@ class TestWriteBox:
             "untidy_middle_recipient_out_of_three",
         ],
     )
-    @pytest.mark.parametrize("key", keys_for_command("CYCLE_COMPOSE_FOCUS"))
-    def test_tidying_recipients_on_cycling_out(
+    @pytest.mark.parametrize(
+        "key",
+        keys_for_command("SEND_MESSAGE")
+        + keys_for_command("SAVE_AS_DRAFT")
+        + keys_for_command("CYCLE_COMPOSE_FOCUS"),
+    )
+    def test_tidying_recipients_on_keypresses(
         self, mocker, write_box, widget_size, key, raw_recipients, tidied_recipients
     ):
         write_box.model.is_valid_private_recipient = mocker.Mock(return_value=True)
@@ -148,7 +153,12 @@ class TestWriteBox:
         ],
         ids=["name_email_mismatch", "no_name_specified", "no_email_specified"],
     )
-    @pytest.mark.parametrize("key", keys_for_command("CYCLE_COMPOSE_FOCUS"))
+    @pytest.mark.parametrize(
+        "key",
+        keys_for_command("SEND_MESSAGE")
+        + keys_for_command("SAVE_AS_DRAFT")
+        + keys_for_command("CYCLE_COMPOSE_FOCUS"),
+    )
     def test_footer_notification_on_invalid_recipients(
         self,
         write_box,

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -176,7 +176,14 @@ class TestWriteBox:
 
         write_box.to_write_box.edit_text = raw_recipients
         write_box.to_write_box.set_edit_pos(len(raw_recipients))
-        expected_lines = "Invalid recipient(s) - " + invalid_recipients
+        expected_lines = [
+            "Invalid recipient(s) - " + invalid_recipients,
+            " - Use ",
+            ("footer_contrast", primary_key_for_command("AUTOCOMPLETE")),
+            " or ",
+            ("footer_contrast", primary_key_for_command("AUTOCOMPLETE_REVERSE")),
+            " to autocomplete.",
+        ]
 
         size = widget_size(write_box)
         write_box.keypress(size, key)

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1019,9 +1019,8 @@ class Model:
                 else:
                     raise RuntimeError("Unknown typing event operation")
 
-    def get_invalid_recipient_emails(self, recipient_emails: List[str]) -> List[str]:
-
-        return [email for email in recipient_emails if email not in self.user_dict]
+    def is_valid_private_recipient(self, recipient_email: str) -> bool:
+        return recipient_email in self.user_dict
 
     def is_valid_stream(self, stream_name: str) -> bool:
         for stream in self.stream_dict.values():

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1019,8 +1019,15 @@ class Model:
                 else:
                     raise RuntimeError("Unknown typing event operation")
 
-    def is_valid_private_recipient(self, recipient_email: str) -> bool:
-        return recipient_email in self.user_dict
+    def is_valid_private_recipient(
+        self,
+        recipient_email: str,
+        recipient_name: str,
+    ) -> bool:
+        return (
+            recipient_email in self.user_dict
+            and self.user_dict[recipient_email]["full_name"] == recipient_name
+        )
 
     def is_valid_stream(self, stream_name: str) -> bool:
         for stream in self.stream_dict.values():

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -247,9 +247,17 @@ class WriteBox(urwid.Pile):
         write_box.edit_pos = len(write_box.edit_text)
 
         if invalid_recipients:
-            invalid_recipients_error = (
-                f"Invalid recipient(s) - {', '.join(invalid_recipients)}"
-            )
+            invalid_recipients_error = [
+                "Invalid recipient(s) - " + ", ".join(invalid_recipients),
+                " - Use ",
+                ("footer_contrast", primary_key_for_command("AUTOCOMPLETE")),
+                " or ",
+                (
+                    "footer_contrast",
+                    primary_key_for_command("AUTOCOMPLETE_REVERSE"),
+                ),
+                " to autocomplete.",
+            ]
             self.view.controller.report_error(invalid_recipients_error)
             return False
 

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -600,6 +600,11 @@ class WriteBox(urwid.Pile):
                         msg_id=self.msg_edit_id,
                     )
                 else:
+                    all_valid = self._tidy_valid_recipients_and_notify_invalid_ones(
+                        self.to_write_box
+                    )
+                    if not all_valid:
+                        return key
                     self.update_recipient_emails(self.to_write_box)
                     if self.recipient_emails:
                         success = self.model.send_private_message(
@@ -626,6 +631,11 @@ class WriteBox(urwid.Pile):
         elif is_command_key("SAVE_AS_DRAFT", key):
             if not self.msg_edit_id:
                 if self.to_write_box:
+                    all_valid = self._tidy_valid_recipients_and_notify_invalid_ones(
+                        self.to_write_box
+                    )
+                    if not all_valid:
+                        return key
                     self.update_recipient_emails(self.to_write_box)
                     this_draft: Composition = PrivateComposition(
                         type="private",

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -651,9 +651,12 @@ class WriteBox(urwid.Pile):
                         header.focus_col = self.FOCUS_HEADER_BOX_STREAM
                 else:
                     self.update_recipient_emails(self.to_write_box)
-                    invalid_emails = self.model.get_invalid_recipient_emails(
-                        self.recipient_emails
-                    )
+                    invalid_emails = [
+                        recipient_email
+                        for recipient_email in self.recipient_emails
+                        if not self.model.is_valid_private_recipient(recipient_email)
+                    ]
+
                     if invalid_emails:
                         invalid_emails_error = (
                             f"Invalid recipient(s) - {', '.join(invalid_emails)}"


### PR DESCRIPTION
This PR adds a commit that refactors the `get_invalid_recipients_emails()` method
of the model to `check_recipient_validity()` which checks if the
recipient's name and email match.

This commit follows this strategy:
* Ensures that the email and the name are of the same user.
* Removes extra text after the email.

The recipients' information is also tidied for all the valid recipients,
by formatting the information to fit the `name <email>` format.