### PR TITLE
refactor: tests: Add path prefixes for patching class methods

### DIFF
--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -16,6 +16,10 @@ from zulipterminal.model import ServerConnectionFailure
 from zulipterminal.version import ZT_VERSION
 
 
+MODULE = "zulipterminal.cli.run"
+CONTROLLER = MODULE + ".Controller"
+
+
 @pytest.mark.parametrize(
     "color, code",
     [
@@ -50,7 +54,7 @@ def test_get_login_id(mocker, json, label):
     response = mocker.Mock(json=lambda: json)
     mocked_get = mocker.patch("requests.get", return_value=response)
     mocked_styled_input = mocker.patch(
-        "zulipterminal.cli.run.styled_input", return_value="input return value"
+        MODULE + ".styled_input", return_value="input return value"
     )
 
     result = get_login_id("REALM_URL")
@@ -108,7 +112,7 @@ def test_valid_zuliprc_but_no_connection(
     capsys, mocker, minimal_zuliprc, server_connection_error="some_error"
 ):
     mocker.patch(
-        "zulipterminal.core.Controller.__init__",
+        CONTROLLER + ".__init__",
         side_effect=ServerConnectionFailure(server_connection_error),
     )
 
@@ -152,15 +156,15 @@ def test_warning_regarding_incomplete_theme(
     server_connection_error="sce",
 ):
     mocker.patch(
-        "zulipterminal.core.Controller.__init__",
+        CONTROLLER + ".__init__",
         side_effect=ServerConnectionFailure(server_connection_error),
     )
-    mocker.patch("zulipterminal.cli.run.all_themes", return_value=("a", "b", "c", "d"))
+    mocker.patch(MODULE + ".all_themes", return_value=("a", "b", "c", "d"))
     mocker.patch(
-        "zulipterminal.cli.run.complete_and_incomplete_themes",
+        MODULE + ".complete_and_incomplete_themes",
         return_value=expected_complete_incomplete_themes,
     )
-    mocker.patch("zulipterminal.cli.run.generate_theme")
+    mocker.patch(MODULE + ".generate_theme")
 
     with pytest.raises(SystemExit) as e:
         main(["-c", minimal_zuliprc, "-t", bad_theme])
@@ -305,7 +309,7 @@ def test_main_cannot_write_zuliprc_given_good_credentials(
     # Give some arbitrary input and fake that it's always valid
     mocker.patch.object(builtins, "input", lambda _: "text\n")
     response = mocker.Mock(json=lambda: dict(api_key=""), status_code=200)
-    mocker.patch("zulipterminal.cli.run.get_api_key", return_value=(response, None))
+    mocker.patch(MODULE + ".get_api_key", return_value=(response, None))
 
     with pytest.raises(SystemExit):
         main([])
@@ -368,8 +372,8 @@ def test_successful_main_function_with_config(
     }
     config[config_key] = config_value
     zuliprc = parameterized_zuliprc(config)
-    mocker.patch("zulipterminal.core.Controller.__init__", return_value=None)
-    mocker.patch("zulipterminal.core.Controller.main", return_value=None)
+    mocker.patch(CONTROLLER + ".__init__", return_value=None)
+    mocker.patch(CONTROLLER + ".main", return_value=None)
 
     with pytest.raises(SystemExit):
         main(["-c", zuliprc])
@@ -408,8 +412,8 @@ def test_main_error_with_invalid_zuliprc_options(
     error_message,
 ):
     zuliprc = parameterized_zuliprc(zulip_config)
-    mocker.patch("zulipterminal.core.Controller.__init__", return_value=None)
-    mocker.patch("zulipterminal.core.Controller.main", return_value=None)
+    mocker.patch(CONTROLLER + ".__init__", return_value=None)
+    mocker.patch(CONTROLLER + ".main", return_value=None)
 
     with pytest.raises(SystemExit) as e:
         main(["-c", zuliprc])

--- a/tests/helper/test_helper.py
+++ b/tests/helper/test_helper.py
@@ -15,11 +15,15 @@ from zulipterminal.helper import (
 )
 
 
+MODULE = "zulipterminal.helper"
+MODEL = "zulipterminal.model.Model"
+
+
 def test_index_messages_narrow_all_messages(
     mocker, messages_successful_response, index_all_messages, initial_index
 ) -> None:
     messages = messages_successful_response["messages"]
-    model = mocker.patch("zulipterminal.model.Model.__init__", return_value=None)
+    model = mocker.patch(MODEL + ".__init__", return_value=None)
     model.index = initial_index
     model.narrow = []
     assert index_messages(messages, model, model.index) == index_all_messages
@@ -29,7 +33,7 @@ def test_index_messages_narrow_stream(
     mocker, messages_successful_response, index_stream, initial_index
 ) -> None:
     messages = messages_successful_response["messages"]
-    model = mocker.patch("zulipterminal.model.Model.__init__", return_value=None)
+    model = mocker.patch(MODEL + ".__init__", return_value=None)
     model.index = initial_index
     model.narrow = [["stream", "PTEST"]]
     model.is_search_narrow.return_value = False
@@ -41,7 +45,7 @@ def test_index_messages_narrow_topic(
     mocker, messages_successful_response, index_topic, initial_index
 ) -> None:
     messages = messages_successful_response["messages"]
-    model = mocker.patch("zulipterminal.model.Model.__init__", return_value=None)
+    model = mocker.patch(MODEL + ".__init__", return_value=None)
     model.index = initial_index
     model.narrow = [["stream", "7"], ["topic", "Test"]]
     model.is_search_narrow.return_value = False
@@ -53,7 +57,7 @@ def test_index_messages_narrow_user(
     mocker, messages_successful_response, index_user, initial_index
 ) -> None:
     messages = messages_successful_response["messages"]
-    model = mocker.patch("zulipterminal.model.Model.__init__", return_value=None)
+    model = mocker.patch(MODEL + ".__init__", return_value=None)
     model.index = initial_index
     model.narrow = [["pm_with", "boo@zulip.com"]]
     model.is_search_narrow.return_value = False
@@ -70,7 +74,7 @@ def test_index_messages_narrow_user_multiple(
     mocker, messages_successful_response, index_user_multiple, initial_index
 ) -> None:
     messages = messages_successful_response["messages"]
-    model = mocker.patch("zulipterminal.model.Model.__init__", return_value=None)
+    model = mocker.patch(MODEL + ".__init__", return_value=None)
     model.index = initial_index
     model.narrow = [["pm_with", "boo@zulip.com, bar@zulip.com"]]
     model.is_search_narrow.return_value = False
@@ -103,7 +107,7 @@ def test_index_edited_message(
     for msg in messages:
         if msg["id"] in edited_msgs:
             msg["edit_history"] = []
-    model = mocker.patch("zulipterminal.model.Model.__init__", return_value=None)
+    model = mocker.patch(MODEL + ".__init__", return_value=None)
     model.index = initial_index
     model.narrow = []
 
@@ -137,7 +141,7 @@ def test_index_starred(
         if msg["id"] in msgs_with_stars and "starred" not in msg["flags"]:
             msg["flags"].append("starred")
 
-    model = mocker.patch("zulipterminal.model.Model.__init__", return_value=None)
+    model = mocker.patch(MODEL + ".__init__", return_value=None)
     model.index = initial_index
     model.narrow = [["is", "starred"]]
     model.is_search_narrow.return_value = False
@@ -169,7 +173,7 @@ def test_index_mentioned_messages(
         ):
             msg["flags"].append("wildcard_mentioned")
 
-    model = mocker.patch("zulipterminal.model.Model.__init__", return_value=None)
+    model = mocker.patch(MODEL + ".__init__", return_value=None)
     model.index = initial_index
     model.narrow = [["is", "mentioned"]]
     model.is_search_narrow.return_value = False
@@ -293,10 +297,10 @@ def test_invalid_color_format(mocker, color):
 def test_notify(mocker, OS, is_notification_sent):
     title = "Author"
     text = "Hello!"
-    mocker.patch("zulipterminal.helper.WSL", OS[0])
-    mocker.patch("zulipterminal.helper.MACOS", OS[1])
-    mocker.patch("zulipterminal.helper.LINUX", OS[2])
-    subprocess = mocker.patch("zulipterminal.helper.subprocess")
+    mocker.patch(MODULE + ".WSL", OS[0])
+    mocker.patch(MODULE + ".MACOS", OS[1])
+    mocker.patch(MODULE + ".LINUX", OS[2])
+    subprocess = mocker.patch(MODULE + ".subprocess")
     notify(title, text)
     assert subprocess.run.called == is_notification_sent
 
@@ -320,7 +324,7 @@ def test_notify(mocker, OS, is_notification_sent):
     ],
 )
 def test_notify_quotes(monkeypatch, mocker, OS, cmd_length, title, text):
-    subprocess = mocker.patch("zulipterminal.helper.subprocess")
+    subprocess = mocker.patch(MODULE + ".subprocess")
 
     for os in ("LINUX", "MACOS", "WSL"):
         if os != OS:

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -17,8 +17,9 @@ from zulipterminal.model import (
 )
 
 
+MODULE = "zulipterminal.model"
+MODEL = MODULE + ".Model"
 CONTROLLER = "zulipterminal.core.Controller"
-MODEL = "zulipterminal.model.Model"
 
 
 class TestModel:
@@ -30,10 +31,10 @@ class TestModel:
         self.client.base_url = "chat.zulip.zulip"
         mocker.patch(MODEL + "._start_presence_updates")
         self.display_error_if_present = mocker.patch(
-            "zulipterminal.model.display_error_if_present"
+            MODULE + ".display_error_if_present"
         )
         self.notify_if_message_sent_outside_narrow = mocker.patch(
-            "zulipterminal.model.notify_if_message_sent_outside_narrow"
+            MODULE + ".notify_if_message_sent_outside_narrow"
         )
 
     @pytest.fixture
@@ -43,10 +44,10 @@ class TestModel:
         mocker.patch(MODEL + ".get_all_users", return_value=[])
         # NOTE: PATCH WHERE USED NOT WHERE DEFINED
         self.classify_unread_counts = mocker.patch(
-            "zulipterminal.model.classify_unread_counts", return_value=[]
+            MODULE + ".classify_unread_counts", return_value=[]
         )
         self.client.get_profile.return_value = user_profile
-        mocker.patch("zulipterminal.model.unicode_emojis", EMOJI_DATA=unicode_emojis)
+        mocker.patch(MODULE + ".unicode_emojis", EMOJI_DATA=unicode_emojis)
         model = Model(self.controller)
         return model
 
@@ -143,7 +144,7 @@ class TestModel:
         mocker.patch(MODEL + ".get_all_users", return_value=[])
         mocker.patch(MODEL + "._subscribe_to_streams")
         self.classify_unread_counts = mocker.patch(
-            "zulipterminal.model.classify_unread_counts", return_value=[]
+            MODULE + ".classify_unread_counts", return_value=[]
         )
 
         with pytest.raises(ServerConnectionFailure) as e:
@@ -161,7 +162,7 @@ class TestModel:
         mocker.patch(MODEL + ".get_all_users", return_value=[])
         mocker.patch(MODEL + "._subscribe_to_streams")
         self.classify_unread_counts = mocker.patch(
-            "zulipterminal.model.classify_unread_counts", return_value=[]
+            MODULE + ".classify_unread_counts", return_value=[]
         )
 
         with pytest.raises(ServerConnectionFailure) as e:
@@ -687,14 +688,12 @@ class TestModel:
         mocker.patch(MODEL + ".get_all_users", return_value=[])
         mocker.patch(MODEL + "._subscribe_to_streams")
         self.classify_unread_counts = mocker.patch(
-            "zulipterminal.model.classify_unread_counts", return_value=[]
+            MODULE + ".classify_unread_counts", return_value=[]
         )
 
         # Setup mocks before calling get_messages
         self.client.get_messages.return_value = messages_successful_response
-        mocker.patch(
-            "zulipterminal.model.index_messages", return_value=index_all_messages
-        )
+        mocker.patch(MODULE + ".index_messages", return_value=index_all_messages)
         model = Model(self.controller)
         request = {
             "anchor": 0,
@@ -813,15 +812,13 @@ class TestModel:
         mocker.patch(MODEL + ".get_all_users", return_value=[])
         mocker.patch(MODEL + "._subscribe_to_streams")
         self.classify_unread_counts = mocker.patch(
-            "zulipterminal.model.classify_unread_counts", return_value=[]
+            MODULE + ".classify_unread_counts", return_value=[]
         )
 
         # Setup mocks before calling get_messages
         messages_successful_response["anchor"] = 0
         self.client.get_messages.return_value = messages_successful_response
-        mocker.patch(
-            "zulipterminal.model.index_messages", return_value=index_all_messages
-        )
+        mocker.patch(MODULE + ".index_messages", return_value=index_all_messages)
 
         model = Model(self.controller)
         model.get_messages(num_before=num_before, num_after=num_after, anchor=0)
@@ -845,7 +842,7 @@ class TestModel:
         mocker.patch(MODEL + ".get_all_users", return_value=[])
         mocker.patch(MODEL + "._subscribe_to_streams")
         self.classify_unread_counts = mocker.patch(
-            "zulipterminal.model.classify_unread_counts", return_value=[]
+            MODULE + ".classify_unread_counts", return_value=[]
         )
 
         # Setup mock before calling get_messages
@@ -927,7 +924,7 @@ class TestModel:
         mocker.patch(MODEL + ".get_all_users", return_value=[])
         mocker.patch(MODEL + "._subscribe_to_streams")
         self.classify_unread_counts = mocker.patch(
-            "zulipterminal.model.classify_unread_counts", return_value=[]
+            MODULE + ".classify_unread_counts", return_value=[]
         )
 
         # Setup mocks before calling get_messages
@@ -957,7 +954,7 @@ class TestModel:
         self.client.register.return_value = initial_data
         mocker.patch(MODEL + "._subscribe_to_streams")
         self.classify_unread_counts = mocker.patch(
-            "zulipterminal.model.classify_unread_counts", return_value=[]
+            MODULE + ".classify_unread_counts", return_value=[]
         )
         model = Model(self.controller)
         assert model.user_dict == user_dict
@@ -985,10 +982,10 @@ class TestModel:
     ):
         model._have_last_message[repr([])] = True
         mocker.patch(MODEL + "._update_topic_index")
-        index_msg = mocker.patch("zulipterminal.model.index_messages", return_value={})
+        index_msg = mocker.patch(MODULE + ".index_messages", return_value={})
         self.controller.view.message_view = mocker.Mock(log=[])
         create_msg_box_list = mocker.patch(
-            "zulipterminal.model.create_msg_box_list", return_value=["msg_w"]
+            MODULE + ".create_msg_box_list", return_value=["msg_w"]
         )
         model.notify_user = mocker.Mock()
         event = {"type": "message", "message": message_fixture}
@@ -1004,10 +1001,10 @@ class TestModel:
     def test__handle_message_event_with_valid_log(self, mocker, model, message_fixture):
         model._have_last_message[repr([])] = True
         mocker.patch(MODEL + "._update_topic_index")
-        index_msg = mocker.patch("zulipterminal.model.index_messages", return_value={})
+        index_msg = mocker.patch(MODULE + ".index_messages", return_value={})
         self.controller.view.message_view = mocker.Mock(log=[mocker.Mock()])
         create_msg_box_list = mocker.patch(
-            "zulipterminal.model.create_msg_box_list", return_value=["msg_w"]
+            MODULE + ".create_msg_box_list", return_value=["msg_w"]
         )
         model.notify_user = mocker.Mock()
         event = {"type": "message", "message": message_fixture}
@@ -1026,13 +1023,13 @@ class TestModel:
     def test__handle_message_event_with_flags(self, mocker, model, message_fixture):
         model._have_last_message[repr([])] = True
         mocker.patch(MODEL + "._update_topic_index")
-        index_msg = mocker.patch("zulipterminal.model.index_messages", return_value={})
+        index_msg = mocker.patch(MODULE + ".index_messages", return_value={})
         self.controller.view.message_view = mocker.Mock(log=[mocker.Mock()])
         create_msg_box_list = mocker.patch(
-            "zulipterminal.model.create_msg_box_list", return_value=["msg_w"]
+            MODULE + ".create_msg_box_list", return_value=["msg_w"]
         )
         model.notify_user = mocker.Mock()
-        set_count = mocker.patch("zulipterminal.model.set_count")
+        set_count = mocker.patch(MODULE + ".set_count")
 
         # Test event with flags
         event = {
@@ -1166,11 +1163,11 @@ class TestModel:
     ):
         model._have_last_message[repr(narrow)] = True
         mocker.patch(MODEL + "._update_topic_index")
-        index_msg = mocker.patch("zulipterminal.model.index_messages", return_value={})
+        index_msg = mocker.patch(MODULE + ".index_messages", return_value={})
         create_msg_box_list = mocker.patch(
-            "zulipterminal.model.create_msg_box_list", return_value=["msg_w"]
+            MODULE + ".create_msg_box_list", return_value=["msg_w"]
         )
-        set_count = mocker.patch("zulipterminal.model.set_count")
+        set_count = mocker.patch(MODULE + ".set_count")
         self.controller.view.message_view = mocker.Mock(log=[])
         (
             self.controller.view.left_panel.is_in_topic_view_with_stream_id.return_value
@@ -1275,7 +1272,7 @@ class TestModel:
                     }
                 }
             )
-        notify = mocker.patch("zulipterminal.model.notify")
+        notify = mocker.patch(MODULE + ".notify")
 
         model.notify_user(message_fixture)
 
@@ -1306,7 +1303,7 @@ class TestModel:
         message_fixture.update({"sender_id": 2, "flags": ["mentioned"]})
         model.controller.notify_enabled = notify_enabled
         model.user_id = 1
-        notify = mocker.patch("zulipterminal.model.notify")
+        notify = mocker.patch(MODULE + ".notify")
         model.notify_user(message_fixture)
         assert notify.called == is_notify_called
 
@@ -1623,9 +1620,7 @@ class TestModel:
         self.controller.view.message_view = mocker.Mock(log=[msg_w, other_msg_w])
         # New msg widget generated after updating index.
         new_msg_w = mocker.Mock()
-        cmbl = mocker.patch(
-            "zulipterminal.model.create_msg_box_list", return_value=[new_msg_w]
-        )
+        cmbl = mocker.patch(MODULE + ".create_msg_box_list", return_value=[new_msg_w])
 
         model._update_rendered_view(msg_id)
 
@@ -1662,9 +1657,7 @@ class TestModel:
         # New msg widget generated after updating index.
         original_widget = mocker.Mock(message=dict(id=2))  # FIXME: id matters?
         new_msg_w = mocker.Mock(original_widget=original_widget)
-        cmbl = mocker.patch(
-            "zulipterminal.model.create_msg_box_list", return_value=[new_msg_w]
-        )
+        cmbl = mocker.patch(MODULE + ".create_msg_box_list", return_value=[new_msg_w])
 
         model._update_rendered_view(msg_id)
 
@@ -1819,7 +1812,7 @@ class TestModel:
             operation: "add",
         }
         mocker.patch(MODEL + "._update_rendered_view")
-        set_count = mocker.patch("zulipterminal.model.set_count")
+        set_count = mocker.patch(MODULE + ".set_count")
 
         model._handle_update_message_flags_event(event)
 
@@ -1845,7 +1838,7 @@ class TestModel:
             "all": False,
         }
         mocker.patch(MODEL + "._update_rendered_view")
-        set_count = mocker.patch("zulipterminal.model.set_count")
+        set_count = mocker.patch(MODULE + ".set_count")
         with pytest.raises(RuntimeError):
             model._handle_update_message_flags_event(event)
         model._update_rendered_view.assert_not_called()
@@ -1906,7 +1899,7 @@ class TestModel:
         }
         self.controller.view.starred_button.count = 0
         mocker.patch(MODEL + "._update_rendered_view")
-        set_count = mocker.patch("zulipterminal.model.set_count")
+        set_count = mocker.patch(MODULE + ".set_count")
         update_star_count = self.controller.view.starred_button.update_count
 
         model._handle_update_message_flags_event(event)
@@ -1988,7 +1981,7 @@ class TestModel:
         }
 
         mocker.patch(MODEL + "._update_rendered_view")
-        set_count = mocker.patch("zulipterminal.model.set_count")
+        set_count = mocker.patch(MODULE + ".set_count")
 
         model._handle_update_message_flags_event(event)
 
@@ -2380,7 +2373,7 @@ class TestModel:
         first_msg_w.original_widget.message = {"id": 1}
         second_msg_w.original_widget.message = {"id": 2}
         self.controller.view.message_view = mocker.Mock(log=[first_msg_w, second_msg_w])
-        create_msg_box_list = mocker.patch("zulipterminal.model.create_msg_box_list")
+        create_msg_box_list = mocker.patch(MODULE + ".create_msg_box_list")
         model.twenty_four_hr_format = None  # initial value is not True/False
 
         model._handle_update_display_settings_event(event)
@@ -2606,7 +2599,7 @@ class TestModel:
 
     def test_poll_for_events__no_disconnect(self, mocker, model, raising_event):
         mocker.patch(MODEL + "._register_desired_events")
-        sleep = mocker.patch("zulipterminal.model.time.sleep")
+        sleep = mocker.patch(MODULE + ".time.sleep")
 
         self.client.get_events.side_effect = [
             {
@@ -2636,7 +2629,7 @@ class TestModel:
         mocker.patch(
             MODEL + "._register_desired_events", side_effect=register_return_value
         )
-        sleep = mocker.patch("zulipterminal.model.time.sleep")
+        sleep = mocker.patch(MODULE + ".time.sleep")
 
         self.client.get_events.side_effect = [
             {

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -30,13 +30,12 @@ from zulipterminal.ui_tools.views import (
 )
 
 
-VIEWS = "zulipterminal.ui_tools.views"
-MESSAGEBOX = "zulipterminal.ui_tools.boxes.MessageBox"
-BOXES = "zulipterminal.ui_tools.boxes"
+SUBDIR = "zulipterminal.ui_tools"
+BOXES = SUBDIR + ".boxes"
+VIEWS = SUBDIR + ".views"
+MESSAGEVIEW = VIEWS + ".MessageView"
+MIDCOLVIEW = VIEWS + ".MiddleColumnView"
 
-# FIXME This likely indicates we can improve the code
-TOPBUTTON = "zulipterminal.ui_tools.buttons.TopButton"
-STREAMBUTTON = "zulipterminal.ui_tools.buttons.StreamButton"
 
 SERVER_URL = "https://chat.zulip.zulip"
 
@@ -84,9 +83,9 @@ class TestMessageView:
 
     @pytest.fixture
     def msg_view(self, mocker, msg_box):
-        mocker.patch(VIEWS + ".MessageView.main_view", return_value=[msg_box])
-        mocker.patch(VIEWS + ".MessageView.read_message")
-        mocker.patch(VIEWS + ".MessageView.set_focus")
+        mocker.patch(MESSAGEVIEW + ".main_view", return_value=[msg_box])
+        mocker.patch(MESSAGEVIEW + ".read_message")
+        mocker.patch(MESSAGEVIEW + ".set_focus")
         msg_view = MessageView(self.model, self.view)
         msg_view.log = mocker.Mock()
         msg_view.body = mocker.Mock()
@@ -100,9 +99,9 @@ class TestMessageView:
 
     @pytest.mark.parametrize("narrow_focus_pos, focus_msg", [(set(), 1), (0, 0)])
     def test_main_view(self, mocker, narrow_focus_pos, focus_msg):
-        mocker.patch(VIEWS + ".MessageView.read_message")
+        mocker.patch(MESSAGEVIEW + ".read_message")
         self.urwid.SimpleFocusListWalker.return_value = mocker.Mock()
-        mocker.patch(VIEWS + ".MessageView.set_focus")
+        mocker.patch(MESSAGEVIEW + ".set_focus")
         msg_list = ["MSG1", "MSG2"]
         mocker.patch(VIEWS + ".create_msg_box_list", return_value=msg_list)
         self.model.get_focus_in_current_narrow.return_value = narrow_focus_pos
@@ -297,8 +296,8 @@ class TestMessageView:
     def test_keypress_GO_DOWN(self, mocker, msg_view, key, widget_size):
         size = widget_size(msg_view)
         msg_view.new_loading = False
-        mocker.patch(VIEWS + ".MessageView.focus_position", return_value=0)
-        mocker.patch(VIEWS + ".MessageView.set_focus_valign")
+        mocker.patch(MESSAGEVIEW + ".focus_position", return_value=0)
+        mocker.patch(MESSAGEVIEW + ".set_focus_valign")
         msg_view.log.next_position.return_value = 1
         msg_view.keypress(size, key)
         msg_view.log.next_position.assert_called_once_with(msg_view.focus_position)
@@ -312,12 +311,12 @@ class TestMessageView:
     ):
         size = widget_size(msg_view)
         msg_view.new_loading = False
-        mocker.patch(VIEWS + ".MessageView.focus_position", return_value=0)
-        mocker.patch(VIEWS + ".MessageView.set_focus_valign")
+        mocker.patch(MESSAGEVIEW + ".focus_position", return_value=0)
+        mocker.patch(MESSAGEVIEW + ".set_focus_valign")
 
         msg_view.log.next_position = Exception()
         mocker.patch(
-            VIEWS + ".MessageView.focus",
+            MESSAGEVIEW + ".focus",
             mocker.MagicMock() if view_is_focused else None,
         )
         mocker.patch.object(msg_view, "load_new_messages")
@@ -335,8 +334,8 @@ class TestMessageView:
     @pytest.mark.parametrize("key", keys_for_command("GO_UP"))
     def test_keypress_GO_UP(self, mocker, msg_view, key, widget_size):
         size = widget_size(msg_view)
-        mocker.patch(VIEWS + ".MessageView.focus_position", return_value=0)
-        mocker.patch(VIEWS + ".MessageView.set_focus_valign")
+        mocker.patch(MESSAGEVIEW + ".focus_position", return_value=0)
+        mocker.patch(MESSAGEVIEW + ".set_focus_valign")
         msg_view.old_loading = False
         msg_view.log.prev_position.return_value = 1
         msg_view.keypress(size, key)
@@ -351,12 +350,12 @@ class TestMessageView:
     ):
         size = widget_size(msg_view)
         msg_view.old_loading = False
-        mocker.patch(VIEWS + ".MessageView.focus_position", return_value=0)
-        mocker.patch(VIEWS + ".MessageView.set_focus_valign")
+        mocker.patch(MESSAGEVIEW + ".focus_position", return_value=0)
+        mocker.patch(MESSAGEVIEW + ".set_focus_valign")
 
         msg_view.log.prev_position = Exception()
         mocker.patch(
-            VIEWS + ".MessageView.focus",
+            MESSAGEVIEW + ".focus",
             mocker.MagicMock() if view_is_focused else None,
         )
         mocker.patch.object(msg_view, "load_old_messages")
@@ -372,10 +371,10 @@ class TestMessageView:
         assert return_value == key
 
     def test_read_message(self, mocker, msg_box):
-        mocker.patch(VIEWS + ".MessageView.main_view", return_value=[msg_box])
+        mocker.patch(MESSAGEVIEW + ".main_view", return_value=[msg_box])
         self.urwid.SimpleFocusListWalker.return_value = mocker.Mock()
-        mocker.patch(VIEWS + ".MessageView.set_focus")
-        mocker.patch(VIEWS + ".MessageView.update_search_box_narrow")
+        mocker.patch(MESSAGEVIEW + ".set_focus")
+        mocker.patch(MESSAGEVIEW + ".update_search_box_narrow")
         msg_view = MessageView(self.model, self.view)
         msg_view.model.is_search_narrow = lambda: False
         msg_view.model.controller.in_explore_mode = False
@@ -398,7 +397,7 @@ class TestMessageView:
             },
             "pointer": {"[]": 0},
         }
-        mocker.patch(VIEWS + ".MessageView.focus_position")
+        mocker.patch(MESSAGEVIEW + ".focus_position")
         msg_view.focus_position = 1
         msg_view.model.controller.view.body.focus_col = 1
         msg_view.log = list(msg_view.model.index["messages"])
@@ -424,9 +423,9 @@ class TestMessageView:
         self.model.mark_message_ids_as_read.assert_not_called()
 
     def test_read_message_in_explore_mode(self, mocker, msg_box):
-        mocker.patch(VIEWS + ".MessageView.main_view", return_value=[msg_box])
-        mocker.patch(VIEWS + ".MessageView.set_focus")
-        mocker.patch(VIEWS + ".MessageView.update_search_box_narrow")
+        mocker.patch(MESSAGEVIEW + ".main_view", return_value=[msg_box])
+        mocker.patch(MESSAGEVIEW + ".set_focus")
+        mocker.patch(MESSAGEVIEW + ".update_search_box_narrow")
         msg_view = MessageView(self.model, self.view)
         msg_w = mocker.Mock()
         msg_view.body = mocker.Mock()
@@ -440,9 +439,9 @@ class TestMessageView:
         assert not self.model.mark_message_ids_as_read.called
 
     def test_read_message_search_narrow(self, mocker, msg_box):
-        mocker.patch(VIEWS + ".MessageView.main_view", return_value=[msg_box])
-        mocker.patch(VIEWS + ".MessageView.set_focus")
-        mocker.patch(VIEWS + ".MessageView.update_search_box_narrow")
+        mocker.patch(MESSAGEVIEW + ".main_view", return_value=[msg_box])
+        mocker.patch(MESSAGEVIEW + ".set_focus")
+        mocker.patch(MESSAGEVIEW + ".update_search_box_narrow")
         msg_view = MessageView(self.model, self.view)
         msg_view.model.controller.view = mocker.Mock()
         msg_w = mocker.Mock()
@@ -459,8 +458,8 @@ class TestMessageView:
     def test_read_message_last_unread_message_focused(
         self, mocker, message_fixture, empty_index, msg_box
     ):
-        mocker.patch(VIEWS + ".MessageView.main_view", return_value=[msg_box])
-        mocker.patch(VIEWS + ".MessageView.set_focus")
+        mocker.patch(MESSAGEVIEW + ".main_view", return_value=[msg_box])
+        mocker.patch(MESSAGEVIEW + ".set_focus")
         msg_view = MessageView(self.model, self.view)
         msg_view.model.is_search_narrow = lambda: False
         msg_view.model.controller.in_explore_mode = False
@@ -679,10 +678,8 @@ class TestTopicsView:
     def test_update_topics_list(
         self, mocker, topic_view, topic_name, topic_initial_log, topic_final_log
     ):
-        mocker.patch(TOPBUTTON + ".__init__", return_value=None)
-        set_focus_valign = mocker.patch(
-            "zulipterminal.ui_tools.buttons.urwid.ListBox.set_focus_valign"
-        )
+        mocker.patch(SUBDIR + ".buttons.TopButton.__init__", return_value=None)
+        set_focus_valign = mocker.patch(VIEWS + ".urwid.ListBox.set_focus_valign")
         topic_view.view.controller.model.stream_dict = {86: {"name": "PTEST"}}
         topic_view.view.controller.model.is_muted_topic = mocker.Mock(
             return_value=False
@@ -758,7 +755,7 @@ class TestUsersView:
     def test_mouse_event_left_click(
         self, mocker, user_view, widget_size, compose_box_is_open
     ):
-        super_mouse_event = mocker.patch("zulipterminal.ui.urwid.ListBox.mouse_event")
+        super_mouse_event = mocker.patch(VIEWS + ".urwid.ListBox.mouse_event")
         user_view.controller.is_in_editor_mode.return_value = compose_box_is_open
         size = widget_size(user_view)
         focus = mocker.Mock()
@@ -797,7 +794,7 @@ class TestUsersView:
 class TestMiddleColumnView:
     @pytest.fixture(autouse=True)
     def mock_external_classes(self, mocker):
-        mocker.patch(VIEWS + ".MessageView", return_value="MSG_LIST")
+        mocker.patch(MESSAGEVIEW + "", return_value="MSG_LIST")
         self.model = mocker.Mock()
         self.view = mocker.Mock()
         self.write_box = mocker.Mock()
@@ -862,9 +859,9 @@ class TestMiddleColumnView:
     @pytest.mark.parametrize("key", keys_for_command("GO_BACK"))
     def test_keypress_GO_BACK(self, mid_col_view, mocker, key, widget_size):
         size = widget_size(mid_col_view)
-        mocker.patch(VIEWS + ".MiddleColumnView.header")
-        mocker.patch(VIEWS + ".MiddleColumnView.footer")
-        mocker.patch(VIEWS + ".MiddleColumnView.set_focus")
+        mocker.patch(MIDCOLVIEW + ".header")
+        mocker.patch(MIDCOLVIEW + ".footer")
+        mocker.patch(MIDCOLVIEW + ".set_focus")
 
         mid_col_view.keypress(size, key)
 
@@ -883,8 +880,8 @@ class TestMiddleColumnView:
     @pytest.mark.parametrize("key", keys_for_command("SEARCH_MESSAGES"))
     def test_keypress_SEARCH_MESSAGES(self, mid_col_view, mocker, key, widget_size):
         size = widget_size(mid_col_view)
-        mocker.patch(VIEWS + ".MiddleColumnView.focus_position")
-        mocker.patch(VIEWS + ".MiddleColumnView.set_focus")
+        mocker.patch(MIDCOLVIEW + ".focus_position")
+        mocker.patch(MIDCOLVIEW + ".set_focus")
 
         mid_col_view.keypress(size, key)
 
@@ -899,10 +896,10 @@ class TestMiddleColumnView:
         self, mid_col_view, mocker, widget_size, reply_message_key, enter_key
     ):
         size = widget_size(mid_col_view)
-        mocker.patch(VIEWS + ".MiddleColumnView.body")
-        mocker.patch(VIEWS + ".MiddleColumnView.footer")
-        mocker.patch(VIEWS + ".MiddleColumnView.focus_position")
-        mocker.patch(VIEWS + ".MiddleColumnView.set_focus")
+        mocker.patch(MIDCOLVIEW + ".body")
+        mocker.patch(MIDCOLVIEW + ".footer")
+        mocker.patch(MIDCOLVIEW + ".focus_position")
+        mocker.patch(MIDCOLVIEW + ".set_focus")
 
         mid_col_view.keypress(size, reply_message_key)
 
@@ -913,10 +910,10 @@ class TestMiddleColumnView:
     @pytest.mark.parametrize("key", keys_for_command("STREAM_MESSAGE"))
     def test_keypress_STREAM_MESSAGE(self, mid_col_view, mocker, key, widget_size):
         size = widget_size(mid_col_view)
-        mocker.patch(VIEWS + ".MiddleColumnView.body")
-        mocker.patch(VIEWS + ".MiddleColumnView.footer")
-        mocker.patch(VIEWS + ".MiddleColumnView.focus_position")
-        mocker.patch(VIEWS + ".MiddleColumnView.set_focus")
+        mocker.patch(MIDCOLVIEW + ".body")
+        mocker.patch(MIDCOLVIEW + ".footer")
+        mocker.patch(MIDCOLVIEW + ".focus_position")
+        mocker.patch(MIDCOLVIEW + ".set_focus")
 
         mid_col_view.keypress(size, key)
 
@@ -927,10 +924,10 @@ class TestMiddleColumnView:
     @pytest.mark.parametrize("key", keys_for_command("REPLY_AUTHOR"))
     def test_keypress_REPLY_AUTHOR(self, mid_col_view, mocker, key, widget_size):
         size = widget_size(mid_col_view)
-        mocker.patch(VIEWS + ".MiddleColumnView.body")
-        mocker.patch(VIEWS + ".MiddleColumnView.footer")
-        mocker.patch(VIEWS + ".MiddleColumnView.focus_position")
-        mocker.patch(VIEWS + ".MiddleColumnView.set_focus")
+        mocker.patch(MIDCOLVIEW + ".body")
+        mocker.patch(MIDCOLVIEW + ".footer")
+        mocker.patch(MIDCOLVIEW + ".focus_position")
+        mocker.patch(MIDCOLVIEW + ".set_focus")
 
         mid_col_view.keypress(size, key)
 
@@ -943,9 +940,9 @@ class TestMiddleColumnView:
         self, mid_col_view, mocker, widget_size, key
     ):
         size = widget_size(mid_col_view)
-        mocker.patch(VIEWS + ".MiddleColumnView.focus_position")
+        mocker.patch(MIDCOLVIEW + ".focus_position")
         mocker.patch(
-            VIEWS + ".MiddleColumnView.get_next_unread_topic",
+            MIDCOLVIEW + ".get_next_unread_topic",
             return_value=("1", "topic"),
         )
         mid_col_view.model.stream_dict = {"1": {"name": "stream"}}
@@ -961,10 +958,8 @@ class TestMiddleColumnView:
         self, mid_col_view, mocker, widget_size, key
     ):
         size = widget_size(mid_col_view)
-        mocker.patch(VIEWS + ".MiddleColumnView.focus_position")
-        mocker.patch(
-            VIEWS + ".MiddleColumnView.get_next_unread_topic", return_value=None
-        )
+        mocker.patch(MIDCOLVIEW + ".focus_position")
+        mocker.patch(MIDCOLVIEW + ".get_next_unread_topic", return_value=None)
 
         return_value = mid_col_view.keypress(size, key)
         assert return_value == key
@@ -974,8 +969,8 @@ class TestMiddleColumnView:
         self, mid_col_view, mocker, key, widget_size
     ):
         size = widget_size(mid_col_view)
-        mocker.patch(VIEWS + ".MiddleColumnView.focus_position")
-        mocker.patch(VIEWS + ".MiddleColumnView.get_next_unread_pm", return_value=1)
+        mocker.patch(MIDCOLVIEW + ".focus_position")
+        mocker.patch(MIDCOLVIEW + ".get_next_unread_pm", return_value=1)
         mid_col_view.model.user_id_email_dict = {1: "EMAIL"}
 
         mid_col_view.keypress(size, key)
@@ -990,8 +985,8 @@ class TestMiddleColumnView:
         self, mid_col_view, mocker, key, widget_size
     ):
         size = widget_size(mid_col_view)
-        mocker.patch(VIEWS + ".MiddleColumnView.focus_position")
-        mocker.patch(VIEWS + ".MiddleColumnView.get_next_unread_pm", return_value=None)
+        mocker.patch(MIDCOLVIEW + ".focus_position")
+        mocker.patch(MIDCOLVIEW + ".get_next_unread_pm", return_value=None)
 
         return_value = mid_col_view.keypress(size, key)
         assert return_value == key
@@ -999,8 +994,8 @@ class TestMiddleColumnView:
     @pytest.mark.parametrize("key", keys_for_command("PRIVATE_MESSAGE"))
     def test_keypress_PRIVATE_MESSAGE(self, mid_col_view, mocker, key, widget_size):
         size = widget_size(mid_col_view)
-        mocker.patch(VIEWS + ".MiddleColumnView.focus_position")
-        mocker.patch(VIEWS + ".MiddleColumnView.get_next_unread_pm", return_value=None)
+        mocker.patch(MIDCOLVIEW + ".focus_position")
+        mocker.patch(MIDCOLVIEW + ".get_next_unread_pm", return_value=None)
         mid_col_view.footer = mocker.Mock()
         return_value = mid_col_view.keypress(size, key)
         mid_col_view.footer.private_box_view.assert_called_once_with()
@@ -1180,7 +1175,7 @@ class TestLeftColumnView:
         starred_button = mocker.patch(VIEWS + ".StarredButton")
         mocker.patch(VIEWS + ".urwid.ListBox")
         mocker.patch(VIEWS + ".urwid.SimpleFocusListWalker")
-        mocker.patch(STREAMBUTTON + ".mark_muted")
+        mocker.patch(VIEWS + ".StreamButton.mark_muted")
         left_col_view = LeftColumnView(width, self.view)
         home_button.assert_called_once_with(
             left_col_view.controller, count=2, width=width
@@ -1200,7 +1195,6 @@ class TestLeftColumnView:
         stream_view = mocker.patch(VIEWS + ".StreamsView")
         line_box = mocker.patch(VIEWS + ".urwid.LineBox")
         divider = mocker.patch(VIEWS + ".StreamsViewDivider")
-        mocker.patch(STREAMBUTTON + ".mark_muted")
 
         left_col_view = LeftColumnView(width, self.view)
 
@@ -1306,7 +1300,9 @@ class TestMessageBox:
             timestamp=150989984,
         )
         self.model.user_email = "foo@zulip.com"
-        mocker.patch(MESSAGEBOX + "._is_private_message_to_self", return_value=True)
+        mocker.patch(
+            BOXES + ".MessageBox._is_private_message_to_self", return_value=True
+        )
         mocker.patch.object(MessageBox, "main_view")
         msg_box = MessageBox(message, self.model, None)
 
@@ -1913,7 +1909,7 @@ class TestMessageBox:
         ],
     )
     def test_main_view_renders_slash_me(self, mocker, message, content, is_me_message):
-        mocker.patch(VIEWS + ".urwid.Text")
+        mocker.patch(BOXES + ".urwid.Text")
         message["content"] = content
         message["is_me_message"] = is_me_message
         msg_box = MessageBox(message, self.model, message)
@@ -2149,7 +2145,7 @@ class TestMessageBox:
         starred_msg,
         to_vary_in_last_message,
     ):
-        date = mocker.patch("zulipterminal.ui_tools.boxes.date")
+        date = mocker.patch(BOXES + ".date")
         date.today.return_value = datetime.date(current_year, 1, 1)
         date.side_effect = lambda *args, **kw: datetime.date(*args, **kw)
 
@@ -2338,7 +2334,7 @@ class TestMessageBox:
         write_box = msg_box.model.controller.view.write_box
         write_box.msg_edit_state = None
         write_box.msg_body_edit_enabled = None
-        mocker.patch("zulipterminal.ui_tools.boxes.time", return_value=100)
+        mocker.patch(BOXES + ".time", return_value=100)
         # private messages cannot be edited after time-limit, if there is one.
         if (
             varied_message["type"] == "private"

--- a/tests/ui/test_utils.py
+++ b/tests/ui/test_utils.py
@@ -3,6 +3,9 @@ import pytest
 from zulipterminal.ui_tools.utils import create_msg_box_list, is_muted
 
 
+MODULE = "zulipterminal.ui_tools.utils"
+
+
 @pytest.mark.parametrize(
     "msg, narrow, muted_streams, is_muted_topic_return_value, muted",
     [
@@ -146,13 +149,11 @@ def test_create_msg_box_list(
         },
         "pointer": {},
     }
-    msg_box = mocker.patch("zulipterminal.ui_tools.utils.MessageBox")
-    mocker.patch("zulipterminal.ui_tools.utils.urwid.AttrMap", return_value="MSG")
-    mock_muted = mocker.patch(
-        "zulipterminal.ui_tools.utils.is_muted", return_value=muted
-    )
+    msg_box = mocker.patch(MODULE + ".MessageBox")
+    mocker.patch(MODULE + ".urwid.AttrMap", return_value="MSG")
+    mock_muted = mocker.patch(MODULE + ".is_muted", return_value=muted)
     mocker.patch(
-        "zulipterminal.ui_tools.utils.is_unsubscribed_message",
+        MODULE + ".is_unsubscribed_message",
         return_value=unsubscribed,
     )
 

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -10,7 +10,8 @@ from zulipterminal.config.symbols import (
 from zulipterminal.ui_tools.boxes import PanelSearchBox, WriteBox, _MessageEditState
 
 
-BOXES = "zulipterminal.ui_tools.boxes"
+MODULE = "zulipterminal.ui_tools.boxes"
+WRITEBOX = MODULE + ".WriteBox"
 
 
 class TestWriteBox:
@@ -471,7 +472,7 @@ class TestWriteBox:
     def test_generic_autocomplete_user_mentions(
         self, write_box, mocker, text, expected_distinct_prefix, state=1
     ):
-        _process_typeaheads = mocker.patch(BOXES + ".WriteBox._process_typeaheads")
+        _process_typeaheads = mocker.patch(WRITEBOX + "._process_typeaheads")
 
         write_box.generic_autocomplete(text, state)
 
@@ -635,7 +636,7 @@ class TestWriteBox:
     def test__to_box_autocomplete(
         self, mocker, write_box, text, matching_users, matching_users_info, state=1
     ):
-        _process_typeaheads = mocker.patch(BOXES + ".WriteBox._process_typeaheads")
+        _process_typeaheads = mocker.patch(WRITEBOX + "._process_typeaheads")
 
         write_box._to_box_autocomplete(text, state)
 
@@ -742,7 +743,7 @@ class TestWriteBox:
     def test__to_box_autocomplete_with_multiple_recipients(
         self, mocker, write_box, text, matching_users, matching_users_info, state=1
     ):
-        _process_typeaheads = mocker.patch(BOXES + ".WriteBox._process_typeaheads")
+        _process_typeaheads = mocker.patch(WRITEBOX + "._process_typeaheads")
 
         write_box._to_box_autocomplete(text, state)
 
@@ -792,7 +793,7 @@ class TestWriteBox:
         for stream in streams_to_pin:
             write_box.view.unpinned_streams.remove(stream)
         write_box.view.pinned_streams = streams_to_pin
-        _process_typeaheads = mocker.patch(BOXES + ".WriteBox._process_typeaheads")
+        _process_typeaheads = mocker.patch(WRITEBOX + "._process_typeaheads")
 
         write_box._stream_box_autocomplete(text, state)
 
@@ -848,7 +849,7 @@ class TestWriteBox:
     def test__stream_box_autocomplete_with_spaces(
         self, mocker, write_box, widget_size, text, expected_text
     ):
-        mocker.patch(BOXES + ".WriteBox._set_stream_write_box_style")
+        mocker.patch(WRITEBOX + "._set_stream_write_box_style")
         write_box.stream_box_view(1000)
         stream_focus = write_box.FOCUS_HEADER_BOX_STREAM
         write_box.header_write_box[stream_focus].set_edit_text(text)
@@ -876,7 +877,7 @@ class TestWriteBox:
         self, mocker, write_box, text, topics, matching_topics, state=1
     ):
         write_box.model.topics_in_stream.return_value = topics
-        _process_typeaheads = mocker.patch(BOXES + ".WriteBox._process_typeaheads")
+        _process_typeaheads = mocker.patch(WRITEBOX + "._process_typeaheads")
 
         write_box._topic_box_autocomplete(text, state)
 
@@ -894,7 +895,7 @@ class TestWriteBox:
     def test__topic_box_autocomplete_with_spaces(
         self, mocker, write_box, widget_size, text, expected_text, topics
     ):
-        mocker.patch(BOXES + ".WriteBox._set_stream_write_box_style")
+        mocker.patch(WRITEBOX + "._set_stream_write_box_style")
         write_box.stream_box_view(1000)
         write_box.model.topics_in_stream.return_value = topics
         topic_focus = write_box.FOCUS_HEADER_BOX_TOPIC
@@ -1177,11 +1178,11 @@ class TestWriteBox:
         mocker,
         stream_id=10,
     ):
-        mocker.patch(BOXES + ".WriteBox._set_stream_write_box_style")
+        mocker.patch(WRITEBOX + "._set_stream_write_box_style")
 
         if box_type == "stream":
             if message_being_edited:
-                mocker.patch(BOXES + ".EditModeButton")
+                mocker.patch(MODULE + ".EditModeButton")
                 write_box.stream_box_edit_view(stream_id)
                 write_box.msg_edit_state = _MessageEditState(
                     message_id=10, old_topic="some old topic"
@@ -1231,8 +1232,8 @@ class TestWriteBox:
     def test_write_box_header_contents(
         self, write_box, expected_box_size, mocker, msg_type
     ):
-        mocker.patch(BOXES + ".WriteBox._set_stream_write_box_style")
-        mocker.patch(BOXES + ".WriteBox.set_editor_mode")
+        mocker.patch(WRITEBOX + "._set_stream_write_box_style")
+        mocker.patch(WRITEBOX + ".set_editor_mode")
         if msg_type == "stream":
             write_box.stream_box_view(1000)
         elif msg_type == "stream_edit":
@@ -1251,7 +1252,7 @@ class TestPanelSearchBox:
     @pytest.fixture
     def panel_search_box(self, mocker):
         # X is the return from keys_for_command("UNTESTED_TOKEN")
-        mocker.patch(BOXES + ".keys_for_command", return_value="X")
+        mocker.patch(MODULE + ".keys_for_command", return_value="X")
         panel_view = mocker.Mock()
         update_func = mocker.Mock()
         return PanelSearchBox(panel_view, "UNTESTED_TOKEN", update_func)

--- a/tests/ui_tools/test_buttons.py
+++ b/tests/ui_tools/test_buttons.py
@@ -15,9 +15,9 @@ from zulipterminal.ui_tools.buttons import (
 )
 
 
-BUTTONS = "zulipterminal.ui_tools.buttons"
-TOPBUTTON = "zulipterminal.ui_tools.buttons.TopButton"
-STREAMBUTTON = "zulipterminal.ui_tools.buttons.StreamButton"
+MODULE = "zulipterminal.ui_tools.buttons"
+MSGLINKBUTTON = MODULE + ".MessageLinkButton"
+
 
 SERVER_URL = "https://chat.zulip.zulip"
 
@@ -67,7 +67,7 @@ class TestTopButton:
     def test_text_content(
         self, mocker, prefix, width, count, short_text, caption="caption"
     ):
-        mocker.patch(STREAMBUTTON + ".mark_muted")
+        mocker.patch(MODULE + ".StreamButton.mark_muted")
         show_function = mocker.Mock()
 
         # To test having more space available with no bullet, but using
@@ -122,7 +122,7 @@ class TestTopButton:
             count_style="starred_count",
         )
         # Avoid testing use in initialization by patching afterwards
-        update_widget = mocker.patch(TOPBUTTON + ".update_widget")
+        update_widget = mocker.patch(MODULE + ".TopButton.update_widget")
 
         top_button.update_count(new_count)
 
@@ -271,7 +271,7 @@ class TestUserButton:
         ],
     )
     def test_text_content(self, mocker, width, count, short_text, caption="caption"):
-        mocker.patch(STREAMBUTTON + ".mark_muted")
+        mocker.patch(MODULE + ".StreamButton.mark_muted")
         user: Dict[str, Any] = {
             "email": "some_email",  # value unimportant
             "user_id": 5,  # value unimportant
@@ -312,7 +312,7 @@ class TestUserButton:
             "user_id": user_id,
             "full_name": caption,
         }
-        activate = mocker.patch(BUTTONS + ".UserButton.activate")
+        activate = mocker.patch(MODULE + ".UserButton.activate")
         user_button = UserButton(
             user,
             controller=mocker.Mock(),
@@ -349,7 +349,7 @@ class TestTopicButton:
         }
         controller.model.is_muted_topic = mocker.Mock(return_value=False)
         view = mocker.Mock()
-        top_button = mocker.patch(TOPBUTTON + ".__init__")
+        top_button = mocker.patch(MODULE + ".TopButton.__init__")
         params = dict(controller=controller, width=width, count=count)
 
         topic_button = TopicButton(
@@ -384,9 +384,7 @@ class TestTopicButton:
     def test_init_calls_mark_muted(
         self, mocker, stream_name, title, is_muted_topic_return_value, is_muted_called
     ):
-        mark_muted = mocker.patch(
-            "zulipterminal.ui_tools.buttons.TopicButton.mark_muted"
-        )
+        mark_muted = mocker.patch(MODULE + ".TopicButton.mark_muted")
         controller = mocker.Mock()
         controller.model.is_muted_topic = mocker.Mock(
             return_value=is_muted_topic_return_value
@@ -418,8 +416,8 @@ class TestMessageLinkButton:
     @pytest.fixture(autouse=True)
     def mock_external_classes(self, mocker):
         self.controller = mocker.Mock()
-        self.super_init = mocker.patch(BUTTONS + ".urwid.Button.__init__")
-        self.connect_signal = mocker.patch(BUTTONS + ".urwid.connect_signal")
+        self.super_init = mocker.patch(MODULE + ".urwid.Button.__init__")
+        self.connect_signal = mocker.patch(MODULE + ".urwid.connect_signal")
 
     def message_link_button(self, caption="", link="", display_attr=None):
         self.caption = caption
@@ -430,7 +428,7 @@ class TestMessageLinkButton:
         )
 
     def test_init(self, mocker):
-        self.update_widget = mocker.patch(BUTTONS + ".MessageLinkButton.update_widget")
+        self.update_widget = mocker.patch(MSGLINKBUTTON + ".update_widget")
 
         mocked_button = self.message_link_button()
 
@@ -452,7 +450,7 @@ class TestMessageLinkButton:
     def test_update_widget(
         self, mocker, caption, expected_cursor_position, display_attr=None
     ):
-        self.selectable_icon = mocker.patch(BUTTONS + ".urwid.SelectableIcon")
+        self.selectable_icon = mocker.patch(MODULE + ".urwid.SelectableIcon")
 
         # The method update_widget() is called in MessageLinkButton's init.
         mocked_button = self.message_link_button(
@@ -479,9 +477,7 @@ class TestMessageLinkButton:
     )
     def test_handle_link(self, mocker, link, handle_narrow_link_called):
         self.controller.model.server_url = SERVER_URL
-        self.handle_narrow_link = mocker.patch(
-            BUTTONS + ".MessageLinkButton.handle_narrow_link"
-        )
+        self.handle_narrow_link = mocker.patch(MSGLINKBUTTON + ".handle_narrow_link")
         mocked_button = self.message_link_button(link=link)
 
         mocked_button.handle_link()
@@ -888,11 +884,9 @@ class TestMessageLinkButton:
         exit_popup_called,
     ):
         self.controller.loop.widget = mocker.Mock(spec=Overlay)
-        mocker.patch(BUTTONS + ".MessageLinkButton._parse_narrow_link")
-        mocker.patch(
-            BUTTONS + ".MessageLinkButton._validate_narrow_link", return_value=error
-        )
-        mocker.patch(BUTTONS + ".MessageLinkButton._switch_narrow_to")
+        mocker.patch(MSGLINKBUTTON + "._parse_narrow_link")
+        mocker.patch(MSGLINKBUTTON + "._validate_narrow_link", return_value=error)
+        mocker.patch(MSGLINKBUTTON + "._switch_narrow_to")
         mocked_button = self.message_link_button()
 
         mocked_button.handle_narrow_link()

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -19,7 +19,8 @@ from zulipterminal.ui_tools.views import (
 from zulipterminal.version import MINIMUM_SUPPORTED_SERVER_VERSION, ZT_VERSION
 
 
-VIEWS = "zulipterminal.ui_tools.views"
+MODULE = "zulipterminal.ui_tools.views"
+LISTWALKER = MODULE + ".urwid.SimpleFocusListWalker"
 
 # Test classes are grouped/ordered below as:
 #  * an independent popup class
@@ -33,12 +34,10 @@ class TestPopUpConfirmationView:
         self.controller = mocker.Mock()
         self.controller.view.LEFT_WIDTH = 27
         self.callback = mocker.Mock()
-        self.list_walker = mocker.patch(
-            VIEWS + ".urwid.SimpleFocusListWalker", return_value=[]
-        )
-        self.divider = mocker.patch(VIEWS + ".urwid.Divider")
-        self.text = mocker.patch(VIEWS + ".urwid.Text")
-        self.wrapper_w = mocker.patch(VIEWS + ".urwid.WidgetWrap")
+        self.list_walker = mocker.patch(LISTWALKER, return_value=[])
+        self.divider = mocker.patch(MODULE + ".urwid.Divider")
+        self.text = mocker.patch(MODULE + ".urwid.Text")
+        self.wrapper_w = mocker.patch(MODULE + ".urwid.WidgetWrap")
         return PopUpConfirmationView(
             self.controller,
             self.text,
@@ -84,11 +83,9 @@ class TestPopUpView:
         self.widget = mocker.Mock()
         mocker.patch.object(self.widget, "rows", return_value=1)
         self.widgets = [self.widget]
-        self.list_walker = mocker.patch(
-            VIEWS + ".urwid.SimpleFocusListWalker", return_value=[]
-        )
-        self.super_init = mocker.patch(VIEWS + ".urwid.ListBox.__init__")
-        self.super_keypress = mocker.patch(VIEWS + ".urwid.ListBox.keypress")
+        self.list_walker = mocker.patch(LISTWALKER, return_value=[])
+        self.super_init = mocker.patch(MODULE + ".urwid.ListBox.__init__")
+        self.super_keypress = mocker.patch(MODULE + ".urwid.ListBox.keypress")
         self.pop_up_view = PopUpView(
             self.controller, self.widgets, self.command, self.width, self.title
         )
@@ -110,7 +107,7 @@ class TestPopUpView:
     def test_keypress_command_key(self, mocker, widget_size):
         size = widget_size(self.pop_up_view)
         mocker.patch(
-            VIEWS + ".is_command_key",
+            MODULE + ".is_command_key",
             side_effect=(lambda command, key: command == self.command),
         )
         self.pop_up_view.keypress(size, "cmd_key")
@@ -125,7 +122,7 @@ class TestPopUpView:
         # when its parameters are (self.command, key) as there is no
         # self.command='COMMAND' command in keys.py.
         mocker.patch(
-            VIEWS + ".is_command_key",
+            MODULE + ".is_command_key",
             side_effect=(
                 lambda command, key: False
                 if command == self.command
@@ -143,7 +140,7 @@ class TestAboutView:
         mocker.patch.object(
             self.controller, "maximum_popup_dimensions", return_value=(64, 64)
         )
-        mocker.patch(VIEWS + ".urwid.SimpleFocusListWalker", return_value=[])
+        mocker.patch(LISTWALKER, return_value=[])
         server_version, server_feature_level = MINIMUM_SUPPORTED_SERVER_VERSION
 
         self.about_view = AboutView(
@@ -178,7 +175,7 @@ class TestAboutView:
     ):
         key, expected_key = navigation_key_expected_key_pair
         size = widget_size(self.about_view)
-        super_keypress = mocker.patch(VIEWS + ".urwid.ListBox.keypress")
+        super_keypress = mocker.patch(MODULE + ".urwid.ListBox.keypress")
         self.about_view.keypress(size, key)
         super_keypress.assert_called_once_with(size, expected_key)
 
@@ -187,7 +184,7 @@ class TestAboutView:
         mocker.patch.object(
             self.controller, "maximum_popup_dimensions", return_value=(64, 64)
         )
-        mocker.patch(VIEWS + ".urwid.SimpleFocusListWalker", return_value=[])
+        mocker.patch(LISTWALKER, return_value=[])
         server_version, server_feature_level = zulip_version
 
         about_view = AboutView(
@@ -217,7 +214,7 @@ class TestEditHistoryView:
         )
         self.controller.model.fetch_message_history = mocker.Mock(return_value=[])
         self.controller.model.formatted_local_time.return_value = "Tue Mar 13 10:55:22"
-        mocker.patch(VIEWS + ".urwid.SimpleFocusListWalker", return_value=[])
+        mocker.patch(LISTWALKER, return_value=[])
         # NOTE: Given that the EditHistoryView just uses the message ID from
         # the message data currently, message_fixture is not used to avoid
         # adding extra test runs unnecessarily.
@@ -277,7 +274,7 @@ class TestEditHistoryView:
     ):
         size = widget_size(self.edit_history_view)
         key, expected_key = navigation_key_expected_key_pair
-        super_keypress = mocker.patch(VIEWS + ".urwid.ListBox.keypress")
+        super_keypress = mocker.patch(MODULE + ".urwid.ListBox.keypress")
 
         self.edit_history_view.keypress(size, key)
 
@@ -314,7 +311,7 @@ class TestEditHistoryView:
         tag="(Current Version)",
     ):
         self._get_author_prefix = mocker.patch(
-            VIEWS + ".EditHistoryView._get_author_prefix",
+            MODULE + ".EditHistoryView._get_author_prefix",
         )
         snapshot = dict(**snapshot, user_id=user_id) if user_id else snapshot
 
@@ -423,7 +420,7 @@ class TestEditModeView:
     def edit_mode_view(self, mocker):
         controller = mocker.Mock()
         controller.maximum_popup_dimensions.return_value = (64, 64)
-        mocker.patch(VIEWS + ".urwid.SimpleFocusListWalker", return_value=[])
+        mocker.patch(LISTWALKER, return_value=[])
         button = mocker.Mock()
         return EditModeView(controller, button)
 
@@ -455,7 +452,7 @@ class TestHelpView:
         mocker.patch.object(
             self.controller, "maximum_popup_dimensions", return_value=(64, 64)
         )
-        mocker.patch(VIEWS + ".urwid.SimpleFocusListWalker", return_value=[])
+        mocker.patch(LISTWALKER, return_value=[])
         self.help_view = HelpView(self.controller, "Help Menu")
 
     def test_keypress_any_key(self, widget_size):
@@ -477,7 +474,7 @@ class TestHelpView:
     ):
         key, expected_key = navigation_key_expected_key_pair
         size = widget_size(self.help_view)
-        super_keypress = mocker.patch(VIEWS + ".urwid.ListBox.keypress")
+        super_keypress = mocker.patch(MODULE + ".urwid.ListBox.keypress")
         self.help_view.keypress(size, key)
         super_keypress.assert_called_once_with(size, expected_key)
 
@@ -489,7 +486,7 @@ class TestMsgInfoView:
         mocker.patch.object(
             self.controller, "maximum_popup_dimensions", return_value=(64, 64)
         )
-        mocker.patch(VIEWS + ".urwid.SimpleFocusListWalker", return_value=[])
+        mocker.patch(LISTWALKER, return_value=[])
         # The subsequent patches (index and initial_data) set
         # show_edit_history_label to False for this autoused fixture.
         self.controller.model.index = {"edited_messages": set()}
@@ -584,7 +581,7 @@ class TestMsgInfoView:
     def test_keypress_view_in_browser(self, mocker, widget_size, message_fixture, key):
         size = widget_size(self.msg_info_view)
         self.msg_info_view.server_url = "https://chat.zulip.org/"
-        mocker.patch(VIEWS + ".near_message_url")
+        mocker.patch(MODULE + ".near_message_url")
 
         self.msg_info_view.keypress(size, key)
 
@@ -711,7 +708,7 @@ class TestMsgInfoView:
     ):
         key, expected_key = navigation_key_expected_key_pair
         size = widget_size(self.msg_info_view)
-        super_keypress = mocker.patch(VIEWS + ".urwid.ListBox.keypress")
+        super_keypress = mocker.patch(MODULE + ".urwid.ListBox.keypress")
         self.msg_info_view.keypress(size, key)
         super_keypress.assert_called_once_with(size, expected_key)
 
@@ -725,7 +722,7 @@ class TestStreamInfoView:
         )
         self.controller.model.is_muted_stream.return_value = False
         self.controller.model.is_pinned_stream.return_value = False
-        mocker.patch(VIEWS + ".urwid.SimpleFocusListWalker", return_value=[])
+        mocker.patch(LISTWALKER, return_value=[])
         self.stream_id = 10
         self.controller.model.stream_dict = {
             self.stream_id: {
@@ -845,7 +842,7 @@ class TestStreamInfoView:
     ):
         key, expected_key = navigation_key_expected_key_pair
         size = widget_size(self.stream_info_view)
-        super_keypress = mocker.patch(VIEWS + ".urwid.ListBox.keypress")
+        super_keypress = mocker.patch(MODULE + ".urwid.ListBox.keypress")
         self.stream_info_view.keypress(size, key)
         super_keypress.assert_called_once_with(size, expected_key)
 
@@ -881,7 +878,7 @@ class TestStreamMembersView:
         )
         self.controller.model.get_other_subscribers_in_stream.return_value = []
         self.controller.model.user_full_name = ""
-        mocker.patch(VIEWS + ".urwid.SimpleFocusListWalker", return_value=[])
+        mocker.patch(LISTWALKER, return_value=[])
         stream_id = 10
         self.stream_members_view = StreamMembersView(self.controller, stream_id)
 
@@ -901,6 +898,6 @@ class TestStreamMembersView:
     ):
         key, expected_key = navigation_key_expected_key_pair
         size = widget_size(self.stream_members_view)
-        super_keypress = mocker.patch(VIEWS + ".urwid.ListBox.keypress")
+        super_keypress = mocker.patch(MODULE + ".urwid.ListBox.keypress")
         self.stream_members_view.keypress(size, key)
         super_keypress.assert_called_once_with(size, expected_key)


### PR DESCRIPTION
Currently, in pytests, several statements use hard-coded module path strings for patching purposes.
The intent of this PR is to refactor such statements and as a result, reduce code duplication.