### PR TITLE
boxes: Prefill stream name when user presses `c` in stream/topic narrow.

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1858,7 +1858,7 @@ class TestMessageBox:
     @pytest.mark.parametrize('key', keys_for_command('STREAM_MESSAGE'))
     @pytest.mark.parametrize('narrow, expect_to_prefill', [
         ([], False),
-        ([['stream', 'general']], False),
+        ([['stream', 'general']], True),
         ([['stream', 'general'], ['topic', 'Test']], True),
         ([['is', 'starred']], False),
         ([['is', 'mentioned']], False),

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -1388,7 +1388,10 @@ class MessageBox(urwid.Pile):
                     stream_id=self.stream_id,
                 )
         elif is_command_key('STREAM_MESSAGE', key):
-            if len(self.model.narrow) == 2:
+            if (
+                len(self.model.narrow) != 0
+                and self.model.narrow[0][0] == "stream"
+               ):
                 self.model.controller.view.write_box.stream_box_view(
                     caption=self.message['display_recipient'],
                     stream_id=self.stream_id,


### PR DESCRIPTION
An earlier commit 2b8a3050 brought about consistency in using `x` and `c`.
This commit aims to build on top of that by prefilling the steam name in
`stream_box_view` when the user presses `c` from stream/topic narrow.

Minor test amendment.