### PR TITLE
popup: core: Use linear scaling for small terminal sizes.

### DIFF
--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -343,3 +343,19 @@ class TestController:
             num_after=0, num_before=30, anchor=10000000000)
         create_msg.assert_called_once_with(controller.model, msg_ids)
         assert controller.model.index == {'search': msg_ids}
+
+    @pytest.mark.parametrize('screen_size, expected_popup_size', [
+        ((150, 90), (3 * 150 // 4, 3 * 90 // 4)),
+        ((90, 75), (7 * 90 // 8, 3 * 75 // 4)),
+        ((70, 60), (70, 3 * 60 // 4)),
+    ], ids=[
+        'above_linear_range', 'in_linear_range', 'below_linear_range',
+    ])
+    def test_maximum_popup_dimensions(self, mocker, controller,
+                                      screen_size, expected_popup_size):
+        controller.loop.screen.get_cols_rows = mocker.Mock(
+            return_value=screen_size)
+
+        popup_size = controller.maximum_popup_dimensions()
+
+        assert popup_size == expected_popup_size

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -163,11 +163,30 @@ class Controller:
 
     def maximum_popup_dimensions(self) -> Tuple[int, int]:
         """
-        Returns 3/4th of the screen estate's columns and rows.
+        Returns 3/4th of the screen estate's columns if columns are greater
+        than 100 (MAX_LINEAR_SCALING_WIDTH) else scales accordingly untill
+        popup width becomes full width at 80 (MIN_SUPPORTED_POPUP_WIDTH) below
+        which popup width remains full width.
+        The screen estate's rows are always scaled by 3/4th to get the
+        popup rows.
         """
-        max_cols, max_rows = map(lambda num: 3 * num // 4,
-                                 self.loop.screen.get_cols_rows())
-        return max_cols, max_rows
+        MIN_SUPPORTED_POPUP_WIDTH = 80
+        MAX_LINEAR_SCALING_WIDTH = 100
+
+        def clamp(n: int, minn: int, maxn: int) -> int:
+            return max(min(maxn, n), minn)
+
+        max_cols, max_rows = self.loop.screen.get_cols_rows()
+        min_width = MIN_SUPPORTED_POPUP_WIDTH
+        max_width = MAX_LINEAR_SCALING_WIDTH
+        # Scale Width
+        width = clamp(max_cols, min_width, max_width)
+        scaling = 1 - ((width - min_width) / (4 * (max_width - min_width)))
+        max_popup_cols = int(scaling * max_cols)
+        # Scale Height
+        max_popup_rows = 3 * max_rows // 4
+
+        return max_popup_cols, max_popup_rows
 
     def show_pop_up(self, to_show: Any, style: str) -> None:
         border_lines = dict(tlcorner='▛', tline='▀', trcorner='▜',


### PR DESCRIPTION
This commit is a step towards solving #1005 especially the first
2 points. This changes the fixed scaling fraction of 3/4 to one that
is linear in the range 80 - 100 column width:

* The scaling fraction increases from 3/4 to 1 (full-width) as the
available size increases from 80 to 100. This increases the range of
sizes for which the popup is rendered properly.
* For width's smaller than 80 it defaults to full width.
* For width's greater than 100 it defaults to 3/4.

The values 80 and 100 are given by:
* MIN_SUPPORTED_POPUP_WIDTH = 80
* MAX_LINEAR_SCALING_WIDTH = 100

The popup height has a fixed scaling factor of 2/3.

Tests added

80 < Width < 100
<img src='https://user-images.githubusercontent.com/64144419/116774514-aa033100-aa7a-11eb-8f2b-7f61cfbc482a.png' width=400>
Width = 80
<img src='https://user-images.githubusercontent.com/64144419/116774497-8a6c0880-aa7a-11eb-8ddd-2b73a0fb0952.png' width=400>
Width > 100 (Full screen)
<img src='https://user-images.githubusercontent.com/64144419/116774469-6a3c4980-aa7a-11eb-87c0-54f6b3bd8c7e.png' width=400>





