### PR TITLE
Add support for stream + topic autocomplete

### DIFF
--- a/tests/config/test_themes.py
+++ b/tests/config/test_themes.py
@@ -5,6 +5,7 @@ from typing import Dict, Optional, Tuple
 import pytest
 from pytest_mock import MockerFixture
 
+from zulipterminal.config.regexes import REGEX_COLOR_VALID_FORMATS
 from zulipterminal.config.themes import (
     REQUIRED_STYLES,
     THEMES,
@@ -73,11 +74,8 @@ def test_builtin_theme_completeness(theme_name: str) -> None:
         assert len(codes) == 3
         # Check if 16-color alias is correct
         assert codes[0].replace("_", " ") in aliases_16_color
-        # Check if 24-bit and 256 color is any of
-        # #000000-#ffffff or #000-#fff or h0-h255 or g0-g100 0r g#00-g#ff
-        pattern = re.compile(
-            "#[\\da-f]{6}|#[\\da-f]{3}|(?:h|g)([\\d]{1,3})|g#[\\da-f]{2}|default$"
-        )
+        # Check if 24-bit and 256 color is any of the valid color codes
+        pattern = re.compile(REGEX_COLOR_VALID_FORMATS)
         for code in [codes[1], codes[2]]:
             code = pattern.match(code)
             assert code

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -86,9 +86,13 @@ class TestWriteBox:
             ("#**Stream 1>", -2, True, "#**Stream 1>This is a topic**"),
             # Fenced prefix
             ("#**Stream 1**>T", 0, True, "#**Stream 1>Topic 1**"),
+            # Unfenced prefix
+            ("#Stream 1>T", 0, True, "#**Stream 1>Topic 1**"),
+            ("#Stream 1>T", 1, True, "#**Stream 1>This is a topic**"),
             # Invalid stream
             ("#**invalid stream>", 0, False, None),
             ("#**invalid stream**>", 0, False, None),
+            ("#invalid stream>", 0, False, None),
             # Invalid prefix format
             ("#**Stream 1*>", 0, True, None),
             ("#*Stream 1>", 0, True, None),

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -84,9 +84,13 @@ class TestWriteBox:
             ("#**Stream 1>", 1, True, "#**Stream 1>This is a topic**"),
             ("#**Stream 1>", -1, True, "#**Stream 1>Hello there!**"),
             ("#**Stream 1>", -2, True, "#**Stream 1>This is a topic**"),
+            # Fenced prefix
+            ("#**Stream 1**>T", 0, True, "#**Stream 1>Topic 1**"),
             # Invalid stream
             ("#**invalid stream>", 0, False, None),
+            ("#**invalid stream**>", 0, False, None),
             # Invalid prefix format
+            ("#**Stream 1*>", 0, True, None),
             ("#*Stream 1>", 0, True, None),
             # Complex autocomplete prefixes.
             ("(#**Stream 1>", 0, True, "(#**Stream 1>Topic 1**"),
@@ -94,6 +98,7 @@ class TestWriteBox:
             ("@#**Stream 1>", 0, True, "@#**Stream 1>Topic 1**"),
             ("@_#**Stream 1>", 0, True, "@_#**Stream 1>Topic 1**"),
             (":#**Stream 1>", 0, True, ":#**Stream 1>Topic 1**"),
+            ("(#**Stream 1**>", 0, True, "(#**Stream 1>Topic 1**"),
         ],
     )
     def test_generic_autocomplete_stream_and_topic(

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -402,13 +402,13 @@ class TestWriteBox:
             ("@Hum", 1, "@**Human 1**"),
             ("@Huma", 1, "@**Human 1**"),
             ("@Human", 1, "@**Human 1**"),
-            ("@Human 1", 0, "@**Human 1**"),
+            ("@Human 1", 0, "@**Human 1**"),  # Space-containing text
             ("@_H", 1, "@_**Human 1**"),
             ("@_Hu", 1, "@_**Human 1**"),
             ("@_Hum", 1, "@_**Human 1**"),
             ("@_Huma", 1, "@_**Human 1**"),
             ("@_Human", 1, "@_**Human 1**"),
-            ("@_Human 1", 0, "@_**Human 1**"),
+            ("@_Human 1", 0, "@_**Human 1**"),  # Space-containing text
             ("@Group", 0, "@*Group 1*"),
             ("@Group", 1, "@*Group 2*"),
             ("@G", 0, "@*Group 1*"),
@@ -439,6 +439,7 @@ class TestWriteBox:
             ("@", 4, "@**Human Duplicate|14**"),
             ("@**", 5, None),  # Reached last match
             ("@**", 6, None),  # Beyond end
+            ("@**Human 1", 0, "@**Human 1**"),  # Space-containing text
             # Expected sequence of autocompletes from '@*' (only groups)
             ("@*", 0, "@*Group 1*"),
             ("@*", 1, "@*Group 2*"),
@@ -455,6 +456,8 @@ class TestWriteBox:
             ("@_", 5, None),  # Reached last match
             ("@_", 6, None),  # Beyond end
             ("@_", -1, "@_**Human Duplicate|14**"),
+            ("@_Human 1", 0, "@_**Human 1**"),  # Space-containing text
+            ("@_**Human 1", 0, "@_**Human 1**"),  # Space-containing text
             # Complex autocomplete prefixes.
             ("(@H", 0, "(@**Human Myself**"),
             ("(@H", 1, "(@**Human 1**"),

--- a/zulipterminal/config/regexes.py
+++ b/zulipterminal/config/regexes.py
@@ -1,0 +1,9 @@
+# Referred and translated from zulip/static/shared/js/fenced_code.js
+# Example: ```quote\nThis is a quote.\n```
+REGEX_QUOTED_FENCE_LENGTH = r"^ {0,3}(`{3,})"
+
+
+# Example: #fff
+REGEX_COLOR_3_DIGIT = r"^#[0-9A-Fa-f]{3}$"
+# Example: #ffffff
+REGEX_COLOR_6_DIGIT = r"^#[0-9A-Fa-f]{6}$"

--- a/zulipterminal/config/regexes.py
+++ b/zulipterminal/config/regexes.py
@@ -15,6 +15,8 @@ REGEX_STREAM_FENCED = r"#\*\*{stream}\*\*".format(stream=REGEX_STREAM_NAME)
 REGEX_STREAM_AND_TOPIC_FENCED_HALF = f"{REGEX_STREAM_FENCED_HALF}>{REGEX_TOPIC_NAME}$"
 # (*) Example text: #**stream name**>Topic name
 REGEX_STREAM_AND_TOPIC_FENCED = f"{REGEX_STREAM_FENCED}>{REGEX_TOPIC_NAME}$"
+# (*) Example text: #stream name>Topic name
+REGEX_STREAM_AND_TOPIC_UNFENCED = f"#{REGEX_STREAM_NAME}>{REGEX_TOPIC_NAME}$"
 
 
 # Referred and translated from zulip/static/shared/js/fenced_code.js

--- a/zulipterminal/config/regexes.py
+++ b/zulipterminal/config/regexes.py
@@ -13,6 +13,10 @@ REGEX_COLOR_6_DIGIT = r"^#[0-9A-Fa-f]{6}$"
 REGEX_RECIPIENT_EMAIL = r"[\w\.-]+@[\w\.-]+"
 # Example: Test User <example-user@zulip.com>
 REGEX_CLEANED_RECIPIENT = r"^(.*?)(?:\s*?<?({})>?(.*))?$".format(REGEX_RECIPIENT_EMAIL)
+# Example: # #000000-#ffffff or #000-#fff or h0-h255 or g0-g100 or g#00-g#ff
+REGEX_COLOR_VALID_FORMATS = (
+    "#[\\da-f]{6}|#[\\da-f]{3}|(?:h|g)([\\d]{1,3})|g#[\\da-f]{2}|default$"
+)
 
 
 # Example: 6-test-stream

--- a/zulipterminal/config/regexes.py
+++ b/zulipterminal/config/regexes.py
@@ -13,3 +13,7 @@ REGEX_COLOR_6_DIGIT = r"^#[0-9A-Fa-f]{6}$"
 REGEX_RECIPIENT_EMAIL = r"[\w\.-]+@[\w\.-]+"
 # Example: Test User <example-user@zulip.com>
 REGEX_CLEANED_RECIPIENT = r"^(.*?)(?:\s*?<?({})>?(.*))?$".format(REGEX_RECIPIENT_EMAIL)
+
+
+# Example: 6-test-stream
+REGEX_INTERNAL_LINK_STREAM_ID = r"^[0-9]+-"

--- a/zulipterminal/config/regexes.py
+++ b/zulipterminal/config/regexes.py
@@ -7,3 +7,9 @@ REGEX_QUOTED_FENCE_LENGTH = r"^ {0,3}(`{3,})"
 REGEX_COLOR_3_DIGIT = r"^#[0-9A-Fa-f]{3}$"
 # Example: #ffffff
 REGEX_COLOR_6_DIGIT = r"^#[0-9A-Fa-f]{6}$"
+
+
+# Example: example-user@zulip.com
+REGEX_RECIPIENT_EMAIL = r"[\w\.-]+@[\w\.-]+"
+# Example: Test User <example-user@zulip.com>
+REGEX_CLEANED_RECIPIENT = r"^(.*?)(?:\s*?<?({})>?(.*))?$".format(REGEX_RECIPIENT_EMAIL)

--- a/zulipterminal/config/regexes.py
+++ b/zulipterminal/config/regexes.py
@@ -1,3 +1,18 @@
+# All regexes with (*) are inspired from webapp's
+# zulip/static/js/composebox_typeahead.js
+
+
+# (*) Stream and topic regexes
+REGEX_STREAM_NAME = r"([^*>]+)"
+REGEX_TOPIC_NAME = r"([^*]*)"
+
+
+# (*) Example: #**zulip-terminal
+REGEX_STREAM_FENCED_HALF = r"#\*\*{stream}".format(stream=REGEX_STREAM_NAME)
+# (*) Example text: #**stream name>Topic name
+REGEX_STREAM_AND_TOPIC_FENCED_HALF = f"{REGEX_STREAM_FENCED_HALF}>{REGEX_TOPIC_NAME}$"
+
+
 # Referred and translated from zulip/static/shared/js/fenced_code.js
 # Example: ```quote\nThis is a quote.\n```
 REGEX_QUOTED_FENCE_LENGTH = r"^ {0,3}(`{3,})"

--- a/zulipterminal/config/regexes.py
+++ b/zulipterminal/config/regexes.py
@@ -9,8 +9,12 @@ REGEX_TOPIC_NAME = r"([^*]*)"
 
 # (*) Example: #**zulip-terminal
 REGEX_STREAM_FENCED_HALF = r"#\*\*{stream}".format(stream=REGEX_STREAM_NAME)
+# (*) Example: #**zulip-terminal**
+REGEX_STREAM_FENCED = r"#\*\*{stream}\*\*".format(stream=REGEX_STREAM_NAME)
 # (*) Example text: #**stream name>Topic name
 REGEX_STREAM_AND_TOPIC_FENCED_HALF = f"{REGEX_STREAM_FENCED_HALF}>{REGEX_TOPIC_NAME}$"
+# (*) Example text: #**stream name**>Topic name
+REGEX_STREAM_AND_TOPIC_FENCED = f"{REGEX_STREAM_FENCED}>{REGEX_TOPIC_NAME}$"
 
 
 # Referred and translated from zulip/static/shared/js/fenced_code.js

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -26,6 +26,11 @@ from urllib.parse import unquote
 from typing_extensions import TypedDict
 
 from zulipterminal.api_types import Composition, EmojiType, Message
+from zulipterminal.config.regexes import (
+    REGEX_COLOR_3_DIGIT,
+    REGEX_COLOR_6_DIGIT,
+    REGEX_QUOTED_FENCE_LENGTH,
+)
 
 
 class StreamData(TypedDict):
@@ -620,10 +625,10 @@ def canonicalize_color(color: str) -> str:
     Given a color of the format '#xxxxxx' or '#xxx', produces one of the
     format '#xxx'. Always produces lowercase hex digits.
     """
-    if match("^#[0-9A-Fa-f]{6}$", color, ASCII) is not None:
+    if match(REGEX_COLOR_6_DIGIT, color, ASCII) is not None:
         # '#xxxxxx' color, stored by current zulip server
         return (color[:2] + color[3] + color[5]).lower()
-    elif match("^#[0-9A-Fa-f]{3}$", color, ASCII) is not None:
+    elif match(REGEX_COLOR_3_DIGIT, color, ASCII) is not None:
         # '#xxx' color, which may be stored by the zulip server <= 2.0.0
         # Potentially later versions too
         return color.lower()
@@ -680,10 +685,9 @@ def get_unused_fence(content: str) -> str:
     of continuous back-ticks. Referred and translated from
     zulip/static/shared/js/fenced_code.js.
     """
-    fence_length_regex = "^ {0,3}(`{3,})"
     max_length_fence = 3
 
-    matches = findall(fence_length_regex, content, flags=MULTILINE)
+    matches = findall(REGEX_QUOTED_FENCE_LENGTH, content, flags=MULTILINE)
     if len(matches) != 0:
         max_length_fence = max(max_length_fence, len(max(matches, key=len)) + 1)
 

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -58,6 +58,9 @@ class _MessageEditState(NamedTuple):
     old_topic: str
 
 
+DELIMS_MESSAGE_COMPOSE = "\t\n;"
+
+
 class WriteBox(urwid.Pile):
     def __init__(self, view: Any) -> None:
         super().__init__(self.main_view(True))
@@ -190,6 +193,8 @@ class WriteBox(urwid.Pile):
             key=primary_key_for_command("AUTOCOMPLETE"),
             key_reverse=primary_key_for_command("AUTOCOMPLETE_REVERSE"),
         )
+        self.msg_write_box.set_completer_delims(DELIMS_MESSAGE_COMPOSE)
+
         self.header_write_box = urwid.Columns([self.to_write_box])
         header_line_box = urwid.LineBox(
             self.header_write_box,
@@ -311,6 +316,8 @@ class WriteBox(urwid.Pile):
             key=primary_key_for_command("AUTOCOMPLETE"),
             key_reverse=primary_key_for_command("AUTOCOMPLETE_REVERSE"),
         )
+        self.msg_write_box.set_completer_delims(DELIMS_MESSAGE_COMPOSE)
+
         self.stream_write_box = ReadlineEdit(
             edit_text=caption, max_char=self.model.max_stream_name_length
         )

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -25,6 +25,7 @@ from zulipterminal.config.regexes import (
     REGEX_RECIPIENT_EMAIL,
     REGEX_STREAM_AND_TOPIC_FENCED,
     REGEX_STREAM_AND_TOPIC_FENCED_HALF,
+    REGEX_STREAM_AND_TOPIC_UNFENCED,
 )
 from zulipterminal.config.symbols import (
     INVALID_MARKER,
@@ -640,6 +641,7 @@ class WriteBox(urwid.Pile):
         """
         match = re.search(REGEX_STREAM_AND_TOPIC_FENCED_HALF, text)
         match_fenced = re.search(REGEX_STREAM_AND_TOPIC_FENCED, text)
+        match_unfenced = re.search(REGEX_STREAM_AND_TOPIC_UNFENCED, text)
         if match:
             prefix = f"#**{match.group(1)}>"
             prefix_indices[prefix] = match.start()
@@ -650,7 +652,13 @@ class WriteBox(urwid.Pile):
             prefix_indices[prefix] = match_fenced.start()
             # Amending the text to have new prefix (without `**` fence)
             text = text[: match_fenced.start()] + prefix_with_topic
-        if match or match_fenced:
+        elif match_unfenced:
+            prefix = f"#**{match_unfenced.group(1)}>"
+            prefix_with_topic = prefix + match_unfenced.group(2)
+            prefix_indices[prefix] = match_unfenced.start()
+            # Amending the text to have new prefix (with `**` fence)
+            text = text[: match_unfenced.start()] + prefix_with_topic
+        if match or match_fenced or match_unfenced:
             autocomplete_map.update({prefix: self.autocomplete_stream_and_topic})
 
         return text

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -23,6 +23,7 @@ from zulipterminal.config.keys import (
 from zulipterminal.config.regexes import (
     REGEX_CLEANED_RECIPIENT,
     REGEX_RECIPIENT_EMAIL,
+    REGEX_STREAM_AND_TOPIC_FENCED,
     REGEX_STREAM_AND_TOPIC_FENCED_HALF,
 )
 from zulipterminal.config.symbols import (
@@ -638,10 +639,19 @@ class WriteBox(urwid.Pile):
         and return the (updated) text.
         """
         match = re.search(REGEX_STREAM_AND_TOPIC_FENCED_HALF, text)
+        match_fenced = re.search(REGEX_STREAM_AND_TOPIC_FENCED, text)
         if match:
             prefix = f"#**{match.group(1)}>"
-            autocomplete_map.update({prefix: self.autocomplete_stream_and_topic})
             prefix_indices[prefix] = match.start()
+        elif match_fenced:
+            # Amending the prefix to remove stream fence `**`
+            prefix = f"#**{match_fenced.group(1)}>"
+            prefix_with_topic = prefix + match_fenced.group(2)
+            prefix_indices[prefix] = match_fenced.start()
+            # Amending the text to have new prefix (without `**` fence)
+            text = text[: match_fenced.start()] + prefix_with_topic
+        if match or match_fenced:
+            autocomplete_map.update({prefix: self.autocomplete_stream_and_topic})
 
         return text
 

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -20,6 +20,7 @@ from zulipterminal.config.keys import (
     keys_for_command,
     primary_key_for_command,
 )
+from zulipterminal.config.regexes import REGEX_CLEANED_RECIPIENT, REGEX_RECIPIENT_EMAIL
 from zulipterminal.config.symbols import (
     INVALID_MARKER,
     MESSAGE_CONTENT_MARKER,
@@ -250,7 +251,7 @@ class WriteBox(urwid.Pile):
         urwid.connect_signal(self.msg_write_box, "change", on_type_send_status)
 
     def update_recipient_emails(self, write_box: ReadlineEdit) -> None:
-        self.recipient_emails = re.findall(r"[\w\.-]+@[\w\.-]+", write_box.edit_text)
+        self.recipient_emails = re.findall(REGEX_RECIPIENT_EMAIL, write_box.edit_text)
 
     def _tidy_valid_recipients_and_notify_invalid_ones(
         self, write_box: ReadlineEdit
@@ -265,9 +266,7 @@ class WriteBox(urwid.Pile):
         ]
 
         for recipient in recipients:
-            cleaned_recipient_list = re.findall(
-                r"^(.*?)(?:\s*?<?([\w\.-]+@[\w\.-]+)>?(.*))?$", recipient
-            )
+            cleaned_recipient_list = re.findall(REGEX_CLEANED_RECIPIENT, recipient)
             recipient_name, recipient_email, invalid_text = cleaned_recipient_list[0]
             # Discard invalid_text as part of tidying up the recipient.
 

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -8,6 +8,7 @@ from typing_extensions import TypedDict
 
 from zulipterminal.api_types import EditPropagateMode
 from zulipterminal.config.keys import is_command_key, primary_key_for_command
+from zulipterminal.config.regexes import REGEX_INTERNAL_LINK_STREAM_ID
 from zulipterminal.config.symbols import (
     MUTE_MARKER,
     STREAM_MARKER_PRIVATE,
@@ -368,7 +369,7 @@ class MessageLinkButton(urwid.Button):
         Returns a dict with optional stream ID and stream name.
         """
         # Modern links come patched with the stream ID and '-' as delimiters.
-        if re.match("^[0-9]+-", encoded_stream_data):
+        if re.match(REGEX_INTERNAL_LINK_STREAM_ID, encoded_stream_data):
             stream_id, *_ = encoded_stream_data.split("-")
             # Given how encode_stream() in zerver/lib/url_encoding.py
             # replaces ' ' with '-' in the stream name, skip extracting the


### PR DESCRIPTION
The PR does the following tasks:
 - Fixes a bug re space-separated typeaheads (commit 1),
 - Extracts all regexes to a new file `regexes.py` (commit 2-5)
 - Adds support for stream+topic autocompletes. (commit 6-9).

Ticks a check box in #448.