### PR TITLE
Add warning on startup if locale suggests UTF-8 not enabled

### DIFF
--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import requests
 from urwid import display_common, set_encoding
 
+from zulipterminal.config.symbols import is_utf8_encoding_enabled
 from zulipterminal.config.themes import (
     THEMES,
     aliased_themes,
@@ -416,6 +417,16 @@ def main(options: Optional[List[str]]=None) -> None:
               .format(*zterm['color-depth']))
         print("   notify setting '{}' specified {}."
               .format(*zterm['notify']))
+
+        if not is_utf8_encoding_enabled():
+            print(in_color('yellow',
+                           "   WARNING: Locale doesn't include UTF-8; "
+                           "some icons may not get rendered properly!\n"
+                           "            (there might be '?' markers instead)\n"
+                           "   To enable it by default, add this line to "
+                           "the end of your '~/.bashrc' (restart terminal to "
+                           "see effect)\n"
+                           "      export LANG=en_US.utf-8\n"))
 
         # For binary settings
         # Specify setting in order True, False

--- a/zulipterminal/config/symbols.py
+++ b/zulipterminal/config/symbols.py
@@ -1,3 +1,6 @@
+import os
+
+
 STREAM_MARKER_INVALID = '✗'
 STREAM_MARKER_PRIVATE = 'P'
 STREAM_MARKER_PUBLIC = '#'
@@ -18,3 +21,11 @@ STATUS_ACTIVE = '●'
 STATUS_IDLE = '◒'
 STATUS_OFFLINE = '○'
 STATUS_INACTIVE = '•'
+
+
+def is_utf8_encoding_enabled() -> bool:
+    """
+    It checks whether UTF-8 encoding is enabled in locale.
+    """
+    lang = os.environ.get('LANG', '')
+    return '.utf-8' in lang.lower()


### PR DESCRIPTION
**What does this PR do!?**
 - Shows a warning message on startup if the language/locale settings don't include `utf-8` encoding.

**Commit flow**
 - Add helper to return whether required `utf-8` encoding is enabled in locale.
 - Show warning message on the loading screen if required `utf-8` encoding is disabled.

Fixes #256.

**Screenshots/GIFs**
![warning_message](https://user-images.githubusercontent.com/55916430/114553963-d568dc00-9c83-11eb-8f6e-d582fccd4b9b.png)
