### PR TITLE
bugfix: starred messages: Update messages in starred narrow.

### DIFF
--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -1531,7 +1531,10 @@ class TestModel:
         operation, model.server_feature_level = update_message_flags_operation
 
         model.index = dict(messages={msg_id: {'flags': flags_before}
-                                     for msg_id in indexed_ids})
+                                     for msg_id in indexed_ids},
+                           starred_msg_ids=set([msg_id
+                                                for msg_id in indexed_ids
+                                                if 'starred' in flags_before]))
         event = {
             'type': 'update_message_flags',
             'messages': event_message_ids,
@@ -1543,7 +1546,10 @@ class TestModel:
         set_count = mocker.patch('zulipterminal.model.set_count')
 
         model._handle_update_message_flags_event(event)
-
+        assert (model.index['starred_msg_ids']
+                == set([message_id for message_id, flags_list
+                        in model.index['messages'].items()
+                        if 'starred' in flags_list['flags']]))
         changed_ids = set(indexed_ids) & set(event_message_ids)
         for changed_id in changed_ids:
             assert model.index['messages'][changed_id]['flags'] == flags_after

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1153,9 +1153,14 @@ class Model:
             if operation == 'add':
                 if flag_to_change not in msg['flags']:
                     msg['flags'].append(flag_to_change)
+                if flag_to_change == 'starred':
+                    self.index['starred_msg_ids'].add(message_id)
             elif operation == 'remove':
                 if flag_to_change in msg['flags']:
                     msg['flags'].remove(flag_to_change)
+                if(message_id in self.index['starred_msg_ids']
+                   and flag_to_change == 'starred'):
+                    self.index['starred_msg_ids'].remove(message_id)
             else:
                 raise RuntimeError(event, msg['flags'])
 

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -113,7 +113,8 @@ class MessageView(urwid.ListBox):
         ids_to_keep = self.model.get_message_ids_in_current_narrow()
         if self.log:
             top_message_id = self.log[0].original_widget.message['id']
-            ids_to_keep.remove(top_message_id)  # update this id
+            if top_message_id in ids_to_keep:
+                ids_to_keep.remove(top_message_id)  # update this id
             no_update_baseline = {top_message_id}
         else:
             no_update_baseline = set()


### PR DESCRIPTION
The commit updates ZT behavior in starred message section to match the web app. The current behavior involves removing the message when the user moves out of the starred section.
Fixes #940 .