### PR TITLE
Add script to enable users to test symbol rendering on their terminals

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -66,6 +66,18 @@ One session of Zulip Terminal represents a connection of one user to one Zulip s
 
 Since we expect the above to be straightforward for most users and it allows the code to remain dramatically simpler, we are unlikely to support multiple Zulip servers within the same session in at least the short/medium term. However, we are certainly likely to move towards a system to make access of the different servers simpler, which should be made easier through work such as [zulip-terminal#678](https://github.com/zulip/zulip-terminal/issues/678).
 
+## Unable to render symbols
+
+If some symbols don't render properly on your terminal, it could likely be because of the symbols not being supported on your terminal emulator and/or font.
+
+We provide a tool that you can run with the command `zulip-term-check-symbols` to check whether or not the symbols render properly on your terminal emulator and font configuration.
+
+Ideally, you should see something similar to the following screenshot (taken on the GNOME Terminal) as a result of running the tool:
+
+![Render Symbols Screenshot](https://user-images.githubusercontent.com/60441372/115103315-9a5df580-9f6e-11eb-8c90-3b2585817d08.png)
+
+If you are unable to observe a similar result upon running the tool, please take a screenshot and let us know about it along with your terminal and font configuration by opening an issue or at [#zulip-terminal](https://chat.zulip.org/#narrow/stream/206-zulip-terminal).
+
 ## Unable to open links
 
 If you are unable to open links in messages, then try double right-click on the link.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -66,17 +66,6 @@ One session of Zulip Terminal represents a connection of one user to one Zulip s
 
 Since we expect the above to be straightforward for most users and it allows the code to remain dramatically simpler, we are unlikely to support multiple Zulip servers within the same session in at least the short/medium term. However, we are certainly likely to move towards a system to make access of the different servers simpler, which should be made easier through work such as [zulip-terminal#678](https://github.com/zulip/zulip-terminal/issues/678).
 
-## Unable to render non-ASCII characters
-
-**NOTE** Releases of 0.3.2 onwards should not have this issue, or require this solution.
-
-If you see `?` in place of emojis or Zulip Terminal gives a `UnicodeError` / `CanvasError`, you haven't enabled utf-8
-encoding in your terminal. To enable it by default, add this to the end of you `~/.bashrc`:
-
-```
-export LANG=en_US.utf-8
-```
-
 ## Unable to open links
 
 If you are unable to open links in messages, then try double right-click on the link.

--- a/setup.py
+++ b/setup.py
@@ -101,6 +101,8 @@ setup(
     entry_points={
         'console_scripts': [
             'zulip-term = zulipterminal.cli.run:main',
+            'zulip-term-check-symbols = '
+            'zulipterminal.scripts.render_symbols:main',
         ],
     },
     extras_require={

--- a/zulipterminal/scripts/render_symbols.py
+++ b/zulipterminal/scripts/render_symbols.py
@@ -1,0 +1,52 @@
+import sys
+
+import urwid
+from urwid import set_encoding
+
+from zulipterminal.config import symbols
+
+
+set_encoding('utf-8')
+
+palette = [
+    ('header', 'white, bold', 'dark blue'),
+    ('footer', 'black', 'white'),
+]
+
+symbol_dict = {name: symbol for name, symbol in vars(symbols).items()
+               if not name.startswith('__') and not name.endswith('__')}
+max_symbol_name_length = max([len(name) for name in symbol_dict.keys()])
+
+symbol_names_list = [urwid.Text(name, align='center')
+                     for name in symbol_dict.keys()]
+symbols_list = [urwid.Text(symbol) for symbol in symbol_dict.values()]
+
+symbols_display_box = urwid.Columns([
+    # Allot extra width to the symbol names list to create a neat layout.
+    (max_symbol_name_length + 2, urwid.Pile(symbol_names_list)),
+    # Allot 2 characters to the symbols list to accommodate symbols needing
+    # double character-width to render.
+    (2, urwid.Pile(symbols_list))
+], dividechars=5)
+columns_length = max_symbol_name_length + 10
+
+line_box = urwid.LineBox(symbols_display_box,
+                         title="Render Symbols",
+                         title_attr='header')
+info_box = urwid.Text(('footer', u" Exit: ^C "), align='center')
+display_box = urwid.Pile([
+    line_box,
+    info_box
+])
+
+# Allot extra width to the display_box to render a neat layout.
+body = urwid.Filler(urwid.Padding(display_box, width=columns_length + 5,
+                                  align='center'), valign='middle')
+
+
+def main() -> None:
+    try:
+        loop = urwid.MainLoop(body, palette)
+        loop.run()
+    finally:
+        sys.exit(0)


### PR DESCRIPTION
This PR has 2 commits that do the following:
- Create a tool to be shipped with ZT that allows users to test symbol rendering on their respective terminal emulators. In the current iteration, the command to run the script is `zulip-term-check-symbols`. This script has been placed in a new folder called `scripts/`.
- `FAQ.md` has been updated to point users/contributors to the same, to help increase awareness on possible symbol rendering issues.

Tested on Windows Terminal and GNOME Terminal on Ubuntu, the layout is maintained in both.

**Screenshots:** As observed on Windows Terminal:
![Symbols rendering script](https://user-images.githubusercontent.com/60441372/114244099-779a7280-99ab-11eb-90a5-4448916f856e.png)
