### PR TITLE
Add support for handling delete_message events.

### DIFF
--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1327,6 +1327,12 @@ class Model:
         for msg_w in view.message_view.log:
             msg_box = msg_w.original_widget
             if msg_box.message["id"] == msg_id:
+                # Remove the message if deleted
+                # FIXME: Do we need to check narrow before removing?
+                if msg_id not in self.index["messages"]:
+                    view.message_view.log.remove(msg_w)
+                    self.controller.update_screen()
+                    return
                 # Remove the message if it no longer belongs in the current
                 # narrow.
                 if (


### PR DESCRIPTION
This adds a new event action in model that looks for delete_message events, potentially handling it by removing the message completely from the index, and then updates the rendered_view to handle the event dynamically without needing to switch narrows.

It also looks out for messages being unread before being deleted and updates the count appropriately. Similarly, for messages that were starred before being deleted, this updates the `starred_count` too.

Fixes one check-box of #993.