### PR TITLE
bugfix: Restrict content-length for compose box.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -114,7 +114,7 @@ setup(
     install_requires=[
         'urwid~=2.1.2',
         'zulip>=0.7.0',
-        'urwid_readline>=0.12',
+        'urwid_readline>=0.13',
         'beautifulsoup4>=4.9.0',
         'lxml>=4.6.2',
         'typing_extensions>=3.7',

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -26,6 +26,9 @@ class TestWriteBox:
         write_box = WriteBox(self.view)
         write_box.view.users = users_fixture
         write_box.model.user_dict = user_dict
+        write_box.model.max_stream_name_length = 60
+        write_box.model.max_topic_length = 60
+        write_box.model.max_message_length = 10000
         write_box.model.user_group_names = [
             groups['name'] for groups in user_groups_fixture]
 

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -150,7 +150,8 @@ class WriteBox(urwid.Pile):
         )
         self.to_write_box.set_completer_delims("")
 
-        self.msg_write_box = ReadlineEdit(multiline=True)
+        self.msg_write_box = ReadlineEdit(
+            multiline=True, max_char=self.model.max_message_length)
         self.msg_write_box.enable_autocomplete(
             func=self.generic_autocomplete,
             key=primary_key_for_command('AUTOCOMPLETE'),
@@ -215,13 +216,15 @@ class WriteBox(urwid.Pile):
         self.recipient_user_ids = self.model.get_other_subscribers_in_stream(
                                             stream_id=stream_id)
         self.to_write_box = None
-        self.msg_write_box = ReadlineEdit(multiline=True)
+        self.msg_write_box = ReadlineEdit(
+            multiline=True, max_char=self.model.max_message_length)
         self.msg_write_box.enable_autocomplete(
             func=self.generic_autocomplete,
             key=primary_key_for_command('AUTOCOMPLETE'),
             key_reverse=primary_key_for_command('AUTOCOMPLETE_REVERSE')
         )
-        self.stream_write_box = ReadlineEdit(edit_text=caption)
+        self.stream_write_box = ReadlineEdit(
+            edit_text=caption, max_char=self.model.max_stream_name_length)
         self.stream_write_box.enable_autocomplete(
             func=self._stream_box_autocomplete,
             key=primary_key_for_command('AUTOCOMPLETE'),
@@ -229,7 +232,8 @@ class WriteBox(urwid.Pile):
         )
         self.stream_write_box.set_completer_delims("")
 
-        self.title_write_box = ReadlineEdit(edit_text=title)
+        self.title_write_box = ReadlineEdit(
+            edit_text=title, max_char=self.model.max_topic_length)
         self.title_write_box.enable_autocomplete(
             func=self._topic_box_autocomplete,
             key=primary_key_for_command('AUTOCOMPLETE'),


### PR DESCRIPTION
This PR restricts input beyond certain max-limit for compose
box, as specified by the corresponding parameters in initial_data's
realm object. ZT didn't had this restriction earlier which resulted
in certain long topic names/messages getting cropped from the end
without the user noticing, until the message was sent.
These parameters were recently added in ZFL 53 in [`4a3ad0d`](https://github.com/zulip/zulip/commit/4a3ad0da06b3e8db511e9690b31507b565f7f2fc), so we allow for
backporting by defining hard-coded values for these parameters.

The content restriction of compose boxes was made possible only
after urwid-readline merged a patch in v0.13, which added support
for specifying a `max_char` argument to their `ReadlineEdit` widget.
Related patch: https://github.com/rr-/urwid_readline/pull/18.
