### PR TITLE
view: Fix focus index before and after Panel Search.

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -568,64 +568,38 @@ class TestStreamsView:
     def test_keypress_SEARCH_STREAMS(self, mocker, stream_view, key, widget_size):
         size = widget_size(stream_view)
         mocker.patch.object(stream_view, "set_focus")
+        stream_view.log.extend(["FOO", "foo", "fan", "boo", "BOO"])
+        stream_view.log.set_focus(3)
+
         stream_view.keypress(size, key)
+
+        assert stream_view.focus_index_before_search == 3
         stream_view.set_focus.assert_called_once_with("header")
 
     @pytest.mark.parametrize("key", keys_for_command("GO_BACK"))
     def test_keypress_GO_BACK(self, mocker, stream_view, key, widget_size):
         size = widget_size(stream_view)
         mocker.patch.object(stream_view, "set_focus")
+        mocker.patch(VIEWS + ".urwid.Frame.keypress")
         mocker.patch.object(stream_view.stream_search_box, "reset_search_text")
+        stream_view.streams_btn_list = ["FOO", "foo", "fan", "boo", "BOO"]
+        stream_view.focus_index_before_search = 3
+
+        # Simulate search
+        stream_view.log.clear()
+        stream_view.log.extend(stream_view.streams_btn_list[3])
+        stream_view.log.set_focus(0)
+        stream_view.keypress(size, "down")
+        assert stream_view.log.get_focus()[1] != stream_view.focus_index_before_search
+
+        # Exit search
         stream_view.keypress(size, key)
+
+        # Check state reset after search
         stream_view.set_focus.assert_called_once_with("body")
         assert stream_view.stream_search_box.reset_search_text.called
-        assert stream_view.log == self.streams_btn_list
-
-    @pytest.mark.parametrize("search_streams_key", keys_for_command("SEARCH_STREAMS"))
-    @pytest.mark.parametrize("go_back_key", keys_for_command("GO_BACK"))
-    @pytest.mark.parametrize(
-        "current_focus, stream",
-        [
-            (0, "FOO"),
-            (2, "fan"),
-            (4, "BOO"),
-        ],
-    )
-    def test_return_to_focus_after_search(
-        self,
-        mocker,
-        stream_view,
-        widget_size,
-        current_focus,
-        stream,
-        search_streams_key,
-        go_back_key,
-    ):
-        # Initialize log
-        stream_view.streams_btn_list = [
-            mocker.Mock(stream_name=stream_name)
-            for stream_name in ["FOO", "foo", "fan", "boo", "BOO"]
-        ]
-        stream_view.log.extend(stream_view.streams_btn_list)
-
-        # Set initial stream focus to 'current_focus' and name to 'stream'
-        stream_view.log.set_focus(current_focus)
-        stream_view.focus_index_before_search = current_focus
-        previous_focus = stream_view.log.get_focus()[1]
-        previous_focus_stream_name = stream
-
-        # Toggle Stream Search
-        size = widget_size(stream_view)
-        stream_view.keypress(size, search_streams_key)
-
-        # Exit Stream Search
-        stream_view.keypress(size, go_back_key)
-
-        # Obtain new stream focus
-        new_focus = stream_view.log.get_focus()[1]
-        new_focus_stream_name = stream_view.log[new_focus].stream_name
-        assert new_focus == previous_focus
-        assert previous_focus_stream_name == new_focus_stream_name
+        assert stream_view.log == stream_view.streams_btn_list
+        assert stream_view.log.get_focus()[1] == stream_view.focus_index_before_search
 
 
 class TestTopicsView:
@@ -741,65 +715,39 @@ class TestTopicsView:
     def test_keypress_SEARCH_TOPICS(self, mocker, topic_view, key, widget_size):
         size = widget_size(topic_view)
         mocker.patch(VIEWS + ".TopicsView.set_focus")
+        topic_view.log.extend(["FOO", "foo", "fan", "boo", "BOO"])
+        topic_view.log.set_focus(3)
+
         topic_view.keypress(size, key)
+
         topic_view.set_focus.assert_called_once_with("header")
         topic_view.header_list.set_focus.assert_called_once_with(2)
+        assert topic_view.focus_index_before_search == 3
 
     @pytest.mark.parametrize("key", keys_for_command("GO_BACK"))
     def test_keypress_GO_BACK(self, mocker, topic_view, key, widget_size):
         size = widget_size(topic_view)
         mocker.patch(VIEWS + ".TopicsView.set_focus")
+        mocker.patch(VIEWS + ".urwid.Frame.keypress")
         mocker.patch.object(topic_view.topic_search_box, "reset_search_text")
+        topic_view.topics_btn_list = ["FOO", "foo", "fan", "boo", "BOO"]
+        topic_view.focus_index_before_search = 3
+
+        # Simulate search
+        topic_view.log.clear()
+        topic_view.log.extend(topic_view.topics_btn_list[3])
+        topic_view.log.set_focus(0)
+        topic_view.keypress(size, "down")
+        assert topic_view.log.get_focus()[1] != topic_view.focus_index_before_search
+
+        # Exit search
         topic_view.keypress(size, key)
+
+        # Check state reset after search
         topic_view.set_focus.assert_called_once_with("body")
         assert topic_view.topic_search_box.reset_search_text.called
-        assert topic_view.log == self.topics_btn_list
-
-    @pytest.mark.parametrize("search_topics_key", keys_for_command("SEARCH_TOPICS"))
-    @pytest.mark.parametrize("go_back_key", keys_for_command("GO_BACK"))
-    @pytest.mark.parametrize(
-        "current_focus, topic",
-        [
-            (0, "FOO"),
-            (2, "fan"),
-            (4, "BOO"),
-        ],
-    )
-    def test_return_to_focus_after_search(
-        self,
-        mocker,
-        topic_view,
-        widget_size,
-        current_focus,
-        topic,
-        search_topics_key,
-        go_back_key,
-    ):
-        # Initialize log
-        topic_view.topics_btn_list = [
-            mocker.Mock(topic_name=topic_name)
-            for topic_name in ["FOO", "foo", "fan", "boo", "BOO"]
-        ]
-        topic_view.log.extend(topic_view.topics_btn_list)
-
-        # Set initial focus to 'current_focus' and name to 'topic'
-        topic_view.log.set_focus(current_focus)
-        topic_view.focus_index_before_search = current_focus
-        previous_focus = topic_view.log.get_focus()[1]
-        previous_focus_topic_name = topic
-
-        # Toggle Search
-        size = widget_size(topic_view)
-        topic_view.keypress(size, search_topics_key)
-
-        # Exit Search
-        topic_view.keypress(size, go_back_key)
-
-        # Obtain new focus
-        new_focus = topic_view.log.get_focus()[1]
-        new_focus_topic_name = topic_view.log[new_focus].topic_name
-        assert new_focus == previous_focus
-        assert previous_focus_topic_name == new_focus_topic_name
+        assert topic_view.log == topic_view.topics_btn_list
+        assert topic_view.log.get_focus()[1] == topic_view.focus_index_before_search
 
 
 class TestUsersView:

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -365,6 +365,7 @@ class StreamsView(urwid.Frame):
 
     def keypress(self, size: urwid_Size, key: str) -> Optional[str]:
         if is_command_key("SEARCH_STREAMS", key):
+            _, self.focus_index_before_search = self.log.get_focus()
             self.set_focus("header")
             return key
         elif is_command_key("GO_BACK", key):
@@ -375,9 +376,7 @@ class StreamsView(urwid.Frame):
             self.log.set_focus(self.focus_index_before_search)
             self.view.controller.update_screen()
             return key
-        return_value = super().keypress(size, key)
-        _, self.focus_index_before_search = self.log.get_focus()
-        return return_value
+        return super().keypress(size, key)
 
 
 class TopicsView(urwid.Frame):
@@ -477,6 +476,7 @@ class TopicsView(urwid.Frame):
             self.view.show_left_panel(visible=False)
             self.view.body.focus_col = 1
         if is_command_key("SEARCH_TOPICS", key):
+            _, self.focus_index_before_search = self.log.get_focus()
             self.set_focus("header")
             self.header_list.set_focus(2)
             return key
@@ -488,9 +488,7 @@ class TopicsView(urwid.Frame):
             self.log.set_focus(self.focus_index_before_search)
             self.view.controller.update_screen()
             return key
-        return_value = super().keypress(size, key)
-        _, self.focus_index_before_search = self.log.get_focus()
-        return return_value
+        return super().keypress(size, key)
 
 
 class UsersView(urwid.ListBox):


### PR DESCRIPTION
This PR corrects what the code for `focus_index_before_search` was intended to do. See #975
The focus index was still being updated even in the search results.

This is fixed by moving `get_focus` into the SEARCH_STREAM/TOPIC
conditional.

Fixes #975

| Before Commit: | After Commit: |
| :-------------------: | :-----------------: |
| <img src="https://user-images.githubusercontent.com/64144419/113336052-6f0ac200-9343-11eb-97df-ee06a8739082.gif" alt="wrong-focus" height="300"/> | <img src="https://user-images.githubusercontent.com/64144419/113336589-47682980-9344-11eb-8d78-a03df5a7e743.gif" alt="right-focus" height=300/> |
