### PR TITLE
bugfix: ui: Focus on content_area when draft is opened from side-panels.

### DIFF
--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -247,6 +247,7 @@ class View(urwid.WidgetWrap):
                 content = saved_draft['content']
                 self.write_box.msg_write_box.edit_text = content
                 self.write_box.msg_write_box.edit_pos = len(content)
+                self.body.focus_col = 1
                 self.middle_column.set_focus('footer')
             else:
                 self.set_footer_text('No draft message was saved in'


### PR DESCRIPTION
This commit fixes a bug that caused the focus to not move to the content
area if the draft was opened from the side-panels. This is minor bugfix
that should set the focus to the message_column before setting it to
the footer(i.e. content_area).