### PR TITLE
Panel Search Box UI Enhancements

### DIFF
--- a/tests/ui/test_ui.py
+++ b/tests/ui/test_ui.py
@@ -298,7 +298,6 @@ class TestView:
 
         view.users_view.keypress.assert_called_once_with(size, key)
         assert view.body.focus_position == 2
-        view.user_search.set_edit_text.assert_called_once_with("")
         view.controller.enter_editor_mode_with.assert_called_once_with(view.user_search)
 
     @pytest.mark.parametrize("key", keys_for_command("SEARCH_STREAMS"))
@@ -324,7 +323,6 @@ class TestView:
 
         view.left_panel.keypress.assert_called_once_with(size, key)
         assert view.body.focus_position == 0
-        view.stream_w.stream_search_box.set_edit_text.assert_called_once_with("")
         view.controller.enter_editor_mode_with.assert_called_once_with(
             view.stream_w.stream_search_box
         )

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -576,7 +576,7 @@ class TestStreamsView:
 
         assert stream_view.focus_index_before_search == 3
         stream_view.set_focus.assert_called_once_with("header")
-        stream_view.stream_search_box.set_caption.assert_called_once_with("")
+        stream_view.stream_search_box.set_caption.assert_called_once_with(" ")
 
     @pytest.mark.parametrize("key", keys_for_command("GO_BACK"))
     def test_keypress_GO_BACK(self, mocker, stream_view, key, widget_size):
@@ -707,7 +707,7 @@ class TestTopicsView:
         topic_view.set_focus.assert_called_once_with("header")
         topic_view.header_list.set_focus.assert_called_once_with(2)
         assert topic_view.focus_index_before_search == 3
-        topic_view.topic_search_box.set_caption.assert_called_once_with("")
+        topic_view.topic_search_box.set_caption.assert_called_once_with(" ")
 
     @pytest.mark.parametrize("key", keys_for_command("GO_BACK"))
     def test_keypress_GO_BACK(self, mocker, topic_view, key, widget_size):
@@ -1128,7 +1128,7 @@ class TestRightColumnView:
         mocker.patch.object(right_col_view.user_search, "set_caption")
         right_col_view.keypress(size, key)
         right_col_view.set_focus.assert_called_once_with("header")
-        right_col_view.user_search.set_caption.assert_called_once_with("")
+        right_col_view.user_search.set_caption.assert_called_once_with(" ")
 
     @pytest.mark.parametrize("key", keys_for_command("GO_BACK"))
     def test_keypress_GO_BACK(self, right_col_view, mocker, key, widget_size):

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -568,6 +568,7 @@ class TestStreamsView:
     def test_keypress_SEARCH_STREAMS(self, mocker, stream_view, key, widget_size):
         size = widget_size(stream_view)
         mocker.patch.object(stream_view, "set_focus")
+        mocker.patch.object(stream_view.stream_search_box, "set_caption")
         stream_view.log.extend(["FOO", "foo", "fan", "boo", "BOO"])
         stream_view.log.set_focus(3)
 
@@ -575,6 +576,7 @@ class TestStreamsView:
 
         assert stream_view.focus_index_before_search == 3
         stream_view.set_focus.assert_called_once_with("header")
+        stream_view.stream_search_box.set_caption.assert_called_once_with("")
 
     @pytest.mark.parametrize("key", keys_for_command("GO_BACK"))
     def test_keypress_GO_BACK(self, mocker, stream_view, key, widget_size):
@@ -696,6 +698,7 @@ class TestTopicsView:
     def test_keypress_SEARCH_TOPICS(self, mocker, topic_view, key, widget_size):
         size = widget_size(topic_view)
         mocker.patch(VIEWS + ".TopicsView.set_focus")
+        mocker.patch.object(topic_view.topic_search_box, "set_caption")
         topic_view.log.extend(["FOO", "foo", "fan", "boo", "BOO"])
         topic_view.log.set_focus(3)
 
@@ -704,6 +707,7 @@ class TestTopicsView:
         topic_view.set_focus.assert_called_once_with("header")
         topic_view.header_list.set_focus.assert_called_once_with(2)
         assert topic_view.focus_index_before_search == 3
+        topic_view.topic_search_box.set_caption.assert_called_once_with("")
 
     @pytest.mark.parametrize("key", keys_for_command("GO_BACK"))
     def test_keypress_GO_BACK(self, mocker, topic_view, key, widget_size):
@@ -1121,8 +1125,10 @@ class TestRightColumnView:
     def test_keypress_SEARCH_PEOPLE(self, right_col_view, mocker, key, widget_size):
         size = widget_size(right_col_view)
         mocker.patch(VIEWS + ".RightColumnView.set_focus")
+        mocker.patch.object(right_col_view.user_search, "set_caption")
         right_col_view.keypress(size, key)
         right_col_view.set_focus.assert_called_once_with("header")
+        right_col_view.user_search.set_caption.assert_called_once_with("")
 
     @pytest.mark.parametrize("key", keys_for_command("GO_BACK"))
     def test_keypress_GO_BACK(self, right_col_view, mocker, key, widget_size):

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -1247,7 +1247,7 @@ class TestWriteBox:
 
 
 class TestPanelSearchBox:
-    search_caption = "Search Results "
+    search_caption = " Search Results  "
 
     @pytest.fixture
     def panel_search_box(self, mocker):
@@ -1258,7 +1258,7 @@ class TestPanelSearchBox:
         return PanelSearchBox(panel_view, "UNTESTED_TOKEN", update_func)
 
     def test_init(self, panel_search_box):
-        assert panel_search_box.search_text == "Search [X]: "
+        assert panel_search_box.search_text == " Search [X]: "
         assert panel_search_box.caption == panel_search_box.search_text
         assert panel_search_box.edit_text == ""
 

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -1247,7 +1247,7 @@ class TestWriteBox:
 
 
 class TestPanelSearchBox:
-    search_caption = " Search Results  "
+    search_caption = " Search Results \n > "
 
     @pytest.fixture
     def panel_search_box(self, mocker):

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -1259,8 +1259,8 @@ class TestPanelSearchBox:
 
     def test_init(self, panel_search_box):
         assert panel_search_box.search_text == "Search [X]: "
-        assert panel_search_box.caption == ""
-        assert panel_search_box.edit_text == panel_search_box.search_text
+        assert panel_search_box.caption == panel_search_box.search_text
+        assert panel_search_box.edit_text == ""
 
     def test_reset_search_text(self, panel_search_box):
         panel_search_box.set_caption(self.search_caption)
@@ -1268,8 +1268,8 @@ class TestPanelSearchBox:
 
         panel_search_box.reset_search_text()
 
-        assert panel_search_box.caption == ""
-        assert panel_search_box.edit_text == panel_search_box.search_text
+        assert panel_search_box.caption == panel_search_box.search_text
+        assert panel_search_box.edit_text == ""
 
     @pytest.mark.parametrize(
         "search_text, entered_string, expected_result",
@@ -1345,8 +1345,8 @@ class TestPanelSearchBox:
         panel_search_box.keypress(size, back_key)
 
         # Reset display
-        assert panel_search_box.caption == ""
-        assert panel_search_box.edit_text == panel_search_box.search_text
+        assert panel_search_box.caption == panel_search_box.search_text
+        assert panel_search_box.edit_text == ""
 
         # Leave editor mode
         panel_view.view.controller.exit_editor_mode.assert_called_once_with()

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -225,7 +225,6 @@ class View(urwid.WidgetWrap):
             self.users_view.keypress(size, "w")
             self.show_left_panel(visible=False)
             self.show_right_panel(visible=True)
-            self.user_search.set_edit_text("")
             self.controller.enter_editor_mode_with(self.user_search)
             return key
         elif is_command_key("SEARCH_STREAMS", key) or is_command_key(
@@ -240,7 +239,6 @@ class View(urwid.WidgetWrap):
                 search_box = self.topic_w.topic_search_box
             else:
                 search_box = self.stream_w.stream_search_box
-            search_box.set_edit_text("")
             self.controller.enter_editor_mode_with(search_box)
             return key
         elif is_command_key("OPEN_DRAFT", key):

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -1841,7 +1841,7 @@ class PanelSearchBox(urwid.Edit):
             self.panel_view.keypress(size, "esc")
         elif is_command_key("ENTER", key) and not self.panel_view.empty_search:
             self.panel_view.view.controller.exit_editor_mode()
-            self.set_caption([("filter_results", " Search Results "), " "])
+            self.set_caption([("filter_results", " Search Results \n"), " > "])
             self.panel_view.set_focus("body")
             if hasattr(self.panel_view, "log"):
                 self.panel_view.body.set_focus(0)

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -1806,7 +1806,7 @@ class PanelSearchBox(urwid.Edit):
     ) -> None:
         self.panel_view = panel_view
         self.search_command = search_command
-        self.search_text = f"Search [{', '.join(keys_for_command(search_command))}]: "
+        self.search_text = f" Search [{', '.join(keys_for_command(search_command))}]: "
         self.search_error = urwid.AttrMap(
             urwid.Text([" ", INVALID_MARKER, " No Results"]), "search_error"
         )
@@ -1841,7 +1841,7 @@ class PanelSearchBox(urwid.Edit):
             self.panel_view.keypress(size, "esc")
         elif is_command_key("ENTER", key) and not self.panel_view.empty_search:
             self.panel_view.view.controller.exit_editor_mode()
-            self.set_caption([("filter_results", "Search Results"), " "])
+            self.set_caption([("filter_results", " Search Results "), " "])
             self.panel_view.set_focus("body")
             if hasattr(self.panel_view, "log"):
                 self.panel_view.body.set_focus(0)

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -1811,11 +1811,11 @@ class PanelSearchBox(urwid.Edit):
             urwid.Text([" ", INVALID_MARKER, " No Results"]), "search_error"
         )
         urwid.connect_signal(self, "change", update_function)
-        super().__init__(caption="", edit_text=self.search_text)
+        super().__init__(caption=self.search_text, edit_text="")
 
     def reset_search_text(self) -> None:
-        self.set_caption("")
-        self.set_edit_text(self.search_text)
+        self.set_caption(self.search_text)
+        self.set_edit_text("")
 
     def valid_char(self, ch: str) -> bool:
         # This method 'strips' leading space *before* entering it in the box

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -363,7 +363,7 @@ class StreamsView(urwid.Frame):
         if is_command_key("SEARCH_STREAMS", key):
             _, self.focus_index_before_search = self.log.get_focus()
             self.set_focus("header")
-            self.stream_search_box.set_caption("")
+            self.stream_search_box.set_caption(" ")
             return key
         elif is_command_key("GO_BACK", key):
             self.stream_search_box.reset_search_text()
@@ -475,7 +475,7 @@ class TopicsView(urwid.Frame):
             _, self.focus_index_before_search = self.log.get_focus()
             self.set_focus("header")
             self.header_list.set_focus(2)
-            self.topic_search_box.set_caption("")
+            self.topic_search_box.set_caption(" ")
             return key
         elif is_command_key("GO_BACK", key):
             self.topic_search_box.reset_search_text()
@@ -750,7 +750,7 @@ class RightColumnView(urwid.Frame):
         if is_command_key("SEARCH_PEOPLE", key):
             self.allow_update_user_list = False
             self.set_focus("header")
-            self.user_search.set_caption("")
+            self.user_search.set_caption(" ")
             return key
         elif is_command_key("GO_BACK", key):
             self.user_search.reset_search_text()

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -363,6 +363,7 @@ class StreamsView(urwid.Frame):
         if is_command_key("SEARCH_STREAMS", key):
             _, self.focus_index_before_search = self.log.get_focus()
             self.set_focus("header")
+            self.stream_search_box.set_caption("")
             return key
         elif is_command_key("GO_BACK", key):
             self.stream_search_box.reset_search_text()
@@ -474,6 +475,7 @@ class TopicsView(urwid.Frame):
             _, self.focus_index_before_search = self.log.get_focus()
             self.set_focus("header")
             self.header_list.set_focus(2)
+            self.topic_search_box.set_caption("")
             return key
         elif is_command_key("GO_BACK", key):
             self.topic_search_box.reset_search_text()
@@ -748,6 +750,7 @@ class RightColumnView(urwid.Frame):
         if is_command_key("SEARCH_PEOPLE", key):
             self.allow_update_user_list = False
             self.set_focus("header")
+            self.user_search.set_caption("")
             return key
         elif is_command_key("GO_BACK", key):
             self.user_search.reset_search_text()


### PR DESCRIPTION
This PR deals UI enhancements related to display and reattempting search.
While reattempting search:
* The caption sets to empty string
* The previous edit_text does not get erased so that users can edit typos.

Display:
* Aligns the text inside search box with the rest of the panel
* Displays edit text on new line, which reads clearer and helps render long searches properly

<img src="https://user-images.githubusercontent.com/64144419/123751215-1b256000-d8d5-11eb-9edb-324aec5ec486.png" width=300>
