### PR TITLE
Improve incomplete theme warning text when all are incomplete.

### DIFF
--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -135,12 +135,20 @@ def test_valid_zuliprc_but_no_connection(
     assert captured.err == ""
 
 
-@pytest.mark.parametrize("bad_theme", ["c", "d"])
+@pytest.mark.parametrize(
+    "bad_theme, expected_complete_incomplete_themes, expected_warning",
+    [
+        ("c", (["a", "b"], ["c", "d"]), "(you could try: a, b)"),
+        ("d", ([], ["a", "b", "c", "d"]), "(all themes are incomplete)"),
+    ],
+)
 def test_warning_regarding_incomplete_theme(
     capsys,
     mocker,
     minimal_zuliprc,
     bad_theme,
+    expected_complete_incomplete_themes,
+    expected_warning,
     server_connection_error="sce",
 ):
     mocker.patch(
@@ -150,7 +158,7 @@ def test_warning_regarding_incomplete_theme(
     mocker.patch("zulipterminal.cli.run.all_themes", return_value=("a", "b", "c", "d"))
     mocker.patch(
         "zulipterminal.cli.run.complete_and_incomplete_themes",
-        return_value=(["a", "b"], ["c", "d"]),
+        return_value=expected_complete_incomplete_themes,
     )
     mocker.patch("zulipterminal.cli.run.generate_theme")
 
@@ -166,7 +174,7 @@ def test_warning_regarding_incomplete_theme(
         "Loading with:",
         f"   theme '{bad_theme}' specified on command line.",
         "\x1b[93m   WARNING: Incomplete theme; results may vary!",
-        f"      (you could try: {'a'}, {'b'})\x1b[0m",
+        f"      {expected_warning}\x1b[0m",
         "   autohide setting 'no_autohide' specified with no config.",
         "   maximum footlinks value '3' specified with no config.",
         "   color depth setting '256' specified with no config.",

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -439,10 +439,16 @@ def main(options: Optional[List[str]] = None) -> None:
         print("   theme '{}' specified {}.".format(*theme_to_use))
         complete, incomplete = complete_and_incomplete_themes()
         if theme_to_use[0] in incomplete:
-            incomplete_theme_warning = (
-                "   WARNING: Incomplete theme; results may vary!\n"
-                "      (you could try: {})".format(", ".join(complete))
-            )
+            if complete:
+                incomplete_theme_warning = (
+                    "   WARNING: Incomplete theme; results may vary!\n"
+                    "      (you could try: {})".format(", ".join(complete))
+                )
+            else:
+                incomplete_theme_warning = (
+                    "   WARNING: Incomplete theme; results may vary!\n"
+                    "      (all themes are incomplete)"
+                )
             print(in_color("yellow", incomplete_theme_warning))
         print("   autohide setting '{}' specified {}.".format(*zterm["autohide"]))
         if zterm["footlinks"][1] == ZULIPRC_CONFIG:


### PR DESCRIPTION
This commit changes the warning text shown at startup if the theme
is incomplete. If there aren't any complete themes to suggest
the warning displays "(all themes are incomplete)".

Tests updated.