### PR TITLE
refactor: Migrate to f-strings in tests wherever reasonable.

### DIFF
--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -113,8 +113,8 @@ def test_valid_zuliprc_but_no_connection(capsys, mocker, minimal_zuliprc,
         "   maximum footlinks value '3' specified with no config.",
         "   color depth setting '256' specified with no config.",
         "\x1b[91m",
-        ("Error connecting to Zulip server: {}.\x1b[0m".
-            format(server_connection_error)),
+        ("Error connecting to Zulip server: "
+         f"{server_connection_error}.\x1b[0m"),
     ]
     assert lines == expected_lines
 
@@ -144,17 +144,17 @@ def test_warning_regarding_incomplete_theme(capsys, mocker, monkeypatch,
     lines = captured.out.strip().split("\n")
     expected_lines = [
         "Loading with:",
-        "   theme '{}' specified on command line.".format(bad_theme),
+        f"   theme '{bad_theme}' specified on command line.",
         "\x1b[93m"
         "   WARNING: Incomplete theme; results may vary!",
-        "      (you could try: {}, {})"
-        "\x1b[0m".format('a', 'b'),
+        f"      (you could try: {'a'}, {'b'})"
+        "\x1b[0m",
         "   autohide setting 'no_autohide' specified with no config.",
         "   maximum footlinks value '3' specified with no config.",
         "   color depth setting '256' specified with no config.",
         "\x1b[91m",
-        ("Error connecting to Zulip server: {}.\x1b[0m".
-            format(server_connection_error)),
+        ("Error connecting to Zulip server: "
+         f"{server_connection_error}.\x1b[0m"),
     ]
     assert lines == expected_lines
 
@@ -200,8 +200,8 @@ def test_main_multiple_autohide_options(capsys, options):
     captured = capsys.readouterr()
     lines = captured.err.strip('\n')
     lines = lines.split("pytest: ", 1)[1]
-    expected = ("error: argument {}: not allowed "
-                "with argument {}".format(options[1], options[0]))
+    expected = (f"error: argument {options[1]}: not allowed "
+                f"with argument {options[0]}")
     assert lines == expected
 
 
@@ -364,7 +364,7 @@ def test_exit_with_error(error_code, helper_text,
     captured = capsys.readouterr()
     lines = captured.out.strip().split("\n")
 
-    expected_line = "\033[91m{}\033[0m".format(error_message)
+    expected_line = f"\033[91m{error_message}\033[0m"
     assert lines[0] == expected_line
 
     if helper_text:
@@ -380,7 +380,7 @@ def test__write_zuliprc__success(tmpdir, id="id", key="key", url="url"):
 
     assert error_message == ""
 
-    expected_contents = "[api]\nemail={}\nkey={}\nsite={}".format(id, key, url)
+    expected_contents = f"[api]\nemail={id}\nkey={key}\nsite={url}"
     with open(path) as f:
         assert f.read() == expected_contents
 
@@ -424,9 +424,9 @@ def test_show_error_if_loading_zuliprc_with_open_permissions(
 
     lines = captured.out.split('\n')[:-1]
     expected_last_lines = [
-        "(it currently has permissions '{}')".format(current_mode),
+        f"(it currently has permissions '{current_mode}')",
         "This can often be achieved with a command such as:",
-        "  chmod og-rwx {}".format(minimal_zuliprc),
+        f"  chmod og-rwx {minimal_zuliprc}",
         "Consider regenerating the [api] part of your zuliprc to ensure "
         "your account is secure."
         "\x1b[0m"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,8 +89,8 @@ def users_fixture(logged_on_user):
     for i in range(1, 3):
         users.append({
             'user_id': 10 + i,
-            'full_name': 'Human {}'.format(i),
-            'email': 'person{}@example.com'.format(i),
+            'full_name': f"Human {i}",
+            'email': f"person{i}@example.com",
             'avatar_url': None,
             'is_active': True,
             'bot_type': None,
@@ -107,8 +107,8 @@ def user_groups_fixture():
     for i in range(1, 5):
         user_groups.append({
             'id': 10 + i,
-            'name': 'Group {}'.format(i),
-            'description': 'Core developers of Group {}'.format(i),
+            'name': f"Group {i}",
+            'description': f"Core developers of Group {i}",
             'members': members[i - 1],
         })
     return user_groups
@@ -166,19 +166,19 @@ def streams_fixture():
     streams = [general_stream, secret_stream]
     for i in range(1, 3):
         streams.append({
-            'name': 'Stream {}'.format(i),
+            'name': f"Stream {i}",
             'invite_only': False,
             'color': '#b0a5fd',
             'pin_to_top': False,
             'stream_id': i,
             'in_home_view': True,
             'audible_notifications': False,
-            'description': 'A description of stream {}'.format(i),
+            'description': f"A description of stream {i}",
             'is_old_stream': True,
             'desktop_notifications': False,
             'stream_weekly_traffic': 0,
             'push_notifications': False,
-            'email_address': 'stream{}@example.com'.format(i),
+            'email_address': f"stream{i}@example.com",
             'subscribers': [1001, 11, 12]
         })
     return deepcopy(streams)

--- a/tests/helper/test_helper.py
+++ b/tests/helper/test_helper.py
@@ -242,7 +242,7 @@ def test_color_formats(mocker, color):
 def test_invalid_color_format(mocker, color):
     with pytest.raises(ValueError) as e:
         canon = canonicalize_color(color)
-    assert str(e.value) == 'Unknown format for color "{}"'.format(color)
+    assert str(e.value) == f'Unknown format for color "{color}"'
 
 
 @pytest.mark.parametrize('OS, is_notification_sent', [

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -1028,7 +1028,7 @@ class TestModel:
                 target = 'you'
                 if len(message_fixture['display_recipient']) > 2:
                     target += ', Bar Bar'
-            title = 'Test Organization Name:\nFoo Foo (to {})'.format(target)
+            title = f"Test Organization Name:\nFoo Foo (to {target})"
             # TODO: Test message content too?
             notify.assert_called_once_with(title, mocker.ANY)
         else:

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1367,8 +1367,7 @@ class TestMessageBox:
          [('msg_link', 'blah.gif'), ' ', ('msg_link_index', '[1]')]),
         ('<a href="/api"',
          [('msg_link', '/api'), ' ', ('msg_link_index', '[1]')]),
-        ('<a href="some/relative_url">{}/some/relative_url</a>'
-         .format(SERVER_URL),
+        (f'<a href="some/relative_url">{SERVER_URL}/some/relative_url</a>',
          [('msg_link', '/some/relative_url'), ' ', ('msg_link_index', '[1]')]),
         ('<a href="http://foo.com/bar">foo.com/bar</a>',
          [('msg_link', 'foo.com'), ' ', ('msg_link_index', '[1]')]),
@@ -1459,11 +1458,11 @@ class TestMessageBox:
         ('<time datetime="2020-08-07T04:30:00Z"> Fri, Aug 7 2020, 10:00AM IST'
          '</time>', [(
             'msg_time',
-            ' {} Fri, Aug 7 2020, 10:00 (IST) '.format(TIME_MENTION_MARKER)
+            f" {TIME_MENTION_MARKER} Fri, Aug 7 2020, 10:00 (IST) "
          )]),
         ('<time datetime="2020-08-11T16:32:58Z"> 1597163578</time>', [(
             'msg_time',
-            ' {} Tue, Aug 11 2020, 22:02 (IST) '.format(TIME_MENTION_MARKER)
+            f" {TIME_MENTION_MARKER} Tue, Aug 11 2020, 22:02 (IST) "
          )]),
         ('<span class="katex-display">some-math</span>', ['some-math']),
         ('<span class="katex">some-math</span>', ['some-math']),
@@ -1714,15 +1713,15 @@ class TestMessageBox:
 
     @pytest.mark.parametrize(['msg_narrow', 'msg_type', 'assert_header_bar',
                               'assert_search_bar'], [
-        ([], 0, "PTEST {} ".format(STREAM_TOPIC_SEPARATOR),
+        ([], 0, f"PTEST {STREAM_TOPIC_SEPARATOR} ",
          'All messages'),
         ([], 1, 'You and ', 'All messages'),
         ([], 2, 'You and ', 'All messages'),
         ([['stream', 'PTEST']], 0,
-         'PTEST {} '.format(STREAM_TOPIC_SEPARATOR),
+         f"PTEST {STREAM_TOPIC_SEPARATOR} ",
          ('bar', [('s#bd6', 'PTEST')])),
         ([['stream', 'PTEST'], ['topic', 'b']], 0,
-         'PTEST {}'.format(STREAM_TOPIC_SEPARATOR),
+         f"PTEST {STREAM_TOPIC_SEPARATOR}",
          ('bar', [('s#bd6', 'PTEST'), ('s#bd6', ': topic narrow')])),
         ([['is', 'private']], 1, 'You and ', 'All private messages'),
         ([['is', 'private']], 2, 'You and ', 'All private messages'),
@@ -1731,16 +1730,16 @@ class TestMessageBox:
         ([['pm_with', 'boo@zulip.com, bar@zulip.com']], 2, 'You and ',
          'Group private conversation'),
         ([['is', 'starred']], 0,
-         'PTEST {} '.format(STREAM_TOPIC_SEPARATOR),
+         f"PTEST {STREAM_TOPIC_SEPARATOR} ",
          'Starred messages'),
         ([['is', 'starred']], 1, 'You and ', 'Starred messages'),
         ([['is', 'starred']], 2, 'You and ', 'Starred messages'),
         ([['is', 'starred'], ['search', 'FOO']], 1, 'You and ',
          'Starred messages'),
         ([['search', 'FOO']], 0,
-         'PTEST {} '.format(STREAM_TOPIC_SEPARATOR), 'All messages'),
+         f"PTEST {STREAM_TOPIC_SEPARATOR} ", 'All messages'),
         ([['is', 'mentioned']], 0,
-         'PTEST {} '.format(STREAM_TOPIC_SEPARATOR), 'Mentions'),
+         f"PTEST {STREAM_TOPIC_SEPARATOR} ", 'Mentions'),
         ([['is', 'mentioned']], 1, 'You and ', 'Mentions'),
         ([['is', 'mentioned']], 2, 'You and ', 'Mentions'),
         ([['is', 'mentioned'], ['search', 'FOO']], 1, 'You and ',
@@ -2245,7 +2244,7 @@ class TestMessageBox:
 
     @pytest.mark.parametrize(
         'key', keys_for_command('ENTER'),
-        ids=lambda param: 'left_click-key:{}'.format(param)
+        ids=lambda param: f"left_click-key:{param}"
     )
     def test_mouse_event_left_click(self, mocker, msg_box, key, widget_size,
                                     compose_box_is_open):

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -561,7 +561,7 @@ class TestWriteBox:
                                 'zulipterminal.ui.View.set_typeahead_footer')
         # Use an example formatting to differentiate between
         # typeaheads and suggestions.
-        typeaheads = ['*{}*'.format(s) for s in suggestions]
+        typeaheads = [f"*{s}*" for s in suggestions]
 
         typeahead = write_box._process_typeaheads(typeaheads, state,
                                                   suggestions)


### PR DESCRIPTION
Some expressions are tidy enough in the current format and are therefore excluded.