### PR TITLE
Add Codeblock Syntax Highlighting using Pygments

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -110,6 +110,7 @@ setup(
         "urwid_readline>=0.13",
         "beautifulsoup4>=4.9.0",
         "lxml>=4.6.2",
+        "pygments>=2.8.1",
         "typing_extensions>=3.7",
         "python-dateutil>=2.8.1",
         "tzlocal>=2.1",

--- a/tests/config/test_themes.py
+++ b/tests/config/test_themes.py
@@ -172,9 +172,23 @@ def test_parse_themefile(
                 },
             },
             [
-                ("pygments:k", "white", "black", "bold", "#abc", "#def"),
-                ("pygments:kr", "white", "black", "bold", "#abc", "#def"),
-                ("pygments:sd", "white", "black", "bold", "#123, bold", "#def"),
+                ("pygments:k", "light blue, bold", "dark gray", "bold", "#abc", "#def"),
+                (
+                    "pygments:kr",
+                    "light blue, bold",
+                    "dark gray",
+                    "bold",
+                    "#abc",
+                    "#def",
+                ),
+                (
+                    "pygments:sd",
+                    "light gray",
+                    "dark gray",
+                    "bold",
+                    "#123, bold",
+                    "#def",
+                ),
             ],
         )
     ],

--- a/tests/config/test_themes.py
+++ b/tests/config/test_themes.py
@@ -1,8 +1,9 @@
 import re
 from enum import Enum
-from typing import Dict, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 import pytest
+from pygments.styles.perldoc import PerldocStyle
 from pytest_mock import MockerFixture
 
 from zulipterminal.config.regexes import REGEX_COLOR_VALID_FORMATS
@@ -10,6 +11,7 @@ from zulipterminal.config.themes import (
     REQUIRED_STYLES,
     THEMES,
     ThemeSpec,
+    add_pygments_style,
     all_themes,
     complete_and_incomplete_themes,
     parse_themefile,
@@ -61,6 +63,7 @@ def test_builtin_theme_completeness(theme_name: str) -> None:
     theme = THEMES[theme_name]
     theme_styles = theme.STYLES
     theme_colors = theme.Color
+    theme_meta = theme.META
 
     # Check if STYLE and REQUIRED_STYLES use the same styles.
     assert len(theme_styles) == len(REQUIRED_STYLES)
@@ -87,6 +90,11 @@ def test_builtin_theme_completeness(theme_name: str) -> None:
     for style_name, style_conf in theme_styles.items():
         fg, bg = style_conf
         assert fg in theme_colors and bg in theme_colors
+    # Check completeness of META
+    expected_META = {"pygments": ["styles", "background", "overrides"]}
+    for metadata, config in expected_META.items():
+        assert theme_meta[metadata]
+        assert all([theme_meta[metadata][c] for c in config])
 
 
 def test_complete_and_incomplete_themes() -> None:
@@ -147,3 +155,39 @@ def test_parse_themefile(
     req_styles = {"s1": "", "s2": "bold"}
     mocker.patch.dict("zulipterminal.config.themes.REQUIRED_STYLES", req_styles)
     assert parse_themefile(STYLES, color_depth) == expected_urwid_theme
+
+
+@pytest.mark.parametrize(
+    "theme_meta, expected_styles",
+    [
+        (
+            {
+                "pygments": {
+                    "styles": PerldocStyle().styles,
+                    "background": "#def",
+                    "overrides": {
+                        "k": "#abc",
+                        "sd": "#123, bold",
+                    },
+                },
+            },
+            [
+                ("pygments:k", "white", "black", "bold", "#abc", "#def"),
+                ("pygments:kr", "white", "black", "bold", "#abc", "#def"),
+                ("pygments:sd", "white", "black", "bold", "#123, bold", "#def"),
+            ],
+        )
+    ],
+)
+def test_add_pygments_style(
+    mocker: MockerFixture, theme_meta: Dict[str, Any], expected_styles: ThemeSpec
+) -> None:
+    urwid_theme: ThemeSpec = [(None, "#xxx", "#yyy")]
+
+    urwid_theme_with_syntax_styles = add_pygments_style(theme_meta, urwid_theme)
+
+    # Check if original exists
+    assert urwid_theme[0] in urwid_theme_with_syntax_styles
+    # Check for overrides(k,sd) and inheriting styles (kr)
+    for style in expected_styles:
+        assert style in urwid_theme_with_syntax_styles

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1365,9 +1365,94 @@ class TestMessageBox:
             ),
             case("<code>some code", [("msg_code", "some code")], id="code"),
             case(
-                '<div class="codehilite">some code',
-                [("msg_code", "some code")],
-                id="codehilite",
+                '<div class="codehilite" data-code-language="python">'
+                "<pre><span></span>"
+                "<code><span>def</span> <span>func</span><span>():</span>\n"
+                '    <span class="pg">print</span><span>()</span><span></span>\n'
+                "\n"
+                "<span>class</span> <span>New</span><span>:</span>\n"
+                '    <span>name</span> <span>=</span> <span>"name"</span>\n'
+                "</code></pre></div>",
+                [
+                    ("pygments:w", "def"),
+                    ("pygments:w", " "),
+                    ("pygments:w", "func"),
+                    ("pygments:w", "():"),
+                    ("pygments:w", "\n" "    "),
+                    ("pygments:pg", "print"),
+                    ("pygments:w", "()"),
+                    ("pygments:w", "\n" "\n"),
+                    ("pygments:w", "class"),
+                    ("pygments:w", " "),
+                    ("pygments:w", "New"),
+                    ("pygments:w", ":"),
+                    ("pygments:w", "\n" "    "),
+                    ("pygments:w", "name"),
+                    ("pygments:w", " "),
+                    ("pygments:w", "="),
+                    ("pygments:w", " "),
+                    ("pygments:w", '"name"'),
+                    ("pygments:w", "\n"),
+                ],
+                id="codehilite-code",
+            ),
+            case(
+                '<div class="codehilite" data-code-language="python">'
+                "<pre><span></span>"
+                "<span>def</span> <span>func</span><span>():</span>\n"
+                '    <span class="pg">print</span><span>()</span>\n'
+                "\n"
+                "<span>class</span> <span>New</span><span>:</span>\n"
+                '    <span>name</span> <span>=</span> <span>"name"</span>\n'
+                "</pre></div>",
+                [
+                    ("pygments:w", "def"),
+                    ("pygments:w", " "),
+                    ("pygments:w", "func"),
+                    ("pygments:w", "():"),
+                    ("pygments:w", "\n" "    "),
+                    ("pygments:pg", "print"),
+                    ("pygments:w", "()"),
+                    ("pygments:w", "\n" "\n"),
+                    ("pygments:w", "class"),
+                    ("pygments:w", " "),
+                    ("pygments:w", "New"),
+                    ("pygments:w", ":"),
+                    ("pygments:w", "\n" "    "),
+                    ("pygments:w", "name"),
+                    ("pygments:w", " "),
+                    ("pygments:w", "="),
+                    ("pygments:w", " "),
+                    ("pygments:w", '"name"'),
+                    ("pygments:w", "\n"),
+                ],
+                id="codehilite-code-old",
+            ),
+            case(
+                '<div class="codehilite">'
+                "<pre><span></span>"
+                "<code>This is a\n"
+                "    Plain\n"
+                "\n"
+                "    Codeblock\n"
+                "</code></pre></div>",
+                [
+                    ("pygments:w", "This is a\n    Plain\n\n    Codeblock\n"),
+                ],
+                id="codehilite-plain-text-codeblock",
+            ),
+            case(
+                '<div class="codehilite">'
+                "<pre><span></span>"
+                "This is a\n"
+                "    Plain\n"
+                "\n"
+                "    Codeblock\n"
+                "</pre></div>",
+                [
+                    ("pygments:w", "This is a\n    Plain\n\n    Codeblock\n"),
+                ],
+                id="codehilite-plain-text-codeblock-old",
             ),
             case("<strong>Something", [("msg_bold", "Something")], id="strong"),
             case("<em>Something", [("msg_bold", "Something")], id="em"),

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1378,21 +1378,26 @@ class TestMessageBox:
                     ("pygments:w", " "),
                     ("pygments:w", "func"),
                     ("pygments:w", "():"),
-                    ("pygments:w", "\n" "    "),
+                    ("pygments:w", "      \n"),
+                    ("pygments:w", "    "),
                     ("pygments:pg", "print"),
                     ("pygments:w", "()"),
-                    ("pygments:w", "\n" "\n"),
+                    ("pygments:w", "      \n"),
+                    ("pygments:w", "                 \n"),
+                    ("pygments:w", ""),
                     ("pygments:w", "class"),
                     ("pygments:w", " "),
                     ("pygments:w", "New"),
                     ("pygments:w", ":"),
-                    ("pygments:w", "\n" "    "),
+                    ("pygments:w", "       \n"),
+                    ("pygments:w", "    "),
                     ("pygments:w", "name"),
                     ("pygments:w", " "),
                     ("pygments:w", "="),
                     ("pygments:w", " "),
                     ("pygments:w", '"name"'),
                     ("pygments:w", "\n"),
+                    ("pygments:w", ""),
                 ],
                 id="codehilite-code",
             ),
@@ -1410,21 +1415,26 @@ class TestMessageBox:
                     ("pygments:w", " "),
                     ("pygments:w", "func"),
                     ("pygments:w", "():"),
-                    ("pygments:w", "\n" "    "),
+                    ("pygments:w", "      \n"),
+                    ("pygments:w", "    "),
                     ("pygments:pg", "print"),
                     ("pygments:w", "()"),
-                    ("pygments:w", "\n" "\n"),
+                    ("pygments:w", "      \n"),
+                    ("pygments:w", "                 \n"),
+                    ("pygments:w", ""),
                     ("pygments:w", "class"),
                     ("pygments:w", " "),
                     ("pygments:w", "New"),
                     ("pygments:w", ":"),
-                    ("pygments:w", "\n" "    "),
+                    ("pygments:w", "       \n"),
+                    ("pygments:w", "    "),
                     ("pygments:w", "name"),
                     ("pygments:w", " "),
                     ("pygments:w", "="),
                     ("pygments:w", " "),
                     ("pygments:w", '"name"'),
                     ("pygments:w", "\n"),
+                    ("pygments:w", ""),
                 ],
                 id="codehilite-code-old",
             ),
@@ -1437,9 +1447,14 @@ class TestMessageBox:
                 "    Codeblock\n"
                 "</code></pre></div>",
                 [
-                    ("pygments:w", "This is a\n    Plain\n\n    Codeblock\n"),
+                    ("pygments:w", "This is a"),
+                    ("pygments:w", "    \n"),
+                    ("pygments:w", "    Plain    \n"),
+                    ("pygments:w", "             \n"),
+                    ("pygments:w", "    Codeblock\n"),
+                    ("pygments:w", ""),
                 ],
-                id="codehilite-plain-text-codeblock",
+                id="codehilite-no-language-codeblock",
             ),
             case(
                 '<div class="codehilite">'
@@ -1450,9 +1465,54 @@ class TestMessageBox:
                 "    Codeblock\n"
                 "</pre></div>",
                 [
-                    ("pygments:w", "This is a\n    Plain\n\n    Codeblock\n"),
+                    ("pygments:w", "This is a"),
+                    ("pygments:w", "    \n"),
+                    ("pygments:w", "    Plain    \n"),
+                    ("pygments:w", "             \n"),
+                    ("pygments:w", "    Codeblock\n"),
+                    ("pygments:w", ""),
                 ],
-                id="codehilite-plain-text-codeblock-old",
+                id="codehilite-no-language-codeblock-old",
+            ),
+            case(
+                '<div class="codehilite">'
+                "<pre><span></span>"
+                "This is a partially\n"
+                "  <span>pigmentized</span>\n"
+                "\n"
+                "codeblock\n"
+                "</pre></div>",
+                [
+                    ("pygments:w", "This is a partially"),
+                    ("pygments:w", "\n"),
+                    ("pygments:w", "  "),
+                    ("pygments:w", "pigmentized"),
+                    ("pygments:w", "      \n"),
+                    ("pygments:w", "                   \n"),
+                    ("pygments:w", "codeblock          \n"),
+                    ("pygments:w", ""),
+                ],
+                id="codehilite-partial-codeblock",
+            ),
+            case(
+                '<div class="codehilite">'
+                "<pre><span></span>"
+                "<code>This is a partially\n"
+                "  <span>pigmentized</span>\n"
+                "\n"
+                "codeblock\n"
+                "</code></pre></div>",
+                [
+                    ("pygments:w", "This is a partially"),
+                    ("pygments:w", "\n"),
+                    ("pygments:w", "  "),
+                    ("pygments:w", "pigmentized"),
+                    ("pygments:w", "      \n"),
+                    ("pygments:w", "                   \n"),
+                    ("pygments:w", "codeblock          \n"),
+                    ("pygments:w", ""),
+                ],
+                id="codehilite-partial-codeblock-old",
             ),
             case("<strong>Something", [("msg_bold", "Something")], id="strong"),
             case("<em>Something", [("msg_bold", "Something")], id="em"),

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1363,7 +1363,7 @@ class TestMessageBox:
                 [("msg_mention", "@A Group")],
                 id="group-mention",
             ),
-            case("<code>some code", [("msg_code", "some code")], id="code"),
+            case("<code>some code", [("pygments:w", "some code")], id="inline-code"),
             case(
                 '<div class="codehilite" data-code-language="python">'
                 "<pre><span></span>"

--- a/zulipterminal/config/color.py
+++ b/zulipterminal/config/color.py
@@ -7,6 +7,23 @@ For further details on themefiles look at the theme contribution guide.
 from enum import Enum
 from typing import Any
 
+from pygments.style import Style
+from pygments.token import (
+    Comment,
+    Error,
+    Escape,
+    Generic,
+    Keyword,
+    Literal,
+    Name,
+    Number,
+    Operator,
+    Punctuation,
+    String,
+    Text,
+    Whitespace,
+)
+
 
 # fmt: off
 # NOTE: The 24bit color codes use 256 color which can be
@@ -61,3 +78,39 @@ def color_properties(colors: Any, *prop: str) -> Any:
 
 
 DefaultBoldColor = color_properties(DefaultColor, "BOLD")
+
+
+# fmt: off
+class Term16Style(Style):
+    """
+    This style is a 16 color syntax style made for use in all ZT themes.
+    "var" bypasses pygments style format checking.
+    "_" is used in place of space and changed later below.
+    """
+    background_color = "dark gray"
+
+    styles = {
+        Text:                          "var:light_gray",
+        Escape:                        "var:light_cyan",
+        Error:                         "var:dark_red",
+        Whitespace:                    "var:light_gray",
+        Keyword:                       "var:light_blue,_bold",
+        Name:                          "var:brown",
+        Name.Class:                    "var:yellow",
+        Name.Function:                 "var:light_green",
+        Literal:                       "var:light_green",
+        String:                        "var:dark_green",
+        String.Escape:                 "var:light_gray",
+        String.Doc:                    "var:light_gray",
+        Number:                        "var:light_red",
+        Operator:                      "var:light_cyan",
+        Punctuation:                   "var:light_gray,_bold",
+        Comment:                       "var:light_gray",
+        Generic:                       "var:light_gray",
+    }
+# fmt:on
+
+
+term16 = Term16Style()
+for style, code in term16.styles.items():
+    term16.styles[style] = code[4:].replace("_", " ")

--- a/zulipterminal/config/themes.py
+++ b/zulipterminal/config/themes.py
@@ -43,7 +43,6 @@ REQUIRED_STYLES = {
     'msg_link'        : '',
     'msg_link_index'  : 'bold',
     'msg_quote'       : 'underline',
-    'msg_code'        : 'bold',
     'msg_bold'        : 'bold',
     'msg_time'        : 'bold',
     'footer'          : 'standout',

--- a/zulipterminal/config/themes.py
+++ b/zulipterminal/config/themes.py
@@ -2,6 +2,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 from pygments.token import STANDARD_TYPES
 
+from zulipterminal.config.color import term16
 from zulipterminal.themes import gruvbox, zt_blue, zt_dark, zt_light
 
 
@@ -183,6 +184,9 @@ def add_pygments_style(theme_meta: Dict[str, Any], urwid_theme: ThemeSpec) -> Th
     pygments_bg = pygments["background"]
     pygments_overrides = pygments["overrides"]
 
+    term16_styles = term16.styles
+    term16_bg = term16.background_color
+
     for token, css_class in STANDARD_TYPES.items():
         if css_class in pygments_overrides:
             pygments_styles[token] = pygments_overrides[css_class]
@@ -196,10 +200,17 @@ def add_pygments_style(theme_meta: Dict[str, Any], urwid_theme: ThemeSpec) -> Th
             except IndexError:
                 pass
 
+        if term16_styles[token] == "":
+            try:
+                t = [k for k, v in STANDARD_TYPES.items() if v == css_class[0]]
+                term16_styles[token] = term16_styles[t[0]]
+            except IndexError:
+                pass
+
         new_style = (
             f"pygments:{css_class}",
-            "white",
-            "black",
+            term16_styles[token],
+            term16_bg,
             "bold",  # Mono style
             pygments_styles[token],
             pygments_bg,

--- a/zulipterminal/config/themes.py
+++ b/zulipterminal/config/themes.py
@@ -1,5 +1,7 @@
 from typing import Any, Dict, List, Optional, Tuple, Union
 
+from pygments.token import STANDARD_TYPES
+
 from zulipterminal.themes import gruvbox, zt_blue, zt_dark, zt_light
 
 
@@ -71,6 +73,14 @@ REQUIRED_STYLES = {
     'task:error'      : 'standout',
     'task:warning'    : 'standout',
 }
+
+REQUIRED_META = {
+    'pygments': {
+        'styles'     : None,
+        'background' : None,
+        'overrides'  : None,
+    }
+}
 # fmt: on
 
 THEMES = {
@@ -101,6 +111,9 @@ def complete_and_incomplete_themes() -> Tuple[List[str], List[str]]:
         name
         for name, theme in THEMES.items()
         if set(theme.STYLES) == set(REQUIRED_STYLES)
+        if set(theme.META) == set(REQUIRED_META)
+        for meta, conf in theme.META.items()
+        if set(conf) == set(REQUIRED_META.get(meta, {}))
     }
     incomplete = list(set(THEMES) - complete)
     return sorted(list(complete)), sorted(incomplete)
@@ -109,6 +122,13 @@ def complete_and_incomplete_themes() -> Tuple[List[str], List[str]]:
 def generate_theme(theme_name: str, color_depth: int) -> ThemeSpec:
     theme_styles = THEMES[theme_name].STYLES
     urwid_theme = parse_themefile(theme_styles, color_depth)
+
+    try:
+        theme_meta = THEMES[theme_name].META
+        uwwid_theme = add_pygments_style(theme_meta, urwid_theme)
+    except AttributeError:
+        pass
+
     return urwid_theme
 
 
@@ -139,5 +159,50 @@ def parse_themefile(
             bg = " ".join([bg_code24] + bg_props)
             new_style = (style_name, "", "", "", fg, bg)
 
+        urwid_theme.append(new_style)
+    return urwid_theme
+
+
+def add_pygments_style(theme_meta: Dict[str, Any], urwid_theme: ThemeSpec) -> ThemeSpec:
+    """
+    This function adds pygments styles for use in syntax
+    highlighting of code blocks and inline code.
+    pygments["styles"]:
+        one of those available in pygments/styles.
+    pygments["background"]:
+        used to set a different background for codeblocks instead of the
+        one used in the syntax style, if it doesn't match with
+        the overall zt theme.
+        The default is available as Eg: MaterialStyle.background_color
+    pygments["overrides"]:
+        used to override certain pygments styles to match to urwid format.
+        It can also be used to customize the syntax style.
+    """
+    pygments = theme_meta["pygments"]
+    pygments_styles = pygments["styles"]
+    pygments_bg = pygments["background"]
+    pygments_overrides = pygments["overrides"]
+
+    for token, css_class in STANDARD_TYPES.items():
+        if css_class in pygments_overrides:
+            pygments_styles[token] = pygments_overrides[css_class]
+
+        # Inherit parent pygments style if not defined.
+        # Eg: Use `String` if `String.Double` is not present.
+        if pygments_styles[token] == "":
+            try:
+                t = [k for k, v in STANDARD_TYPES.items() if v == css_class[0]]
+                pygments_styles[token] = pygments_styles[t[0]]
+            except IndexError:
+                pass
+
+        new_style = (
+            f"pygments:{css_class}",
+            "white",
+            "black",
+            "bold",  # Mono style
+            pygments_styles[token],
+            pygments_bg,
+        )
         urwid_theme.append(new_style)
     return urwid_theme

--- a/zulipterminal/themes/gruvbox.py
+++ b/zulipterminal/themes/gruvbox.py
@@ -66,7 +66,6 @@ STYLES = {
     'msg_link'         : (Color.BRIGHT_BLUE,           Color.DARK0_HARD),
     'msg_link_index'   : (Color.BRIGHT_BLUE__BOLD,     Color.DARK0_HARD),
     'msg_quote'        : (Color.FADED_YELLOW,          Color.DARK0_HARD),
-    'msg_code'         : (Color.DARK0_HARD,            Color.LIGHT2),
     'msg_bold'         : (Color.LIGHT2__BOLD,          Color.DARK0_HARD),
     'msg_time'         : (Color.DARK0_HARD,            Color.LIGHT2),
     'footer'           : (Color.DARK0_HARD,            Color.LIGHT4),

--- a/zulipterminal/themes/gruvbox.py
+++ b/zulipterminal/themes/gruvbox.py
@@ -5,9 +5,15 @@ This theme uses the official gruvbox color scheme.
 For color reference see:
     https://github.com/morhetz/gruvbox/blob/master/colors/gruvbox.vim
 
+For syntax highlighting, this theme uses the solarized dark styles
+from pygments. This could be updated to a gruvbox style when the style
+is released.
+
 For further details on themefiles look at the theme contribution guide
 """
 from enum import Enum
+
+from pygments.styles.solarized import SolarizedDarkStyle
 
 from zulipterminal.config.color import color_properties
 
@@ -90,5 +96,26 @@ STYLES = {
     'task:success'     : (Color.DARK0_HARD,            Color.BRIGHT_GREEN),
     'task:error'       : (Color.LIGHT2,                Color.FADED_RED),
     'task:warning'     : (Color.DARK0_HARD,            Color.BRIGHT_RED),
+}
+
+META = {
+    'pygments': {
+        'styles'    : SolarizedDarkStyle().styles,
+        'background': 'h236',
+        'overrides' : {
+            'c'   : '#586e75, italics',    # base01
+            'cp'  : '#d33682',             # magenta
+            'cpf' : '#586e75',             # base01
+            'ge'  : '#839496, italics',    # base0
+            'gh'  : '#839496, bold',       # base0
+            'gu'  : '#839496, underline',  # base0
+            'gp'  : '#268bd2, bold',       # blue
+            'gs'  : '#839496, bold',       # base0
+            'err' : '#dc322f',             # red
+            'n'   : '#bdae93',             # gruvbox: light4
+            'p'   : '#bdae93',             # gruvbox: light4
+            'w'   : '#bdae93',             # gruvbox: light4
+        }
+    }
 }
 # fmt: on

--- a/zulipterminal/themes/zt_blue.py
+++ b/zulipterminal/themes/zt_blue.py
@@ -4,6 +4,8 @@ ZT BLUE
 This theme uses the default color scheme.
 For further details on themefiles look at the theme contribution guide
 """
+from pygments.styles.zenburn import ZenburnStyle
+
 from zulipterminal.config.color import DefaultBoldColor as Color
 
 
@@ -64,5 +66,31 @@ STYLES = {
     'task:success'    : (Color.WHITE,               Color.DARK_GREEN),
     'task:error'      : (Color.WHITE,               Color.DARK_RED),
     'task:warning'    : (Color.WHITE,               Color.BROWN),
+}
+
+META = {
+    'pygments': {
+        'styles'    : ZenburnStyle().styles,
+        'background': 'h25',
+        'overrides' : {
+            'err' : '#e37170, bold',
+            'kt'  : '#dfdfbf, bold',
+            'nt'  : '#e89393, bold',
+            'ne'  : '#c3bf9f, bold',
+            'si'  : '#dca3a3, bold',
+            'c'   : '#7f9f7f, italics',
+            'cp'  : '#dfaf8f, bold',
+            'cs'  : '#dfdfdf, bold',
+            'g'   : '#ecbcbc, bold',
+            'ge'  : '#ffffff, bold',
+            'go'  : '#5b605e, bold',
+            'gh'  : '#efefef, bold',
+            'gd'  : '#c3bf9f',
+            'gi'  : '#709080, bold',
+            'gt'  : '#80d4aa, bold',
+            'gu'  : '#efefef, bold',
+            'w'   : '#dcdccc',  # inline/plain-codeblock
+        }
+    }
 }
 # fmt: on

--- a/zulipterminal/themes/zt_blue.py
+++ b/zulipterminal/themes/zt_blue.py
@@ -36,7 +36,6 @@ STYLES = {
     'msg_link'        : (Color.DARK_BLUE,           Color.LIGHT_GRAY),
     'msg_link_index'  : (Color.DARK_BLUE__BOLD,     Color.LIGHT_GRAY),
     'msg_quote'       : (Color.BROWN,               Color.DARK_BLUE),
-    'msg_code'        : (Color.DARK_BLUE,           Color.WHITE),
     'msg_bold'        : (Color.WHITE__BOLD,         Color.DARK_BLUE),
     'msg_time'        : (Color.DARK_BLUE,           Color.WHITE),
     'footer'          : (Color.WHITE,               Color.DARK_GRAY),

--- a/zulipterminal/themes/zt_dark.py
+++ b/zulipterminal/themes/zt_dark.py
@@ -4,6 +4,8 @@ ZT DARK
 This theme uses the default color scheme.
 For further details on themefiles look at the theme contribution guide.
 """
+from pygments.styles.material import MaterialStyle
+
 from zulipterminal.config.color import DefaultBoldColor as Color
 
 
@@ -64,5 +66,22 @@ STYLES = {
     'task:success'    : (Color.WHITE,               Color.DARK_GREEN),
     'task:error'      : (Color.WHITE,               Color.DARK_RED),
     'task:warning'    : (Color.WHITE,               Color.BROWN),
+}
+
+META = {
+    'pygments': {
+        'styles'    : MaterialStyle().styles,
+        'background': 'h235',
+        'overrides' : {
+            'kn' : MaterialStyle().cyan  + ', italics',
+            'sd' : MaterialStyle().faded + ', italics',
+            'ow' : MaterialStyle().cyan  + ', italics',
+            'c'  : MaterialStyle().faded + ', italics',
+            'n'  : MaterialStyle().paleblue,
+            'no' : MaterialStyle().paleblue,
+            'nx' : MaterialStyle().paleblue,
+            'w'  : MaterialStyle().paleblue,  # inline/plain-codeblock
+        }
+    }
 }
 # fmt: on

--- a/zulipterminal/themes/zt_dark.py
+++ b/zulipterminal/themes/zt_dark.py
@@ -36,7 +36,6 @@ STYLES = {
     'msg_link'        : (Color.LIGHT_BLUE,          Color.BLACK),
     'msg_link_index'  : (Color.LIGHT_BLUE__BOLD,    Color.BLACK),
     'msg_quote'       : (Color.BROWN,               Color.BLACK),
-    'msg_code'        : (Color.BLACK,               Color.WHITE),
     'msg_bold'        : (Color.WHITE__BOLD,         Color.BLACK),
     'msg_time'        : (Color.BLACK,               Color.WHITE),
     'footer'          : (Color.BLACK,               Color.LIGHT_GRAY),

--- a/zulipterminal/themes/zt_light.py
+++ b/zulipterminal/themes/zt_light.py
@@ -4,6 +4,8 @@ ZT LIGHT
 This theme uses the default color scheme.
 For further details on themefiles look at the theme contribution guide.
 """
+from pygments.styles.perldoc import PerldocStyle
+
 from zulipterminal.config.color import DefaultBoldColor as Color
 
 
@@ -64,5 +66,30 @@ STYLES = {
     'task:success'    : (Color.BLACK,               Color.DARK_GREEN),
     'task:error'      : (Color.WHITE,               Color.DARK_RED),
     'task:warning'    : (Color.BLACK,               Color.YELLOW),
+}
+
+META = {
+    'pygments': {
+        'styles'    : PerldocStyle().styles,
+        'background': PerldocStyle().background_color,
+        'overrides' : {
+            'cs'  : '#8B008B, bold',
+            'sh'  : '#1c7e71, italics',
+            'k'   : '#8B008B, bold',
+            'nc'  : '#008b45, bold',
+            'ne'  : '#008b45, bold',
+            'nn'  : '#008b45, underline',
+            'nt'  : '#8B008B, bold',
+            'gh'  : '#000080, bold',
+            'gu'  : '#800080, bold',
+            'ge'  : 'default, italics',
+            'gs'  : 'default, bold',
+            'err' : '#a61717',
+            'n'   : '#666666',
+            'p'   : '#666666',
+            'o'   : '#8B008B',
+            'w'   : '#666666',  # inline/plain-codeblock
+        }
+    }
 }
 # fmt: on

--- a/zulipterminal/themes/zt_light.py
+++ b/zulipterminal/themes/zt_light.py
@@ -36,7 +36,6 @@ STYLES = {
     'msg_link'        : (Color.DARK_BLUE,           Color.WHITE),
     'msg_link_index'  : (Color.DARK_BLUE__BOLD,     Color.WHITE),
     'msg_quote'       : (Color.BLACK,               Color.BROWN),
-    'msg_code'        : (Color.BLACK,               Color.LIGHT_GRAY),
     'msg_bold'        : (Color.WHITE__BOLD,         Color.DARK_GRAY),
     'msg_time'        : (Color.WHITE,               Color.DARK_GRAY),
     'footer'          : (Color.WHITE,               Color.DARK_GRAY),

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -1339,8 +1339,40 @@ class MessageBox(urwid.Pile):
                 # CODE (INLINE?)
                 markup.append(("msg_code", tag_text))
             elif tag == "div" and "codehilite" in tag_classes:
-                # CODE (BLOCK?)
-                markup.append(("msg_code", tag_text))
+                """
+                CODE BLOCK
+                -------------
+                Structure:   # Language is optional
+                    <div class="codehilite" data-code-language="python">
+                      <pre>
+                        <span></span>
+                        <code>
+                          Code HTML
+                          Made of <span>'s and NavigableStrings
+                        </code>
+                      </pre>
+                    </div>
+                """
+                code_soup = element.pre.code
+                # NOTE: Old messages don't have the additional `code` tag.
+                # Ref: https://github.com/Python-Markdown/markdown/pull/862
+                if code_soup is None:
+                    code_soup = element.pre
+
+                for code_element in code_soup.contents:
+                    code_text = (
+                        code_element.text
+                        if isinstance(code_element, Tag)
+                        else code_element.string
+                    )
+
+                    if code_element.name == "span":
+                        if len(code_text) == 0:
+                            continue
+                        css_style = code_element.attrs.get("class", ["w"])
+                        markup.append((f"pygments:{css_style[0]}", code_text))
+                    else:
+                        markup.append(("pygments:w", code_text))
             elif tag in ("strong", "em"):
                 # BOLD & ITALIC
                 markup.append(("msg_bold", tag_text))

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -1727,10 +1727,12 @@ class MessageBox(urwid.Pile):
             it would have <pre><span></span>xxx</pre>
         """
         markup = []
+        MAX_NO_WRAP_WIDTH = 60
 
         # Find longest line
         code_text = code_soup.text
         max_line_len = len(max(code_text.split("\n"), key=lambda x: len(x)))
+        max_line_len = min(max_line_len, MAX_NO_WRAP_WIDTH)
 
         line_len = 0
         for code_element in code_soup.contents:

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -1336,8 +1336,13 @@ class MessageBox(urwid.Pile):
                 # BLOCKQUOTE TEXT
                 markup.append(("msg_quote", cls.soup2markup(element, metadata)[0]))
             elif tag == "code":
-                # CODE (INLINE?)
-                markup.append(("msg_code", tag_text))
+                """
+                CODE INLINE
+                -----------
+                Uses the same style as plain text codeblocks
+                which is the `whitespace` token of pygments.
+                """
+                markup.append(("pygments:w", tag_text))
             elif tag == "div" and "codehilite" in tag_classes:
                 """
                 CODE BLOCK


### PR DESCRIPTION
This PR implements syntax highlighting for markdown code blocks by creating a padded "box" which would
visually separate as code. Currently, only looks good in dark theme.

 **Commit 1:** themes: codehilite: Adding Pygments style to the palette.
* This commit uses Pygments internal dictionaries and Pygments
Material Style and adds it into the palette after the Screen is
initialized. This is done inside `add_codehilite_style` and called
in `Controller.__init__`.

**Commit 2:** boxes: codehilite: Implement syntax highlighting functionality.
* Basic syntax highlighting functionality was implemented in
soup2markup by extracting the `css_style` of each `span` tag in the
soup and using it as urwid style attributes. The remaining
NavigableStrings are given a style attribute of `w` which is the
whitespace css class in Pygments.

**Commit 3:** boxes: codehilite: Create a visual "box" by padding whitespaces.
* This commit moves the previous code into `parse_codeblock`, a static
method which creates a visual "box" by:
   * Finding the longest line using `code_soup.text`.
   * Appending `span` text into markup
   * Adding `code_indent` part of the NavigableString to markup.
   * Adding `right_padding` to each line.
   * Making sure multiple empty lines are padded using `padded_line`.
   * Adding the remaining NavigableStrings not contributing to line
breaks into markup.
* The NavigableString is added in parts and not all at once because
though it would produce the same output, it would later help while
implementing `hl_lines` preventing the case where half the previous
line is highlighted along with the line expected.

**Commit 4:** boxes: codehilite: Implement padding for Plain Codeblocks.
* Plain Codeblock have to be treated differently as they don't come in
the usual multiple `span`'s in a `pre` tag package. The whole code
is a NavigableString which does not start with `\n`.
* Hence, if this String has multiple lines it is split and padded
accordingly.

**Commit 5:** boxes: codehilite: Restrict padding to avoid wrapping.
* This commit sets a limit to how much padding is to be added. Many a
times most of the code has smaller lines and there is one line which
is very long which causes all the lines to wrap and this makes the
"box" look very messy. To avoid this a `MAX_NO_WRAP_WIDTH` constant
of 80 is used which is a reasonable limit for in a full screen
no autohide mode.
