### PR TITLE
bugfix: views: Restore functionality of keypress `n`.

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -974,10 +974,11 @@ class TestMiddleColumnView:
                                                key):
         size = widget_size(mid_col_view)
         mocker.patch(VIEWS + '.MiddleColumnView.focus_position')
-        topic_btn = mocker.patch(VIEWS + '.TopicButton')
         mocker.patch(VIEWS + '.MiddleColumnView.get_next_unread_topic',
-                     return_value=('stream', 'topic'))
-
+                     return_value=('1', 'topic'))
+        mid_col_view.model.stream_dict = {
+            '1': {'name': 'stream'}
+        }
         mid_col_view.keypress(size, key)
 
         mid_col_view.get_next_unread_topic.assert_called_once_with()
@@ -991,7 +992,6 @@ class TestMiddleColumnView:
                                                   key):
         size = widget_size(mid_col_view)
         mocker.patch(VIEWS + '.MiddleColumnView.focus_position')
-        topic_btn = mocker.patch(VIEWS + '.TopicButton')
         mocker.patch(VIEWS + '.MiddleColumnView.get_next_unread_topic',
                      return_value=None)
 

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -578,9 +578,9 @@ class MiddleColumnView(urwid.Frame):
             stream_topic = self.get_next_unread_topic()
             if stream_topic is None:
                 return key
-            stream, topic = stream_topic
+            stream_id, topic = stream_topic
             self.controller.narrow_to_topic(
-                stream_name=stream,
+                stream_name=self.model.stream_dict[stream_id]['name'],
                 topic_name=topic,
             )
             return key


### PR DESCRIPTION
This commit fixes a bug which originated in commit a9306da0 due to
stream id being passed into `narrow_to_topic` function in place of
stream name.

Tests amended.

Fixes #957.