### PR TITLE
ui_mappings: New file for edit_mode_captions

### DIFF
--- a/docs/developer-file-overview.md
+++ b/docs/developer-file-overview.md
@@ -19,6 +19,7 @@ Zulip Terminal uses [Zulip's API](https://zulip.com/api/) to store and retrieve 
 | zulipterminal/config   | keys.py             | Stores keybindings and their helper functions                                                          |
 |                        | symbols.py          | Stores terminal characters used to mark particular elements of the user interface                      |
 |                        | themes.py           | Stores styles and their colour mappings in each theme, with helper functions                           |
+|                        | ui_mappings.py      | Stores relationships between state/API data and presentation in the UI                                 |
 |                        |                     |                                                                                                        |
 | zulipterminal/ui_tools | boxes.py            | UI boxes for displaying messages and entering text, such as `MessageBox`, `SearchBox`, `WriteBox`, etc.|
 |                        | buttons.py          | UI buttons for 'narrowing' and showing unread counts, such as Stream, PM, Topic, Home, Starred, etc    |

--- a/zulipterminal/config/ui_mappings.py
+++ b/zulipterminal/config/ui_mappings.py
@@ -1,0 +1,5 @@
+edit_mode_captions = {
+    'change_one': 'Change only this message topic',
+    'change_later': 'Also change later messages to this topic',
+    'change_all': 'Also change previous and following messages to this topic',
+}

--- a/zulipterminal/config/ui_mappings.py
+++ b/zulipterminal/config/ui_mappings.py
@@ -1,4 +1,9 @@
-edit_mode_captions = {
+from typing import Dict
+
+from zulipterminal.api_types import EditPropagateMode
+
+
+EDIT_MODE_CAPTIONS: Dict[EditPropagateMode, str] = {
     'change_one': 'Change only this message topic',
     'change_later': 'Also change later messages to this topic',
     'change_all': 'Also change previous and following messages to this topic',

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -94,13 +94,6 @@ class UnreadCounts(TypedDict):
     streams: Dict[int, int]  # stream_id
 
 
-edit_mode_captions = {
-    'change_one': 'Change only this message topic',
-    'change_later': 'Also change later messages to this topic',
-    'change_all': 'Also change previous and following messages to this topic',
-}
-
-
 def asynch(func: Callable[..., None]) -> Callable[..., None]:
     """
     Decorator for executing a function in a separate :class:`threading.Thread`.

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -12,11 +12,8 @@ from zulipterminal.config.symbols import (
     STREAM_MARKER_PRIVATE,
     STREAM_MARKER_PUBLIC,
 )
-from zulipterminal.helper import (
-    StreamData,
-    edit_mode_captions,
-    hash_util_decode,
-)
+from zulipterminal.config.ui_mappings import edit_mode_captions
+from zulipterminal.helper import StreamData, hash_util_decode
 from zulipterminal.urwid_types import urwid_Size
 
 

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -6,13 +6,14 @@ from urllib.parse import urljoin, urlparse
 import urwid
 from typing_extensions import TypedDict
 
+from zulipterminal.api_types import EditPropagateMode
 from zulipterminal.config.keys import is_command_key, primary_key_for_command
 from zulipterminal.config.symbols import (
     MUTE_MARKER,
     STREAM_MARKER_PRIVATE,
     STREAM_MARKER_PUBLIC,
 )
-from zulipterminal.config.ui_mappings import edit_mode_captions
+from zulipterminal.config.ui_mappings import EDIT_MODE_CAPTIONS
 from zulipterminal.helper import StreamData, hash_util_decode
 from zulipterminal.urwid_types import urwid_Size
 
@@ -527,7 +528,7 @@ class EditModeButton(urwid.Button):
                          on_press=controller.show_topic_edit_mode)
         self.set_selected_mode('change_later')  # set default mode
 
-    def set_selected_mode(self, mode: str) -> None:
+    def set_selected_mode(self, mode: EditPropagateMode) -> None:
         self.mode = mode
         self._w = urwid.AttrMap(urwid.SelectableIcon(
-            edit_mode_captions[self.mode], self.width), None, 'selected')
+            EDIT_MODE_CAPTIONS[self.mode], self.width), None, 'selected')

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -22,13 +22,8 @@ from zulipterminal.config.symbols import (
     STREAM_MARKER_PRIVATE,
     STREAM_MARKER_PUBLIC,
 )
-from zulipterminal.helper import (
-    Message,
-    asynch,
-    edit_mode_captions,
-    match_stream,
-    match_user,
-)
+from zulipterminal.config.ui_mappings import edit_mode_captions
+from zulipterminal.helper import Message, asynch, match_stream, match_user
 from zulipterminal.ui_tools.boxes import MessageBox, PanelSearchBox
 from zulipterminal.ui_tools.buttons import (
     HomeButton,

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -5,6 +5,7 @@ from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 import urwid
 from typing_extensions import Literal
 
+from zulipterminal.api_types import EditPropagateMode
 from zulipterminal.config.keys import (
     HELP_CATEGORIES,
     KEY_BINDINGS,
@@ -22,7 +23,7 @@ from zulipterminal.config.symbols import (
     STREAM_MARKER_PRIVATE,
     STREAM_MARKER_PUBLIC,
 )
-from zulipterminal.config.ui_mappings import edit_mode_captions
+from zulipterminal.config.ui_mappings import EDIT_MODE_CAPTIONS
 from zulipterminal.helper import Message, asynch, match_stream, match_user
 from zulipterminal.ui_tools.boxes import MessageBox, PanelSearchBox
 from zulipterminal.ui_tools.buttons import (
@@ -1348,7 +1349,7 @@ class EditModeView(PopUpView):
         self.edit_mode_button = button
         self.widgets: List[urwid.RadioButton] = []
 
-        for mode in ['change_one', 'change_later', 'change_all']:
+        for mode in EDIT_MODE_CAPTIONS.keys():
             self.add_radio_button(mode)
         super().__init__(controller, self.widgets, 'ENTER', 62,
                          'Topic edit propagation mode')
@@ -1362,10 +1363,10 @@ class EditModeView(PopUpView):
         if new_state:
             self.edit_mode_button.set_selected_mode(mode)
 
-    def add_radio_button(self, mode: str) -> None:
+    def add_radio_button(self, mode: EditPropagateMode) -> None:
         state = mode == self.edit_mode_button.mode
         radio_button = urwid.RadioButton(self.widgets,
-                                         edit_mode_captions[mode],
+                                         EDIT_MODE_CAPTIONS[mode],
                                          state=state)
         urwid.connect_signal(radio_button, 'change', self.set_selected_mode,
                              mode)


### PR DESCRIPTION
This moves and renames (capitalized) edit_mode_captions into the new
config/ui_mappings.py, representing relationships between state and how
it is presented.

Documentation added for the file content.