### PR TITLE
Use `user_id`s as message destinations

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -964,6 +964,22 @@ def user_dict(logged_on_user):
 
 
 @pytest.fixture
+def user_id_email_dict(logged_on_user):
+    """
+    User_id_email_dict created according to `initial_data` fixture.
+    """
+    return {
+        logged_on_user["user_id"]: logged_on_user["email"],
+        11: "person1@example.com",
+        12: "person2@example.com",
+        6: "emailgateway@zulip.com",
+        1: "feedback@zulip.com",
+        5: "notification-bot@zulip.com",
+        4: "welcome-bot@zulip.com",
+    }
+
+
+@pytest.fixture
 def user_list(logged_on_user):
     """
     List of users created corresponding to

--- a/tests/helper/test_helper.py
+++ b/tests/helper/test_helper.py
@@ -336,34 +336,32 @@ def test_display_error_if_present(
     "req, narrow, footer_updated",
     [
         case(
-            {"type": "private", "to": ["foo@gmail.com"], "content": "bar"},
+            {"type": "private", "to": [1], "content": "bar"},
             [["is", "private"]],
             False,
             id="all_private__pm__not_notified",
         ),
         case(
-            {
-                "type": "private",
-                "to": ["foo@zulip.com", "bar@zulip.com"],
-                "content": "Hi",
-            },
-            [["pm_with", "foo@zulip.com, bar@zulip.com"]],
+            {"type": "private", "to": [4, 5], "content": "Hi"},
+            [["pm_with", "welcome-bot@zulip.com, notification-bot@zulip.com"]],
             False,
             id="group_private_conv__same_group_pm__not_notified",
         ),
         case(
-            {
-                "type": "private",
-                "to": ["user@abc.com", "user@chat.com"],
-                "content": "Hi",
-            },
-            [["pm_with", "user@0abc.com"]],
+            {"type": "private", "to": [4, 5], "content": "Hi"},
+            [["pm_with", "welcome-bot@zulip.com"]],
             True,
             id="private_conv__other_pm__notified",
         ),
         case(
-            {"type": "private", "to": ["bar-bar@foo.com"], "content": ":party_parrot:"},
-            [["pm_with", "user@abc.com, user@chat.com, bar-bar@foo.com"]],
+            {"type": "private", "to": [4], "content": ":party_parrot:"},
+            [
+                [
+                    "pm_with",
+                    "person1@example.com, person2@example.com, "
+                    "welcome-bot@zulip.com",
+                ]
+            ],
             True,
             id="private_conv__other_pm2__notified",
         ),
@@ -402,7 +400,7 @@ def test_display_error_if_present(
             id="starred__stream__notified",
         ),
         case(
-            {"type": "private", "to": ["2@aBd%8@random.com"], "content": "fist_bump"},
+            {"type": "private", "to": [1], "content": "fist_bump"},
             [["is", "mentioned"]],
             True,
             id="mentioned__private_no_mention__notified",
@@ -420,10 +418,12 @@ def test_notify_if_message_sent_outside_narrow(
     req: Composition,
     narrow: List[Any],
     footer_updated: bool,
+    user_id_email_dict: Dict[int, str],
 ) -> None:
     controller = mocker.Mock()
     report_success = controller.report_success
     controller.model.narrow = narrow
+    controller.model.user_id_email_dict = user_id_email_dict
 
     notify_if_message_sent_outside_narrow(req, controller)
 

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -524,9 +524,7 @@ class TestModel:
             ({"result": "some_failure"}, False),
         ],
     )
-    @pytest.mark.parametrize(
-        "recipients", [["iago@zulip.com"], ["iago@zulip.com", "hamlet@zulip.com"]]
-    )
+    @pytest.mark.parametrize("recipients", [[5179], [5179, 5180]])
     def test_send_private_message(
         self, mocker, model, recipients, response, return_value, content="hi!"
     ):

--- a/tests/ui/test_ui.py
+++ b/tests/ui/test_ui.py
@@ -442,7 +442,6 @@ class TestView:
                 )
             else:
                 mocked_private_box_view.assert_called_once_with(
-                    emails=["foo@zulip.com", "bar@gmail.com"],
                     recipient_user_ids=draft["to"],
                 )
 

--- a/tests/ui/test_ui.py
+++ b/tests/ui/test_ui.py
@@ -394,7 +394,7 @@ class TestView:
             },
             {
                 "type": "private",
-                "to": ["foo@zulip.com", "bar@gmail.com"],
+                "to": [1, 2],
                 "content": "this is a private message content",
             },
             None,
@@ -426,10 +426,7 @@ class TestView:
         view.controller.is_in_editor_mode = lambda: False
         view.model.stream_id_from_name.return_value = 10
         view.model.session_draft_message.return_value = draft
-        view.model.user_dict = {
-            "foo@zulip.com": {"user_id": 1},
-            "bar@gmail.com": {"user_id": 2},
-        }
+        view.model.user_id_email_dict = {1: "foo@zulip.com", 2: "bar@gmail.com"}
         mocked_stream_box_view = mocker.patch.object(view.write_box, "stream_box_view")
         mocked_private_box_view = mocker.patch.object(
             view.write_box, "private_box_view"
@@ -445,7 +442,8 @@ class TestView:
                 )
             else:
                 mocked_private_box_view.assert_called_once_with(
-                    emails=draft["to"], recipient_user_ids=[1, 2]
+                    emails=["foo@zulip.com", "bar@gmail.com"],
+                    recipient_user_ids=draft["to"],
                 )
 
             assert view.body.focus_col == 1

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -339,6 +339,34 @@ class TestWriteBox:
         )
 
     @pytest.mark.parametrize(
+        "header, expected_recipient_emails, expected_recipient_user_ids",
+        [
+            case(
+                "Human 1 <person1@example.com>",
+                ["person1@example.com"],
+                [11],
+                id="single_recipient",
+            ),
+            case(
+                "Human 1 <person1@example.com>, Human 2 <person2@example.com>",
+                ["person1@example.com", "person2@example.com"],
+                [11, 12],
+                id="multiple_recipients",
+            ),
+        ],
+    )
+    def test_update_recipients(
+        self, write_box, header, expected_recipient_emails, expected_recipient_user_ids
+    ):
+        write_box.private_box_view()
+        write_box.to_write_box.edit_text = header
+
+        write_box.update_recipients(write_box.to_write_box)
+
+        assert write_box.recipient_emails == expected_recipient_emails
+        assert write_box.recipient_user_ids == expected_recipient_user_ids
+
+    @pytest.mark.parametrize(
         "text, state",
         [
             ("Plain Text", 0),

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -69,7 +69,7 @@ class TestWriteBox:
 
     def test_not_calling_typing_method_without_recipients(self, mocker, write_box):
         write_box.model.send_typing_status_by_user_ids = mocker.Mock()
-        write_box.private_box_view(emails=[], recipient_user_ids=[])
+        write_box.private_box_view(recipient_user_ids=[])
         # Set idle_status_tracking to True to avoid setting off the
         # idleness tracker function.
         write_box.idle_status_tracking = True
@@ -134,10 +134,10 @@ class TestWriteBox:
         assert typeahead_string == required_typeahead
 
     @pytest.mark.parametrize(
-        "emails, user_ids, expect_method_called, typing_recipient_user_ids",
+        "user_ids, expect_method_called, typing_recipient_user_ids",
         [
-            (["FOOBOO@gmail.com"], [1001], False, []),
-            (["FOOBOO@gmail.com", "person1@example.com"], [1001, 11], True, [11]),
+            ([1001], False, []),
+            ([1001, 11], True, [11]),
         ],
         ids=["pm_only_with_oneself", "group_pm"],
     )
@@ -146,14 +146,15 @@ class TestWriteBox:
         mocker,
         write_box,
         expect_method_called,
-        emails,
         logged_on_user,
         user_ids,
         typing_recipient_user_ids,
+        user_id_email_dict,
     ):
         write_box.model.send_typing_status_by_user_ids = mocker.Mock()
+        write_box.model.user_id_email_dict = user_id_email_dict
         write_box.model.user_id = logged_on_user["user_id"]
-        write_box.private_box_view(emails=emails, recipient_user_ids=user_ids)
+        write_box.private_box_view(recipient_user_ids=user_ids)
         # Set idle_status_tracking to True to avoid setting off the
         # idleness tracker function.
         write_box.idle_status_tracking = True
@@ -180,7 +181,7 @@ class TestWriteBox:
         self, key, mocker, write_box, widget_size
     ):
         write_box.model.send_private_message = mocker.Mock()
-        write_box.private_box_view(emails=[], recipient_user_ids=[])
+        write_box.private_box_view(recipient_user_ids=[])
         write_box.msg_write_box.edit_text = "random text"
 
         size = widget_size(write_box)
@@ -190,12 +191,11 @@ class TestWriteBox:
 
     @pytest.mark.parametrize("key", keys_for_command("GO_BACK"))
     def test__compose_attributes_reset_for_private_compose(
-        self, key, mocker, write_box, widget_size
+        self, key, mocker, write_box, widget_size, user_id_email_dict
     ):
         mocker.patch("urwid.connect_signal")
-        write_box.private_box_view(
-            emails=["person1@example.com"], recipient_user_ids=[11]
-        )
+        write_box.model.user_id_email_dict = user_id_email_dict
+        write_box.private_box_view(recipient_user_ids=[11])
         write_box.msg_write_box.edit_text = "random text"
 
         size = widget_size(write_box)
@@ -825,11 +825,10 @@ class TestWriteBox:
         ],
     )
     def test__to_box_autocomplete_with_spaces(
-        self, write_box, text, expected_text, widget_size
+        self, write_box, text, expected_text, widget_size, user_id_email_dict
     ):
-        write_box.private_box_view(
-            emails=["feedback@zulip.com"], recipient_user_ids=[1]
-        )
+        write_box.model.user_id_email_dict = user_id_email_dict
+        write_box.private_box_view(recipient_user_ids=[1])
         write_box.to_write_box.set_edit_text(text)
         write_box.to_write_box.set_edit_pos(len(text))
         write_box.focus_position = write_box.FOCUS_CONTAINER_HEADER
@@ -1410,18 +1409,17 @@ class TestWriteBox:
         ],
     )
     def test_write_box_header_contents(
-        self, write_box, expected_box_size, mocker, msg_type
+        self, write_box, expected_box_size, mocker, msg_type, user_id_email_dict
     ):
         mocker.patch(WRITEBOX + "._set_stream_write_box_style")
         mocker.patch(WRITEBOX + ".set_editor_mode")
+        write_box.model.user_id_email_dict = user_id_email_dict
         if msg_type == "stream":
             write_box.stream_box_view(1000)
         elif msg_type == "stream_edit":
             write_box.stream_box_edit_view(1000)
         else:
-            write_box.private_box_view(
-                emails=["feedback@zulip.com"], recipient_user_ids=[1]
-            )
+            write_box.private_box_view(recipient_user_ids=[1])
 
         assert len(write_box.header_write_box.widget_list) == expected_box_size
 

--- a/zulipterminal/api_types.py
+++ b/zulipterminal/api_types.py
@@ -19,7 +19,7 @@ MessageFlag = Literal[
 class PrivateComposition(TypedDict):
     type: Literal["private"]
     content: str
-    to: List[str]  # emails  # TODO: Migrate to using List[int] (user ids)
+    to: List[int]  # User ids
 
 
 class StreamComposition(TypedDict):

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -665,7 +665,10 @@ def notify_if_message_sent_outside_narrow(
         check_narrow_and_notify(stream_narrow, topic_narrow, controller)
     elif message["type"] == "private":
         pm_narrow = [["is", "private"]]
-        pm_with_narrow = [["pm_with", ", ".join(message["to"])]]
+        recipient_emails = [
+            controller.model.user_id_email_dict[user_id] for user_id in message["to"]
+        ]
+        pm_with_narrow = [["pm_with", ", ".join(recipient_emails)]]
         check_narrow_and_notify(pm_narrow, pm_with_narrow, controller)
 
 

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -422,7 +422,7 @@ class Model:
         else:
             raise RuntimeError("Empty recipient list.")
 
-    def send_private_message(self, recipients: List[str], content: str) -> bool:
+    def send_private_message(self, recipients: List[int], content: str) -> bool:
         if recipients:
             composition = PrivateComposition(
                 type="private",

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -280,13 +280,13 @@ class View(urwid.WidgetWrap):
                         stream_id=stream_id,
                     )
                 elif saved_draft["type"] == "private":
-                    email_list = saved_draft["to"]
-                    recipient_user_ids = [
-                        self.model.user_dict[email.strip()]["user_id"]
-                        for email in email_list
+                    recipient_user_ids = saved_draft["to"]
+                    recipient_emails = [
+                        self.model.user_id_email_dict[user_id]
+                        for user_id in recipient_user_ids
                     ]
                     self.write_box.private_box_view(
-                        emails=email_list,
+                        emails=recipient_emails,
                         recipient_user_ids=recipient_user_ids,
                     )
                 content = saved_draft["content"]

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -281,12 +281,7 @@ class View(urwid.WidgetWrap):
                     )
                 elif saved_draft["type"] == "private":
                     recipient_user_ids = saved_draft["to"]
-                    recipient_emails = [
-                        self.model.user_id_email_dict[user_id]
-                        for user_id in recipient_user_ids
-                    ]
                     self.write_box.private_box_view(
-                        emails=recipient_emails,
                         recipient_user_ids=recipient_user_ids,
                     )
                 content = saved_draft["content"]

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -760,9 +760,9 @@ class WriteBox(urwid.Pile):
                     if not all_valid:
                         return key
                     self.update_recipients(self.to_write_box)
-                    if self.recipient_emails:
+                    if self.recipient_user_ids:
                         success = self.model.send_private_message(
-                            recipients=self.recipient_emails,
+                            recipients=self.recipient_user_ids,
                             content=self.msg_write_box.edit_text,
                         )
                     else:
@@ -795,7 +795,7 @@ class WriteBox(urwid.Pile):
                     self.update_recipients(self.to_write_box)
                     this_draft: Composition = PrivateComposition(
                         type="private",
-                        to=self.recipient_emails,
+                        to=self.recipient_user_ids,
                         content=self.msg_write_box.edit_text,
                     )
                 elif self.compose_box_status == "open_with_stream":

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -287,8 +287,11 @@ class WriteBox(urwid.Pile):
 
         urwid.connect_signal(self.msg_write_box, "change", on_type_send_status)
 
-    def update_recipient_emails(self, write_box: ReadlineEdit) -> None:
+    def update_recipients(self, write_box: ReadlineEdit) -> None:
         self.recipient_emails = re.findall(REGEX_RECIPIENT_EMAIL, write_box.edit_text)
+        self._set_regular_and_typing_recipient_user_ids(
+            [self.model.user_dict[email]["user_id"] for email in self.recipient_emails]
+        )
 
     def _tidy_valid_recipients_and_notify_invalid_ones(
         self, write_box: ReadlineEdit
@@ -756,7 +759,7 @@ class WriteBox(urwid.Pile):
                     )
                     if not all_valid:
                         return key
-                    self.update_recipient_emails(self.to_write_box)
+                    self.update_recipients(self.to_write_box)
                     if self.recipient_emails:
                         success = self.model.send_private_message(
                             recipients=self.recipient_emails,
@@ -789,7 +792,7 @@ class WriteBox(urwid.Pile):
                     )
                     if not all_valid:
                         return key
-                    self.update_recipient_emails(self.to_write_box)
+                    self.update_recipients(self.to_write_box)
                     this_draft: Composition = PrivateComposition(
                         type="private",
                         to=self.recipient_emails,
@@ -857,14 +860,10 @@ class WriteBox(urwid.Pile):
                     )
                     if not all_valid:
                         return key
-                    # We extract emails into self.recipient_emails only once we know
+                    # We extract recipients' user_ids and emails only once we know
                     # that all the recipients are valid, to avoid including any
                     # invalid ones.
-                    self.update_recipient_emails(self.to_write_box)
-                    users = self.model.user_dict
-                    self._set_regular_and_typing_recipient_user_ids(
-                        [users[email]["user_id"] for email in self.recipient_emails]
-                    )
+                    self.update_recipients(self.to_write_box)
 
             if not self.msg_body_edit_enabled:
                 return key

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -267,9 +267,7 @@ class UserButton(TopButton):
             recipient_emails=[self.email],
         )
         self._view.body.focus.original_widget.set_focus("footer")
-        self._view.write_box.private_box_view(
-            emails=[self.email], recipient_user_ids=[self.user_id]
-        )
+        self._view.write_box.private_box_view(recipient_user_ids=[self.user_id])
 
     def keypress(self, size: urwid_Size, key: str) -> Optional[str]:
         if is_command_key("USER_INFO", key):


### PR DESCRIPTION
There are 4 commits to this PR:
- The first commit refactors `update_recipient_emails()` to `update_recipients()`, also updating the recipients' `user_id`s now, which is a preparatory step for the third commit. A test has also been added for this method.
- The second commit adds a test fixture for `user_id_email_dict` as a prep commit for the third commit.
- The third commit migrates from using delivery emails as message destinations to using `user_id`s instead. Tests updated.
- The fourth commit deprecates the `emails` parameter from `private_box_view()`. Tests updated.
 
The abstraction between the narrow model and the Composition API type is maintained by modifying the corresponding connections to the narrow model such that the delivery emails are still in use in the narrow model currently, making this a message-destination-only change. 

This change also serves as a prelude to the larger scale narrow model refactoring, which needs `Model` and narrow structure abstraction.

This would accommodate the first point under #965.