### PR TITLE
bugfix: Don't send and display typing updates from oneself.

### DIFF
--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -2080,8 +2080,39 @@ class TestModel:
                 },
                 True,
             ),
+            # In narrow with oneself, OP - 'start'
+            (
+                [["pm_with", "iago@zulip.com"]],
+                {
+                    "type": "typing",
+                    "op": "start",
+                    "sender": {"user_id": 5, "email": "iago@zulip.com"},
+                    "recipients": [{"user_id": 5, "email": "iago@zulip.com"}],
+                    "id": 0,
+                },
+                False,
+            ),
+            # In narrow with oneself, OP - 'stop'
+            (
+                [["pm_with", "iago@zulip.com"]],
+                {
+                    "type": "typing",
+                    "op": "stop",
+                    "sender": {"user_id": 5, "email": "iago@zulip.com"},
+                    "recipients": [{"user_id": 5, "email": "iago@zulip.com"}],
+                    "id": 0,
+                },
+                False,
+            ),
         ],
-        ids=["not_in_pm_narrow", "not_in_pm_narrow_with_sender", "start", "stop"],
+        ids=[
+            "not_in_pm_narrow",
+            "not_in_pm_narrow_with_sender",
+            "start",
+            "stop",
+            "start_in_narrow_with_oneself",
+            "stop_in_narrow_with_oneself",
+        ],
     )
     def test__handle_typing_event(self, mocker, model, narrow, event, called):
         event["type"] = "typing"
@@ -2089,6 +2120,7 @@ class TestModel:
         mocker.patch("zulipterminal.ui.View.set_footer_text")
         model.narrow = narrow
         model.user_dict = {"hamlet@zulip.com": {"full_name": "hamlet"}}
+        model.user_id = 5  # Iago's user_id
 
         model._handle_typing_event(event)
 

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1003,11 +1003,13 @@ class Model:
         assert event["type"] == "typing"
         if hasattr(self.controller, "view"):
             # If the user is in pm narrow with the person typing
+            # and the person typing isn't the user themselves
             narrow = self.narrow
             if (
                 len(narrow) == 1
                 and narrow[0][0] == "pm_with"
                 and event["sender"]["email"] in narrow[0][1].split(",")
+                and event["sender"]["user_id"] != self.user_id
             ):
                 if event["op"] == "start":
                     user = self.user_dict[event["sender"]["email"]]

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -116,6 +116,20 @@ class WriteBox(urwid.Pile):
     def set_editor_mode(self) -> None:
         self.view.controller.enter_editor_mode_with(self)
 
+    def _set_regular_and_typing_recipient_user_ids(
+        self, user_id_list: Optional[List[int]] = None
+    ) -> None:
+        if user_id_list:
+            self.recipient_user_ids = user_id_list
+            self.typing_recipient_user_ids = [
+                user_id
+                for user_id in self.recipient_user_ids
+                if user_id != self.model.user_id
+            ]
+        else:
+            self.recipient_user_ids = list()
+            self.typing_recipient_user_ids = list()
+
     def send_stop_typing_status(self) -> None:
         # Send 'stop' updates only for PM narrows.
         if self.to_write_box and self.typing_recipient_user_ids:
@@ -139,7 +153,7 @@ class WriteBox(urwid.Pile):
         self.set_editor_mode()
 
         if recipient_user_ids and emails:
-            self.recipient_user_ids = recipient_user_ids
+            self._set_regular_and_typing_recipient_user_ids(recipient_user_ids)
             self.recipient_emails = emails
             recipient_info = ", ".join(
                 [
@@ -147,14 +161,8 @@ class WriteBox(urwid.Pile):
                     for email in emails
                 ]
             )
-            self.typing_recipient_user_ids = [
-                user_id
-                for user_id in self.recipient_user_ids
-                if user_id != self.model.user_id
-            ]
         else:
-            self.recipient_user_ids = []
-            self.typing_recipient_user_ids = []
+            self._set_regular_and_typing_recipient_user_ids()
             self.recipient_emails = []
             recipient_info = ""
 
@@ -739,14 +747,9 @@ class WriteBox(urwid.Pile):
                     # invalid ones.
                     self.update_recipient_emails(self.to_write_box)
                     users = self.model.user_dict
-                    self.recipient_user_ids = [
-                        users[email]["user_id"] for email in self.recipient_emails
-                    ]
-                    self.typing_recipient_user_ids = [
-                        user_id
-                        for user_id in self.recipient_user_ids
-                        if user_id is not self.model.user_id
-                    ]
+                    self._set_regular_and_typing_recipient_user_ids(
+                        [users[email]["user_id"] for email in self.recipient_emails]
+                    )
 
             if not self.msg_body_edit_enabled:
                 return key

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -76,9 +76,13 @@ class WriteBox(urwid.Pile):
 
         # Used in PM and stream boxes
         # (empty list implies PM box empty, or not initialized)
-        # * prioritizes autocomplete in message body
-        # * updates server on PM typing events
+        # Prioritizes autocomplete in message body
         self.recipient_user_ids: List[int] = []
+
+        # Updates server on PM typing events
+        # Is separate from recipient_user_ids because we
+        # don't include the user's own id in this list
+        self.typing_recipient_user_ids: List[int] = []
 
         # Private message recipient text entry, None if stream-box
         # or not initialized
@@ -114,9 +118,9 @@ class WriteBox(urwid.Pile):
 
     def send_stop_typing_status(self) -> None:
         # Send 'stop' updates only for PM narrows.
-        if self.to_write_box and self.recipient_user_ids:
+        if self.to_write_box and self.typing_recipient_user_ids:
             self.model.send_typing_status_by_user_ids(
-                self.recipient_user_ids, status="stop"
+                self.typing_recipient_user_ids, status="stop"
             )
             self.send_next_typing_update = datetime.now()
             self.idle_status_tracking = False
@@ -143,8 +147,14 @@ class WriteBox(urwid.Pile):
                     for email in emails
                 ]
             )
+            self.typing_recipient_user_ids = [
+                user_id
+                for user_id in self.recipient_user_ids
+                if user_id != self.model.user_id
+            ]
         else:
             self.recipient_user_ids = []
+            self.typing_recipient_user_ids = []
             self.recipient_emails = []
             recipient_info = ""
 
@@ -194,11 +204,11 @@ class WriteBox(urwid.Pile):
         stop_period_delta = timedelta(seconds=TYPING_STOPPED_WAIT_PERIOD)
 
         def on_type_send_status(edit: object, new_edit_text: str) -> None:
-            if new_edit_text and self.recipient_user_ids:
+            if new_edit_text and self.typing_recipient_user_ids:
                 self.last_key_update = datetime.now()
                 if self.last_key_update > self.send_next_typing_update:
                     self.model.send_typing_status_by_user_ids(
-                        self.recipient_user_ids, status="start"
+                        self.typing_recipient_user_ids, status="start"
                     )
                     self.send_next_typing_update += start_period_delta
                     # Initiate tracker function only if it isn't already
@@ -731,6 +741,11 @@ class WriteBox(urwid.Pile):
                     users = self.model.user_dict
                     self.recipient_user_ids = [
                         users[email]["user_id"] for email in self.recipient_emails
+                    ]
+                    self.typing_recipient_user_ids = [
+                        user_id
+                        for user_id in self.recipient_user_ids
+                        if user_id is not self.model.user_id
                     ]
 
             if not self.msg_body_edit_enabled:


### PR DESCRIPTION
First commit:
- Typing events from oneself are currently handled and
displayed on the footer. This commit adds an extra check in the
typing event handler's conditional to verify that the sender
isn't the logged in user themselves before displaying the update.
Tests added.

Second commit:
- Prior to this commit, typing updates were sent to all recipients of
the current private message as specified in `recipient_user_ids`,
which is an unnecesary expense for the server though minute.

- This commit uses another list, `typing_recipients`, that stores all the
recipient user_ids except for the user's own, that can be used to send
typing updates. This list is initiated as a part of WriteBox for
persistence to send start and stop updates.