### PR TITLE
WIP: Action for dev env setup test

### DIFF
--- a/.github/workflows/setup-dev-env.yml
+++ b/.github/workflows/setup-dev-env.yml
@@ -1,0 +1,50 @@
+name: Test setting up dev environment
+
+on: [push, workflow_dispatch]
+
+jobs:
+  setup:
+    strategy:
+      # Not failing fast allows all matrix jobs to try & finish even if one fails early
+      fail-fast: false
+      matrix:
+        env:
+          - {PYTHON: 3.6, OS: ubuntu-latest, NAME: "CPython 3.6 (ubuntu)"}
+          - {PYTHON: 3.7, OS: ubuntu-latest, NAME: "CPython 3.7 (ubuntu)"}
+          - {PYTHON: 3.8, OS: ubuntu-latest, NAME: "CPython 3.8 (ubuntu)"}
+          - {PYTHON: 3.9, OS: ubuntu-latest, NAME: "CPython 3.9 (ubuntu)", CODECOV: true}
+            # mypy requires typed-ast, which has no support for pypy
+            #- {PYTHON: 'pypy3', OS: ubuntu-latest, NAME: "PyPy 3 (ubuntu)"}
+          - {PYTHON: 3.9, OS: macos-latest, NAME: "CPython 3.9 (macos)"}
+        install-method: ['pip', 'pipenv', 'make']
+    runs-on: ${{ matrix.env.OS }}
+    name: Install - ${{ matrix.env.NAME}} using ${{matrix.install-method}}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Python version ${{ matrix.env.PYTHON }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.env.PYTHON }}
+      - name: Output Python version
+        run: python --version
+      - name: Ensure libxml-related libraries are installed (pypy3 only)
+        if: matrix.env.PYTHON == 'pypy3'
+        run: sudo apt install libxml2-dev libxslt1-dev
+      - name: MAKE - Set up full dev environment
+        run: make
+        if: matrix.install-method == 'make'
+      - name: PIP - Upgrade pip
+        run: python -m pip install --upgrade pip
+        if: matrix.install-method == 'pip'
+      - name: PIP - Set up full dev environment
+        run: pip install '.[dev]'
+        if: matrix.install-method == 'pip'
+      - name: PIPENV - Install pipenv
+        run: pip install --user pipenv
+        if: matrix.install-method == 'pipenv'
+      - name: PIPENV - Setup dev env
+        run: pipenv install --dev
+        if: matrix.install-method == 'pipenv'
+      - name: PIPENV - Check installed
+        run: pipenv run pip install '.[dev]'
+        if: matrix.install-method == 'pipenv'


### PR DESCRIPTION
I just threw this together based on an extension of the pytest matrix, to see if we can test installing the build environment using the methods we currently suggest, ie. pip, pipenv, make.

This was inspired by the discussion at #**zulip-terminal>Dev Setup Installation**.

This raises a number of points:
* current pip has a clever back-tracking dependency resolver - but so much that it checks ~30 versions of coverage!
* pipenv fails to resolve the conflict with the latest versions of autopep8 and flake8 matching our pinned versions, though one is possible via pip
* pipenv fails differently on macos?
* unsurprisingly make is both simple and works - it uses the pip approach underneath
* pypy cannot be used as a standard dev environment, as it lacks support for mypy via typed-ast

We can add something like this as an on-demand action (workflow_dispatch) to avoid running on every push and failing CI, or perhaps also on push to main branches once this workflow is passing?

Issues to consider arising from this:
* How best to handle these dev dependencies? (or others generally?)
* Add a note that pypy cannot be used for development as per above reason
* Is all the pip backtracking something we can simplify? (maybe just with better versions/dependency options?)
* Do we really want to keep pipenv?

I'd prefer if the matrix used in this could be reused, but this needs to be in a separate file if running via workflow_dispatch and not on push?