### PR TITLE
Add support for opening message and external links in browser.

### DIFF
--- a/docs/hotkeys.md
+++ b/docs/hotkeys.md
@@ -55,6 +55,7 @@
 |Add/remove star status of the current message|<kbd>ctrl</kbd> + <kbd>s</kbd> / <kbd>*</kbd>|
 |Show/hide message information|<kbd>i</kbd>|
 |Show/hide edit history (from message information)|<kbd>e</kbd>|
+|View current message in browser (from message information)|<kbd>v</kbd>|
 
 ## Stream list actions
 |Command|Key Combination|

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -580,8 +580,18 @@ class TestMsgInfoView:
         self.msg_info_view.keypress(size, key)
         assert self.controller.exit_popup.called
 
+    @pytest.mark.parametrize("key", keys_for_command("VIEW_IN_BROWSER"))
+    def test_keypress_view_in_browser(self, mocker, widget_size, message_fixture, key):
+        size = widget_size(self.msg_info_view)
+        self.msg_info_view.server_url = "https://chat.zulip.org/"
+        mocker.patch(VIEWS + ".near_message_url")
+
+        self.msg_info_view.keypress(size, key)
+
+        assert self.controller.open_in_browser.called
+
     def test_height_noreactions(self):
-        expected_height = 3
+        expected_height = 4
         assert self.msg_info_view.height == expected_height
 
     # FIXME This is the same parametrize as MessageBox:test_reactions_view
@@ -644,8 +654,9 @@ class TestMsgInfoView:
             OrderedDict(),
             list(),
         )
-        # 9 = 3 labels + 1 blank line + 1 'Reactions' (category) + 4 reactions.
-        expected_height = 9
+        # 10 = 4 labels + 1 blank line + 1 'Reactions' (category)
+        # + 4 reactions (excluding 'Message Links').
+        expected_height = 10
         assert self.msg_info_view.height == expected_height
 
     @pytest.mark.parametrize(

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -236,6 +236,13 @@ KEY_BINDINGS: 'OrderedDict[str, KeyBinding]' = OrderedDict([
         'excluded_from_random_tips': True,
         'key_category': 'msg_actions',
     }),
+    ('VIEW_IN_BROWSER', {
+        'keys': ['v'],
+        'help_text':
+            'View current message in browser (from message information)',
+        'excluded_from_random_tips': True,
+        'key_category': 'msg_actions',
+    }),
     ('STREAM_DESC', {
         'keys': ['i'],
         'help_text': 'Show/hide stream information & modify settings',

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -3,6 +3,7 @@ import platform
 import subprocess
 import time
 from collections import OrderedDict, defaultdict
+from contextlib import contextmanager
 from functools import wraps
 from itertools import chain, combinations
 from re import ASCII, MULTILINE, findall, match
@@ -14,6 +15,7 @@ from typing import (
     Dict,
     FrozenSet,
     Iterable,
+    Iterator,
     List,
     Set,
     Tuple,
@@ -714,3 +716,22 @@ def get_unused_fence(content: str) -> str:
         max_length_fence = max(max_length_fence, len(max(matches, key=len)) + 1)
 
     return "`" * max_length_fence
+
+
+@contextmanager
+def suppress_output() -> Iterator[None]:
+    """
+    Context manager to redirect stdout and stderr to /dev/null.
+
+    Adapted from https://stackoverflow.com/a/2323563
+    """
+    stdout = os.dup(1)
+    stderr = os.dup(2)
+    os.close(1)
+    os.close(2)
+    os.open(os.devnull, os.O_RDWR)
+    try:
+        yield
+    finally:
+        os.dup2(stdout, 1)
+        os.dup2(stderr, 2)

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -25,6 +25,7 @@ from zulipterminal.config.symbols import (
 )
 from zulipterminal.config.ui_mappings import EDIT_MODE_CAPTIONS
 from zulipterminal.helper import Message, asynch, match_stream, match_user
+from zulipterminal.server_url import near_message_url
 from zulipterminal.ui_tools.boxes import MessageBox, PanelSearchBox
 from zulipterminal.ui_tools.buttons import (
     HomeButton,
@@ -1297,9 +1298,11 @@ class MsgInfoView(PopUpView):
         self.topic_links = topic_links
         self.message_links = message_links
         self.time_mentions = time_mentions
+        self.server_url = controller.model.server_url
         date_and_time = controller.model.formatted_local_time(
             msg["timestamp"], show_seconds=True, show_year=True
         )
+        view_in_browser_keys = ", ".join(map(repr, keys_for_command("VIEW_IN_BROWSER")))
 
         msg_info = [
             (
@@ -1308,6 +1311,10 @@ class MsgInfoView(PopUpView):
                     ("Date & Time", date_and_time),
                     ("Sender", msg["sender_full_name"]),
                     ("Sender's Email ID", msg["sender_email"]),
+                    (
+                        "View message in browser",
+                        f"Press {view_in_browser_keys} to view message in browser",
+                    ),
                 ],
             ),
         ]
@@ -1410,6 +1417,9 @@ class MsgInfoView(PopUpView):
                 message_links=self.message_links,
                 time_mentions=self.time_mentions,
             )
+        elif is_command_key("VIEW_IN_BROWSER", key):
+            url = near_message_url(self.server_url[:-1], self.msg)
+            self.controller.open_in_browser(url)
         return super().keypress(size, key)
 
 


### PR DESCRIPTION
Thanks to @punchagan and @preetmishra for their major initial work in #397 and #698 respectively. :+1:

This PR extracts some initial commits from both PR's and cleans and refactors them. It also adds support for opening external links in the browser from the `MessageLinkButton`. All the reviews on the previous PR's have also been addressed, facilitating further reviews.

Fixes last point of #452.