### PR TITLE
cryptography requires Rust toolchain on Alpine Linux.

### DIFF
--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -4,7 +4,7 @@ RUN addgroup -S zulipgr \
     && adduser -S zulip -G zulipgr \
     && apk add --no-cache git ca-certificates gcc musl-dev \
                           libffi-dev openssl-dev libxml2-dev \
-                          libxslt-dev
+                          libxslt-dev cargo
 USER zulip
 WORKDIR /home/zulip
 


### PR DESCRIPTION
`cryptography` now requires Rust toolchain on Alpine Linux, xref https://cryptography.io/en/latest/installation/#alpine