### PR TITLE
bugfix: Fix topic editing if topic unchanged

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -2306,6 +2306,7 @@ class TestMessageBox:
 
         if expect_editing_to_succeed:
             assert write_box.msg_edit_state.message_id == varied_message["id"]
+            assert write_box.msg_edit_state.old_topic == varied_message["subject"]
             write_box.msg_write_box.set_edit_text.assert_called_once_with(
                 "Edit this message"
             )

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -2291,7 +2291,7 @@ class TestMessageBox:
             "raw_content": "Edit this message"
         }
         write_box = msg_box.model.controller.view.write_box
-        write_box.msg_edit_id = None
+        write_box.msg_edit_state = None
         write_box.msg_body_edit_enabled = None
         mocker.patch("zulipterminal.ui_tools.boxes.time", return_value=100)
         # private messages cannot be edited after time-limit, if there is one.
@@ -2305,13 +2305,13 @@ class TestMessageBox:
         msg_box.keypress(size, key)
 
         if expect_editing_to_succeed:
-            assert write_box.msg_edit_id == varied_message["id"]
+            assert write_box.msg_edit_state.message_id == varied_message["id"]
             write_box.msg_write_box.set_edit_text.assert_called_once_with(
                 "Edit this message"
             )
             assert write_box.msg_body_edit_enabled == msg_body_edit_enabled
         else:
-            assert write_box.msg_edit_id is None
+            assert write_box.msg_edit_state is None
             write_box.msg_write_box.set_edit_text.assert_not_called()
 
     @pytest.mark.parametrize(

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -846,7 +846,7 @@ class TestWriteBox:
     )
     @pytest.mark.parametrize(
         "msg_edit_state",
-        [_MessageEditState(message_id=10), None],
+        [_MessageEditState(message_id=10, old_topic="old topic"), None],
         ids=["update_message", "send_message"],
     )
     @pytest.mark.parametrize("key", keys_for_command("SEND_MESSAGE"))
@@ -1065,7 +1065,9 @@ class TestWriteBox:
             if message_being_edited:
                 mocker.patch(BOXES + ".EditModeButton")
                 write_box.stream_box_edit_view(stream_id)
-                write_box.msg_edit_state = _MessageEditState(message_id=10)
+                write_box.msg_edit_state = _MessageEditState(
+                    message_id=10, old_topic="some old topic"
+                )
             else:
                 write_box.stream_box_view(stream_id)
         else:

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -7,7 +7,7 @@ from zulipterminal.config.symbols import (
     STREAM_MARKER_PRIVATE,
     STREAM_MARKER_PUBLIC,
 )
-from zulipterminal.ui_tools.boxes import PanelSearchBox, WriteBox
+from zulipterminal.ui_tools.boxes import PanelSearchBox, WriteBox, _MessageEditState
 
 
 BOXES = "zulipterminal.ui_tools.boxes"
@@ -51,7 +51,7 @@ class TestWriteBox:
     def test_init(self, write_box):
         assert write_box.model == self.view.model
         assert write_box.view == self.view
-        assert write_box.msg_edit_id is None
+        assert write_box.msg_edit_state is None
 
     def test_not_calling_typing_method_without_recipients(self, mocker, write_box):
         write_box.model.send_typing_status_by_user_ids = mocker.Mock()
@@ -845,14 +845,16 @@ class TestWriteBox:
         ],
     )
     @pytest.mark.parametrize(
-        "msg_edit_id", [10, None], ids=["update_message", "send_message"]
+        "msg_edit_state",
+        [_MessageEditState(message_id=10), None],
+        ids=["update_message", "send_message"],
     )
     @pytest.mark.parametrize("key", keys_for_command("SEND_MESSAGE"))
     def test_keypress_SEND_MESSAGE_no_topic(
         self,
         mocker,
         write_box,
-        msg_edit_id,
+        msg_edit_state,
         topic_entered_by_user,
         topic_sent_to_server,
         key,
@@ -864,16 +866,16 @@ class TestWriteBox:
         write_box.title_write_box = mocker.Mock(edit_text=topic_entered_by_user)
         write_box.to_write_box = None
         size = widget_size(write_box)
-        write_box.msg_edit_id = msg_edit_id
+        write_box.msg_edit_state = msg_edit_state
         write_box.edit_mode_button = mocker.Mock(mode=propagate_mode)
 
         write_box.keypress(size, key)
 
-        if msg_edit_id:
+        if msg_edit_state:
             write_box.model.update_stream_message.assert_called_once_with(
                 topic=topic_sent_to_server,
                 content=write_box.msg_write_box.edit_text,
-                message_id=msg_edit_id,
+                message_id=msg_edit_state.message_id,
                 propagate_mode=propagate_mode,
             )
         else:
@@ -1063,7 +1065,7 @@ class TestWriteBox:
             if message_being_edited:
                 mocker.patch(BOXES + ".EditModeButton")
                 write_box.stream_box_edit_view(stream_id)
-                write_box.msg_edit_id = 10
+                write_box.msg_edit_state = _MessageEditState(message_id=10)
             else:
                 write_box.stream_box_view(stream_id)
         else:

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -5,7 +5,7 @@ from collections import Counter, OrderedDict, defaultdict
 from datetime import date, datetime, timedelta
 from sys import platform
 from time import sleep, time
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, NamedTuple, Optional, Tuple, Union
 from urllib.parse import urljoin, urlparse
 
 import dateutil.parser
@@ -53,14 +53,18 @@ if typing.TYPE_CHECKING:
     from zulipterminal.model import Model
 
 
+class _MessageEditState(NamedTuple):
+    message_id: int
+
+
 class WriteBox(urwid.Pile):
     def __init__(self, view: Any) -> None:
         super().__init__(self.main_view(True))
         self.model = view.model
         self.view = view
 
-        # If editing a message, its id - otherwise None
-        self.msg_edit_id: Optional[int] = None
+        # If editing a message, its state - otherwise None
+        self.msg_edit_state: Optional[_MessageEditState] = None
         # Determines if the message body (content) can be edited
         self.msg_body_edit_enabled = True
 
@@ -538,9 +542,9 @@ class WriteBox(urwid.Pile):
                 else:
                     topic = self.title_write_box.edit_text
 
-                if self.msg_edit_id:
+                if self.msg_edit_state is not None:
                     args = dict(
-                        message_id=self.msg_edit_id,
+                        message_id=self.msg_edit_state.message_id,
                         topic=topic,
                         propagate_mode=self.edit_mode_button.mode,
                     )
@@ -555,10 +559,10 @@ class WriteBox(urwid.Pile):
                         content=self.msg_write_box.edit_text,
                     )
             else:
-                if self.msg_edit_id:
+                if self.msg_edit_state is not None:
                     success = self.model.update_private_message(
                         content=self.msg_write_box.edit_text,
-                        msg_id=self.msg_edit_id,
+                        msg_id=self.msg_edit_state.message_id,
                     )
                 else:
                     self.update_recipient_emails(self.to_write_box)
@@ -574,18 +578,18 @@ class WriteBox(urwid.Pile):
                         success = None
             if success:
                 self.msg_write_box.edit_text = ""
-                if self.msg_edit_id:
-                    self.msg_edit_id = None
+                if self.msg_edit_state is not None:
+                    self.msg_edit_state = None
                     self.keypress(size, "esc")
         elif is_command_key("GO_BACK", key):
-            self.msg_edit_id = None
+            self.msg_edit_state = None
             self.msg_body_edit_enabled = True
             self.send_stop_typing_status()
             self.view.controller.exit_editor_mode()
             self.main_view(False)
             self.view.middle_column.set_focus("body")
         elif is_command_key("SAVE_AS_DRAFT", key):
-            if not self.msg_edit_id:
+            if self.msg_edit_state is None:
                 if self.to_write_box:
                     self.update_recipient_emails(self.to_write_box)
                     this_draft: Composition = PrivateComposition(
@@ -636,7 +640,7 @@ class WriteBox(urwid.Pile):
                         return key
                     elif (
                         header.focus_col == self.FOCUS_HEADER_BOX_TOPIC
-                        and self.msg_edit_id
+                        and self.msg_edit_state is not None
                     ):
                         header.focus_col = self.FOCUS_HEADER_BOX_EDIT
                         return key
@@ -1612,7 +1616,7 @@ class MessageBox(urwid.Pile):
             msg_id = self.message["id"]
             msg = self.model.client.get_raw_message(msg_id)["raw_content"]
             write_box = self.model.controller.view.write_box
-            write_box.msg_edit_id = msg_id
+            write_box.msg_edit_state = _MessageEditState(message_id=msg_id)
             write_box.msg_write_box.set_edit_text(msg)
             write_box.msg_write_box.set_edit_pos(len(msg))
             write_box.msg_body_edit_enabled = msg_body_edit_enabled


### PR DESCRIPTION
Recent work in resolved/unresolved topics has caused a change in the server (not yet in a release), where it more strictly enforces that if a topic is provided but unchanged in stream message editing/updating, then the propagate mode must be set to change_one - otherwise the edit does not proceed.

This PR works around this and has scope to be expanded towards resolving part or all of #1014.

The need for this was discussed in #**design>closing/solving a topic (#11154)**.

I've not added tests for this change in behavior (yet, at least) - we don't seem to have tests for the existing behavior.