### PR TITLE
Handle edit message events triggering change in mention flags and unreads.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -776,6 +776,7 @@ def empty_index(
             all_msg_ids=set(),
             starred_msg_ids=set(),
             mentioned_msg_ids=set(),
+            unread_mentioned_msg_ids=set(),
             private_msg_ids=set(),
             private_msg_ids_by_user_ids=defaultdict(set, {}),
             stream_msg_ids_by_stream_id=defaultdict(set, {}),

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -1619,7 +1619,8 @@ class TestModel:
         assert notify.called == is_notify_called
 
     @pytest.mark.parametrize(
-        "event, topic_view_enabled, expected_times_messages_rerendered, expected_index",
+        "event, topic_view_enabled, initial_flags, mentioned_msg_ids,"
+        "expected_times_messages_rerendered, expected_index",
         [
             case(
                 {  # Only subject of 1 message is updated.
@@ -1629,6 +1630,8 @@ class TestModel:
                     "message_ids": [1],
                 },
                 False,
+                ["read"],
+                set(),
                 1,
                 {
                     "messages": {
@@ -1637,16 +1640,19 @@ class TestModel:
                             "stream_id": 10,
                             "content": "old content",
                             "subject": "new subject",
+                            "flags": ["read"],
                         },
                         2: {
                             "id": 2,
                             "stream_id": 10,
                             "content": "old content",
                             "subject": "old subject",
+                            "flags": ["read"],
                         },
                     },
                     "edited_messages": {1},
                     "topics": {10: []},
+                    "mentioned_msg_ids": set(),
                 },
                 id="Only subject of 1 message is updated",
             ),
@@ -1658,6 +1664,8 @@ class TestModel:
                     "message_ids": [1, 2],
                 },
                 False,
+                ["read"],
+                set(),
                 2,
                 {
                     "messages": {
@@ -1666,27 +1674,33 @@ class TestModel:
                             "stream_id": 10,
                             "content": "old content",
                             "subject": "new subject",
+                            "flags": ["read"],
                         },
                         2: {
                             "id": 2,
                             "stream_id": 10,
                             "content": "old content",
                             "subject": "new subject",
+                            "flags": ["read"],
                         },
                     },
                     "edited_messages": {1},
                     "topics": {10: []},
+                    "mentioned_msg_ids": set(),
                 },
                 id="Subject of 2 messages is updated",
             ),
             case(
-                {  # Message content is updated
+                {  # Message content is updated, wildcard-mention added
                     "message_id": 1,
                     "stream_id": 10,
                     "rendered_content": "<p>new content</p>",
+                    "flags": ["read", "wildcard_mentioned"],
                 },
                 False,
-                1,
+                ["read"],
+                set(),
+                2,
                 {
                     "messages": {
                         1: {
@@ -1694,29 +1708,35 @@ class TestModel:
                             "stream_id": 10,
                             "content": "<p>new content</p>",
                             "subject": "old subject",
+                            "flags": ["read", "wildcard_mentioned"],
                         },
                         2: {
                             "id": 2,
                             "stream_id": 10,
                             "content": "old content",
                             "subject": "old subject",
+                            "flags": ["read"],
                         },
                     },
                     "edited_messages": {1},
                     "topics": {10: ["old subject"]},
+                    "mentioned_msg_ids": {1},
                 },
-                id="Message content is updated",
+                id="Message content is updated, wildcard-mention added",
             ),
             case(
-                {  # Both message content and subject is updated.
+                {  # Both message content and subject is updated, mention added.
                     "message_id": 1,
                     "rendered_content": "<p>new content</p>",
                     "subject": "new subject",
                     "stream_id": 10,
                     "message_ids": [1],
+                    "flags": ["read", "mentioned"],
                 },
                 False,
-                2,
+                ["read"],
+                set(),
+                3,
                 {  # 2=update of subject & content
                     "messages": {
                         1: {
@@ -1724,18 +1744,21 @@ class TestModel:
                             "stream_id": 10,
                             "content": "<p>new content</p>",
                             "subject": "new subject",
+                            "flags": ["read", "mentioned"],
                         },
                         2: {
                             "id": 2,
                             "stream_id": 10,
                             "content": "old content",
                             "subject": "old subject",
+                            "flags": ["read"],
                         },
                     },
                     "edited_messages": {1},
                     "topics": {10: []},
+                    "mentioned_msg_ids": {1},
                 },
-                id="Both message content and subject is updated",
+                id="Both message content and subject is updated, mention added",
             ),
             case(
                 {  # Some new type of update which we don't handle yet.
@@ -1743,6 +1766,8 @@ class TestModel:
                     "foo": "boo",
                 },
                 False,
+                ["read"],
+                set(),
                 0,
                 {
                     "messages": {
@@ -1751,16 +1776,19 @@ class TestModel:
                             "stream_id": 10,
                             "content": "old content",
                             "subject": "old subject",
+                            "flags": ["read"],
                         },
                         2: {
                             "id": 2,
                             "stream_id": 10,
                             "content": "old content",
                             "subject": "old subject",
+                            "flags": ["read"],
                         },
                     },
                     "edited_messages": {1},
                     "topics": {10: ["old subject"]},
+                    "mentioned_msg_ids": set(),
                 },
                 id="Some new type of update which we don't handle yet",
             ),
@@ -1773,6 +1801,8 @@ class TestModel:
                     "message_ids": [3],
                 },
                 False,
+                ["read"],
+                set(),
                 0,
                 {
                     "messages": {
@@ -1781,16 +1811,19 @@ class TestModel:
                             "stream_id": 10,
                             "content": "old content",
                             "subject": "old subject",
+                            "flags": ["read"],
                         },
                         2: {
                             "id": 2,
                             "stream_id": 10,
                             "content": "old content",
                             "subject": "old subject",
+                            "flags": ["read"],
                         },
                     },
                     "edited_messages": set(),
                     "topics": {10: []},  # This resets the cache
+                    "mentioned_msg_ids": set(),
                 },
                 id="message_id not present in index, topic view closed",
             ),
@@ -1803,6 +1836,8 @@ class TestModel:
                     "message_ids": [3],
                 },
                 True,
+                ["read"],
+                set(),
                 0,
                 {
                     "messages": {
@@ -1811,29 +1846,35 @@ class TestModel:
                             "stream_id": 10,
                             "content": "old content",
                             "subject": "old subject",
+                            "flags": ["read"],
                         },
                         2: {
                             "id": 2,
                             "stream_id": 10,
                             "content": "old content",
                             "subject": "old subject",
+                            "flags": ["read"],
                         },
                     },
                     "edited_messages": set(),
                     "topics": {10: ["new subject", "old subject"]},
+                    "mentioned_msg_ids": set(),
                 },
                 id="message_id not present in index, topic view is enabled",
             ),
             case(
-                {  # Message content is updated and topic view is enabled.
+                {  # Message content updated and topic view is enabled, mention removed.
                     "message_id": 1,
                     "rendered_content": "<p>new content</p>",
                     "subject": "new subject",
                     "stream_id": 10,
                     "message_ids": [1],
+                    "flags": ["read"],
                 },
                 True,
-                2,
+                ["read", "mentioned"],
+                {1},
+                3,
                 {
                     "messages": {
                         1: {
@@ -1841,18 +1882,93 @@ class TestModel:
                             "stream_id": 10,
                             "content": "<p>new content</p>",
                             "subject": "new subject",
+                            "flags": ["read"],
                         },
                         2: {
                             "id": 2,
                             "stream_id": 10,
                             "content": "old content",
                             "subject": "old subject",
+                            "flags": ["read"],
                         },
                     },
                     "edited_messages": {1},
                     "topics": {10: ["new subject", "old subject"]},
+                    "mentioned_msg_ids": set(),
                 },
-                id="Message content is updated and topic view is enabled",
+                id="Message content updated and topic view is enabled, mention removed",
+            ),
+            case(
+                {  # wildcard_mentioned flag added with no subject change
+                    "message_id": 1,
+                    "rendered_content": "<p>new content @**stream**</p>",
+                    "subject": "old subject",
+                    "stream_id": 10,
+                    "message_ids": [1],
+                    "flags": ["read", "wildcard_mentioned"],
+                },
+                False,
+                ["read"],
+                set(),
+                3,
+                {
+                    "messages": {
+                        1: {
+                            "id": 1,
+                            "stream_id": 10,
+                            "content": "<p>new content @**stream**</p>",
+                            "subject": "old subject",
+                            "flags": ["read", "wildcard_mentioned"],
+                        },
+                        2: {
+                            "id": 2,
+                            "stream_id": 10,
+                            "content": "old content",
+                            "subject": "old subject",
+                            "flags": ["read"],
+                        },
+                    },
+                    "mentioned_msg_ids": {1},
+                    "edited_messages": {1},
+                    "topics": {10: []},
+                },
+                id="wildcard_mentioned flag added with no subject change",
+            ),
+            case(
+                {  # wildcard_mentioned flag removed with no subject change.
+                    "message_id": 1,
+                    "rendered_content": "<p>new content</p>",
+                    "subject": "old subject",
+                    "stream_id": 10,
+                    "message_ids": [1],
+                    "flags": ["read"],
+                },
+                False,
+                ["read", "wildcard_mentioned"],
+                {1},
+                3,
+                {
+                    "messages": {
+                        1: {
+                            "id": 1,
+                            "stream_id": 10,
+                            "content": "<p>new content</p>",
+                            "subject": "old subject",
+                            "flags": ["read"],
+                        },
+                        2: {
+                            "id": 2,
+                            "stream_id": 10,
+                            "content": "old content",
+                            "subject": "old subject",
+                            "flags": ["read"],
+                        },
+                    },
+                    "mentioned_msg_ids": set(),
+                    "edited_messages": {1},
+                    "topics": {10: []},
+                },
+                id="wildcard_mentioned flag removed with no subject change",
             ),
         ],
     )
@@ -1862,6 +1978,8 @@ class TestModel:
         model,
         event,
         topic_view_enabled,
+        initial_flags,
+        mentioned_msg_ids,
         expected_times_messages_rerendered,
         expected_index,
     ):
@@ -1874,12 +1992,15 @@ class TestModel:
                     "stream_id": 10,
                     "content": "old content",
                     "subject": "old subject",
+                    "flags": initial_flags if message_id == 1 else ["read"],
                 }
                 for message_id in [1, 2]
             },
+            "mentioned_msg_ids": mentioned_msg_ids,
             "edited_messages": set(),
             "topics": {10: ["old subject"]},
         }
+        model.narrow = [["is", "mentioned"]]
         mocker.patch(MODEL + "._update_rendered_view")
 
         def _set_topics_to_old_and_new(event):

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -1105,6 +1105,8 @@ class TestModel:
             (["read"], "add"),
             (["read", "starred"], "remove"),
             (["starred", "read"], "remove"),
+            (["read", "mentioned", "wildcard_mentioned"], "add"),
+            (["mentioned", "wildcard_mentioned", "starred"], "remove"),
         ],
     )
     def test_toggle_message_star_status(
@@ -2295,11 +2297,18 @@ class TestModel:
             ("add", 1, ["read"], ["read", "starred"]),
             ("add", 1, ["starred"], ["starred"]),
             ("add", 1, ["read", "starred"], ["read", "starred"]),
+            ("add", 1, ["mentioned"], ["mentioned", "starred"]),
+            ("add", 1, ["mentioned", "starred"], ["mentioned", "starred"]),
+            ("add", 1, ["wildcard_mentioned"], ["wildcard_mentioned", "starred"]),
             ("remove", -1, [], []),
             ("remove", -1, ["read"], ["read"]),
             ("remove", -1, ["starred"], []),
             ("remove", -1, ["read", "starred"], ["read"]),
             ("remove", -1, ["starred", "read"], ["read"]),
+            ("remove", -1, ["mentioned"], ["mentioned"]),
+            ("remove", -1, ["wildcard_mentioned"], ["wildcard_mentioned"]),
+            ("remove", -1, ["mentioned", "starred"], ["mentioned"]),
+            ("remove", -1, ["wildcard_mentioned", "starred"], ["wildcard_mentioned"]),
         ],
     )
     def test_update_star_status(
@@ -2318,7 +2327,23 @@ class TestModel:
 
         model.index = dict(
             messages={msg_id: {"flags": flags_before} for msg_id in indexed_ids},
-            unread_mentioned_msg_ids=set(),
+            mentioned_msg_ids=set(
+                [
+                    msg_id
+                    for msg_id in indexed_ids
+                    if {"mentioned", "wildcard_mentioned"} & set(flags_before)
+                ]
+            ),
+            unread_mentioned_msg_ids=set(
+                [
+                    msg_id
+                    for msg_id in indexed_ids
+                    if (
+                        {"mentioned", "wildcard_mentioned"} & set(flags_before)
+                        and "read" not in flags_before
+                    )
+                ]
+            ),
             starred_msg_ids=set(
                 [msg_id for msg_id in indexed_ids if "starred" in flags_before]
             ),
@@ -2379,11 +2404,19 @@ class TestModel:
             ("add", ["read"], ["read"]),
             ("add", ["starred"], ["starred", "read"]),
             ("add", ["read", "starred"], ["read", "starred"]),
+            ("add", ["mentioned"], ["mentioned", "read"]),
+            ("add", ["read", "mentioned"], ["read", "mentioned"]),
+            ("add", ["mentioned", "starred"], ["mentioned", "starred", "read"]),
+            ("add", ["wildcard_mentioned"], ["wildcard_mentioned", "read"]),
             ("remove", [], []),
             ("remove", ["read"], ["read"]),  # msg cannot be marked 'unread'
             ("remove", ["starred"], ["starred"]),
+            ("remove", ["mentioned"], ["mentioned"]),
             ("remove", ["starred", "read"], ["starred", "read"]),
             ("remove", ["read", "starred"], ["read", "starred"]),
+            ("remove", ["read", "mentioned"], ["read", "mentioned"]),
+            ("remove", ["wildcard_mentioned"], ["wildcard_mentioned"]),
+            ("remove", ["read", "wildcard_mentioned"], ["read", "wildcard_mentioned"]),
         ],
     )
     def test_update_read_status(

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -2318,6 +2318,7 @@ class TestModel:
 
         model.index = dict(
             messages={msg_id: {"flags": flags_before} for msg_id in indexed_ids},
+            unread_mentioned_msg_ids=set(),
             starred_msg_ids=set(
                 [msg_id for msg_id in indexed_ids if "starred" in flags_before]
             ),
@@ -2400,6 +2401,7 @@ class TestModel:
 
         model.index = dict(
             messages={msg_id: {"flags": flags_before} for msg_id in indexed_ids},
+            unread_mentioned_msg_ids=set(),
             starred_msg_ids=set(
                 [msg_id for msg_id in indexed_ids if "starred" in flags_before]
             ),

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -1619,7 +1619,7 @@ class TestModel:
         assert notify.called == is_notify_called
 
     @pytest.mark.parametrize(
-        "event, expected_times_messages_rerendered, expected_index, topic_view_enabled",
+        "event, topic_view_enabled, expected_times_messages_rerendered, expected_index",
         [
             case(
                 {  # Only subject of 1 message is updated.
@@ -1628,6 +1628,7 @@ class TestModel:
                     "stream_id": 10,
                     "message_ids": [1],
                 },
+                False,
                 1,
                 {
                     "messages": {
@@ -1647,7 +1648,6 @@ class TestModel:
                     "edited_messages": {1},
                     "topics": {10: []},
                 },
-                False,
                 id="Only subject of 1 message is updated",
             ),
             case(
@@ -1657,6 +1657,7 @@ class TestModel:
                     "stream_id": 10,
                     "message_ids": [1, 2],
                 },
+                False,
                 2,
                 {
                     "messages": {
@@ -1676,7 +1677,6 @@ class TestModel:
                     "edited_messages": {1},
                     "topics": {10: []},
                 },
-                False,
                 id="Subject of 2 messages is updated",
             ),
             case(
@@ -1685,6 +1685,7 @@ class TestModel:
                     "stream_id": 10,
                     "rendered_content": "<p>new content</p>",
                 },
+                False,
                 1,
                 {
                     "messages": {
@@ -1704,7 +1705,6 @@ class TestModel:
                     "edited_messages": {1},
                     "topics": {10: ["old subject"]},
                 },
-                False,
                 id="Message content is updated",
             ),
             case(
@@ -1715,6 +1715,7 @@ class TestModel:
                     "stream_id": 10,
                     "message_ids": [1],
                 },
+                False,
                 2,
                 {  # 2=update of subject & content
                     "messages": {
@@ -1734,7 +1735,6 @@ class TestModel:
                     "edited_messages": {1},
                     "topics": {10: []},
                 },
-                False,
                 id="Both message content and subject is updated",
             ),
             case(
@@ -1742,6 +1742,7 @@ class TestModel:
                     "message_id": 1,
                     "foo": "boo",
                 },
+                False,
                 0,
                 {
                     "messages": {
@@ -1761,7 +1762,6 @@ class TestModel:
                     "edited_messages": {1},
                     "topics": {10: ["old subject"]},
                 },
-                False,
                 id="Some new type of update which we don't handle yet",
             ),
             case(
@@ -1772,6 +1772,7 @@ class TestModel:
                     "stream_id": 10,
                     "message_ids": [3],
                 },
+                False,
                 0,
                 {
                     "messages": {
@@ -1791,7 +1792,6 @@ class TestModel:
                     "edited_messages": set(),
                     "topics": {10: []},  # This resets the cache
                 },
-                False,
                 id="message_id not present in index, topic view closed",
             ),
             case(
@@ -1802,6 +1802,7 @@ class TestModel:
                     "stream_id": 10,
                     "message_ids": [3],
                 },
+                True,
                 0,
                 {
                     "messages": {
@@ -1821,7 +1822,6 @@ class TestModel:
                     "edited_messages": set(),
                     "topics": {10: ["new subject", "old subject"]},
                 },
-                True,
                 id="message_id not present in index, topic view is enabled",
             ),
             case(
@@ -1832,6 +1832,7 @@ class TestModel:
                     "stream_id": 10,
                     "message_ids": [1],
                 },
+                True,
                 2,
                 {
                     "messages": {
@@ -1851,7 +1852,6 @@ class TestModel:
                     "edited_messages": {1},
                     "topics": {10: ["new subject", "old subject"]},
                 },
-                True,
                 id="Message content is updated and topic view is enabled",
             ),
         ],
@@ -1861,9 +1861,9 @@ class TestModel:
         mocker,
         model,
         event,
-        expected_index,
-        expected_times_messages_rerendered,
         topic_view_enabled,
+        expected_times_messages_rerendered,
+        expected_index,
     ):
         event["type"] = "update_message"
 

--- a/zulipterminal/api_types.py
+++ b/zulipterminal/api_types.py
@@ -151,6 +151,7 @@ class UpdateMessageEvent(TypedDict):
     message_ids: List[int]
     subject: str
     stream_id: int
+    flags: List[MessageFlag]
 
 
 class ReactionEvent(TypedDict):

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -70,6 +70,7 @@ class Index(TypedDict):
     all_msg_ids: Set[int]
     starred_msg_ids: Set[int]
     mentioned_msg_ids: Set[int]
+    unread_mentioned_msg_ids: Set[int]
     private_msg_ids: Set[int]
     private_msg_ids_by_user_ids: Dict[FrozenSet[int], Set[int]]
     stream_msg_ids_by_stream_id: Dict[int, Set[int]]
@@ -87,6 +88,7 @@ initial_index = Index(
     all_msg_ids=set(),
     starred_msg_ids=set(),
     mentioned_msg_ids=set(),
+    unread_mentioned_msg_ids=set(),
     private_msg_ids=set(),
     private_msg_ids_by_user_ids=defaultdict(set),
     stream_msg_ids_by_stream_id=defaultdict(set),
@@ -302,6 +304,11 @@ def index_messages(messages: List[Message], model: Any, index: Index) -> Index:
         'mentioned_msg_ids': {
             14423,
             33234,
+            ...
+        },
+        'unread_mentioned_msg_ids': {
+            13244,
+            22315,
             ...
         },
         'stream_msg_ids_by_stream_id': {

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -190,6 +190,11 @@ class Model:
             self.initial_data["realm_emoji"]
         )
 
+        # Store initial unread mentioned messages in Index.
+        self.index["unread_mentioned_msg_ids"] = set(
+            self.initial_data["unread_msgs"]["mentions"]
+        )
+
         self.twenty_four_hr_format = self.initial_data["twenty_four_hour_time"]
         self.new_user_input = True
         self._start_presence_updates()


### PR DESCRIPTION
The commit structure is as follows:

- **helper/model: Copy unread mentioned messages from initial_data to Index.**: Creates a new field in `index` as `unread_mentioned_msg_ids` which stores the message ids of unread mentioned messages obtained from the initial_data.

- **bugfix: api_types/model: Update mention flags on message edit events.**: This commit updates the index, unread_count and flags if the message was indexed when an update message event with change in mention flag(s) is detected. If the message was not in `index`, we just update the unread_count. The count is updated after checking with initial data's unread mentioned msgs field which does not stay synced with the server, hence the logic is buggy.

- **model: Update index's "unread_mentioned_msg_ids" field from events.**: This commit updates the `index.unread_mentioned_msg_ids` field through `update_message` and `update_message_flag` events.

- **tests: model: Extend other tests to incorporate both mentioned flags.**: This commit expands some of the fixtures of present tests with the mentioned/wildcard_mentioned flags to make the tests more robust and generalized.