### PR TITLE
Update topic and stream headers on update message events mid-compose.

### DIFF
--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -771,6 +771,28 @@ class TestWriteBox:
             "being composed to has been changed."
         )
 
+    def test_update_stream_compose_header(
+        self,
+        mocker,
+        write_box,
+        current_stream_id=1,
+        new_stream_id=2,
+        new_stream_name="Stream 2",
+    ):
+        mocker.patch(WRITEBOX + "._set_stream_write_box_style")
+        write_box.view.controller.report_warning = mocker.Mock()
+        write_box.stream_box_view(current_stream_id)
+
+        write_box.update_stream_compose_header(new_stream_name, new_stream_id)
+
+        assert write_box.stream_id == new_stream_id
+        assert write_box.stream_write_box.edit_text == new_stream_name
+        assert write_box.stream_write_box.edit_pos == len(new_stream_name)
+        write_box.view.controller.report_warning.assert_called_once_with(
+            "The stream header has been updated because the topic currently being "
+            "composed to has been moved to another stream."
+        )
+
     @pytest.mark.parametrize(
         "text, matching_users, matching_users_info",
         [

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -750,6 +750,27 @@ class TestWriteBox:
         typeahead_string = write_box.generic_autocomplete(text, state)
         assert typeahead_string == required_typeahead
 
+    def test_update_topic_compose_header(
+        self,
+        mocker,
+        write_box,
+        current_topic="some topic",
+        new_topic="new topic",
+        stream_id=1,
+    ):
+        mocker.patch(WRITEBOX + "._set_stream_write_box_style")
+        write_box.view.controller.report_warning = mocker.Mock()
+        write_box.stream_box_view(stream_id, title=current_topic)
+
+        write_box.update_topic_compose_header(new_topic)
+
+        assert write_box.title_write_box.edit_text == new_topic
+        assert write_box.title_write_box.edit_pos == len(new_topic)
+        write_box.view.controller.report_warning.assert_called_once_with(
+            "The topic header has been updated because the name of the topic currently "
+            "being composed to has been changed."
+        )
+
     @pytest.mark.parametrize(
         "text, matching_users, matching_users_info",
         [

--- a/zulipterminal/api_types.py
+++ b/zulipterminal/api_types.py
@@ -149,7 +149,9 @@ class UpdateMessageEvent(TypedDict):
     rendered_content: str
     # B: Subject of these message ids needs updating?
     message_ids: List[int]
+    orig_subject: str
     subject: str
+    propagate_mode: EditPropagateMode
     stream_id: int
 
 

--- a/zulipterminal/api_types.py
+++ b/zulipterminal/api_types.py
@@ -153,6 +153,7 @@ class UpdateMessageEvent(TypedDict):
     subject: str
     propagate_mode: EditPropagateMode
     stream_id: int
+    new_stream_id: int
 
 
 class ReactionEvent(TypedDict):

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1335,6 +1335,21 @@ class Model:
                     else:
                         self.index["topics"][stream_id] = []
 
+            if event["propagate_mode"] in ["change_later", "change_all"]:
+                old_subject = event["orig_subject"]
+
+                # If the user is composing a message to this topic, update the topic in
+                # the title_write_box header on a 'change_later' or 'change_all' update
+                # in the topic.
+                if hasattr(self.controller, "view"):
+                    write_box = self.controller.view.write_box
+                    if (
+                        write_box.compose_box_status == "open_with_stream"
+                        and write_box.stream_id == stream_id
+                        and write_box.title_write_box.edit_text == old_subject
+                    ):
+                        write_box.update_topic_compose_header(new_subject)
+
     def _handle_reaction_event(self, event: Event) -> None:
         """
         Handle change to reactions on a message

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1350,6 +1350,25 @@ class Model:
                     ):
                         write_box.update_topic_compose_header(new_subject)
 
+        # Present only when the stream is changed.
+        if "new_stream_id" in event:
+            old_stream_id = event["stream_id"]
+            new_stream_id = event["new_stream_id"]
+            new_stream_name = self.stream_dict[new_stream_id]["name"]
+
+            # If the user is composing a message to the topic/message
+            # being moved across streams, update the stream header
+            # accordingly.
+            if hasattr(self.controller, "view"):
+                write_box = self.controller.view.write_box
+                if (
+                    write_box.compose_box_status == "open_with_stream"
+                    and write_box.stream_id == old_stream_id
+                ):
+                    write_box.update_stream_compose_header(
+                        new_stream_name, new_stream_id
+                    )
+
     def _handle_reaction_event(self, event: Event) -> None:
         """
         Handle change to reactions on a message

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -447,6 +447,18 @@ class WriteBox(urwid.Pile):
             "being composed to has been changed."
         )
 
+    def update_stream_compose_header(
+        self, new_stream_name: str, new_stream_id: int
+    ) -> None:
+        self.stream_id = new_stream_id
+        self.stream_write_box.set_edit_text(new_stream_name)
+        self.stream_write_box.set_edit_pos(len(new_stream_name))
+
+        self.view.controller.report_warning(
+            "The stream header has been updated because the topic currently being "
+            "composed to has been moved to another stream."
+        )
+
     def _to_box_autocomplete(self, text: str, state: Optional[int]) -> Optional[str]:
         users_list = self.view.users
         recipients = text.rsplit(",", 1)

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -438,6 +438,15 @@ class WriteBox(urwid.Pile):
             (color, stream_marker)
         )
 
+    def update_topic_compose_header(self, new_topic: str) -> None:
+        self.title_write_box.set_edit_text(new_topic)
+        self.title_write_box.set_edit_pos(len(new_topic))
+
+        self.view.controller.report_warning(
+            "The topic header has been updated because the name of the topic currently "
+            "being composed to has been changed."
+        )
+
     def _to_box_autocomplete(self, text: str, state: Optional[int]) -> Optional[str]:
         users_list = self.view.users
         recipients = text.rsplit(",", 1)


### PR DESCRIPTION
**PR structure**:
- **tests: Generalize the update message index using factory.**
This commit adds a factory to generate the messages index relevant to
update message event tests, in an effort to reduce code duplications
for future tests. The factory requires three parameters - msg_stream_id,
(stream_id of the messages in the index), topics (dict containing streams
as keys, and a list of topics as the values, consistent with the structure
in the index) and message_ids (which is a list of the message ids to be
generated in the index). The factory uses these parameters to customize
the index.
- **boxes: Create helper function to update the topic compose header.**
This commit adds a helper function facilitating abstracted updates
to the topic in the topic compose header (title_write_box), and also
sets the edit_pos appropriately.
Test added.
- **api_types: Extend UpdateMessageEvent to accomodate topic updates.**
This commit includes more fields under the UpdateMessageEvent class
to ensure type-consistent handling for said fields in the update message
events conveying topic updates.
- **model: Handle topic updates in the compose header mid-compose.**
This commit enables dynamic behaviour in the compose box when a topic
is updated when the user is currently composing. The topic that the user
is currently writing a message to is checked and the relevant update is
done if the topic in the event matches the corresponding header.
Tests added.
- **boxes: Create helper function to update the stream compose header.**
This commit adds a helper function facilitating abstracted updates
to the stream name in the stream compose header (title_write_box),
the corresponding edit_pos modification, as well as the stream_id
attribute of the WriteBox object in use.
Test added.
- **api_types: Extend UpdateMessageEvent to handle cross-stream updates.**
This commit extends the UpdateMessageEvent class by including the
new_stream_id field to ensure type-consistent handling of cross-stream
updates (moving topics between streams) in the update message events.
- **model: Handle stream updates in the compose header mid-compose.**
This commit updates the compose header when a stream is updated while
the user is currently composing. The stream that the user is currently
writing a message to is checked and the relevant update is done if the
stream_id in the event matches the corresponding header.
Tests added.

**Testing and linting:**
I've ran tests locally on each commit. I've also ran `black` checks and then the more extensive `./tools/lint-all`.

Fixes #1040.