### PR TITLE
Handle read events to the same server from different clients

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -573,7 +573,8 @@ def empty_index():
             stream_msg_template['id']: stream_msg_template,
             pm_template['id']: pm_template,
             group_pm_template['id']: group_pm_template,
-        })
+        }),
+        'unread_msgs': defaultdict(dict),
     })
 
 
@@ -842,10 +843,10 @@ def processed_muted_topics(request):
 @pytest.fixture
 def classified_unread_counts():
     """
-    Unread counts return by
-    helper.classify_unread_counts function.
+    Tuple of unread counts and unread_msg data
+    returned by helper.classify_unread_counts function.
     """
-    return {
+    return ({
         'all_msg': 12,
         'all_pms': 8,
         'unread_topics': {
@@ -864,7 +865,33 @@ def classified_unread_counts():
             1000: 3,
             99: 1
         }
-    }
+    }, {
+        1: {'type': 'private', 'sender_id': 1, 'flags': []},
+        2: {'type': 'private', 'sender_id': 1, 'flags': []},
+        3: {'type': 'private', 'sender_id': 2, 'flags': []},
+        4: {'type': 'stream',  'display_recipient': 'Some general stream',
+            'stream_id': 1000, 'subject': 'Some general unread topic',
+            'sender_ids': frozenset({1, 2}), 'flags': []},
+        5: {'type': 'stream', 'display_recipient': 'Some general stream',
+            'stream_id': 1000, 'subject': 'Some general unread topic',
+            'sender_ids': frozenset({1, 2}), 'flags': []},
+        6: {'type': 'stream', 'display_recipient': 'Some general stream',
+            'stream_id': 1000, 'subject': 'Some general unread topic',
+            'sender_ids': frozenset({1, 2}), 'flags': []},
+        7: {'type': 'stream', 'display_recipient': 'Secret stream',
+            'stream_id': 99, 'subject': 'Some private unread topic',
+            'sender_ids': frozenset({1, 2}), 'flags': []},
+        11: {'type': 'private', 'display_recipient':
+                                frozenset({11, 12, 1001}), 'flags': []},
+        12: {'type': 'private', 'display_recipient':
+                                frozenset({11, 12, 1001}), 'flags': []},
+        13: {'type': 'private', 'display_recipient':
+                                frozenset({11, 12, 1001}), 'flags': []},
+        101: {'type': 'private', 'display_recipient':
+                                 frozenset({11, 12, 13, 1001}), 'flags': []},
+        102: {'type': 'private', 'display_recipient':
+                                 frozenset({11, 12, 13, 1001}), 'flags': []},
+    })
 
 # --------------- UI Fixtures -----------------------------------------
 

--- a/tests/helper/test_helper.py
+++ b/tests/helper/test_helper.py
@@ -224,8 +224,9 @@ def test_classify_unread_counts(mocker, initial_data, stream_dict,
         [model.stream_dict[stream_id]['name'], topic] in muted_topics
     ))
     model.muted_streams = muted_streams
-    assert classify_unread_counts(model) == dict(classified_unread_counts,
-                                                 **vary_in_unreads)
+    assert classify_unread_counts(model) == (dict(classified_unread_counts[0],
+                                                  **vary_in_unreads),
+                                             classified_unread_counts[1])
 
 
 @pytest.mark.parametrize('color', [

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -37,7 +37,7 @@ class TestModel:
         # NOTE: PATCH WHERE USED NOT WHERE DEFINED
         self.classify_unread_counts = mocker.patch(
             'zulipterminal.model.classify_unread_counts',
-            return_value=[])
+            return_value=([], {}))
         self.client.get_profile.return_value = user_profile
         mocker.patch('zulipterminal.model.unicode_emojis',
                      EMOJI_DATA=unicode_emojis)
@@ -128,7 +128,7 @@ class TestModel:
         mocker.patch('zulipterminal.model.Model._subscribe_to_streams')
         self.classify_unread_counts = mocker.patch(
             'zulipterminal.model.classify_unread_counts',
-            return_value=[])
+            return_value=([], {}))
 
         with pytest.raises(ServerConnectionFailure) as e:
             model = Model(self.controller)
@@ -148,7 +148,7 @@ class TestModel:
         mocker.patch('zulipterminal.model.Model._subscribe_to_streams')
         self.classify_unread_counts = mocker.patch(
             'zulipterminal.model.classify_unread_counts',
-            return_value=[])
+            return_value=([], {}))
 
         with pytest.raises(ServerConnectionFailure) as e:
             model = Model(self.controller)
@@ -576,7 +576,7 @@ class TestModel:
         mocker.patch('zulipterminal.model.Model._subscribe_to_streams')
         self.classify_unread_counts = mocker.patch(
             'zulipterminal.model.classify_unread_counts',
-            return_value=[])
+            return_value=([], {}))
 
         # Setup mocks before calling get_messages
         self.client.get_messages.return_value = messages_successful_response
@@ -642,7 +642,7 @@ class TestModel:
         mocker.patch('zulipterminal.model.Model._subscribe_to_streams')
         self.classify_unread_counts = mocker.patch(
             'zulipterminal.model.classify_unread_counts',
-            return_value=[])
+            return_value=([], {}))
 
         # Setup mocks before calling get_messages
         messages_successful_response['anchor'] = 0
@@ -674,7 +674,7 @@ class TestModel:
         mocker.patch('zulipterminal.model.Model._subscribe_to_streams')
         self.classify_unread_counts = mocker.patch(
             'zulipterminal.model.classify_unread_counts',
-            return_value=[])
+            return_value=([], {}))
 
         # Setup mock before calling get_messages
         # FIXME This has no influence on the result
@@ -757,7 +757,7 @@ class TestModel:
         mocker.patch('zulipterminal.model.Model._subscribe_to_streams')
         self.classify_unread_counts = mocker.patch(
             'zulipterminal.model.classify_unread_counts',
-            return_value=[])
+            return_value=([], {}))
 
         # Setup mocks before calling get_messages
         self.client.register.return_value = initial_data
@@ -789,7 +789,7 @@ class TestModel:
         mocker.patch('zulipterminal.model.Model._subscribe_to_streams')
         self.classify_unread_counts = mocker.patch(
             'zulipterminal.model.classify_unread_counts',
-            return_value=[])
+            return_value=([], {}))
         model = Model(self.controller)
         assert model.user_dict == user_dict
         assert model.users == user_list

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -145,9 +145,8 @@ def _set_count_in_model(new_count: int, changed_messages: List[Message],
             update_unreads(unread_counts['unread_topics'],
                            (stream_id, message['subject']))
             update_unreads(unread_counts['streams'], stream_id)
-        # self-pm has only one display_recipient
         # 1-1 pms have 2 display_recipient
-        elif len(message['display_recipient']) <= 2:
+        elif len(message['display_recipient']) == 2:
             update_unreads(unread_counts['unread_pms'], message['sender_id'])
         else:  # If it's a group pm
             update_unreads(unread_counts['unread_huddles'],
@@ -197,7 +196,7 @@ def _set_count_in_view(controller: Any, new_count: int,
                         stream_button.update_count(stream_button.count
                                                    + new_count)
                         break
-            # FIXME: Update unread_counts['unread_topics']?
+
             if controller.model.is_muted_topic(stream_id, msg_topic):
                 add_to_counts = False
             if is_open_topic_view and stream_id == toggled_stream_id:

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1227,6 +1227,7 @@ class Model:
             return
 
         indexed_message_ids = set(self.index['messages'])
+        indexed_unread_msg_ids = set(self.index['unread_msgs'].keys())
         message_ids_to_mark = set(event['messages'])
 
         for message_id in message_ids_to_mark & indexed_message_ids:
@@ -1249,8 +1250,10 @@ class Model:
             self._update_rendered_view(message_id)
 
         if operation == 'add' and flag_to_change == 'read':
-            set_count(list(message_ids_to_mark & indexed_message_ids),
-                      self.controller, -1)
+            msgs_to_mark_as_read = message_ids_to_mark & indexed_unread_msg_ids
+            set_count(list(msgs_to_mark_as_read), self.controller, -1)
+            for message_id in msgs_to_mark_as_read:
+                self.index['unread_msgs'].pop(message_id)
 
     def formatted_local_time(
         self, timestamp: int, *, show_seconds: bool, show_year: bool = False

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1066,9 +1066,28 @@ class Model:
             self.controller.update_screen()
             self._notified_user_of_notification_failure = True
 
-        # Index messages before calling set_count.
         self.index = index_messages([message], self, self.index)
         if 'read' not in message['flags']:
+            if message['type'] == 'stream':
+                unread_data = {'type': 'stream', 'display_recipient':
+                               message['display_recipient'],
+                               'stream_id': message['stream_id'],
+                               'subject': message['subject'],
+                               'flags': message['flags']}
+            elif len(message['display_recipient']) <= 2:
+                # pm and self-pm
+                unread_data = {'type': 'private',
+                               'sender_id': message['sender_id'],
+                               'flags': message['flags']}
+            else:
+                # huddles
+                message_recipients = frozenset(
+                    [user['id'] for user in message['display_recipient']])
+                unread_data = {'type': 'private',
+                               'display_recipient': message_recipients,
+                               'flags': message['flags']}
+            self.index['unread_msgs'].update(
+                            {int(message['id']): unread_data})
             set_count([message['id']], self.controller, 1)
 
         if (hasattr(self.controller, 'view')

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -154,7 +154,8 @@ class Model:
         self.user_group_by_id: Dict[int, Dict[str, Any]] = {}
         self.user_group_names = self._group_info_from_realm_user_groups(groups)
 
-        self.unread_counts = classify_unread_counts(self)
+        (self.unread_counts,
+            self.index['unread_msgs']) = classify_unread_counts(self)
 
         self._draft: Optional[Composition] = None
         unicode_emoji_data = unicode_emojis.EMOJI_DATA


### PR DESCRIPTION
Taking forward @kaustubh-nair 's work on #535.
I have added a commit to update `set_count` function to use index[`unread_msgs`] along with necessary changes to make sure that the application does not crash.