### PR TITLE
bugfix: Construct narrow appropriately before verifying and triggering footer notifications.

### DIFF
--- a/tests/helper/test_helper.py
+++ b/tests/helper/test_helper.py
@@ -365,6 +365,16 @@ def test_display_error_if_present(mocker, response, footer_updated):
         case(
             {
                 "type": "private",
+                "to": ["foo@zulip.com", "bar@zulip.com"],
+                "content": "Hi",
+            },
+            [["pm_with", "foo@zulip.com, bar@zulip.com"]],
+            False,
+            id="group_private_conv__same_group_pm__not_notified",
+        ),
+        case(
+            {
+                "type": "private",
                 "to": ["user@abc.com", "user@chat.com"],
                 "content": "Hi",
             },

--- a/tests/helper/test_helper.py
+++ b/tests/helper/test_helper.py
@@ -357,19 +357,23 @@ def test_display_error_if_present(mocker, response, footer_updated):
     "req, narrow, footer_updated",
     [
         case(
-            {"type": "private", "to": "foo@gmail.com", "content": "bar"},
+            {"type": "private", "to": ["foo@gmail.com"], "content": "bar"},
             [["is", "private"]],
             False,
             id="all_private__pm__not_notified",
         ),
         case(
-            {"type": "private", "to": "user@abc.com, user@chat.com", "content": "Hi"},
+            {
+                "type": "private",
+                "to": ["user@abc.com", "user@chat.com"],
+                "content": "Hi",
+            },
             [["pm_with", "user@0abc.com"]],
             True,
             id="private_conv__other_pm__notified",
         ),
         case(
-            {"type": "private", "to": "bar-bar@foo.com", "content": ":party_parrot:"},
+            {"type": "private", "to": ["bar-bar@foo.com"], "content": ":party_parrot:"},
             [["pm_with", "user@abc.com, user@chat.com, bar-bar@foo.com"]],
             True,
             id="private_conv__other_pm2__notified",
@@ -409,7 +413,7 @@ def test_display_error_if_present(mocker, response, footer_updated):
             id="starred__stream__notified",
         ),
         case(
-            {"type": "private", "to": "2@aBd%8@random.com", "content": "fist_bump"},
+            {"type": "private", "to": ["2@aBd%8@random.com"], "content": "fist_bump"},
             [["is", "mentioned"]],
             True,
             id="mentioned__private_no_mention__notified",

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -685,7 +685,7 @@ def notify_if_message_sent_outside_narrow(
         check_narrow_and_notify(stream_narrow, topic_narrow, controller)
     elif message["type"] == "private":
         pm_narrow = [["is", "private"]]
-        pm_with_narrow = [["pm_with", ",".join(message["to"])]]
+        pm_with_narrow = [["pm_with", ", ".join(message["to"])]]
         check_narrow_and_notify(pm_narrow, pm_with_narrow, controller)
 
 


### PR DESCRIPTION
**PR Structure:**

- **refactor: tests: Change req parameter to use a list of recipient emails.**
This commit refactors the test cases of the `req` parameter in
`test_notify_if_message_sent_outside_narrow` from a string of ', '
separated emails to a list of emails, consistent with the current type
of the `to` attribute of PrivateComposition.
Tests updated.

- **bugfix: helper: Use ', ' as separator to construct narrow to verify.**
This commit fixes a bug that previously caused a "Message sent outside
current narrow." message in the footer in group pms (huddles) even when
on the right narrow. This happened because of the wrong separator being
used, ','. This has been changed to the relevant separator - ', '.
Test added.

**Testing and linting:**
I've ran tests locally on each commit. I've also ran `black` checks and then the more extensive `./tools/lint-all`.