### PR TITLE
core/run/views: Add `--notify` and `--no-notify` flags as a command-line argument for ZT

### DIFF
--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -74,7 +74,9 @@ def test_main_help(capsys, options):
         '--no-autohide',
         '-v, --version',
         '-e, --explore',
-        '--color-depth'
+        '--color-depth',
+        '--notify',
+        '--no-notify',
     }
     optional_argument_lines = {line[2:] for line in lines
                                if len(line) > 2 and line[2] == '-'}
@@ -191,6 +193,34 @@ def test_parse_args_valid_autohide_option(option, autohide):
         ['--no-autohide', '--autohide']
 ])
 def test_main_multiple_autohide_options(capsys, options):
+    with pytest.raises(SystemExit) as e:
+        main(options)
+
+    assert str(e.value) == "2"
+
+    captured = capsys.readouterr()
+    lines = captured.err.strip('\n')
+    lines = lines.split("pytest: ", 1)[1]
+    expected = (f"error: argument {options[1]}: not allowed "
+                f"with argument {options[0]}")
+    assert lines == expected
+
+
+@pytest.mark.parametrize('option, notify_option', [
+        ('--notify', 'enabled'),
+        ('--no-notify', 'disabled'),
+        ('--profile', None),  # disabled by default
+])
+def test__parse_args_valid_notify_option(option, notify_option):
+    args = parse_args([option])
+    assert args.notify == notify_option
+
+
+@pytest.mark.parametrize('options', [
+        ['--notify', '--no-notify'],
+        ['--no-notify', '--notify'],
+])
+def test_main_multiple_notify_options(capsys, options):
     with pytest.raises(SystemExit) as e:
         main(options)
 

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -114,6 +114,7 @@ def test_valid_zuliprc_but_no_connection(capsys, mocker, minimal_zuliprc,
         "   autohide setting 'no_autohide' specified with no config.",
         "   maximum footlinks value '3' specified with no config.",
         "   color depth setting '256' specified with no config.",
+        "   notify setting 'disabled' specified with no config.",
         "\x1b[91m",
         ("Error connecting to Zulip server: "
          f"{server_connection_error}.\x1b[0m"),
@@ -154,6 +155,7 @@ def test_warning_regarding_incomplete_theme(capsys, mocker, monkeypatch,
         "   autohide setting 'no_autohide' specified with no config.",
         "   maximum footlinks value '3' specified with no config.",
         "   color depth setting '256' specified with no config.",
+        "   notify setting 'disabled' specified with no config.",
         "\x1b[91m",
         f"Error connecting to Zulip server: {server_connection_error}.\x1b[0m",
     ]
@@ -340,7 +342,8 @@ def test_successful_main_function_with_config(
         "   theme 'zt_dark' specified in zuliprc file (by alias 'default').",
         "   autohide setting 'autohide' specified in zuliprc file.",
         f"   maximum footlinks value {footlinks_output}",
-        "   color depth setting '256' specified in zuliprc file."
+        "   color depth setting '256' specified in zuliprc file.",
+        "   notify setting 'enabled' specified in zuliprc file."
     ]
     assert lines == expected_lines
 

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -141,6 +141,7 @@ class TestAboutView:
                                     server_feature_level=server_feature_level,
                                     theme_name='zt_dark',
                                     color_depth=256,
+                                    notify_enabled=False,
                                     autohide_enabled=False,
                                     maximum_footlinks=3)
 
@@ -177,6 +178,7 @@ class TestAboutView:
                                server_feature_level=server_feature_level,
                                theme_name='zt_dark',
                                color_depth=256,
+                               notify_enabled=False,
                                autohide_enabled=False,
                                maximum_footlinks=3)
 

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -414,6 +414,9 @@ def main(options: Optional[List[str]]=None) -> None:
                 .format(*zterm['maximum-footlinks']))
         print("   color depth setting '{}' specified {}."
               .format(*zterm['color-depth']))
+        print("   notify setting '{}' specified {}."
+              .format(*zterm['notify']))
+
         # For binary settings
         # Specify setting in order True, False
         valid_settings = {

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -95,6 +95,13 @@ def parse_args(argv: List[str]) -> argparse.Namespace:
                         choices=['1', '16', '256'],
                         help="Force the color depth "
                              f"(default {DEFAULT_SETTINGS['color-depth']}).")
+    notify_group = parser.add_mutually_exclusive_group()
+    notify_group.add_argument('--notify', dest='notify', default=None,
+                              action='store_const', const='enabled',
+                              help='Enable desktop notifications.')
+    notify_group.add_argument('--no-notify', dest='notify', default=None,
+                              action='store_const', const='disabled',
+                              help='Disable desktop notifications.')
     # debug mode
     parser.add_argument("-d",
                         "--debug",
@@ -382,6 +389,9 @@ def main(options: Optional[List[str]]=None) -> None:
             zterm['color-depth'] = (args.color_depth, 'on command line')
 
         color_depth = int(zterm['color-depth'][0])
+
+        if args.notify:
+            zterm['notify'] = (args.notify, 'on command line')
 
         print("Loading with:")
         print("   theme '{}' specified {}.".format(*theme_to_use))

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -227,10 +227,13 @@ class Controller:
 
     def show_about(self) -> None:
         self.show_pop_up(
-            AboutView(self, 'About', zt_version=ZT_VERSION,
+            AboutView(self, 'About',
+                      zt_version=ZT_VERSION,
                       server_version=self.model.server_version,
                       server_feature_level=self.model.server_feature_level,
-                      theme_name=self.theme_name, color_depth=self.color_depth,
+                      theme_name=self.theme_name,
+                      color_depth=self.color_depth,
+                      notify_enabled=self.notify_enabled,
                       autohide_enabled=self.autohide,
                       maximum_footlinks=self.maximum_footlinks),
             'area:help'

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1017,7 +1017,8 @@ class AboutView(PopUpView):
                  server_version: str,
                  server_feature_level: Optional[int],
                  theme_name: str, color_depth: int,
-                 autohide_enabled: bool, maximum_footlinks: int) -> None:
+                 autohide_enabled: bool, maximum_footlinks: int,
+                 notify_enabled: bool) -> None:
         self.feature_level_content = (
             [('Feature level', str(server_feature_level))]
             if server_feature_level else []
@@ -1030,7 +1031,9 @@ class AboutView(PopUpView):
                 ('Theme', theme_name),
                 ('Autohide', 'enabled' if autohide_enabled else 'disabled'),
                 ('Maximum footlinks', str(maximum_footlinks)),
-                ('Color depth', str(color_depth))])
+                ('Color depth', str(color_depth)),
+                ('Notifications',
+                 'enabled' if notify_enabled else 'disabled'), ])
         ]
 
         popup_width, column_widths = self.calculate_table_widths(contents,


### PR DESCRIPTION
This PR adds new command-line configurations for ZT - the `--notify` and `--no-notify` flags. These should specify whether the notifications will be enabled in the current session or not respectively. If these flags are used as a command-line argument then the corresponding value in the `zuliprc` file is overridden by its value for the current session.

The attribute of this config is also shown in the terminal while ZT is loading, and in the About menu when it has loaded.