### PR TITLE
Add message formatting tips help menu

### DIFF
--- a/docs/hotkeys.md
+++ b/docs/hotkeys.md
@@ -6,6 +6,7 @@
 |Command|Key Combination|
 | :--- | :---: |
 |Show/hide help menu|<kbd>?</kbd>|
+|Show/hide markdown help menu|<kbd>meta</kbd> + <kbd>m</kbd>|
 |Show/hide about menu|<kbd>meta</kbd> + <kbd>?</kbd>|
 |Go Back|<kbd>esc</kbd>|
 |Open draft message saved in this session|<kbd>d</kbd>|

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -1260,6 +1260,14 @@ class TestWriteBox:
                 expected_focus_col_name
             )
 
+    @pytest.mark.parametrize("key", keys_for_command("MARKDOWN_HELP"))
+    def test_keypress_MARKDOWN_HELP(self, mocker, write_box, key, widget_size):
+        size = widget_size(write_box)
+
+        write_box.keypress(size, key)
+
+        write_box.view.controller.show_markdown_help.assert_called_once_with()
+
     @pytest.mark.parametrize(
         "msg_type, expected_box_size",
         [

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -13,6 +13,7 @@ from zulipterminal.ui_tools.views import (
     FullRawMsgView,
     FullRenderedMsgView,
     HelpView,
+    MarkdownHelpView,
     MsgInfoView,
     PopUpConfirmationView,
     PopUpView,
@@ -751,6 +752,50 @@ class TestEditModeView:
         radio_button.keypress(size, key)
 
         mode_button.set_selected_mode.assert_called_once_with(mode)
+
+
+class TestMarkdownHelpView:
+    @pytest.fixture(autouse=True)
+    def mock_external_classes(self, mocker, monkeypatch):
+        self.controller = mocker.Mock()
+        mocker.patch.object(
+            self.controller, "maximum_popup_dimensions", return_value=(64, 64)
+        )
+        self.controller.model.server_url = "https://chat.zulip.org/"
+
+        self.markdown_help_view = MarkdownHelpView(
+            self.controller,
+            "Markdown Help Menu",
+        )
+
+    def test_keypress_any_key(self, widget_size):
+        key = "a"
+        size = widget_size(self.markdown_help_view)
+
+        self.markdown_help_view.keypress(size, key)
+
+        assert not self.controller.exit_popup.called
+
+    @pytest.mark.parametrize(
+        "key", {*keys_for_command("GO_BACK"), *keys_for_command("MARKDOWN_HELP")}
+    )
+    def test_keypress_exit_popup(self, key, widget_size):
+        size = widget_size(self.markdown_help_view)
+
+        self.markdown_help_view.keypress(size, key)
+
+        assert self.controller.exit_popup.called
+
+    def test_keypress_body_navigation(
+        self, mocker, widget_size, navigation_key_expected_key_pair
+    ):
+        key, expected_key = navigation_key_expected_key_pair
+        size = widget_size(self.markdown_help_view)
+        super_keypress = mocker.patch(MODULE + ".urwid.Frame.keypress")
+
+        self.markdown_help_view.keypress(size, key)
+
+        super_keypress.assert_called_once_with(size, expected_key)
 
 
 class TestHelpView:

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -22,6 +22,11 @@ KEY_BINDINGS: 'OrderedDict[str, KeyBinding]' = OrderedDict([
         'excluded_from_random_tips': True,
         'key_category': 'general',
     }),
+    ('MARKDOWN_HELP', {
+        'keys': ['meta m'],
+        'help_text': 'Show/hide markdown help menu',
+        'key_category': 'general',
+    }),
     ('ABOUT', {
         'keys': ['meta ?'],
         'help_text': 'Show/hide about menu',

--- a/zulipterminal/config/markdown_examples.py
+++ b/zulipterminal/config/markdown_examples.py
@@ -1,0 +1,118 @@
+from typing import List
+
+from typing_extensions import TypedDict
+
+
+class MarkdownElements(TypedDict):
+    name: str
+    raw_text: str
+    html_element: str
+
+
+MARKDOWN_ELEMENTS: List[MarkdownElements] = [
+    {
+        # BOLD TEXT
+        "name": "Bold text",
+        "raw_text": "**bold**",
+        "html_element": "<strong>bold</strong>",
+    },
+    {
+        # EMOJI
+        "name": "Emoji",
+        "raw_text": ":heart:",
+        "html_element": '<span class="emoji">:heart:</span>',
+    },
+    {
+        # MESSAGE LINKS
+        "name": "Message links",
+        "raw_text": "[Zulip website]\n(https://zulip.org)",
+        "html_element": '<a href="https://zulip.org">Zulip website</a>',
+    },
+    {
+        # BULLET LISTS
+        "name": "Bullet lists",
+        "raw_text": "* Milk\n* Tea\n  * Green tea\n  * Black tea\n"
+        "  * Oolong tea\n* Coffee",
+        "html_element": "<ul><li>Milk</li><li>Tea<ul><li>Green tea</li>"
+        "<li>Black tea</li><li>Oolong tea</li></ul>"
+        "</li><li>Coffee</li>",
+    },
+    {
+        # NUMBERED LISTS
+        "name": "Numbered lists",
+        "raw_text": "1. Milk\n2. Tea\n3. Coffee",
+        "html_element": "<ol><li>Milk</li><li>Tea</li><li>Coffee</li></ol>",
+    },
+    {
+        # USER MENTIONS
+        "name": "User mentions",
+        "raw_text": "@**King Hamlet**",
+        "html_element": '<span class="user-mention">@King Hamlet</span>',
+    },
+    {
+        # USER SILENT MENTIONS
+        "name": "User silent mentions",
+        "raw_text": "@_**King Hamlet**",
+        "html_element": '<span class="user-mention silent">King Hamlet</span>',
+    },
+    {
+        # NOTIFY ALL RECIPIENTS
+        "name": "Notify all recipients",
+        "raw_text": "@**all**",
+        "html_element": '<span class="user-mention">@all</span>',
+    },
+    {
+        # LINK TO A STREAM
+        "name": "Link to a stream",
+        "raw_text": "#**announce**",
+        "html_element": '<a class="stream" data-stream-id="6" '
+        'href="/#narrow/stream/6-announce">#announce</a>',
+    },
+    {
+        # STATUS MESSAGE
+        "name": "Status message",
+        "raw_text": "/me is busy writing code.",
+        "html_element": "<strong>{user}</strong> is busy writing code.",
+    },
+    {
+        # INLINE CODE
+        "name": "Inline code",
+        "raw_text": "Some inline `code`",
+        "html_element": "Some inline <code>code</code>",
+    },
+    {
+        # CODE BLOCK
+        "name": "Code block",
+        "raw_text": "```\ndef zulip():\n    print 'Zulip'\n```",
+        "html_element": '<div class="codehilite"><pre><span></span><code>\n'
+        "def zulip():\n    print 'Zulip'</code></pre></div>",
+    },
+    {
+        # QUOTED TEXT
+        "name": "Quoted text",
+        "raw_text": ">Quoted",
+        "html_element": "<blockquote>░ Quoted</blockquote>",
+    },
+    {
+        # QUOTED BLOCK
+        "name": "Quoted block",
+        "raw_text": "```quote\nQuoted block\n```",
+        "html_element": "<blockquote>\n░ Quoted block</blockquote>",
+    },
+    {
+        # TABLE RENDERING
+        "name": "Table rendering",
+        "raw_text": "|Name|Id|\n|--|--:|\n|Robert|1|\n|Mary|100|",
+        "html_element": (
+            "<table>"
+            "<thead>"
+            '<tr><th align="left">Name</th><th align="right">Id</th></tr>'
+            "</thead>"
+            "<tbody>"
+            '<tr><td align="left">Robert</td><td align="right">1</td></tr>'
+            '<tr><td align="left">Mary</td><td align="right">100</td></tr>'
+            "</tbody>"
+            "</table>"
+        ),
+    },
+]

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -27,6 +27,7 @@ from zulipterminal.ui_tools.views import (
     FullRawMsgView,
     FullRenderedMsgView,
     HelpView,
+    MarkdownHelpView,
     MsgInfoView,
     NoticeView,
     PopUpConfirmationView,
@@ -241,6 +242,10 @@ class Controller:
     def show_help(self) -> None:
         help_view = HelpView(self, "Help Menu (up/down scrolls)")
         self.show_pop_up(help_view, "area:help")
+
+    def show_markdown_help(self) -> None:
+        markdown_view = MarkdownHelpView(self, "Markdown Help Menu (up/down scrolls)")
+        self.show_pop_up(markdown_view, "area:help")
 
     def show_topic_edit_mode(self, button: Any) -> None:
         self.show_pop_up(EditModeView(self, button), "area:msg")

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -275,6 +275,9 @@ class View(urwid.WidgetWrap):
             # Show help menu
             self.controller.show_help()
             return key
+        elif is_command_key("MARKDOWN_HELP", key):
+            self.controller.show_markdown_help()
+            return key
         # replace alternate keys with arrow/functional keys
         # This is needed for navigating in widgets
         # other than message_view.

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -677,6 +677,9 @@ class WriteBox(urwid.Pile):
             self.view.controller.exit_editor_mode()
             self.main_view(False)
             self.view.middle_column.set_focus("body")
+        elif is_command_key("MARKDOWN_HELP", key):
+            self.view.controller.show_markdown_help()
+            return key
         elif is_command_key("SAVE_AS_DRAFT", key):
             if self.msg_edit_state is None:
                 if self.to_write_box:

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -962,7 +962,9 @@ class TabView(urwid.WidgetWrap):
         super().__init__(tab)
 
 
-PopUpViewTableContent = Sequence[Tuple[str, Sequence[Union[str, Tuple[str, str]]]]]
+# FIXME: This type could be improved, as Any isn't too explicit and clear.
+# (this was previously str, but some types passed in can be more complex)
+PopUpViewTableContent = Sequence[Tuple[str, Sequence[Union[str, Tuple[str, Any]]]]]
 
 
 class PopUpView(urwid.Frame):

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -15,6 +15,7 @@ from zulipterminal.config.keys import (
     keys_for_command,
     primary_key_for_command,
 )
+from zulipterminal.config.markdown_examples import MARKDOWN_ELEMENTS
 from zulipterminal.config.symbols import (
     CHECK_MARK,
     COLUMN_TITLE_BAR_LINE,
@@ -1229,6 +1230,41 @@ class HelpView(PopUpView):
         widgets = self.make_table_with_categories(help_menu_content, column_widths)
 
         super().__init__(controller, widgets, "HELP", popup_width, title)
+
+
+class MarkdownHelpView(PopUpView):
+    def __init__(self, controller: Any, title: str) -> None:
+        raw_menu_content = []  # to calculate table dimensions
+        rendered_menu_content = []  # to display rendered content in table
+        user_name = controller.model.user_full_name
+
+        for element in MARKDOWN_ELEMENTS:
+            raw_content = element["raw_text"]
+            html_element = element["html_element"].format(**dict(user=user_name))
+
+            rendered_content, *_ = MessageBox.transform_content(
+                html_element, controller.model.server_url
+            )
+
+            raw_menu_content.append((raw_content, raw_content))
+            rendered_menu_content.append((raw_content, rendered_content))
+
+        popup_width, column_widths = self.calculate_table_widths(
+            [("", raw_menu_content)], len(title)
+        )
+
+        header_widgets = [
+            urwid.Text([("popup_category", "You type")], align="center"),
+            urwid.Text([("popup_category", "You get")], align="center"),
+        ]
+        header_columns = urwid.Columns(header_widgets)
+        header = urwid.Pile([header_columns, urwid.Divider(COLUMN_TITLE_BAR_LINE)])
+
+        body = self.make_table_with_categories(
+            [("", rendered_menu_content)], column_widths
+        )
+
+        super().__init__(controller, body, "MARKDOWN_HELP", popup_width, title, header)
 
 
 class PopUpConfirmationView(urwid.Overlay):


### PR DESCRIPTION
**What does this PR do?!**
 - Adds a message formatting help menu.
 - Creates a new config file `markdown.py` for markdown-related material.
 - Fixes #623.

**Commit flow**
1. Add hotkey `meta m ` to show markdown popup.
2. Create a new file `markdown_examples.py` containing markdown help data.
3. refactor: Amend the type annotation for PopUpView contents.
4. Structure UI in MarkdownHeloView class.
5. Add UI elements to markdown help view on toggling.
6. Add support for accessing the popup from compose area.

**Doubts/Concerns**
 - The Popup name, i.e., `MarkdownHelpView` could be replaced with one having `message formatting` instead?.
 - The markdown help data might be migrated to `ui_mappings`

**Screenshot(s)/GIF(s)**
![improved_header](https://user-images.githubusercontent.com/55916430/126902377-7672ee58-e8b1-4324-a055-b62408342aed.gif)