### PR TITLE
bugfix: Update stream-setting checkboxes from subscription events.

### DIFF
--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1242,6 +1242,10 @@ class StreamInfoView(PopUpView):
 
         self.widgets.append(muted_setting)
         self.widgets.append(pinned_setting)
+
+        self.controller.model.register_callback(
+            self, "stream_info_open", self.update_checkboxes_from_events
+        )
         super().__init__(controller, self.widgets, "STREAM_DESC", popup_width, title)
 
     def toggle_mute_status(self, button: Any, new_state: bool) -> None:

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1250,6 +1250,16 @@ class StreamInfoView(PopUpView):
     def toggle_pinned_status(self, button: Any, new_state: bool) -> None:
         self.controller.model.toggle_stream_pinned_status(self.stream_id)
 
+    @asynch
+    def update_checkboxes_from_events(self) -> None:
+        self.widgets[-2].set_state(
+            self.controller.model.is_muted_stream(self.stream_id), False
+        )
+
+        self.widgets[-1].set_state(
+            self.controller.model.is_pinned_stream(self.stream_id), False
+        )
+
     def keypress(self, size: urwid_Size, key: str) -> str:
         if is_command_key("STREAM_MEMBERS", key):
             self.controller.show_stream_members(stream_id=self.stream_id)


### PR DESCRIPTION
This PR fixes the mismatch between stream settings if the `StreamInfo` popup is opened in ZT and subscription events are received from the server. The current approach registers a callback when the `StreamInfoView` is opened and looks for `subscription` events to trigger the callback, which in turn updates the checkbox UI.

Fixes #747.