### PR TITLE
refactor: Minor changes in UI keypress.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 import pytest
 
-from zulipterminal.config.keys import keys_for_command, primary_key_for_command
+from zulipterminal.config.keys import primary_key_for_command
 from zulipterminal.helper import initial_index as helper_initial_index
 from zulipterminal.ui_tools.boxes import MessageBox
 from zulipterminal.ui_tools.buttons import StreamButton, TopicButton, UserButton
@@ -1119,29 +1119,6 @@ def classified_unread_counts():
 def mouse_scroll_event(request):
     """
     Returns required parameters for mouse_event keypress
-    """
-    return request.param
-
-
-@pytest.fixture(
-    params=[
-        (key, expected_key)
-        for keys, expected_key in [
-            (keys_for_command("GO_UP"), "up"),
-            (keys_for_command("GO_DOWN"), "down"),
-            (keys_for_command("SCROLL_UP"), "page up"),
-            (keys_for_command("SCROLL_DOWN"), "page down"),
-            (keys_for_command("GO_TO_BOTTOM"), "end"),
-        ]
-        for key in keys
-    ],
-    ids=lambda param: "key:{}-expected_key:{}".format(*param),
-)
-def navigation_key_expected_key_pair(request):
-    """
-    Fixture to generate pairs of navigation keys with their respective
-    expected key.
-    The expected key is the one which is passed to the super `keypress` calls.
     """
     return request.param
 

--- a/tests/ui/test_ui.py
+++ b/tests/ui/test_ui.py
@@ -251,26 +251,43 @@ class TestView:
 
         super_keypress.assert_called_once_with(size, key)
 
-    @pytest.mark.parametrize(
-        "key, narrow_method",
-        [
-            (keys_for_command("ALL_MENTIONS"), "narrow_to_all_mentions"),
-            (keys_for_command("ALL_PM"), "narrow_to_all_pm"),
-            (keys_for_command("ALL_STARRED"), "narrow_to_all_starred"),
-        ],
-    )
-    def test_keypress_special_narrows(
-        self, view, mocker, key, narrow_method, widget_size
-    ):
+    @pytest.mark.parametrize("key", keys_for_command("ALL_MENTIONS"))
+    def test_keypress_ALL_MENTIONS(self, view, mocker, key, widget_size):
         view.body = mocker.Mock()
         view.body.focus_col = None
         view.controller.is_in_editor_mode = lambda: False
         size = widget_size(view)
-        mocked_narrow = mocker.patch.object(view.controller, narrow_method)
+        view.controller.narrow_to_all_mentions = mocker.Mock()
 
         view.keypress(size, key)
 
-        mocked_narrow.assert_called_once_with()
+        view.controller.narrow_to_all_mentions.assert_called_once_with()
+        assert view.body.focus_col == 1
+
+    @pytest.mark.parametrize("key", keys_for_command("ALL_PM"))
+    def test_keypress_ALL_PM(self, view, mocker, key, widget_size):
+        view.body = mocker.Mock()
+        view.body.focus_col = None
+        view.controller.is_in_editor_mode = lambda: False
+        size = widget_size(view)
+        view.controller.narrow_to_all_pm = mocker.Mock()
+
+        view.keypress(size, key)
+
+        view.controller.narrow_to_all_pm.assert_called_once_with()
+        assert view.body.focus_col == 1
+
+    @pytest.mark.parametrize("key", keys_for_command("ALL_STARRED"))
+    def test_keypress_ALL_STARRED(self, view, mocker, key, widget_size):
+        view.body = mocker.Mock()
+        view.body.focus_col = None
+        view.controller.is_in_editor_mode = lambda: False
+        size = widget_size(view)
+        view.controller.narrow_to_all_starred = mocker.Mock()
+
+        view.keypress(size, key)
+
+        view.controller.narrow_to_all_starred.assert_called_once_with()
         assert view.body.focus_col == 1
 
     @pytest.mark.parametrize("key", keys_for_command("STREAM_MESSAGE"))

--- a/tests/ui/test_ui.py
+++ b/tests/ui/test_ui.py
@@ -251,17 +251,26 @@ class TestView:
 
         super_keypress.assert_called_once_with(size, key)
 
-    @pytest.mark.parametrize("key", keys_for_command("ALL_MENTIONS"))
-    def test_keypress_ALL_MENTIONS(self, view, mocker, key, widget_size):
+    @pytest.mark.parametrize(
+        "key, narrow_method",
+        [
+            (keys_for_command("ALL_MENTIONS"), "narrow_to_all_mentions"),
+            (keys_for_command("ALL_PM"), "narrow_to_all_pm"),
+            (keys_for_command("ALL_STARRED"), "narrow_to_all_starred"),
+        ],
+    )
+    def test_keypress_special_narrows(
+        self, view, mocker, key, narrow_method, widget_size
+    ):
         view.body = mocker.Mock()
         view.body.focus_col = None
         view.controller.is_in_editor_mode = lambda: False
         size = widget_size(view)
-        view.controller.narrow_to_all_mentions = mocker.Mock()
+        mocked_narrow = mocker.patch.object(view.controller, narrow_method)
 
         view.keypress(size, key)
 
-        view.controller.narrow_to_all_mentions.assert_called_once_with()
+        mocked_narrow.assert_called_once_with()
         assert view.body.focus_col == 1
 
     @pytest.mark.parametrize("key", keys_for_command("STREAM_MESSAGE"))

--- a/tests/ui/test_ui.py
+++ b/tests/ui/test_ui.py
@@ -1,6 +1,6 @@
 import pytest
 
-from zulipterminal.config.keys import keys_for_command
+from zulipterminal.config.keys import STD_NAV_CMDS, keys_for_command
 from zulipterminal.ui import View
 
 
@@ -234,10 +234,10 @@ class TestView:
         else:
             view.body.options.assert_not_called()
 
-    def test_keypress_normal_mode_navigation(
-        self, view, mocker, widget_size, navigation_key_expected_key_pair
-    ):
-        key, expected_key = navigation_key_expected_key_pair
+    @pytest.mark.parametrize(
+        "key", [key for cmd in STD_NAV_CMDS for key in keys_for_command(cmd)]
+    )
+    def test_keypress_normal_mode_navigation(self, view, mocker, key, widget_size):
         view.users_view = mocker.Mock()
         view.body = mocker.Mock()
         view.user_search = mocker.Mock()
@@ -249,7 +249,7 @@ class TestView:
 
         view.keypress(size, key)
 
-        super_keypress.assert_called_once_with(size, expected_key)
+        super_keypress.assert_called_once_with(size, key)
 
     @pytest.mark.parametrize("key", keys_for_command("ALL_MENTIONS"))
     def test_keypress_ALL_MENTIONS(self, view, mocker, key, widget_size):

--- a/tests/ui/test_ui.py
+++ b/tests/ui/test_ui.py
@@ -257,11 +257,11 @@ class TestView:
         view.body.focus_col = None
         view.controller.is_in_editor_mode = lambda: False
         size = widget_size(view)
-        view.model.controller.narrow_to_all_mentions = mocker.Mock()
+        view.controller.narrow_to_all_mentions = mocker.Mock()
 
         view.keypress(size, key)
 
-        view.model.controller.narrow_to_all_mentions.assert_called_once_with()
+        view.controller.narrow_to_all_mentions.assert_called_once_with()
         assert view.body.focus_col == 1
 
     @pytest.mark.parametrize("key", keys_for_command("STREAM_MESSAGE"))

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 import pytest
 from urwid import Columns, Text
 
-from zulipterminal.config.keys import is_command_key, keys_for_command
+from zulipterminal.config.keys import STD_NAV_CMDS, is_command_key, keys_for_command
 from zulipterminal.ui_tools.boxes import MessageBox
 from zulipterminal.ui_tools.views import (
     AboutView,
@@ -114,10 +114,10 @@ class TestPopUpView:
         self.pop_up_view.keypress(size, "cmd_key")
         assert self.controller.exit_popup.called
 
-    def test_keypress_navigation(
-        self, mocker, widget_size, navigation_key_expected_key_pair
-    ):
-        key, expected_key = navigation_key_expected_key_pair
+    @pytest.mark.parametrize(
+        "key", [key for cmd in STD_NAV_CMDS for key in keys_for_command(cmd)]
+    )
+    def test_keypress_navigation(self, mocker, key, widget_size):
         size = widget_size(self.pop_up_view)
         # Patch `is_command_key` to not raise an 'Invalid Command' exception
         # when its parameters are (self.command, key) as there is no
@@ -131,7 +131,7 @@ class TestPopUpView:
             ),
         )
         self.pop_up_view.keypress(size, key)
-        self.super_keypress.assert_called_once_with(size, expected_key)
+        self.super_keypress.assert_called_once_with(size, key)
 
 
 class TestAboutView:
@@ -170,15 +170,6 @@ class TestAboutView:
         size = widget_size(self.about_view)
         self.about_view.keypress(size, key)
         assert not self.controller.exit_popup.called
-
-    def test_keypress_navigation(
-        self, mocker, widget_size, navigation_key_expected_key_pair
-    ):
-        key, expected_key = navigation_key_expected_key_pair
-        size = widget_size(self.about_view)
-        super_keypress = mocker.patch(MODULE + ".urwid.ListBox.keypress")
-        self.about_view.keypress(size, key)
-        super_keypress.assert_called_once_with(size, expected_key)
 
     def test_feature_level_content(self, mocker, zulip_version):
         self.controller = mocker.Mock()
@@ -320,15 +311,6 @@ class TestUserInfoView:
         self.user_info_view.keypress(size, key)
         assert not self.controller.exit_popup.called
 
-    def test_keypress_navigation(
-        self, mocker, widget_size, navigation_key_expected_key_pair
-    ):
-        key, expected_key = navigation_key_expected_key_pair
-        size = widget_size(self.user_info_view)
-        super_keypress = mocker.patch(MODULE + ".urwid.ListBox.keypress")
-        self.user_info_view.keypress(size, key)
-        super_keypress.assert_called_once_with(size, expected_key)
-
 
 class TestEditHistoryView:
     @pytest.fixture(autouse=True)
@@ -393,17 +375,6 @@ class TestEditHistoryView:
             message_links=OrderedDict(),
             time_mentions=list(),
         )
-
-    def test_keypress_navigation(
-        self, mocker, widget_size, navigation_key_expected_key_pair
-    ):
-        size = widget_size(self.edit_history_view)
-        key, expected_key = navigation_key_expected_key_pair
-        super_keypress = mocker.patch(MODULE + ".urwid.ListBox.keypress")
-
-        self.edit_history_view.keypress(size, key)
-
-        super_keypress.assert_called_once_with(size, expected_key)
 
     @pytest.mark.parametrize(
         "snapshot",
@@ -593,15 +564,6 @@ class TestHelpView:
         size = widget_size(self.help_view)
         self.help_view.keypress(size, key)
         assert self.controller.exit_popup.called
-
-    def test_keypress_navigation(
-        self, mocker, widget_size, navigation_key_expected_key_pair
-    ):
-        key, expected_key = navigation_key_expected_key_pair
-        size = widget_size(self.help_view)
-        super_keypress = mocker.patch(MODULE + ".urwid.ListBox.keypress")
-        self.help_view.keypress(size, key)
-        super_keypress.assert_called_once_with(size, expected_key)
 
 
 class TestMsgInfoView:
@@ -828,15 +790,6 @@ class TestMsgInfoView:
         assert link_w._wrapped_widget.attr_map == expected_attr_map
         assert link_width == expected_link_width
 
-    def test_keypress_navigation(
-        self, mocker, widget_size, navigation_key_expected_key_pair
-    ):
-        key, expected_key = navigation_key_expected_key_pair
-        size = widget_size(self.msg_info_view)
-        super_keypress = mocker.patch(MODULE + ".urwid.ListBox.keypress")
-        self.msg_info_view.keypress(size, key)
-        super_keypress.assert_called_once_with(size, expected_key)
-
 
 class TestStreamInfoView:
     @pytest.fixture(autouse=True)
@@ -963,15 +916,6 @@ class TestStreamInfoView:
         self.stream_info_view.keypress(size, key)
         assert self.controller.exit_popup.called
 
-    def test_keypress_navigation(
-        self, mocker, widget_size, navigation_key_expected_key_pair
-    ):
-        key, expected_key = navigation_key_expected_key_pair
-        size = widget_size(self.stream_info_view)
-        super_keypress = mocker.patch(MODULE + ".urwid.ListBox.keypress")
-        self.stream_info_view.keypress(size, key)
-        super_keypress.assert_called_once_with(size, expected_key)
-
     @pytest.mark.parametrize("key", (*keys_for_command("ENTER"), " "))
     def test_checkbox_toggle_mute_stream(self, mocker, key, widget_size):
         mute_checkbox = self.stream_info_view.widgets[-3]
@@ -1031,12 +975,3 @@ class TestStreamMembersView:
         self.controller.show_stream_info.assert_called_once_with(
             stream_id=stream_id,
         )
-
-    def test_keypress_navigation(
-        self, mocker, widget_size, navigation_key_expected_key_pair
-    ):
-        key, expected_key = navigation_key_expected_key_pair
-        size = widget_size(self.stream_members_view)
-        super_keypress = mocker.patch(MODULE + ".urwid.ListBox.keypress")
-        self.stream_members_view.keypress(size, key)
-        super_keypress.assert_called_once_with(size, expected_key)

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -2,6 +2,7 @@ from collections import OrderedDict
 from typing import List
 
 from typing_extensions import TypedDict
+from urwid.command_map import command_map
 
 
 class KeyBinding(TypedDict, total=False):
@@ -358,6 +359,16 @@ HELP_CATEGORIES = OrderedDict(
     ]
 )
 
+STD_NAV_CMDS = [
+    "GO_UP",
+    "GO_DOWN",
+    "GO_LEFT",
+    "GO_RIGHT",
+    "SCROLL_UP",
+    "SCROLL_DOWN",
+    "GO_TO_BOTTOM",
+]
+
 
 class InvalidCommand(Exception):
     pass
@@ -400,3 +411,19 @@ def commands_for_random_tips() -> List[KeyBinding]:
         for key_binding in KEY_BINDINGS.values()
         if not key_binding.get("excluded_from_random_tips", False)
     ]
+
+
+# Maps alternate nav keys to standard nav keys.
+# Refer urwid/command_map.py
+for cmd in STD_NAV_CMDS:
+    std_key, *alt_keys = keys_for_command(cmd)
+
+    for key in alt_keys:
+        if std_key == "end":
+            urwid_cmd = "cursor max right"
+        elif std_key == "home":
+            urwid_cmd = "cursor max left"
+        else:
+            urwid_cmd = "cursor " + std_key
+
+        command_map.__setitem__(key, urwid_cmd)

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -278,23 +278,7 @@ class View(urwid.WidgetWrap):
             # Show help menu
             self.controller.show_help()
             return key
-        # replace alternate keys with arrow/functional keys
-        # This is needed for navigating in widgets
-        # other than message_view.
-        elif is_command_key("GO_UP", key):
-            key = "up"
-        elif is_command_key("GO_DOWN", key):
-            key = "down"
-        elif is_command_key("GO_LEFT", key):
-            key = "left"
-        elif is_command_key("GO_RIGHT", key):
-            key = "right"
-        elif is_command_key("SCROLL_UP", key):
-            key = "page up"
-        elif is_command_key("SCROLL_DOWN", key):
-            key = "page down"
-        elif is_command_key("GO_TO_BOTTOM", key):
-            key = "end"
+
         return super().keypress(size, key)
 
 

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -211,13 +211,13 @@ class View(urwid.WidgetWrap):
             self.middle_column.keypress(size, key)
             return key
         elif is_command_key("ALL_PM", key):
-            self.model.controller.narrow_to_all_pm()
+            self.controller.narrow_to_all_pm()
             self.body.focus_col = 1
         elif is_command_key("ALL_STARRED", key):
-            self.model.controller.narrow_to_all_starred()
+            self.controller.narrow_to_all_starred()
             self.body.focus_col = 1
         elif is_command_key("ALL_MENTIONS", key):
-            self.model.controller.narrow_to_all_mentions()
+            self.controller.narrow_to_all_mentions()
             self.body.focus_col = 1
         elif is_command_key("SEARCH_PEOPLE", key):
             # Start User Search if not in editor_mode

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1043,16 +1043,7 @@ class PopUpView(urwid.ListBox):
     def keypress(self, size: urwid_Size, key: str) -> str:
         if is_command_key("GO_BACK", key) or is_command_key(self.command, key):
             self.controller.exit_popup()
-        elif is_command_key("GO_UP", key):
-            key = "up"
-        elif is_command_key("GO_DOWN", key):
-            key = "down"
-        elif is_command_key("SCROLL_UP", key):
-            key = "page up"
-        elif is_command_key("SCROLL_DOWN", key):
-            key = "page down"
-        elif is_command_key("GO_TO_BOTTOM", key):
-            key = "end"
+
         return super().keypress(size, key)
 
 


### PR DESCRIPTION
**Commit1**: refactor: view: Minor changes in UI keypress. 
* Changes old notation self.model.controller to self.controller
* Adds missing return key to 3 of the if conditions.
* The 3 if statements had no reason to not `return key`. 
Maybe because they were written by different people hence the difference.
Do tell me if there was a specific reason, I'll revert.

**Commit2**:tests: view: Add UI tests.
* Tests added for Special Narrow keypress actions in View.

**Commit3**:refactor: Minor changes in UI keypress.
* This commit introduces a dictionary ALT_NAV_KEYS to map alt-keys to
standard navigational keys. This is used in `ui.py` and `PopupView`.
* Tests exist.