### PR TITLE
ui/boxes: Improve behaviour of non reply compose keys.

### DIFF
--- a/tests/ui/test_ui.py
+++ b/tests/ui/test_ui.py
@@ -243,6 +243,18 @@ class TestView:
         view.model.controller.show_all_mentions.assert_called_once_with(view)
         assert view.body.focus_col == 1
 
+    @pytest.mark.parametrize('key', keys_for_command('STREAM_MESSAGE'))
+    def test_keypress_STREAM_MESSAGE(self, view, mocker, key, widget_size):
+        view.middle_column = mocker.Mock()
+        view.body = mocker.Mock()
+        view.controller.is_in_editor_mode = lambda: False
+        size = widget_size(view)
+
+        returned_key = view.keypress(size, key)
+        view.middle_column.keypress.assert_called_once_with(size, key)
+        assert returned_key == key
+        assert view.body.focus_col == 1
+
     @pytest.mark.parametrize('key', keys_for_command('SEARCH_PEOPLE'))
     @pytest.mark.parametrize('autohide', [True, False], ids=[
         'autohide', 'no_autohide'])

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1858,6 +1858,32 @@ class TestMessageBox:
             assert label[0].text == 'EDITED'
             assert label[1][1] == 7
 
+    @pytest.mark.parametrize('key', keys_for_command('STREAM_MESSAGE'))
+    @pytest.mark.parametrize('narrow', [
+        [],
+        [['stream', 'general']],
+        [['stream', 'general'], ['topic', 'Test']],
+        [['is', 'starred']],
+        [['is', 'mentioned']],
+        [['is', 'private']],
+        [['pm_with', 'notification-bot@zulip.com']],
+    ], ids=['all_messages_narrow', 'stream_narrow', 'topic_narrow',
+            'private_conversation_narrow', 'starred_messages_narrow',
+            'mentions_narrow', 'private_messages_narrow'])
+    def test_keypress_STREAM_MESSAGE(self, mocker, msg_box, widget_size,
+                                     narrow, key):
+        write_box = msg_box.model.controller.view.write_box
+        msg_box.model.narrow = narrow
+        size = widget_size(msg_box)
+        msg_box.keypress(size, key)
+        if len(narrow) != 2:
+            write_box.stream_box_view.assert_called_once_with(0)
+        else:
+            write_box.stream_box_view.assert_called_once_with(
+                caption='PTEST',
+                stream_id=205,
+            )
+
     @pytest.mark.parametrize('key', keys_for_command('EDIT_MESSAGE'))
     @pytest.mark.parametrize(['to_vary_in_each_message',
                               'realm_editing_allowed',

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -183,6 +183,7 @@ class View(urwid.WidgetWrap):
         elif (is_command_key('SEARCH_MESSAGES', key)
                 or is_command_key('NEXT_UNREAD_TOPIC', key)
                 or is_command_key('NEXT_UNREAD_PM', key)
+                or is_command_key('STREAM_MESSAGE', key)
                 or is_command_key('PRIVATE_MESSAGE', key)):
             self.body.focus_col = 1
             self.middle_column.keypress(size, key)

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -1388,16 +1388,13 @@ class MessageBox(urwid.Pile):
                     stream_id=self.stream_id,
                 )
         elif is_command_key('STREAM_MESSAGE', key):
-            if self.message['type'] == 'private':
-                self.model.controller.view.write_box.private_box_view(
-                    emails=self.recipient_emails,
-                    recipient_user_ids=self.recipient_ids,
-                )
-            elif self.message['type'] == 'stream':
+            if len(self.model.narrow) == 2:
                 self.model.controller.view.write_box.stream_box_view(
                     caption=self.message['display_recipient'],
                     stream_id=self.stream_id,
                 )
+            else:
+                self.model.controller.view.write_box.stream_box_view(0)
         elif is_command_key('STREAM_NARROW', key):
             if self.message['type'] == 'private':
                 self.model.controller.narrow_to_user(self)


### PR DESCRIPTION
Brings in consistent behaviour for use of non reply compose keys `x`/`c`.
Now, keypresses `x` and `c` always opens up `private_box_view` and
`stream_box_view` respectively.

Earlier, non reply compose hotkeys were configured for use only when focus
was on the `MiddleColumnView`. This commit expands its scope to enable use
of `x`/`c` even when focus is on users list, stream list, topics list, or
top buttons.

Tests added.

Fixes #871