### PR TITLE
bugfix: ui: Focus on content_area when draft is opened from side-panels.

### DIFF
--- a/tests/ui/test_ui.py
+++ b/tests/ui/test_ui.py
@@ -344,6 +344,7 @@ class TestView:
     )
     @pytest.mark.parametrize("key", keys_for_command("OPEN_DRAFT"))
     def test_keypress_OPEN_DRAFT(self, view, mocker, draft, key, widget_size):
+        view.body = mocker.Mock()
         view.middle_column = mocker.Mock()
         view.set_footer_text = mocker.Mock()
         view.controller.is_in_editor_mode = lambda: False
@@ -367,6 +368,7 @@ class TestView:
                     emails=draft["to"], recipient_user_ids=[1, 2]
                 )
 
+            assert view.body.focus_col == 1
             assert view.write_box.msg_write_box.edit_text == draft["content"]
             assert view.write_box.msg_write_box.edit_pos == len(draft["content"])
             view.middle_column.set_focus.assert_called_once_with("footer")

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -262,6 +262,7 @@ class View(urwid.WidgetWrap):
                 content = saved_draft["content"]
                 self.write_box.msg_write_box.edit_text = content
                 self.write_box.msg_write_box.edit_pos = len(content)
+                self.body.focus_col = 1
                 self.middle_column.set_focus("footer")
             else:
                 self.set_footer_text("No draft message was saved in this session.", 3)


### PR DESCRIPTION
This commit fixes a bug that caused the focus to not move to the content
area if the draft was opened from the side-panels. This is minor bugfix
that should set the focus to the message_column before setting it to
the footer(i.e. content_area).