### PR TITLE
helper: Sync unread pm message count in all_pms and user button count.

### DIFF
--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -167,6 +167,10 @@ def _set_count_in_view(controller: Any, new_count: int,
     if is_open_topic_view:
         topic_buttons_log = controller.view.topic_w.log
         toggled_stream_id = controller.view.topic_w.stream_button.stream_id
+    users = controller.model.get_all_users()
+    if hasattr(controller, 'view'):
+        controller.view.users_view.update_user_list(
+            user_list=users)
     user_buttons_log = controller.view.user_w.log
     all_msg = controller.view.home_button
     all_pm = controller.view.pm_button


### PR DESCRIPTION
User buttons list is updated using `update_user_list` before count of user
buttons is modified in `_set_count_in_view`. Now, we do not have to wait
for the presence update before displaying the correct unread count.

Fixes #438 