### PR TITLE
boxes: Use indicator attribute to hold compose box status.

### DIFF
--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -188,6 +188,38 @@ class TestWriteBox:
 
         assert not write_box.model.send_private_message.called
 
+    @pytest.mark.parametrize("key", keys_for_command("GO_BACK"))
+    def test__compose_attributes_reset_for_private_compose(
+        self, key, mocker, write_box, widget_size
+    ):
+        mocker.patch("urwid.connect_signal")
+        write_box.private_box_view(
+            emails=["person1@example.com"], recipient_user_ids=[11]
+        )
+        write_box.msg_write_box.edit_text = "random text"
+
+        size = widget_size(write_box)
+        write_box.keypress(size, key)
+
+        assert write_box.to_write_box is None
+        assert write_box.msg_write_box.edit_text == ""
+        assert write_box.compose_box_status == "closed"
+
+    @pytest.mark.parametrize("key", keys_for_command("GO_BACK"))
+    def test__compose_attributes_reset_for_stream_compose(
+        self, key, mocker, write_box, widget_size
+    ):
+        write_box._set_stream_write_box_style = mocker.Mock()
+        write_box.stream_box_view(stream_id=1)
+        write_box.msg_write_box.edit_text = "random text"
+
+        size = widget_size(write_box)
+        write_box.keypress(size, key)
+
+        assert write_box.stream_id is None
+        assert write_box.msg_write_box.edit_text == ""
+        assert write_box.compose_box_status == "closed"
+
     @pytest.mark.parametrize(
         ["raw_recipients", "tidied_recipients"],
         [

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -1,3 +1,5 @@
+import datetime
+
 import pytest
 from pytest import param as case
 
@@ -54,7 +56,15 @@ class TestWriteBox:
         assert write_box.model == self.view.model
         assert write_box.view == self.view
         assert write_box.msg_edit_state is None
-        assert not write_box.sent_start_typing_status
+        assert write_box.msg_body_edit_enabled is True
+        assert write_box.stream_id is None
+        assert write_box.recipient_user_ids == []
+        assert write_box.typing_recipient_user_ids == []
+        assert write_box.to_write_box is None
+        assert isinstance(write_box.send_next_typing_update, datetime.datetime)
+        assert isinstance(write_box.last_key_update, datetime.datetime)
+        assert write_box.idle_status_tracking is False
+        assert write_box.sent_start_typing_status is False
 
     def test_not_calling_typing_method_without_recipients(self, mocker, write_box):
         write_box.model.send_typing_status_by_user_ids = mocker.Mock()

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -55,6 +55,7 @@ class TestWriteBox:
     def test_init(self, write_box):
         assert write_box.model == self.view.model
         assert write_box.view == self.view
+        assert write_box.compose_box_status == "closed"
         assert write_box.msg_edit_state is None
         assert write_box.msg_body_edit_enabled is True
         assert write_box.stream_id is None
@@ -1094,7 +1095,7 @@ class TestWriteBox:
         write_box.stream_write_box = mocker.Mock()
         write_box.msg_write_box = mocker.Mock(edit_text="")
         write_box.title_write_box = mocker.Mock(edit_text=topic_entered_by_user)
-        write_box.to_write_box = None
+        write_box.compose_box_status = "open_with_stream"
         size = widget_size(write_box)
         write_box.msg_edit_state = msg_edit_state
         write_box.edit_mode_button = mocker.Mock(mode=propagate_mode)


### PR DESCRIPTION
**PR structure:**
- **boxes: Use an indicator attribute to specify current compose box status.**
This commit introduces an attribute, `compose_box_status` to the WriteBox
class, to indicate the current compose status of the WriteBox, which can
be one of "open_with_private", "open_with_stream" or "closed". Such an
indicator would be a structured way to check for compose status before
performing status specific tasks.
- **boxes: Create a helper method to set WriteBox attributes to defaults.**
This commit adds a helper method to the WriteBox class to reset all
the WriteBox attributes to their defaults after usage by the
`stream_box_view` or `private_box_view`. This helps to ensure that
the state of the attributes do not persist beyond their function.
- **boxes: Configure `*_box_views` to set and reset WriteBox attributes.**
This commit enables the setting of the `compose_box_status` and
resetting it (by setting it to "closed") along with the other WriteBox
attributes, after a compose.
The `private_box_view` and `stream_box_view` set the `compose_box_view`
status appropriately in their call. The `GO_BACK` keypress now calls
the helper method to reset WriteBox attributes like the `stream_id` and
the `to_write_box` among others, to prevent persistence, which is not
ideal here, because these attributes are specific to the particular
compose action they were set in.
Tests updated.

**Testing and linting:**
I've ran tests locally on each commit. I've also ran `black` checks and then the more extensive `./tools/lint-all`.