### PR TITLE
README/docs: Fix minor typographical errors to improve readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,9 +156,9 @@ Please read our [commit message guidelines](http://zulip.readthedocs.io/en/lates
 [git guide](http://zulip.readthedocs.io/en/latest/git/index.html). **NOTE** Due to the difference in project scale, git commit titles in the Zulip Terminal project read slightly differently - please review our recent git log for examples and see the [GitLint](#gitlint) section below for more guidelines.
 
 A simple [tutorial](https://github.com/zulip/zulip-terminal/blob/main/docs/developer-feature-tutorial.md) is available for implementing the `typing` indicator.
-Follow it to understand the how to implement a new feature for zulip-terminal.
+Follow it to understand how to implement a new feature for zulip-terminal.
 
-You can of course browse the source on GitHub & in the source tree you download, and check the [source file overview](https://github.com/zulip/zulip-terminal/docs/developer-file-overview.md) for ideas of whow files are currently arranged.
+You can of course browse the source on GitHub & in the source tree you download, and check the [source file overview](https://github.com/zulip/zulip-terminal/docs/developer-file-overview.md) for ideas of how files are currently arranged.
 
 ### Urwid
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -84,9 +84,9 @@ If you are unable to open links in messages, then try double right-click on the 
 
 Alternatively, you might try different modifier keys (eg. shift, ctrl, alt) with a right-click.
 
-If you are still facing problems, please discuss it at
-[#zulip-terminal](https://chat.zulip.org/#narrow/stream/206-zulip-terminal) or open an issue
-for it mentioning your terminal name, version, and OS.
+If you are still facing problems, please discuss them at
+[#zulip-terminal](https://chat.zulip.org/#narrow/stream/206-zulip-terminal) or open issues
+for them mentioning your terminal name, version, and OS.
 
 ## Links don't render completely as a footlink
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,7 +8,7 @@ Now let's help you get started with using Zulip Terminal. First, if you haven't 
 
 ## Overview
 
-This tutorial was designed to be interactive. We highly recomend opening up Zulip Terminal and following along! We'll try out a few keyboard shortcuts and send a couple messages to help familiarize ourselves with Zulip Terminal. Here's an overview of the features we'll be walking you through:
+This tutorial was designed to be interactive. We highly recommend opening up Zulip Terminal and following along! We'll try out a few keyboard shortcuts and send a couple of messages to help familiarize ourselves with Zulip Terminal. Here's an overview of the features we'll be walking you through:
 
 0. [Open Zulip Terminal](#Open-Zulip-Terminal)
 1. [Understand the Layout](#Understand-the-Layout)


### PR DESCRIPTION
While reading the README, I stumbled upon a typo and decided to run the README through [Grammarly](https://www.grammarly.com/). We had two. I have fixed them in the commit.