### PR TITLE
refactor: boxes: Refactor soup2mark for better readability.

### DIFF
--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -955,8 +955,8 @@ class MessageBox(urwid.Pile):
                     continue
                 markup.append(element)
             elif (tag == 'div'
-                  and any(cls in tag_classes
-                          for cls in unrendered_div_classes)):
+                  and (set(tag_classes)
+                       & set(unrendered_div_classes))):
                 # UNRENDERED DIV CLASSES
                 matching_class = (set(unrendered_div_classes)
                                   & set(tag_classes))
@@ -981,13 +981,13 @@ class MessageBox(urwid.Pile):
                 # EMOJI
                 markup.append(('msg_emoji', tag_text))
             elif (tag == 'span'
-                  and ('katex-display' in tag_classes
-                       or 'katex' in tag_classes)):
+                  and ({'katex-display', 'katex'}
+                       & set(tag_classes))):
                 # MATH TEXT
                 markup.append(tag_text)
             elif (tag == 'span'
-                  and ('user-group-mention' in tag_classes
-                       or 'user-mention' in tag_classes)):
+                  and ({'user-group-mention', 'user-mention'}
+                       & set(tag_classes))):
                 # USER MENTIONS & USER-GROUP MENTIONS
                 markup.append(('msg_mention', tag_text))
             elif tag == 'a':

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -954,7 +954,7 @@ class MessageBox(urwid.Pile):
                     metadata['bq_len'] -= 1
                     continue
                 markup.append(element)
-            elif (tag == 'div' and tag_attrs
+            elif (tag == 'div'
                   and any(cls in tag_classes
                           for cls in unrendered_div_classes)):
                 # UNRENDERED DIV CLASSES
@@ -976,16 +976,16 @@ class MessageBox(urwid.Pile):
             elif tag in ('p', 'del'):
                 # PARAGRAPH, STRIKE-THROUGH
                 markup.extend(cls.soup2markup(element, metadata)[0])
-            elif (tag == 'span' and tag_attrs
+            elif (tag == 'span'
                   and 'emoji' in tag_classes):
                 # EMOJI
                 markup.append(('msg_emoji', tag_text))
-            elif (tag == 'span' and tag_attrs
+            elif (tag == 'span'
                   and ('katex-display' in tag_classes
                        or 'katex' in tag_classes)):
                 # MATH TEXT
                 markup.append(tag_text)
-            elif (tag == 'span' and tag_attrs
+            elif (tag == 'span'
                   and ('user-group-mention' in tag_classes
                        or 'user-mention' in tag_classes)):
                 # USER MENTIONS & USER-GROUP MENTIONS
@@ -1069,7 +1069,7 @@ class MessageBox(urwid.Pile):
                 markup.append((
                     'msg_code', tag_text
                 ))
-            elif (tag == 'div' and tag_attrs
+            elif (tag == 'div'
                     and 'codehilite' in tag_classes):
                 # CODE (BLOCK?)
                 markup.append((

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -954,17 +954,16 @@ class MessageBox(urwid.Pile):
                     metadata['bq_len'] -= 1
                     continue
                 markup.append(element)
-            elif (tag == 'div'
-                  and (set(tag_classes)
-                       & set(unrendered_div_classes))):
+            elif tag == 'div' and (
+                 set(tag_classes) & set(unrendered_div_classes)):
                 # UNRENDERED DIV CLASSES
-                matching_class = (set(unrendered_div_classes)
-                                  & set(tag_classes))
-                text = unrendered_div_classes[matching_class.pop()]
+                # NOTE: Though `matches` is generalized for multiple
+                # matches it is very unlikely that there would be any.
+                matches = set(unrendered_div_classes) & set(tag_classes)
+                text = unrendered_div_classes[matches.pop()]
                 if text:
                     markup.append(unrendered_template.format(text))
-            elif (tag == 'img'
-                  and tag_classes == ['emoji']):
+            elif tag == 'img' and tag_classes == ['emoji']:
                 # CUSTOM EMOJIS AND ZULIP_EXTRA_EMOJI
                 emoji_name = tag_attrs.get('title', [])
                 markup.append(('msg_emoji', f":{emoji_name}:"))
@@ -976,18 +975,15 @@ class MessageBox(urwid.Pile):
             elif tag in ('p', 'del'):
                 # PARAGRAPH, STRIKE-THROUGH
                 markup.extend(cls.soup2markup(element, metadata)[0])
-            elif (tag == 'span'
-                  and 'emoji' in tag_classes):
+            elif tag == 'span' and 'emoji' in tag_classes:
                 # EMOJI
                 markup.append(('msg_emoji', tag_text))
-            elif (tag == 'span'
-                  and ({'katex-display', 'katex'}
-                       & set(tag_classes))):
+            elif tag == 'span' and (
+                    {'katex-display', 'katex'} & set(tag_classes)):
                 # MATH TEXT
                 markup.append(tag_text)
-            elif (tag == 'span'
-                  and ({'user-group-mention', 'user-mention'}
-                       & set(tag_classes))):
+            elif tag == 'span' and (
+                    {'user-group-mention', 'user-mention'} & set(tag_classes)):
                 # USER MENTIONS & USER-GROUP MENTIONS
                 markup.append(('msg_mention', tag_text))
             elif tag == 'a':
@@ -1066,15 +1062,10 @@ class MessageBox(urwid.Pile):
                 ))
             elif tag == 'code':
                 # CODE (INLINE?)
-                markup.append((
-                    'msg_code', tag_text
-                ))
-            elif (tag == 'div'
-                    and 'codehilite' in tag_classes):
+                markup.append(('msg_code', tag_text))
+            elif tag == 'div' and 'codehilite' in tag_classes:
                 # CODE (BLOCK?)
-                markup.append((
-                    'msg_code', tag_text
-                ))
+                markup.append(('msg_code', tag_text))
             elif tag in ('strong', 'em'):
                 # BOLD & ITALIC
                 markup.append(('msg_bold', tag_text))
@@ -1143,9 +1134,7 @@ class MessageBox(urwid.Pile):
                     'msg_time', f" {TIME_MENTION_MARKER} {time_string} "
                 ))
 
-                source_text = (
-                    f"Original text was {tag_text.strip()}"
-                )
+                source_text = f"Original text was {tag_text.strip()}"
                 metadata['time_mentions'].append((time_string, source_text))
             else:
                 markup.extend(cls.soup2markup(element, metadata)[0])

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -925,6 +925,9 @@ class MessageBox(urwid.Pile):
         markup: List[Union[str, Tuple[Optional[str], Any]]] = ['']
         if soup is None:  # This is not iterable, so return promptly
             return markup, metadata['message_links'], metadata['time_mentions']
+
+        math_classes = ['katex', 'katex-display']
+        mention_classes = ['user-mention', 'user-group-mention']
         unrendered_tags = {  # In pairs of 'tag_name': 'text'
             # TODO: Some of these could be implemented
             'br': '',  # No indicator of absence

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -11,7 +11,7 @@ from urllib.parse import urljoin, urlparse
 import dateutil.parser
 import urwid
 from bs4 import BeautifulSoup
-from bs4.element import NavigableString
+from bs4.element import NavigableString, Tag
 from tzlocal import get_localzone
 from urwid_readline import ReadlineEdit
 
@@ -940,54 +940,62 @@ class MessageBox(urwid.Pile):
         }
         unrendered_template = '[{} NOT RENDERED]'
         for element in soup:
+            if isinstance(element, Tag):
+                # Caching element variables for use in the
+                # if/elif/else chain below for improving legibility.
+                tag = element.name
+                tag_attrs = element.attrs
+                tag_classes = tag_attrs.get('class', [])
+                tag_text = element.text
+
             if isinstance(element, NavigableString):
                 # NORMAL STRINGS
                 if element == '\n' and metadata.get('bq_len', 0) > 0:
                     metadata['bq_len'] -= 1
                     continue
                 markup.append(element)
-            elif (element.name == 'div' and element.attrs
-                  and any(cls in element.attrs.get('class', [])
+            elif (tag == 'div' and tag_attrs
+                  and any(cls in tag_classes
                           for cls in unrendered_div_classes)):
                 # UNRENDERED DIV CLASSES
                 matching_class = (set(unrendered_div_classes)
-                                  & set(element.attrs.get('class')))
+                                  & set(tag_classes))
                 text = unrendered_div_classes[matching_class.pop()]
                 if text:
                     markup.append(unrendered_template.format(text))
-            elif (element.name == 'img'
-                  and element.attrs.get('class', []) == ['emoji']):
+            elif (tag == 'img'
+                  and tag_classes == ['emoji']):
                 # CUSTOM EMOJIS AND ZULIP_EXTRA_EMOJI
-                emoji_name = element.attrs.get('title', [])
+                emoji_name = tag_attrs.get('title', [])
                 markup.append(('msg_emoji', f":{emoji_name}:"))
-            elif element.name in unrendered_tags:
+            elif tag in unrendered_tags:
                 # UNRENDERED SIMPLE TAGS
-                text = unrendered_tags[element.name]
+                text = unrendered_tags[tag]
                 if text:
                     markup.append(unrendered_template.format(text))
-            elif element.name in ('p', 'del'):
+            elif tag in ('p', 'del'):
                 # PARAGRAPH, STRIKE-THROUGH
                 markup.extend(cls.soup2markup(element, metadata)[0])
-            elif (element.name == 'span' and element.attrs
-                  and 'emoji' in element.attrs.get('class', [])):
+            elif (tag == 'span' and tag_attrs
+                  and 'emoji' in tag_classes):
                 # EMOJI
-                markup.append(('msg_emoji', element.text))
-            elif (element.name == 'span' and element.attrs
-                  and ('katex-display' in element.attrs.get('class', [])
-                       or 'katex' in element.attrs.get('class', []))):
+                markup.append(('msg_emoji', tag_text))
+            elif (tag == 'span' and tag_attrs
+                  and ('katex-display' in tag_classes
+                       or 'katex' in tag_classes)):
                 # MATH TEXT
-                markup.append(element.text)
-            elif (element.name == 'span' and element.attrs
-                  and ('user-group-mention' in element.attrs.get('class', [])
-                       or 'user-mention' in element.attrs.get('class', []))):
+                markup.append(tag_text)
+            elif (tag == 'span' and tag_attrs
+                  and ('user-group-mention' in tag_classes
+                       or 'user-mention' in tag_classes)):
                 # USER MENTIONS & USER-GROUP MENTIONS
-                markup.append(('msg_mention', element.text))
-            elif element.name == 'a':
+                markup.append(('msg_mention', tag_text))
+            elif tag == 'a':
                 # LINKS
                 # Use rstrip to avoid anomalies and edge cases like
                 # https://google.com vs https://google.com/.
-                link = element.attrs['href'].rstrip('/')
-                text = element.img['src'] if element.img else element.text
+                link = tag_attrs['href'].rstrip('/')
+                text = element.img['src'] if element.img else tag_text
                 text = text.rstrip('/')
 
                 parsed_link = urlparse(link)
@@ -1051,26 +1059,26 @@ class MessageBox(urwid.Pile):
                     ('msg_link_index',
                      f"[{metadata['message_links'][link][1]}]"),
                 ])
-            elif element.name == 'blockquote':
+            elif tag == 'blockquote':
                 # BLOCKQUOTE TEXT
                 markup.append((
                     'msg_quote', cls.soup2markup(element, metadata)[0]
                 ))
-            elif element.name == 'code':
+            elif tag == 'code':
                 # CODE (INLINE?)
                 markup.append((
-                    'msg_code', element.text
+                    'msg_code', tag_text
                 ))
-            elif (element.name == 'div' and element.attrs
-                    and 'codehilite' in element.attrs.get('class', [])):
+            elif (tag == 'div' and tag_attrs
+                    and 'codehilite' in tag_classes):
                 # CODE (BLOCK?)
                 markup.append((
-                    'msg_code', element.text
+                    'msg_code', tag_text
                 ))
-            elif element.name in ('strong', 'em'):
+            elif tag in ('strong', 'em'):
                 # BOLD & ITALIC
-                markup.append(('msg_bold', element.text))
-            elif element.name in ('ul', 'ol'):
+                markup.append(('msg_bold', tag_text))
+            elif tag in ('ul', 'ol'):
                 # LISTS (UL & OL)
                 for part in element.contents:
                     if part == '\n':
@@ -1082,8 +1090,8 @@ class MessageBox(urwid.Pile):
                 else:
                     state['indent_level'] += 1
                     state['list_start'] = False
-                if element.name == 'ol':
-                    start_number = int(element.attrs.get('start', 1))
+                if tag == 'ol':
+                    start_number = int(tag_attrs.get('start', 1))
                     state['list_index'] = start_number
                     markup.extend(cls.soup2markup(element, metadata,
                                                   **state)[0])
@@ -1094,7 +1102,7 @@ class MessageBox(urwid.Pile):
                     markup.extend(cls.soup2markup(element, metadata,
                                                   **state)[0])
                 del state['indent_level']  # reset indents after any list
-            elif element.name == 'li':
+            elif tag == 'li':
                 # LIST ITEMS (LI)
                 for part in element.contents:
                     if part == '\n':
@@ -1115,9 +1123,9 @@ class MessageBox(urwid.Pile):
                     markup.append(f"{'  ' * indent}{chars[(indent - 1) % 3]} ")
                 state['list_start'] = False
                 markup.extend(cls.soup2markup(element, metadata, **state)[0])
-            elif element.name == 'table':
+            elif tag == 'table':
                 markup.extend(render_table(element))
-            elif element.name == 'time':
+            elif tag == 'time':
                 # New in feature level 16, server version 3.0.
                 # Render time in current user's local time zone.
                 timestamp = element.get('datetime')
@@ -1136,7 +1144,7 @@ class MessageBox(urwid.Pile):
                 ))
 
                 source_text = (
-                    f"Original text was {element.text.strip()}"
+                    f"Original text was {tag_text.strip()}"
                 )
                 metadata['time_mentions'].append((time_string, source_text))
             else:


### PR DESCRIPTION
This PR on the whole is to make soup2mark _cleaner_, more _readable_ and _easier to understand_.

**Commit 1: Shorten soup2mark conditionals.**
* This commit extracts commonly used code in conditional statements
into variables so as to reduce repeatition and improve readability.
HTML semantics like `tag`, `html_attrs`, `css_classes` are used to
name these variables.
* These variables are only extracted when the element is a `Tag` as
`NavigableString`'s don't have these attributes.

**Commit 2: Move css_classes into a single block.**
* This commit moves all code related to css_classes into a single
block which makes for better organization of code.
   * Six conditionals have been moved to a single block.
   * Now these six conditionals can be eliminated in a single shot and
also makes the corresponding conditionals shorter.

**Commit 3: Improve long condition statements.**
* This commit makes the conditions for `MATH TEXT` and `MENTIONS`
shorter and more readable. It follows a pattern similar to
`unrendered_div_classes`.
* `_` underscore is used as a placeholder for css classes and 2 new
class lists were defined which are `math_classes` and
`mention_classes` respectively for the two conditionals.

**Commit 4: Replace `cls` with `_` to remove confusion.**
* This commit replaces the local variable `cls` in the comprehension
with the python variable placeholder `_` so that it is not confused
with the main `cls` variable of the `classmethod` representing a
python class instead of a CSS class.

**Commit 5: Clean whitespace in `code` and `codehilite`.**
* This commit just removes whitespace in `markup.append` argument
of `code` and `codehilite` tag and class respectively

**Commit 6: Simplify UNRENDERED DIV CLASSES code.**
* This comment simplifies the code for UNRENDERED DIV CLASSES by
changing the variable `matching_class` with `match`. This allows for
removal of unnecessary brackets.

**Commit 7: Simplify code for `time` tag.**
* This commit simplifies code for the time tag:
   * Brackets for `source_text` have been removed as the space allows for
it.
   * `markup.append` has been moved to the end to keep it similar and
consistent with the rest of the code.

**Collapsed Screenshot:**
<img src='https://user-images.githubusercontent.com/64144419/115413553-e5983280-a212-11eb-8d80-eadddc80fab4.png' width=400>