### PR TITLE
WIP: Feature: Add Spoiler support

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1840,6 +1840,7 @@ class TestMessageBox:
             server_url=SERVER_URL,
             message_links=OrderedDict(),
             time_mentions=list(),
+            spoilers=list(),
             bq_len=0,
         )
 

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1778,6 +1778,57 @@ class TestMessageBox:
                 [("msg_emoji", ":github:")],
                 id="custom_emoji",
             ),
+            case(
+                '<div class="spoiler-block"><div class="spoiler-header"></div>'
+                '<div aria-hidden="true" class="spoiler-content">'
+                "<p>Test</p></div></div>",
+                [
+                    "┌─",
+                    "────────",
+                    "─┬─",
+                    "───────",
+                    "─┐\n",
+                    "│ ",
+                    ("msg_spoiler", "Spoiler:"),
+                    " │ ",
+                    "",
+                    "",
+                    "",
+                    "Spoiler",
+                    " │\n",
+                    "└─",
+                    "────────",
+                    "─┴─",
+                    "───────",
+                    "─┘",
+                ],
+                id="spoiler_no_header",
+            ),
+            case(
+                '<div class="spoiler-block"><div class="spoiler-header">'
+                '<p>Header</p></div><div aria-hidden="true" class="spoiler-content">'
+                "<p>Test</p></div></div>",
+                [
+                    "┌─",
+                    "────────",
+                    "─┬─",
+                    "──────",
+                    "─┐\n",
+                    "│ ",
+                    ("msg_spoiler", "Spoiler:"),
+                    " │ ",
+                    "",
+                    "",
+                    "Header",
+                    " │\n",
+                    "└─",
+                    "────────",
+                    "─┴─",
+                    "──────",
+                    "─┘",
+                ],
+                id="spoiler_with_header",
+            ),
         ],
     )
     def test_soup2markup(self, content, expected_markup, mocker):

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -229,6 +229,7 @@ class TestEditHistoryView:
             topic_links=OrderedDict(),
             message_links=OrderedDict(),
             time_mentions=list(),
+            spoilers=list(),
             title="Edit History",
         )
 
@@ -238,6 +239,7 @@ class TestEditHistoryView:
         assert self.edit_history_view.topic_links == OrderedDict()
         assert self.edit_history_view.message_links == OrderedDict()
         assert self.edit_history_view.time_mentions == list()
+        assert self.edit_history_view.spoilers == list()
         self.controller.model.fetch_message_history.assert_called_once_with(
             message_id=self.message["id"],
         )
@@ -271,6 +273,7 @@ class TestEditHistoryView:
             topic_links=OrderedDict(),
             message_links=OrderedDict(),
             time_mentions=list(),
+            spoilers=list(),
         )
 
     def test_keypress_navigation(
@@ -542,6 +545,7 @@ class TestMsgInfoView:
             OrderedDict(),
             OrderedDict(),
             list(),
+            list(),
         )
 
     def test_init(self, message_fixture):
@@ -549,6 +553,7 @@ class TestMsgInfoView:
         assert self.msg_info_view.topic_links == OrderedDict()
         assert self.msg_info_view.message_links == OrderedDict()
         assert self.msg_info_view.time_mentions == list()
+        assert self.msg_info_view.spoilers == list()
 
     def test_keypress_any_key(self, widget_size):
         key = "a"
@@ -592,6 +597,7 @@ class TestMsgInfoView:
             topic_links=OrderedDict(),
             message_links=OrderedDict(),
             time_mentions=list(),
+            spoilers=list(),
         )
         size = widget_size(msg_info_view)
 
@@ -603,6 +609,7 @@ class TestMsgInfoView:
                 topic_links=OrderedDict(),
                 message_links=OrderedDict(),
                 time_mentions=list(),
+                spoilers=list(),
             )
         else:
             self.controller.show_edit_history.assert_not_called()
@@ -687,6 +694,7 @@ class TestMsgInfoView:
             "Message Information",
             OrderedDict(),
             OrderedDict(),
+            list(),
             list(),
         )
         # 10 = 4 labels + 1 blank line + 1 'Reactions' (category)

--- a/zulipterminal/config/themes.py
+++ b/zulipterminal/config/themes.py
@@ -35,6 +35,7 @@ required_styles = {  # style-name: monochrome-bit-depth-style
     "msg_code": "bold",
     "msg_bold": "bold",
     "msg_time": "bold",
+    "msg_spoiler": "bold",
     "footer": "standout",
     "footer_contrast": "standout",
     "starred": "bold",
@@ -95,6 +96,7 @@ LIGHTBLUEBOLD = f"{LIGHTBLUE}, bold"
 YELLOW = "h172"  # neutral_yellow
 YELLOWBOLD = f"{YELLOW}, bold"
 LIGHTGREEN = "h142"  # bright_green
+LIGHTGREENBOLD = "%s, bold" % LIGHTGREEN
 LIGHTRED = "h167"  # bright_red
 LIGHTREDBOLD = f"{LIGHTRED}, bold"
 GRAY = "h244"  # gray_244
@@ -115,6 +117,7 @@ LIGHTBLUEBOLD24 = f"{LIGHTBLUE24}, bold"
 YELLOW24 = "#d79921"  # neutral_yellow
 YELLOWBOLD24 = f"{YELLOW24}, bold"
 LIGHTGREEN24 = "#b8bb26"  # bright_green
+LIGHTGREENBOLD24 = f"{LIGHTGREEN24}, bold"
 LIGHTRED24 = "#fb4934"  # bright_red
 LIGHTREDBOLD24 = f"{LIGHTRED24}, bold"
 GRAY24 = "#928374"  # gray_244
@@ -188,6 +191,8 @@ THEMES: Dict[str, ThemeSpec] = {
          None,             DEF['white:bold'],         DEF['black']),
         ('msg_time',       'black',                   'white',
          None,             DEF['black'],              DEF['white']),
+        ('msg_spoiler',    'light green, bold',       'black',
+         None,             DEF['light_green:bold'],   DEF['black']),
         ('footer',         'black',                   'light gray',
          None,             DEF['black'],              DEF['light_gray']),
         ('footer_contrast', 'white',                  'black',
@@ -292,6 +297,8 @@ THEMES: Dict[str, ThemeSpec] = {
          None,             WHITEBOLD,         BLACK),
         ('msg_time',       'black',           'white',
          None,             BLACK,             WHITE),
+        ('msg_spoiler',    'light green, bold', 'black',
+         None,             LIGHTGREENBOLD,    BLACK),
         ('footer',         'black',           'light gray',
          None,             BLACK,             LIGHTGRAY),
         ('footer_contrast', 'white',          'black',
@@ -396,6 +403,8 @@ THEMES: Dict[str, ThemeSpec] = {
          None,             WHITEBOLD24,       BLACK24),
         ('msg_time',       'black',           'white',
          None,             BLACK24,           WHITE24),
+        ('msg_spoiler',    'light green, bold', 'black',
+         None,             LIGHTGREENBOLD24,  BLACK24),
         ('footer',         'black',           'light gray',
          None,             BLACK24,           LIGHTGRAY24),
         ('footer_contrast', 'white',          'black',
@@ -471,6 +480,7 @@ THEMES: Dict[str, ThemeSpec] = {
         ('msg_code',       'black',           'light gray'),
         ('msg_bold',       'white, bold',     'dark gray'),
         ('msg_time',       'white',           'dark gray'),
+        ('msg_spoiler',    'light green, bold', 'white'),
         ('footer',         'white',           'dark gray'),
         ('footer_contrast', 'black',          'white'),
         ('starred',        'light red, bold', 'white'),
@@ -523,6 +533,7 @@ THEMES: Dict[str, ThemeSpec] = {
         ('msg_code',       'dark blue',       'white'),
         ('msg_bold',       'white, bold',     'dark blue'),
         ('msg_time',       'dark blue',       'white'),
+        ('msg_spoiler',    'light green, bold', 'light blue'),
         ('footer',         'white',           'dark gray'),
         ('footer_contrast', 'black',          'white'),
         ('starred',        'light red, bold', 'light blue'),

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -27,6 +27,7 @@ from zulipterminal.ui_tools.views import (
     MsgInfoView,
     NoticeView,
     PopUpConfirmationView,
+    SpoilerView,
     StreamInfoView,
     StreamMembersView,
 )
@@ -349,6 +350,11 @@ class Controller:
         Helper to show a warning message in footer
         """
         self.view.set_footer_text(text, "task:warning", 3)
+
+    def show_spoiler(self, content: str) -> None:
+        self.show_pop_up(
+            SpoilerView(self, "Spoiler (up/down scrolls)", content), "area:msg"
+        )
 
     def search_messages(self, text: str) -> None:
         # Search for a text in messages

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -248,6 +248,7 @@ class Controller:
         topic_links: "OrderedDict[str, Tuple[str, int, bool]]",
         message_links: "OrderedDict[str, Tuple[str, int, bool]]",
         time_mentions: List[Tuple[str, str]],
+        spoilers: List[Tuple[int, List[Any], List[Any]]],
     ) -> None:
         msg_info_view = MsgInfoView(
             self,
@@ -256,6 +257,7 @@ class Controller:
             topic_links,
             message_links,
             time_mentions,
+            spoilers,
         )
         self.show_pop_up(msg_info_view, "area:msg")
 
@@ -293,6 +295,7 @@ class Controller:
         topic_links: "OrderedDict[str, Tuple[str, int, bool]]",
         message_links: "OrderedDict[str, Tuple[str, int, bool]]",
         time_mentions: List[Tuple[str, str]],
+        spoilers: List[Tuple[int, List[Any], List[Any]]],
     ) -> None:
         self.show_pop_up(
             EditHistoryView(
@@ -301,6 +304,7 @@ class Controller:
                 topic_links,
                 message_links,
                 time_mentions,
+                spoilers,
                 "Edit History (up/down scrolls)",
             ),
             "area:msg",

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -1701,7 +1701,11 @@ class MessageBox(urwid.Pile):
             self.model.controller.view.middle_column.set_focus("footer")
         elif is_command_key("MSG_INFO", key):
             self.model.controller.show_msg_info(
-                self.message, self.topic_links, self.message_links, self.time_mentions
+                self.message,
+                self.topic_links,
+                self.message_links,
+                self.time_mentions,
+                self.spoilers,
             )
         return key
 

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -693,6 +693,7 @@ class MessageBox(urwid.Pile):
         self.message_links: "OrderedDict[str, Tuple[str, int, bool]]" = OrderedDict()
         self.topic_links: "OrderedDict[str, Tuple[str, int, bool]]" = OrderedDict()
         self.time_mentions: List[Tuple[str, str]] = list()
+        self.spoilers: List[Tuple[int, List[Any], List[Any]]] = list()
         self.last_message = last_message
         # if this is the first message
         if self.last_message is None:
@@ -985,13 +986,21 @@ class MessageBox(urwid.Pile):
     def soup2markup(
         cls, soup: Any, metadata: Dict[str, Any], **state: Any
     ) -> Tuple[
-        List[Any], "OrderedDict[str, Tuple[str, int, bool]]", List[Tuple[str, str]]
+        List[Any],
+        "OrderedDict[str, Tuple[str, int, bool]]",
+        List[Tuple[str, str]],
+        List[Tuple[int, List[Any], List[Any]]],
     ]:
         # Ensure a string is provided, in case the soup finds none
         # This could occur if eg. an image is removed or not shown
         markup: List[Union[str, Tuple[Optional[str], Any]]] = [""]
         if soup is None:  # This is not iterable, so return promptly
-            return markup, metadata["message_links"], metadata["time_mentions"]
+            return (
+                markup,
+                metadata["message_links"],
+                metadata["time_mentions"],
+                metadata["spoilers"],
+            )
         unrendered_tags = {  # In pairs of 'tag_name': 'text'
             # TODO: Some of these could be implemented
             "br": "",  # No indicator of absence
@@ -1239,9 +1248,33 @@ class MessageBox(urwid.Pile):
                     ]
                 )
                 markup.extend(bottom_border)
+                # Spoiler content.
+                content = element.find(class_="spoiler-content")
+
+                # Remove surrounding newlines.
+                content_contents = content.contents
+                if len(content_contents) > 2:
+                    if content_contents[-1] == "\n":
+                        content.contents.pop(-1)
+                    if content_contents[0] == "\n":
+                        content.contents.pop(0)
+                if len(content_contents) == 1 and content_contents[0] == "\n":
+                    content.contents.pop(0)
+
+                # FIXME: Do not soup2markup content in the MessageBox as it
+                # will render 'sensitive' spoiler anchor tags in the footlinks.
+                processed_content = cls.soup2markup(content, metadata)[0]
+                metadata["spoilers"].append(
+                    (processed_header_len, processed_header, processed_content)
+                )
             else:
                 markup.extend(cls.soup2markup(element, metadata)[0])
-        return markup, metadata["message_links"], metadata["time_mentions"]
+        return (
+            markup,
+            metadata["message_links"],
+            metadata["time_mentions"],
+            metadata["spoilers"],
+        )
 
     def main_view(self) -> List[Any]:
 
@@ -1329,9 +1362,12 @@ class MessageBox(urwid.Pile):
             )
 
         # Transform raw message content into markup (As needed by urwid.Text)
-        content, self.message_links, self.time_mentions = self.transform_content(
-            self.message["content"], self.model.server_url
-        )
+        (
+            content,
+            self.message_links,
+            self.time_mentions,
+            self.spoilers,
+        ) = self.transform_content(self.message["content"], self.model.server_url)
 
         if self.message["id"] in self.model.index["edited_messages"]:
             edited_label_size = 7
@@ -1393,6 +1429,7 @@ class MessageBox(urwid.Pile):
         Tuple[None, Any],
         "OrderedDict[str, Tuple[str, int, bool]]",
         List[Tuple[str, str]],
+        List[Tuple[int, List[Any], List[Any]]],
     ]:
         soup = BeautifulSoup(content, "lxml")
         body = soup.find(name="body")
@@ -1401,13 +1438,14 @@ class MessageBox(urwid.Pile):
             server_url=server_url,
             message_links=OrderedDict(),
             time_mentions=list(),
+            spoilers=list(),
         )  # type: Dict[str, Any]
 
         if body and body.find(name="blockquote"):
             metadata["bq_len"] = cls.indent_quoted_content(soup, QUOTED_TEXT_MARKER)
 
-        markup, message_links, time_mentions = cls.soup2markup(body, metadata)
-        return (None, markup), message_links, time_mentions
+        markup, message_links, time_mentions, spoilers = cls.soup2markup(body, metadata)
+        return (None, markup), message_links, time_mentions, spoilers
 
     @staticmethod
     def indent_quoted_content(soup: Any, padding_char: str) -> int:

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -1,6 +1,6 @@
 import re
 from functools import partial
-from typing import Any, Callable, Dict, Optional, Tuple, Union, cast
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union, cast
 from urllib.parse import urljoin, urlparse
 
 import urwid
@@ -152,6 +152,36 @@ class MentionedButton(TopButton):
             count=count,
             count_style="unread_count",
         )
+
+
+class SpoilerButton(urwid.Button):
+    def __init__(
+        self,
+        controller: Any,
+        header_len: int,
+        header: List[Any],
+        content: List[Any],
+        display_attr: Optional[str],
+    ) -> None:
+        self.controller = controller
+        self.content = content
+
+        super().__init__("")
+        self.update_widget(header_len, header, display_attr)
+        urwid.connect_signal(self, "click", callback=self.show_spoiler)
+
+    def update_widget(
+        self, header_len: int, header: List[Any], display_attr: Optional[str] = None
+    ) -> None:
+        """
+        Overrides the existing button widget for custom styling.
+        """
+        # Set cursor position next to header_len to avoid the cursor.
+        icon = urwid.SelectableIcon(header, cursor_position=header_len + 1)
+        self._w = urwid.AttrMap(icon, display_attr, focus_map="selected")
+
+    def show_spoiler(self, *_: Any) -> None:
+        self.controller.show_spoiler(self.content)
 
 
 class StarredButton(TopButton):

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1051,6 +1051,14 @@ class NoticeView(PopUpView):
         super().__init__(controller, widgets, "GO_BACK", width, title)
 
 
+class SpoilerView(PopUpView):
+    def __init__(self, controller: Any, title: str, content: str) -> None:
+        width, _ = controller.maximum_popup_dimensions()
+        widget = [urwid.Text(content)]
+
+        super().__init__(controller, widget, "ENTER", width, title)
+
+
 class AboutView(PopUpView):
     def __init__(
         self,

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1294,11 +1294,13 @@ class MsgInfoView(PopUpView):
         topic_links: "OrderedDict[str, Tuple[str, int, bool]]",
         message_links: "OrderedDict[str, Tuple[str, int, bool]]",
         time_mentions: List[Tuple[str, str]],
+        spoilers: List[Tuple[int, List[Any], List[Any]]],
     ) -> None:
         self.msg = msg
         self.topic_links = topic_links
         self.message_links = message_links
         self.time_mentions = time_mentions
+        self.spoilers = spoilers
         self.server_url = controller.model.server_url
         date_and_time = controller.model.formatted_local_time(
             msg["timestamp"], show_seconds=True, show_year=True
@@ -1417,6 +1419,7 @@ class MsgInfoView(PopUpView):
                 topic_links=self.topic_links,
                 message_links=self.message_links,
                 time_mentions=self.time_mentions,
+                spoilers=self.spoilers,
             )
         elif is_command_key("VIEW_IN_BROWSER", key):
             url = near_message_url(self.server_url[:-1], self.msg)
@@ -1468,6 +1471,7 @@ class EditHistoryView(PopUpView):
         topic_links: "OrderedDict[str, Tuple[str, int, bool]]",
         message_links: "OrderedDict[str, Tuple[str, int, bool]]",
         time_mentions: List[Tuple[str, str]],
+        spoilers: List[Tuple[int, List[Any], List[Any]]],
         title: str,
     ) -> None:
         self.controller = controller
@@ -1475,6 +1479,7 @@ class EditHistoryView(PopUpView):
         self.topic_links = topic_links
         self.message_links = message_links
         self.time_mentions = time_mentions
+        self.spoilers = spoilers
         width = 64
         widgets: List[Any] = []
 
@@ -1573,6 +1578,7 @@ class EditHistoryView(PopUpView):
                 topic_links=self.topic_links,
                 message_links=self.message_links,
                 time_mentions=self.time_mentions,
+                spoilers=self.spoilers,
             )
             return key
         return super().keypress(size, key)

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -32,6 +32,7 @@ from zulipterminal.ui_tools.buttons import (
     MentionedButton,
     MessageLinkButton,
     PMButton,
+    SpoilerButton,
     StarredButton,
     StreamButton,
     TopicButton,
@@ -1338,6 +1339,8 @@ class MsgInfoView(PopUpView):
             msg_info.append(("Message Links", []))
         if time_mentions:
             msg_info.append(("Time mentions", time_mentions))
+        if spoilers:
+            msg_info.append(("Spoilers", []))
         if msg["reactions"]:
             reactions = sorted(
                 (reaction["emoji_name"], reaction["user"]["full_name"])
@@ -1387,6 +1390,25 @@ class MsgInfoView(PopUpView):
                 widgets[:slice_index] + message_link_widgets + widgets[slice_index:]
             )
             popup_width = max(popup_width, message_link_width)
+
+        if spoilers:
+            spoiler_buttons = []
+            spoiler_width = 0
+            for index, (header_len, header, content) in enumerate(spoilers):
+                spoiler_width = max(header_len, spoiler_width)
+                display_attr = None if index % 2 else "popup_contrast"
+                spoiler_buttons.append(
+                    SpoilerButton(controller, header_len, header, content, display_attr)
+                )
+
+            # slice_index = Number of labels before message links + 1 newline
+            #               + 1 'Spoilers' category label.
+            slice_index = len(msg_info[0][1]) + 2
+            slice_index += sum([len(w) + 2 for w in button_widgets])
+            button_widgets.append(spoiler_buttons)
+
+            widgets = widgets[:slice_index] + spoiler_buttons + widgets[slice_index:]
+            popup_width = max(popup_width, spoiler_width)
 
         super().__init__(controller, widgets, "MSG_INFO", popup_width, title)
 

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1170,7 +1170,7 @@ class StreamInfoView(PopUpView):
         )
         title = f"{stream_marker} {stream['name']}"
         rendered_desc = stream["rendered_description"]
-        self.markup_desc, message_links, _ = MessageBox.transform_content(
+        self.markup_desc, message_links, *_ = MessageBox.transform_content(
             rendered_desc,
             self.controller.model.server_url,
         )


### PR DESCRIPTION
@preetmishra Thanks for your primary work on this in a local branch, that helped me structuring this PR with separate commits and additional tests. This PR adds a basic support for spoilers in ZT.

Fixes #688.

**Potential caveats**
- The links in spoilers are currently revealed in message info view, which isn't expected.

**Commit flow:**
- boxes/themes: Add support for spoiler header markup in MessageBox.
- boxes/views: Extract spoiler content in a variable in MessageBox.
- core/views: Add SpoilerView class and corresponding show_* function.
- boxes/core/views: Pass spoiler data to MsgInfoView popup helpers.
- buttons: Add SpoilerButton class showing spoiler header.
- views: Show SpoilerButton in message info view if present.

**Screenshots/GIFs**

![spoiler_view](https://user-images.githubusercontent.com/55916430/124299473-141f7b80-db7b-11eb-89c9-0f62e74f039c.gif)
