### PR TITLE
Platform handling improvements and WSL bugfix.

### DIFF
--- a/tests/helper/test_helper.py
+++ b/tests/helper/test_helper.py
@@ -13,11 +13,9 @@ from zulipterminal.helper import (
     get_unused_fence,
     hash_util_decode,
     index_messages,
-    notify,
     notify_if_message_sent_outside_narrow,
     powerset,
 )
-from zulipterminal.platform_code import AllPlatforms, SupportedPlatforms
 
 
 MODULE = "zulipterminal.helper"
@@ -311,69 +309,6 @@ def test_invalid_color_format(mocker: MockerFixture, color: str) -> None:
     with pytest.raises(ValueError) as e:
         canon = canonicalize_color(color)
     assert str(e.value) == f'Unknown format for color "{color}"'
-
-
-@pytest.mark.parametrize(
-    "PLATFORM, is_notification_sent",
-    [
-        # PLATFORM: Literal["WSL", "MacOS", "Linux", "unsupported"]
-        pytest.param(
-            "WSL",
-            True,
-            marks=pytest.mark.xfail(reason="WSL notify disabled"),
-        ),
-        ("MacOS", True),
-        ("Linux", True),
-        ("unsupported", False),  # Unsupported OS
-    ],
-)
-def test_notify(
-    mocker: MockerFixture, PLATFORM: AllPlatforms, is_notification_sent: bool
-) -> None:
-    title = "Author"
-    text = "Hello!"
-    mocker.patch(MODULE + ".PLATFORM", PLATFORM)
-    subprocess = mocker.patch(MODULE + ".subprocess")
-    notify(title, text)
-    assert subprocess.run.called == is_notification_sent
-
-
-@pytest.mark.parametrize(
-    "text",
-    ["x", "Spaced text.", "'", '"'],
-    ids=["x", "spaced_text", "single", "double"],
-)
-@pytest.mark.parametrize(
-    "title",
-    ["X", "Spaced title", "'", '"'],
-    ids=["X", "spaced_title", "single", "double"],
-)
-@pytest.mark.parametrize(
-    "PLATFORM, cmd_length",
-    [
-        ("Linux", 4),
-        ("MacOS", 10),
-        pytest.param("WSL", 2, marks=pytest.mark.xfail(reason="WSL notify disabled")),
-    ],
-)
-def test_notify_quotes(
-    monkeypatch: pytest.MonkeyPatch,
-    mocker: MockerFixture,
-    PLATFORM: SupportedPlatforms,
-    cmd_length: int,
-    title: str,
-    text: str,
-) -> None:
-    subprocess = mocker.patch(MODULE + ".subprocess")
-    platform = mocker.patch(MODULE + ".PLATFORM", PLATFORM)
-
-    notify(title, text)
-
-    params = subprocess.run.call_args_list
-    assert len(params) == 1  # One external run call
-    assert len(params[0][0][0]) == cmd_length
-
-    # NOTE: If there is a quoting error, we may get a ValueError too
 
 
 @pytest.mark.parametrize(

--- a/tests/platform_code/test_platform_code.py
+++ b/tests/platform_code/test_platform_code.py
@@ -1,0 +1,69 @@
+import pytest
+from pytest_mock import MockerFixture
+
+from zulipterminal.platform_code import AllPlatforms, SupportedPlatforms, notify
+
+
+MODULE = "zulipterminal.platform_code"
+
+
+@pytest.mark.parametrize(
+    "PLATFORM, is_notification_sent",
+    [
+        # PLATFORM: Literal["WSL", "MacOS", "Linux", "unsupported"]
+        pytest.param(
+            "WSL",
+            True,
+            marks=pytest.mark.xfail(reason="WSL notify disabled"),
+        ),
+        ("MacOS", True),
+        ("Linux", True),
+        ("unsupported", False),  # Unsupported OS
+    ],
+)
+def test_notify(
+    mocker: MockerFixture, PLATFORM: AllPlatforms, is_notification_sent: bool
+) -> None:
+    title = "Author"
+    text = "Hello!"
+    mocker.patch(MODULE + ".PLATFORM", PLATFORM)
+    subprocess = mocker.patch(MODULE + ".subprocess")
+    notify(title, text)
+    assert subprocess.run.called == is_notification_sent
+
+
+@pytest.mark.parametrize(
+    "text",
+    ["x", "Spaced text.", "'", '"'],
+    ids=["x", "spaced_text", "single", "double"],
+)
+@pytest.mark.parametrize(
+    "title",
+    ["X", "Spaced title", "'", '"'],
+    ids=["X", "spaced_title", "single", "double"],
+)
+@pytest.mark.parametrize(
+    "PLATFORM, cmd_length",
+    [
+        ("Linux", 4),
+        ("MacOS", 10),
+        pytest.param("WSL", 2, marks=pytest.mark.xfail(reason="WSL notify disabled")),
+    ],
+)
+def test_notify_quotes(
+    mocker: MockerFixture,
+    PLATFORM: SupportedPlatforms,
+    cmd_length: int,
+    title: str,
+    text: str,
+) -> None:
+    subprocess = mocker.patch(MODULE + ".subprocess")
+    platform = mocker.patch(MODULE + ".PLATFORM", PLATFORM)
+
+    notify(title, text)
+
+    params = subprocess.run.call_args_list
+    assert len(params) == 1  # One external run call
+    assert len(params[0][0][0]) == cmd_length
+
+    # NOTE: If there is a quoting error, we may get a ValueError too

--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -130,6 +130,7 @@ type_consistent_testfiles = [
     "test_keys.py",
     "test_themes.py",
     "test_color.py",
+    "test_platform_code.py",
 ]
 
 for file_path in python_files:

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -15,8 +15,9 @@ from typing_extensions import Literal
 
 from zulipterminal.api_types import Composition, Message
 from zulipterminal.config.themes import ThemeSpec
-from zulipterminal.helper import LINUX, asynch, suppress_output
+from zulipterminal.helper import asynch, suppress_output
 from zulipterminal.model import Model
+from zulipterminal.platform_code import PLATFORM
 from zulipterminal.ui import Screen, View
 from zulipterminal.ui_tools.utils import create_msg_box_list
 from zulipterminal.ui_tools.views import (
@@ -359,7 +360,11 @@ class Controller:
         """
         # Don't try to open web browser if running without a GUI
         # TODO: Explore and eventually support opening links in text-browsers.
-        if LINUX and not os.environ.get("DISPLAY") and os.environ.get("TERM"):
+        if (
+            PLATFORM == "Linux"
+            and not os.environ.get("DISPLAY")
+            and os.environ.get("TERM")
+        ):
             self.report_error(
                 "No DISPLAY environment variable specified. This could "
                 "likely mean the ZT host is running without a GUI."

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -1,5 +1,4 @@
 import os
-import subprocess
 import time
 from collections import OrderedDict, defaultdict
 from contextlib import contextmanager
@@ -24,11 +23,9 @@ from typing import (
 )
 from urllib.parse import unquote
 
-import lxml.html
 from typing_extensions import TypedDict
 
 from zulipterminal.api_types import Composition, EmojiType, Message
-from zulipterminal.platform_code import PLATFORM
 
 
 class StreamData(TypedDict):
@@ -632,39 +629,6 @@ def canonicalize_color(color: str) -> str:
         return color.lower()
     else:
         raise ValueError(f'Unknown format for color "{color}"')
-
-
-def notify(title: str, html_text: str) -> str:
-    document = lxml.html.document_fromstring(html_text)
-    text = document.text_content()
-
-    command_list = None
-    if PLATFORM == "MacOS":
-        command_list = [
-            "osascript",
-            "-e",
-            "on run(argv)",
-            "-e",
-            "return display notification item 1 of argv with title "
-            'item 2 of argv sound name "ZT_NOTIFICATION_SOUND"',
-            "-e",
-            "end",
-            "--",
-            text,
-            title,
-        ]
-    elif PLATFORM == "Linux":
-        command_list = ["notify-send", "--", title, text]
-
-    if command_list is not None:
-        try:
-            subprocess.run(
-                command_list, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
-            )
-        except FileNotFoundError:
-            # This likely means the notification command could not be found
-            return command_list[0]
-    return ""
 
 
 def display_error_if_present(response: Dict[str, Any], controller: Any) -> None:

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -1,5 +1,4 @@
 import os
-import platform
 import subprocess
 import time
 from collections import OrderedDict, defaultdict
@@ -29,11 +28,12 @@ import lxml.html
 from typing_extensions import TypedDict
 
 from zulipterminal.api_types import Composition, EmojiType, Message
+from zulipterminal.platform_code import PLATFORM
 
 
-MACOS = platform.system() == "Darwin"
-LINUX = platform.system() == "Linux"
-WSL = "microsoft" in platform.release().lower()
+MACOS = PLATFORM == "MacOS"
+LINUX = PLATFORM == "Linux"
+WSL = PLATFORM == "WSL"
 
 
 class StreamData(TypedDict):

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -31,11 +31,6 @@ from zulipterminal.api_types import Composition, EmojiType, Message
 from zulipterminal.platform_code import PLATFORM
 
 
-MACOS = PLATFORM == "MacOS"
-LINUX = PLATFORM == "Linux"
-WSL = PLATFORM == "WSL"
-
-
 class StreamData(TypedDict):
     name: str
     id: int
@@ -644,7 +639,7 @@ def notify(title: str, html_text: str) -> str:
     text = document.text_content()
 
     command_list = None
-    if MACOS:
+    if PLATFORM == "MacOS":
         command_list = [
             "osascript",
             "-e",
@@ -658,7 +653,7 @@ def notify(title: str, html_text: str) -> str:
             text,
             title,
         ]
-    elif LINUX:
+    elif PLATFORM == "Linux":
         command_list = ["notify-send", "--", title, text]
 
     if command_list is not None:

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -47,10 +47,10 @@ from zulipterminal.helper import (
     display_error_if_present,
     index_messages,
     initial_index,
-    notify,
     notify_if_message_sent_outside_narrow,
     set_count,
 )
+from zulipterminal.platform_code import notify
 from zulipterminal.ui_tools.utils import create_msg_box_list
 
 

--- a/zulipterminal/platform_code.py
+++ b/zulipterminal/platform_code.py
@@ -22,6 +22,9 @@ else:
 
 
 # PLATFORM DEPENDENT HELPERS
+MOUSE_SELECTION_KEY = "Fn + Alt" if PLATFORM == "MacOS" else "Shift"
+
+
 def notify(title: str, html_text: str) -> str:
     document = lxml.html.document_fromstring(html_text)
     text = document.text_content()

--- a/zulipterminal/platform_code.py
+++ b/zulipterminal/platform_code.py
@@ -1,0 +1,18 @@
+import platform
+
+from typing_extensions import Literal
+
+
+SupportedPlatforms = Literal["Linux", "MacOS", "WSL"]
+AllPlatforms = Literal[SupportedPlatforms, "unsupported"]
+
+raw_platform = platform.system()
+
+PLATFORM: AllPlatforms
+
+if raw_platform == "Linux":
+    PLATFORM = "WSL" if "microsoft" in platform.release().lower() else "Linux"
+elif raw_platform == "Darwin":
+    PLATFORM = "MacOS"
+else:
+    PLATFORM = "unsupported"

--- a/zulipterminal/platform_code.py
+++ b/zulipterminal/platform_code.py
@@ -1,8 +1,11 @@
 import platform
+import subprocess
 
+import lxml.html
 from typing_extensions import Literal
 
 
+# PLATFORM DETECTION
 SupportedPlatforms = Literal["Linux", "MacOS", "WSL"]
 AllPlatforms = Literal[SupportedPlatforms, "unsupported"]
 
@@ -16,3 +19,37 @@ elif raw_platform == "Darwin":
     PLATFORM = "MacOS"
 else:
     PLATFORM = "unsupported"
+
+
+# PLATFORM DEPENDENT HELPERS
+def notify(title: str, html_text: str) -> str:
+    document = lxml.html.document_fromstring(html_text)
+    text = document.text_content()
+
+    command_list = None
+    if PLATFORM == "MacOS":
+        command_list = [
+            "osascript",
+            "-e",
+            "on run(argv)",
+            "-e",
+            "return display notification item 1 of argv with title "
+            'item 2 of argv sound name "ZT_NOTIFICATION_SOUND"',
+            "-e",
+            "end",
+            "--",
+            text,
+            title,
+        ]
+    elif PLATFORM == "Linux":
+        command_list = ["notify-send", "--", title, text]
+
+    if command_list is not None:
+        try:
+            subprocess.run(
+                command_list, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+            )
+        except FileNotFoundError:
+            # This likely means the notification command could not be found
+            return command_list[0]
+    return ""

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -1,7 +1,6 @@
 import random
 import re
 import time
-from sys import platform
 from typing import Any, List, Optional
 
 import urwid
@@ -12,7 +11,7 @@ from zulipterminal.config.symbols import (
     COLUMN_TITLE_BAR_LINE,
 )
 from zulipterminal.helper import asynch
-from zulipterminal.platform_code import PLATFORM
+from zulipterminal.platform_code import MOUSE_SELECTION_KEY, PLATFORM
 from zulipterminal.ui_tools.boxes import SearchBox, WriteBox
 from zulipterminal.ui_tools.views import (
     LeftColumnView,
@@ -298,11 +297,10 @@ class View(urwid.WidgetWrap):
         self, size: urwid_Box, event: str, button: int, col: int, row: int, focus: bool
     ) -> bool:
         if event == "mouse drag":
-            selection_key = "Fn + Alt" if platform == "darwin" else "Shift"
             self.model.controller.view.set_footer_text(
                 [
                     "Try pressing ",
-                    ("footer_contrast", f" {selection_key} "),
+                    ("footer_contrast", f" {MOUSE_SELECTION_KEY} "),
                     " and dragging to select text.",
                 ],
                 "task:warning",

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -11,7 +11,8 @@ from zulipterminal.config.symbols import (
     APPLICATION_TITLE_BAR_LINE,
     COLUMN_TITLE_BAR_LINE,
 )
-from zulipterminal.helper import WSL, asynch
+from zulipterminal.helper import asynch
+from zulipterminal.platform_code import PLATFORM
 from zulipterminal.ui_tools.boxes import SearchBox, WriteBox
 from zulipterminal.ui_tools.views import (
     LeftColumnView,
@@ -316,7 +317,7 @@ class View(urwid.WidgetWrap):
 
 class Screen(urwid.raw_display.Screen):
     def write(self, data: Any) -> None:
-        if WSL:
+        if PLATFORM == "WSL":
             # replace urwid's SI/SO, which produce artifacts under WSL.
             # https://github.com/urwid/urwid/issues/264#issuecomment-358633735
             # Above link describes the change.


### PR DESCRIPTION
This PR improves our platform handling by defining an isolated module `config/platform_detection.py` that contains the platform detection code and uses a single variable `PLATFORM` to hold the name of the platform that the current ZT instance is loaded on. This fixes a bug in WSL where multiple platforms were detected. Related discussion in: [#zulip-terminal>Platform handling (#T791) and WSL issues](https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/Platform.20handling.20.28.23T791.29.20.20and.20WSL.20issues)

Fixes #791.