### PR TITLE
Typing Indicator Animation

### DIFF
--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -553,6 +553,7 @@ class TestController:
                 {
                     "sender_name": "hamlet",
                     "typing_start_time": datetime.now() + timedelta(1),
+                    "narrow": ["pm"],
                 },
                 id="in_pm_narrow_with_sender_typing:start",
             ),
@@ -567,6 +568,7 @@ class TestController:
     ) -> None:
         set_footer_text = mocker.patch(VIEW + ".set_footer_text")
         sleep = mocker.patch(MODULE + ".time.sleep")
+        controller.model.narrow = ["pm"]
         controller.active_conversation_info = active_conversation_info
 
         def mock_typing() -> None:
@@ -598,10 +600,29 @@ class TestController:
         controller: Controller,
     ) -> None:
         set_footer_text = mocker.patch(VIEW + ".set_footer_text")
-        controller.active_conversation_info = {"sender_name": "hamlet"}
+        controller.model.narrow = ["pm"]
+        controller.active_conversation_info = {
+            "sender_name": "hamlet",
+            "narrow": controller.model.narrow,
+        }
         controller.active_conversation_info[
             "typing_start_time"
         ] = datetime.now() - timedelta(seconds=14.5)
+
+        controller.show_typing_notification()
+
+        assert controller.active_conversation_info == {}
+
+    def test_end_typing_notification_on_narrow_change(
+        self, mocker: MockerFixture, controller: Controller
+    ) -> None:
+        set_footer_text = mocker.patch(VIEW + ".set_footer_text")
+        controller.model.narrow = [["pm_with", "othello@zulip.com"]]
+        controller.active_conversation_info = {
+            "sender_name": "hamlet",
+            "narrow": [["pm_with", "hamlet@zulip.com"]],
+        }
+        controller.active_conversation_info["typing_start_time"] = datetime.now()
 
         controller.show_typing_notification()
 

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -2535,6 +2535,8 @@ class TestModel:
         model.controller.is_typing_notification_in_progress = (
             is_notification_in_progress
         )
+        mocked_datetime = mocker.patch(MODULE + ".datetime")
+        mocked_datetime.now.return_value = "UNIXTIME"
         show_typing_notification = mocker.patch(
             CONTROLLER + ".show_typing_notification"
         )
@@ -2545,6 +2547,10 @@ class TestModel:
             assert (
                 model.controller.active_conversation_info["sender_name"]
                 == expected_active_conversation_info["sender_name"]
+            )
+            assert (
+                model.controller.active_conversation_info["typing_start_time"]
+                == "UNIXTIME"
             )
         assert show_typing_notification.called == expected_show_typing_notification
 

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -2552,6 +2552,7 @@ class TestModel:
                 model.controller.active_conversation_info["typing_start_time"]
                 == "UNIXTIME"
             )
+            assert model.controller.active_conversation_info["narrow"] == narrow
         assert show_typing_notification.called == expected_show_typing_notification
 
     @pytest.mark.parametrize(

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -434,6 +434,10 @@ class Controller:
             if time_elapsed > max_duration:
                 self.active_conversation_info = {}
 
+            # If user changes narrow
+            if self.model.narrow != active_conversation_info["narrow"]:
+                self.active_conversation_info = {}
+
             self.view.set_footer_text(
                 [
                     ("footer_contrast", " " + sender_name + " "),

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1197,6 +1197,7 @@ class Model:
             if event["op"] == "start":
                 sender_name = self.user_dict[sender_email]["full_name"]
                 active_conversation_info["sender_name"] = sender_name
+                active_conversation_info["typing_start_time"] = datetime.now()
 
                 if not controller.is_typing_notification_in_progress:
                     controller.show_typing_notification()

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1198,6 +1198,7 @@ class Model:
                 sender_name = self.user_dict[sender_email]["full_name"]
                 active_conversation_info["sender_name"] = sender_name
                 active_conversation_info["typing_start_time"] = datetime.now()
+                active_conversation_info["narrow"] = narrow
 
                 if not controller.is_typing_notification_in_progress:
                     controller.show_typing_notification()


### PR DESCRIPTION
This commit animates the typing feedback using an iterable cycle
object. This is done using an asynchronous function
`_show_typing_animation` and a boolean `is_recipient_typing` to
start and end the animation.

The corner case of not recieving a `stop` signal is handled by
setting `TYPING_STARTED_EXPIRY_PERIOD=15` and checking this
condition using `datetime`. 

**This has to be handled differently from #915 as footer keep updating every half second 
so, footer text's `duration` variable can't be used.**

Tests added.

![animate_typing](https://user-images.githubusercontent.com/64144419/114208939-af89c180-997b-11eb-90c8-0316f6076594.gif)

