### PR TITLE
refactor/bugfix: Migrate keypress to using commands instead of hardcoded keys.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 import pytest
 
-from zulipterminal.config.keys import keys_for_command
+from zulipterminal.config.keys import keys_for_command, primary_key_for_command
 from zulipterminal.helper import initial_index as helper_initial_index
 from zulipterminal.ui_tools.boxes import MessageBox
 from zulipterminal.ui_tools.buttons import StreamButton, TopicButton, UserButton
@@ -1108,8 +1108,8 @@ def classified_unread_counts():
 
 @pytest.fixture(
     params=[
-        ("mouse press", 4, "up"),
-        ("mouse press", 5, "down"),
+        ("mouse press", 4, primary_key_for_command("GO_UP")),
+        ("mouse press", 5, primary_key_for_command("GO_DOWN")),
     ],
     ids=[
         "mouse_scroll_up",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1108,6 +1108,23 @@ def classified_unread_counts():
 
 @pytest.fixture(
     params=[
+        ("mouse press", 4, "up"),
+        ("mouse press", 5, "down"),
+    ],
+    ids=[
+        "mouse_scroll_up",
+        "mouse_scroll_down",
+    ],
+)
+def mouse_scroll_event(request):
+    """
+    Returns required parameters for mouse_event keypress
+    """
+    return request.param
+
+
+@pytest.fixture(
+    params=[
         (key, expected_key)
         for keys, expected_key in [
             (keys_for_command("GO_UP"), "up"),

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -720,6 +720,16 @@ class TestTopicsView:
         assert topic_view.log == topic_view.topics_btn_list
         assert topic_view.log.get_focus()[1] == topic_view.focus_index_before_search
 
+    def test_mouse_event(self, mocker, topic_view, mouse_scroll_event, widget_size):
+        event, button, key = mouse_scroll_event
+        mocker.patch.object(topic_view, "keypress")
+        size = widget_size(topic_view)
+        col = 1
+        row = 1
+        focus = "WIDGET"
+        topic_view.mouse_event(size, event, button, col, row, focus)
+        topic_view.keypress.assert_called_once_with(size, key)
+
 
 class TestUsersView:
     @pytest.fixture

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -7,7 +7,7 @@ from bs4 import BeautifulSoup
 from pytest import param as case
 from urwid import Columns, Divider, Padding, Text
 
-from zulipterminal.config.keys import keys_for_command
+from zulipterminal.config.keys import keys_for_command, primary_key_for_command
 from zulipterminal.config.symbols import (
     QUOTED_TEXT_MARKER,
     STATUS_ACTIVE,
@@ -579,7 +579,7 @@ class TestStreamsView:
         stream_view.log.clear()
         stream_view.log.extend(stream_view.streams_btn_list[3])
         stream_view.log.set_focus(0)
-        stream_view.keypress(size, "down")
+        stream_view.keypress(size, primary_key_for_command("GO_DOWN"))
         assert stream_view.log.get_focus()[1] != stream_view.focus_index_before_search
 
         # Exit search
@@ -708,7 +708,7 @@ class TestTopicsView:
         topic_view.log.clear()
         topic_view.log.extend(topic_view.topics_btn_list[3])
         topic_view.log.set_focus(0)
-        topic_view.keypress(size, "down")
+        topic_view.keypress(size, primary_key_for_command("GO_DOWN"))
         assert topic_view.log.get_focus()[1] != topic_view.focus_index_before_search
 
         # Exit search

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -279,14 +279,8 @@ class TestMessageView:
             num_before=0, num_after=30, anchor=0
         )
 
-    @pytest.mark.parametrize(
-        "event, button, keypress",
-        [
-            ("mouse press", 4, "up"),
-            ("mouse press", 5, "down"),
-        ],
-    )
-    def test_mouse_event(self, mocker, msg_view, event, button, keypress, widget_size):
+    def test_mouse_event(self, mocker, msg_view, mouse_scroll_event, widget_size):
+        event, button, keypress = mouse_scroll_event
         mocker.patch.object(msg_view, "keypress")
         size = widget_size(msg_view)
         msg_view.mouse_event(size, event, button, 0, 0, mocker.Mock())
@@ -550,19 +544,15 @@ class TestStreamsView:
             assert hasattr(stream_view.log[0].original_widget, "text")
         self.view.controller.update_screen.assert_called_once_with()
 
-    def test_mouse_event(self, mocker, stream_view, widget_size):
+    def test_mouse_event(self, mocker, stream_view, mouse_scroll_event, widget_size):
+        event, button, key = mouse_scroll_event
         mocker.patch.object(stream_view, "keypress")
         size = widget_size(stream_view)
         col = 1
         row = 1
         focus = "WIDGET"
-        # Left click
-        stream_view.mouse_event(size, "mouse press", 4, col, row, focus)
-        stream_view.keypress.assert_called_once_with(size, "up")
-
-        # Right click
-        stream_view.mouse_event(size, "mouse press", 5, col, row, focus)
-        stream_view.keypress.assert_called_with(size, "down")
+        stream_view.mouse_event(size, event, button, col, row, focus)
+        stream_view.keypress.assert_called_once_with(size, key)
 
     @pytest.mark.parametrize("key", keys_for_command("SEARCH_STREAMS"))
     def test_keypress_SEARCH_STREAMS(self, mocker, stream_view, key, widget_size):
@@ -738,19 +728,15 @@ class TestUsersView:
         controller = mocker.Mock()
         return UsersView(controller, "USER_BTN_LIST")
 
-    def test_mouse_event(self, mocker, user_view, widget_size):
+    def test_mouse_event(self, mocker, user_view, mouse_scroll_event, widget_size):
+        event, button, key = mouse_scroll_event
         mocker.patch.object(user_view, "keypress")
         size = widget_size(user_view)
         col = 1
         row = 1
         focus = "WIDGET"
-        # Left click
-        user_view.mouse_event(size, "mouse press", 4, col, row, focus)
-        user_view.keypress.assert_called_with(size, "up")
-
-        # Right click
-        user_view.mouse_event(size, "mouse press", 5, col, row, focus)
-        user_view.keypress.assert_called_with(size, "down")
+        user_view.mouse_event(size, event, button, col, row, focus)
+        user_view.keypress.assert_called_with(size, key)
 
     def test_mouse_event_left_click(
         self, mocker, user_view, widget_size, compose_box_is_open

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -886,10 +886,9 @@ class TestMiddleColumnView:
         )
         mid_col_view.set_focus.assert_called_once_with("header")
 
-    @pytest.mark.parametrize("enter_key", keys_for_command("ENTER"))
     @pytest.mark.parametrize("reply_message_key", keys_for_command("REPLY_MESSAGE"))
     def test_keypress_REPLY_MESSAGE(
-        self, mid_col_view, mocker, widget_size, reply_message_key, enter_key
+        self, mid_col_view, mocker, widget_size, reply_message_key
     ):
         size = widget_size(mid_col_view)
         mocker.patch(MIDCOLVIEW + ".body")
@@ -899,7 +898,7 @@ class TestMiddleColumnView:
 
         mid_col_view.keypress(size, reply_message_key)
 
-        mid_col_view.body.keypress.assert_called_once_with(size, enter_key)
+        mid_col_view.body.keypress.assert_called_once_with(size, reply_message_key)
         mid_col_view.set_focus.assert_called_once_with("footer")
         assert mid_col_view.footer.focus_position == 1
 

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -222,7 +222,7 @@ class View(urwid.WidgetWrap):
         elif is_command_key("SEARCH_PEOPLE", key):
             # Start User Search if not in editor_mode
             self.body.focus_position = 2
-            self.users_view.keypress(size, "w")
+            self.users_view.keypress(size, key)
             self.show_left_panel(visible=False)
             self.show_right_panel(visible=True)
             self.user_search.set_edit_text("")
@@ -233,7 +233,7 @@ class View(urwid.WidgetWrap):
         ):
             # jump stream search
             self.body.focus_position = 0
-            self.left_panel.keypress(size, "q")
+            self.left_panel.keypress(size, key)
             self.show_right_panel(visible=False)
             self.show_left_panel(visible=True)
             if self.left_panel.is_in_topic_view:

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -1575,7 +1575,7 @@ class MessageBox(urwid.Pile):
         return super().mouse_event(size, event, button, col, row, focus)
 
     def keypress(self, size: urwid_Size, key: str) -> Optional[str]:
-        if is_command_key("ENTER", key):
+        if is_command_key("REPLY_MESSAGE", key):
             if self.message["type"] == "private":
                 self.model.controller.view.write_box.private_box_view(
                     emails=self.recipient_emails,
@@ -1653,7 +1653,7 @@ class MessageBox(urwid.Pile):
                 recipient_user_ids=[self.message["sender_id"]],
             )
         elif is_command_key("MENTION_REPLY", key):
-            self.keypress(size, "enter")
+            self.keypress(size, primary_key_for_command("REPLY_MESSAGE"))
             mention = f"@**{self.message['sender_full_name']}** "
             self.model.controller.view.write_box.msg_write_box.set_edit_text(mention)
             self.model.controller.view.write_box.msg_write_box.set_edit_pos(
@@ -1661,7 +1661,7 @@ class MessageBox(urwid.Pile):
             )
             self.model.controller.view.middle_column.set_focus("footer")
         elif is_command_key("QUOTE_REPLY", key):
-            self.keypress(size, "enter")
+            self.keypress(size, primary_key_for_command("REPLY_MESSAGE"))
 
             # To correctly quote a message that contains quote/code-blocks,
             # we need to fence quoted message containing ``` with ````,
@@ -1723,7 +1723,7 @@ class MessageBox(urwid.Pile):
                         msg_body_edit_enabled = False
 
             if self.message["type"] == "private":
-                self.keypress(size, "enter")
+                self.keypress(size, primary_key_for_command("REPLY_MESSAGE"))
             elif self.message["type"] == "stream":
                 self.model.controller.view.write_box.stream_box_edit_view(
                     stream_id=self.stream_id,

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -649,7 +649,7 @@ class WriteBox(urwid.Pile):
                 self.msg_write_box.edit_text = ""
                 if self.msg_edit_state is not None:
                     self.msg_edit_state = None
-                    self.keypress(size, "esc")
+                    self.keypress(size, primary_key_for_command("GO_BACK"))
         elif is_command_key("GO_BACK", key):
             self.msg_edit_state = None
             self.msg_body_edit_enabled = True
@@ -1846,7 +1846,7 @@ class PanelSearchBox(urwid.Edit):
             self.panel_view.view.controller.exit_editor_mode()
             self.reset_search_text()
             self.panel_view.set_focus("body")
-            self.panel_view.keypress(size, "esc")
+            self.panel_view.keypress(size, primary_key_for_command("GO_BACK"))
         elif is_command_key("ENTER", key) and not self.panel_view.empty_search:
             self.panel_view.view.controller.exit_editor_mode()
             self.set_caption([("filter_results", "Search Results"), " "])

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -201,15 +201,15 @@ class MessageView(urwid.ListBox):
 
         elif is_command_key("SCROLL_UP", key) and not self.old_loading:
             if self.focus is not None and self.focus_position == 0:
-                return self.keypress(size, "up")
+                return self.keypress(size, primary_key_for_command("GO_UP"))
             else:
-                return super().keypress(size, "page up")
+                return super().keypress(size, primary_key_for_command("SCROLL_UP"))
 
         elif is_command_key("SCROLL_DOWN", key) and not self.old_loading:
             if self.focus is not None and self.focus_position == len(self.log) - 1:
-                return self.keypress(size, "down")
+                return self.keypress(size, primary_key_for_command("GO_DOWN"))
             else:
-                return super().keypress(size, "page down")
+                return super().keypress(size, primary_key_for_command("SCROLL_DOWN"))
 
         elif is_command_key("THUMBS_UP", key):
             if self.focus is not None:
@@ -575,8 +575,8 @@ class MiddleColumnView(urwid.Frame):
 
     def keypress(self, size: urwid_Size, key: str) -> Optional[str]:
         if is_command_key("GO_BACK", key):
-            self.header.keypress(size, "esc")
-            self.footer.keypress(size, "esc")
+            self.header.keypress(size, key)
+            self.footer.keypress(size, key)
             self.set_focus("body")
 
         elif self.focus_position in ["footer", "header"]:
@@ -595,7 +595,7 @@ class MiddleColumnView(urwid.Frame):
             return key
 
         elif is_command_key("STREAM_MESSAGE", key):
-            self.body.keypress(size, "c")
+            self.body.keypress(size, key)
             # For new streams with no previous conversation.
             if self.footer.focus is None:
                 stream_id = self.model.stream_id
@@ -606,7 +606,7 @@ class MiddleColumnView(urwid.Frame):
             return key
 
         elif is_command_key("REPLY_AUTHOR", key):
-            self.body.keypress(size, "R")
+            self.body.keypress(size, key)
             if self.footer.focus is not None:
                 self.set_focus("footer")
                 self.footer.focus_position = 1

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -588,7 +588,7 @@ class MiddleColumnView(urwid.Frame):
             return key
 
         elif is_command_key("REPLY_MESSAGE", key):
-            self.body.keypress(size, "enter")
+            self.body.keypress(size, key)
             if self.footer.focus is not None:
                 self.set_focus("footer")
                 self.footer.focus_position = 1

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -13,6 +13,7 @@ from zulipterminal.config.keys import (
     KEY_BINDINGS,
     is_command_key,
     keys_for_command,
+    primary_key_for_command,
 )
 from zulipterminal.config.symbols import (
     CHECK_MARK,
@@ -165,10 +166,10 @@ class MessageView(urwid.ListBox):
     ) -> bool:
         if event == "mouse press":
             if button == 4:
-                self.keypress(size, "up")
+                self.keypress(size, primary_key_for_command("GO_UP"))
                 return True
             if button == 5:
-                self.keypress(size, "down")
+                self.keypress(size, primary_key_for_command("GO_DOWN"))
                 return True
         return super().mouse_event(size, event, button, col, row, focus)
 
@@ -365,10 +366,10 @@ class StreamsView(urwid.Frame):
     ) -> bool:
         if event == "mouse press":
             if button == 4:
-                self.keypress(size, "up")
+                self.keypress(size, primary_key_for_command("GO_UP"))
                 return True
             elif button == 5:
-                self.keypress(size, "down")
+                self.keypress(size, primary_key_for_command("GO_DOWN"))
                 return True
         return super().mouse_event(size, event, button, col, row, focus)
 
@@ -474,10 +475,10 @@ class TopicsView(urwid.Frame):
     ) -> bool:
         if event == "mouse press":
             if button == 4:
-                self.keypress(size, "up")
+                self.keypress(size, primary_key_for_command("GO_UP"))
                 return True
             elif button == 5:
-                self.keypress(size, "down")
+                self.keypress(size, primary_key_for_command("GO_DOWN"))
                 return True
         return super().mouse_event(size, event, button, col, row, focus)
 
@@ -514,11 +515,11 @@ class UsersView(urwid.ListBox):
                     return True
             if button == 4:
                 for _ in range(5):
-                    self.keypress(size, "up")
+                    self.keypress(size, primary_key_for_command("GO_UP"))
                 return True
             elif button == 5:
                 for _ in range(5):
-                    self.keypress(size, "down")
+                    self.keypress(size, primary_key_for_command("GO_DOWN"))
         return super().mouse_event(size, event, button, col, row, focus)
 
 


### PR DESCRIPTION
This PR aims to replace all hard-coded keys in keypress to use their corresponding commands, to make them future-proof. 
Commit flow:
- The first commit is borrowed from @preetmishra's #539, which parametrizes mouse_event calls and adds mouse_event test for `TopicsView`.
- The second commit migrates all instances of hard-coded keys in mouse_events to use `primary_key_for_commands`.
- The third commit replaces all other instances of hard-coded keys in keypress to use their corresponding commands so that they are future-proof.
- The fourth commit is a bugfix that makes `r` for replying to message independent of `ENTER` key.

Our codebase would have no instances of hard-coded keys now. Can be checked using: `git grep keypress\(size`

Fixes #469 and #533.