### PR TITLE
Show sender's presence status in message content header

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -11,6 +11,7 @@ from zulipterminal.config.keys import keys_for_command
 from zulipterminal.config.symbols import (
     QUOTED_TEXT_MARKER,
     STATUS_ACTIVE,
+    STATUS_INACTIVE,
     STREAM_TOPIC_SEPARATOR,
     TIME_MENTION_MARKER,
 )
@@ -2112,9 +2113,12 @@ class TestMessageBox:
     @pytest.mark.parametrize(
         "expected_header, to_vary_in_last_message",
         [
-            (["alice", " ", "DAYDATETIME"], {"sender_full_name": "bob"}),
-            ([" ", " ", "DAYDATETIME"], {"timestamp": 1532103779}),
-            (["alice", " ", "DAYDATETIME"], {"timestamp": 0}),
+            (
+                [STATUS_INACTIVE, "alice", " ", "DAYDATETIME"],
+                {"sender_full_name": "bob"},
+            ),
+            ([" ", " ", " ", "DAYDATETIME"], {"timestamp": 1532103779}),
+            ([STATUS_INACTIVE, "alice", " ", "DAYDATETIME"], {"timestamp": 0}),
         ],
         ids=[
             "show_author_as_authors_different",
@@ -2142,6 +2146,9 @@ class TestMessageBox:
             " ",
         ] * 2  # called once in __init__ and then in main_view explicitly
 
+        # The empty dict is responsible for INACTIVE status of test user.
+        self.model.user_dict = {}  # called once in main_view explicitly
+
         stars = {
             msg: ({"flags": ["starred"]} if msg == starred_msg else {})
             for msg in ("this", "last")
@@ -2152,10 +2159,10 @@ class TestMessageBox:
 
         msg_box = MessageBox(this_msg, self.model, last_msg)
 
-        expected_header[1] = output_date_time
+        expected_header[2] = output_date_time
         if current_year > 2018:
-            expected_header[1] = "2018 - " + expected_header[1]
-        expected_header[2] = "*" if starred_msg == "this" else " "
+            expected_header[2] = "2018 - " + expected_header[2]
+        expected_header[3] = "*" if starred_msg == "this" else " "
 
         view_components = msg_box.main_view()
 

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -2211,6 +2211,30 @@ class TestMessageBox:
             assert label[0].text == "EDITED"
             assert label[1][1] == 7
 
+    @pytest.mark.parametrize(
+        "to_vary_in_last_message, update_required",
+        [
+            ({"sender_full_name": "Unique name (won't be in next message)"}, True),
+            ({}, False),
+        ],
+        ids=[
+            "author_field_present",
+            "author_field_not_present",
+        ],
+    )
+    def test_update_message_author_status(
+        self,
+        message_fixture,
+        update_required,
+        to_vary_in_last_message,
+    ):
+        message = message_fixture
+        last_msg = dict(message, **to_vary_in_last_message)
+
+        msg_box = MessageBox(message, self.model, last_msg)
+
+        assert msg_box.update_message_author_status() == update_required
+
     @pytest.mark.parametrize("key", keys_for_command("STREAM_MESSAGE"))
     @pytest.mark.parametrize(
         "narrow, expect_to_prefill",

--- a/zulipterminal/config/ui_mappings.py
+++ b/zulipterminal/config/ui_mappings.py
@@ -1,10 +1,25 @@
 from typing import Dict
 
 from zulipterminal.api_types import EditPropagateMode
+from zulipterminal.config.symbols import (
+    STATUS_ACTIVE,
+    STATUS_IDLE,
+    STATUS_INACTIVE,
+    STATUS_OFFLINE,
+)
 
 
 EDIT_MODE_CAPTIONS: Dict[EditPropagateMode, str] = {
     "change_one": "Change only this message topic",
     "change_later": "Also change later messages to this topic",
     "change_all": "Also change previous and following messages to this topic",
+}
+
+
+# Mapping that binds user activity status to corresponding markers.
+STATE_ICON = {
+    "active": STATUS_ACTIVE,
+    "idle": STATUS_IDLE,
+    "offline": STATUS_OFFLINE,
+    "inactive": STATUS_INACTIVE,
 }

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -344,9 +344,9 @@ class Model:
                 self.initial_data["presences"] = response["presences"]
                 self.users = self.get_all_users()
                 if hasattr(self.controller, "view"):
-                    self.controller.view.users_view.update_user_list(
-                        user_list=self.users
-                    )
+                    view = self.controller.view
+                    view.users_view.update_user_list(user_list=self.users)
+                    view.middle_column.update_message_list_status_markers()
             time.sleep(60)
 
     @asynch

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -1429,6 +1429,31 @@ class MessageBox(urwid.Pile):
         ]
         return [part for part, condition in parts if condition]
 
+    def update_message_author_status(self) -> bool:
+        """
+        Update the author status by resetting the entire message box
+        if author field is present.
+        """
+        author_is_present = False
+        author_column = 1  # Index of author field in content header
+        author_field = None
+
+        # Get message author field (if present)
+        if self.need_recipient_header():
+            author_field = self[1][author_column]
+        elif isinstance(self[0][author_column], urwid.Text):
+            author_field = self[0][author_column]
+
+        if author_field is not None:
+            author_is_present = author_field.text != " "
+
+        if author_is_present:
+            # Re initialize the message if update is required.
+            # FIXME: Render specific element (here author field) instead?
+            super().__init__(self.main_view())
+
+        return author_is_present
+
     @classmethod
     def transform_content(
         cls, content: Any, server_url: str

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -552,6 +552,14 @@ class MiddleColumnView(urwid.Frame):
             return pm
         return None
 
+    def update_message_list_status_markers(self) -> None:
+        for message_w in self.body.log:
+            message_box = message_w.original_widget
+
+            message_box.update_message_author_status()
+
+        self.controller.update_screen()
+
     def keypress(self, size: urwid_Size, key: str) -> Optional[str]:
         if is_command_key("GO_BACK", key):
             self.header.keypress(size, "esc")

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -16,14 +16,10 @@ from zulipterminal.config.symbols import (
     CHECK_MARK,
     COLUMN_TITLE_BAR_LINE,
     PINNED_STREAMS_DIVIDER,
-    STATUS_ACTIVE,
-    STATUS_IDLE,
-    STATUS_INACTIVE,
-    STATUS_OFFLINE,
     STREAM_MARKER_PRIVATE,
     STREAM_MARKER_PUBLIC,
 )
-from zulipterminal.config.ui_mappings import EDIT_MODE_CAPTIONS
+from zulipterminal.config.ui_mappings import EDIT_MODE_CAPTIONS, STATE_ICON
 from zulipterminal.helper import Message, asynch, match_stream, match_user
 from zulipterminal.server_url import near_message_url
 from zulipterminal.ui_tools.boxes import MessageBox, PanelSearchBox
@@ -711,13 +707,6 @@ class RightColumnView(urwid.Frame):
             users = self.view.users.copy()
             reset_default_view_users = True
 
-        state_icon = {
-            "active": STATUS_ACTIVE,
-            "idle": STATUS_IDLE,
-            "offline": STATUS_OFFLINE,
-            "inactive": STATUS_INACTIVE,
-        }
-
         users_btn_list = list()
         for user in users:
             status = user["status"]
@@ -734,7 +723,7 @@ class RightColumnView(urwid.Frame):
                     controller=self.view.controller,
                     view=self.view,
                     width=self.width,
-                    state_marker=state_icon[status],
+                    state_marker=STATE_ICON[status],
                     color=f"user_{status}",
                     count=unread_count,
                     is_current_user=is_current_user,


### PR DESCRIPTION
**What does this PR do?!**
 - Adds sender's presence status marker in a message content header

**Commit flow**
 - Centralize the state icons in `ui_mappings.py` (*refactor*)
 - Add state marker as a prefix to sender names in the message header.
 - Add helper in `MessageBox` to update author field if present.
 - Add a method to render presence markers in messages regularly.

**Screenshots/GIFs**

![Screenshot from 2021-06-26 23-02-58](https://user-images.githubusercontent.com/55916430/123521220-fe213f00-d6d2-11eb-89e7-4be5fc0d6d3d.png)

Fixes #896.