### PR TITLE
Fix focus index before and after search

### DIFF
--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -293,13 +293,17 @@ class StreamsViewDivider(urwid.Divider):
 class StreamsView(urwid.Frame):
     def __init__(self, streams_btn_list: List[Any], view: Any) -> None:
         self.view = view
-        self.log = urwid.SimpleFocusListWalker(streams_btn_list)
+        # Create Stream List Box
         self.streams_btn_list = streams_btn_list
-        self.focus_index_before_search = 0
+        self.log = urwid.SimpleFocusListWalker(streams_btn_list)
         list_box = urwid.ListBox(self.log)
+        # Create Stream Search Box
         self.stream_search_box = PanelSearchBox(self,
                                                 'SEARCH_STREAMS',
                                                 self.update_streams)
+        self.focus_index_before_search = 0
+        self.in_search_mode = False
+        # Create Stream View Frame
         super().__init__(list_box, header=urwid.LineBox(
             self.stream_search_box, tlcorner='─', tline='', lline='',
             trcorner='─', blcorner='─', rline='',
@@ -356,6 +360,7 @@ class StreamsView(urwid.Frame):
 
     def keypress(self, size: urwid_Size, key: str) -> Optional[str]:
         if is_command_key('SEARCH_STREAMS', key):
+            self.in_search_mode = True
             self.set_focus('header')
             return key
         elif is_command_key('GO_BACK', key):
@@ -365,9 +370,11 @@ class StreamsView(urwid.Frame):
             self.set_focus('body')
             self.log.set_focus(self.focus_index_before_search)
             self.view.controller.update_screen()
+            self.in_search_mode = False
             return key
         return_value = super().keypress(size, key)
-        _, self.focus_index_before_search = self.log.get_focus()
+        if not self.in_search_mode:
+            _, self.focus_index_before_search = self.log.get_focus()
         return return_value
 
 
@@ -375,17 +382,21 @@ class TopicsView(urwid.Frame):
     def __init__(self, topics_btn_list: List[Any], view: Any,
                  stream_button: Any) -> None:
         self.view = view
-        self.log = urwid.SimpleFocusListWalker(topics_btn_list)
-        self.topics_btn_list = topics_btn_list
         self.stream_button = stream_button
-        self.focus_index_before_search = 0
+        # Create Topic List Box
+        self.topics_btn_list = topics_btn_list
+        self.log = urwid.SimpleFocusListWalker(topics_btn_list)
         self.list_box = urwid.ListBox(self.log)
+        # Create Topic Search Box
         self.topic_search_box = PanelSearchBox(self,
                                                'SEARCH_TOPICS',
                                                self.update_topics)
+        self.focus_index_before_search = 0
+        self.in_search_mode = False
         self.header_list = urwid.Pile([self.stream_button,
                                        urwid.Divider('─'),
                                        self.topic_search_box])
+        # Create Topic View Frame
         super().__init__(self.list_box, header=urwid.LineBox(
             self.header_list, tlcorner='─', tline='', lline='',
             trcorner='─', blcorner='─', rline='',
@@ -452,6 +463,7 @@ class TopicsView(urwid.Frame):
             self.view.show_left_panel(visible=False)
             self.view.body.focus_col = 1
         if is_command_key('SEARCH_TOPICS', key):
+            self.in_search_mode = True
             self.set_focus('header')
             self.header_list.set_focus(2)
             return key
@@ -462,9 +474,11 @@ class TopicsView(urwid.Frame):
             self.set_focus('body')
             self.log.set_focus(self.focus_index_before_search)
             self.view.controller.update_screen()
+            self.in_search_mode = False
             return key
         return_value = super().keypress(size, key)
-        _, self.focus_index_before_search = self.log.get_focus()
+        if not self.in_search_mode:
+            _, self.focus_index_before_search = self.log.get_focus()
         return return_value
 
 


### PR DESCRIPTION
This PR corrects what the code for `focus_index_before_search` was intended to do. See #975
The focus index was still being updated even in the search results.

This is fixed by adding a boolean `in_search_mode` which does not
call `get_focus` untill the search is over. Slight reordering was
done in `__init__` to fit the boolean in an ideal place w.r.t.
readability.

Fixes #975

| Before Commit: | After Commit: |
| :-------------------: | :-----------------: |
| <img src="https://user-images.githubusercontent.com/64144419/113336052-6f0ac200-9343-11eb-97df-ee06a8739082.gif" alt="wrong-focus" height="300"/> | <img src="https://user-images.githubusercontent.com/64144419/113336589-47682980-9344-11eb-8d78-a03df5a7e743.gif" alt="right-focus" height=300/> |
