### PR TITLE
bugfix: core: Fix cases where message was not focused on narrowing with anchor.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -357,6 +357,14 @@ def stream_msg_template():
 
 
 @pytest.fixture
+def extra_stream_msg_template():
+    msg_template = msg_template_factory(
+        537289, "stream", 1520918740, subject="Test", stream_id=205
+    )
+    return msg_template
+
+
+@pytest.fixture
 def pm_template():
     recipients = display_recipient_factory([(5179, "Boo Boo"), (5140, "Foo Foo")])
     return msg_template_factory(537287, "private", 1520918736, recipients=recipients)
@@ -728,6 +736,20 @@ def index_topic(empty_index):
     """
     diff = {"topic_msg_ids": defaultdict(dict, {205: {"Test": {537286}}})}
     return dict(empty_index, **diff)
+
+
+@pytest.fixture
+def index_multiple_topic_msg(empty_index, extra_stream_msg_template):
+    """
+    Index of initial_data with multiple message when model.narrow = [['stream, '7'],
+                                                                     ['topic', 'Test']]
+    """
+    empty_index_with_multiple_topic_msg = empty_index
+    empty_index_with_multiple_topic_msg["messages"].update(
+        {extra_stream_msg_template["id"]: extra_stream_msg_template}
+    )
+    diff = {"topic_msg_ids": defaultdict(dict, {205: {"Test": {537286, 537289}}})}
+    return dict(empty_index_with_multiple_topic_msg, **diff)
 
 
 @pytest.fixture

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -127,12 +127,16 @@ class TestController:
         assert {widget.original_widget.message["id"]} == id_list
 
     @pytest.mark.parametrize(
-        ["initial_narrow", "anchor", "expected_final_focus"],
+        ["initial_narrow", "initial_stream_id", "anchor", "expected_final_focus"],
         [
-            ([], None, 537289),
+            ([], None, None, 537289),
+            ([["stream", "PTEST"], ["topic", "Test"]], 205, 537286, 537286),
+            ([["stream", "PTEST"], ["topic", "Test"]], 205, 537289, 537289),
         ],
         ids=[
             "all-messages_to_topic_narrow_no_anchor",
+            "topic_narrow_to_same_topic_narrow_with_anchor",
+            "topic_narrow_to_same_topic_narrow_with_other_anchor",
         ],
     )
     def test_narrow_to_topic(
@@ -142,6 +146,7 @@ class TestController:
         msg_box,
         index_multiple_topic_msg,
         initial_narrow,
+        initial_stream_id,
         anchor,
         expected_final_focus,
     ):
@@ -151,6 +156,7 @@ class TestController:
         ]
         controller.model.narrow = initial_narrow
         controller.model.index = index_multiple_topic_msg
+        controller.model.stream_id = initial_stream_id
         controller.view.message_view = mocker.patch("urwid.ListBox")
         controller.model.stream_dict = {
             205: {

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -386,7 +386,8 @@ class Controller:
 
     def _narrow_to(self, anchor: Optional[int], **narrow: Any) -> None:
         already_narrowed = self.model.set_narrow(**narrow)
-        if already_narrowed:
+
+        if already_narrowed and anchor is None:
             return
 
         msg_id_list = self.model.get_message_ids_in_current_narrow()

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -392,8 +392,10 @@ class Controller:
 
         msg_id_list = self.model.get_message_ids_in_current_narrow()
 
-        # if no messages are found get more messages
-        if len(msg_id_list) == 0:
+        # If no messages are found in the current narrow
+        # OR, given anchor is not present in msg_id_list
+        # then, get more messages.
+        if len(msg_id_list) == 0 or (anchor is not None and anchor not in msg_id_list):
             self.model.get_messages(num_before=30, num_after=10, anchor=anchor)
             msg_id_list = self.model.get_message_ids_in_current_narrow()
 


### PR DESCRIPTION
This bugfix fixes selecting messages if a contextual msg-id (anchor) is provided to the `_narrow_to()` function for some edge cases. Earlier, if the user was within the same narrow then narrowing to a quoted message from `MsgLinkButton` did not select that message. Also, sometimes pressing `a` on a particular message did not focus on it when narrowed to the `all_messages` narrow.

Tests added.
Fixes #954.