### PR TITLE
Fix bad rendering of new topics when topics list was open.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,6 +86,7 @@ def user_button(mocker):
         controller=mocker.patch("zulipterminal.core.Controller"),
         view=mocker.patch("zulipterminal.ui.View"),
         state_marker="*",
+        count=0,
     )
 
 

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1196,7 +1196,9 @@ class TestLeftColumnView:
             controller=left_col_view.controller, count=2
         )
         pm_button.assert_called_once_with(controller=left_col_view.controller, count=0)
-        starred_button.assert_called_once_with(left_col_view.controller, count=3)
+        starred_button.assert_called_once_with(
+            controller=left_col_view.controller, count=3
+        )
 
     @pytest.mark.parametrize("pinned", powerset([1, 2, 99, 1000]))
     def test_streams_view(self, mocker, streams, pinned):

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1195,7 +1195,7 @@ class TestLeftColumnView:
         home_button.assert_called_once_with(
             controller=left_col_view.controller, count=2
         )
-        pm_button.assert_called_once_with(left_col_view.controller, count=0)
+        pm_button.assert_called_once_with(controller=left_col_view.controller, count=0)
         starred_button.assert_called_once_with(left_col_view.controller, count=3)
 
     @pytest.mark.parametrize("pinned", powerset([1, 2, 99, 1000]))

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1219,7 +1219,7 @@ class TestLeftColumnView:
         stream_button.assert_has_calls(
             [
                 mocker.call(
-                    stream,
+                    properties=stream,
                     controller=self.view.controller,
                     view=self.view,
                     count=1,

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1192,7 +1192,9 @@ class TestLeftColumnView:
         mocker.patch(VIEWS + ".urwid.SimpleFocusListWalker")
         mocker.patch(VIEWS + ".StreamButton.mark_muted")
         left_col_view = LeftColumnView(self.view)
-        home_button.assert_called_once_with(left_col_view.controller, count=2)
+        home_button.assert_called_once_with(
+            controller=left_col_view.controller, count=2
+        )
         pm_button.assert_called_once_with(left_col_view.controller, count=0)
         starred_button.assert_called_once_with(left_col_view.controller, count=3)
 

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1114,7 +1114,7 @@ class TestRightColumnView:
         if status != "inactive":
             unread_counts = right_col_view.view.model.unread_counts
             user_btn.assert_called_once_with(
-                self.view.users[0],
+                user=self.view.users[0],
                 controller=self.view.controller,
                 view=self.view,
                 color="user_" + self.view.users[0]["status"],

--- a/tests/ui_tools/test_buttons.py
+++ b/tests/ui_tools/test_buttons.py
@@ -290,7 +290,10 @@ class TestMessageLinkButton:
         self.link = link
         self.display_attr = display_attr
         return MessageLinkButton(
-            self.controller, self.caption, self.link, self.display_attr
+            controller=self.controller,
+            caption=self.caption,
+            link=self.link,
+            display_attr=self.display_attr,
         )
 
     def test_init(self, mocker):

--- a/tests/ui_tools/test_buttons.py
+++ b/tests/ui_tools/test_buttons.py
@@ -175,7 +175,7 @@ class TestUserButton:
         }
         activate = mocker.patch(MODULE + ".UserButton.activate")
         user_button = UserButton(
-            user,
+            user=user,
             controller=mocker.Mock(),
             view=mocker.Mock(),
             color=mocker.Mock(),

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -373,7 +373,10 @@ class WriteBox(urwid.Pile):
         self, stream_id: int, caption: str = "", title: str = ""
     ) -> None:
         self.stream_box_view(stream_id, caption, title)
-        self.edit_mode_button = EditModeButton(self.model.controller, 20)
+        self.edit_mode_button = EditModeButton(
+            controller=self.model.controller,
+            width=20,
+        )
 
         self.header_write_box.widget_list.append(self.edit_mode_button)
 

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -142,7 +142,7 @@ class MentionedButton(TopButton):
 
 
 class StarredButton(TopButton):
-    def __init__(self, controller: Any, count: int = 0) -> None:
+    def __init__(self, *, controller: Any, count: int) -> None:
         button_text = f"Starred messages [{primary_key_for_command('ALL_STARRED')}]"
 
         super().__init__(

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -552,7 +552,7 @@ class MessageLinkButton(urwid.Button):
 
 
 class EditModeButton(urwid.Button):
-    def __init__(self, controller: Any, width: int) -> None:
+    def __init__(self, *, controller: Any, width: int) -> None:
         self.controller = controller
         self.width = width
         super().__init__(label="", on_press=controller.show_topic_edit_mode)

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -114,7 +114,7 @@ class HomeButton(TopButton):
 
 
 class PMButton(TopButton):
-    def __init__(self, controller: Any, count: int = 0) -> None:
+    def __init__(self, *, controller: Any, count: int) -> None:
         button_text = f"Private messages [{primary_key_for_command('ALL_PM')}]"
 
         super().__init__(

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -229,12 +229,13 @@ class StreamButton(TopButton):
 class UserButton(TopButton):
     def __init__(
         self,
+        *,
         user: Dict[str, Any],
         controller: Any,
         view: Any,
         state_marker: str,
         color: Optional[str] = None,
-        count: int = 0,
+        count: int,
         is_current_user: bool = False,
     ) -> None:
         # Properties accessed externally

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -128,7 +128,7 @@ class PMButton(TopButton):
 
 
 class MentionedButton(TopButton):
-    def __init__(self, controller: Any, count: int = 0) -> None:
+    def __init__(self, *, controller: Any, count: int) -> None:
         button_text = f"Mentions         [{primary_key_for_command('ALL_MENTIONS')}]"
 
         super().__init__(

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -335,7 +335,7 @@ class ParsedNarrowLink(TypedDict, total=False):
 
 class MessageLinkButton(urwid.Button):
     def __init__(
-        self, controller: Any, caption: str, link: str, display_attr: Optional[str]
+        self, *, controller: Any, caption: str, link: str, display_attr: Optional[str]
     ) -> None:
         self.controller = controller
         self.model = self.controller.model

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -277,11 +277,12 @@ class UserButton(TopButton):
 class TopicButton(TopButton):
     def __init__(
         self,
+        *,
         stream_id: int,
         topic: str,
         controller: Any,
         view: Any,
-        count: int = 0,
+        count: int,
     ) -> None:
         self.stream_name = controller.model.stream_dict[stream_id]["name"]
         self.topic_name = topic

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -100,7 +100,7 @@ class TopButton(urwid.Button):
 
 
 class HomeButton(TopButton):
-    def __init__(self, controller: Any, count: int = 0) -> None:
+    def __init__(self, *, controller: Any, count: int) -> None:
         button_text = f"All messages     [{primary_key_for_command('ALL_MESSAGES')}]"
 
         super().__init__(

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -158,10 +158,11 @@ class StarredButton(TopButton):
 class StreamButton(TopButton):
     def __init__(
         self,
+        *,
         properties: StreamData,
         controller: Any,
         view: Any,
-        count: int = 0,
+        count: int,
     ) -> None:
         # FIXME Is having self.stream_id the best way to do this?
         # (self.stream_id is used elsewhere)

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -820,7 +820,9 @@ class LeftColumnView(urwid.Pile):
 
         # Starred messages are by definition read already
         count = len(self.model.initial_data["starred_messages"])
-        self.view.starred_button = StarredButton(self.controller, count=count)
+        self.view.starred_button = StarredButton(
+            controller=self.controller, count=count
+        )
         menu_btn_list = [
             self.view.home_button,
             self.view.pm_button,

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -470,11 +470,11 @@ class TopicsView(urwid.Frame):
         # No previous topics with same topic names are found
         # hence we create a new topic button for it.
         new_topic_button = TopicButton(
-            stream_id,
-            topic_name,
-            self.view.controller,
-            self.view,
-            0,
+            stream_id=stream_id,
+            topic=topic_name,
+            controller=self.view.controller,
+            view=self.view,
+            count=0,
         )
         self.log.insert(0, new_topic_button)
         self.list_box.set_focus_valign("bottom")

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -811,7 +811,7 @@ class LeftColumnView(urwid.Pile):
         self.view.home_button = HomeButton(controller=self.controller, count=count)
 
         count = self.model.unread_counts.get("all_pms", 0)
-        self.view.pm_button = PMButton(self.controller, count=count)
+        self.view.pm_button = PMButton(controller=self.controller, count=count)
 
         self.view.mentioned_button = MentionedButton(
             self.controller,

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -814,7 +814,7 @@ class LeftColumnView(urwid.Pile):
         self.view.pm_button = PMButton(controller=self.controller, count=count)
 
         self.view.mentioned_button = MentionedButton(
-            self.controller,
+            controller=self.controller,
             count=self.model.unread_counts["all_mentions"],
         )
 

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -835,7 +835,7 @@ class LeftColumnView(urwid.Pile):
     def streams_view(self) -> Any:
         streams_btn_list = [
             StreamButton(
-                stream,
+                properties=stream,
                 controller=self.controller,
                 view=self.view,
                 count=self.model.unread_counts["streams"].get(stream["id"], 0),
@@ -848,7 +848,7 @@ class LeftColumnView(urwid.Pile):
 
         streams_btn_list += [
             StreamButton(
-                stream,
+                properties=stream,
                 controller=self.controller,
                 view=self.view,
                 count=self.model.unread_counts["streams"].get(stream["id"], 0),

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -754,7 +754,7 @@ class RightColumnView(urwid.Frame):
             is_current_user = user["user_id"] == self.view.model.user_id
             users_btn_list.append(
                 UserButton(
-                    user,
+                    user=user,
                     controller=self.view.controller,
                     view=self.view,
                     state_marker=STATE_ICON[status],

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -808,7 +808,7 @@ class LeftColumnView(urwid.Pile):
 
     def menu_view(self) -> Any:
         count = self.model.unread_counts.get("all_msg", 0)
-        self.view.home_button = HomeButton(self.controller, count=count)
+        self.view.home_button = HomeButton(controller=self.controller, count=count)
 
         count = self.model.unread_counts.get("all_pms", 0)
         self.view.pm_button = PMButton(self.controller, count=count)

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1551,7 +1551,12 @@ class MsgInfoView(PopUpView):
 
             display_attr = None if index % 2 else "popup_contrast"
             link_widgets.append(
-                MessageLinkButton(controller, caption, link, display_attr)
+                MessageLinkButton(
+                    controller=controller,
+                    caption=caption,
+                    link=link,
+                    display_attr=display_attr,
+                )
             )
 
         return link_widgets, link_width


### PR DESCRIPTION
This PR fixes the bug that made incoming new topics rendered badly when the topic list was open due to incorrect parameters being passed to `TopicButton`. This PR also migrates `TopicButton` to accept only named parameters so that there's no scope of bug and connascence between parts of the program is reduced.

The discussion regarding this bug can be found in [#zulip-terminal>New-topic topic-list bug](https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/New-topic.20topic-list.20bug/)