### PR TITLE
Improve variable terminal width support

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,18 +111,29 @@ site=https://realm.zulipchat.com
 [zterm]
 # Alternative themes are gruvbox, light and blue
 theme=default
-# Autohide defaults to 'no_autohide', but can be set to 'autohide' to hide the left & right panels except when focused.
-autohide=autohide
+
+# Layout defaults to 'dynamic', in which the panels adapt to variable terminal widths.
+# Other options include:
+#    'autohide_fluid' which hide the panels except when focused and with better wide terminal support.
+#    Backwards compatible 'autohide' and 'no_autohide'.
+layout=dynamic
+
+# Backwards compatible autohide config use *layout* instead.
+#autohide=autohide
+
 # Footlinks default to 'enabled', but can be set to 'disabled' to hide footlinks.
 # disabled won't show any footlinks.
 # enabled will show the first 3 per message.
-footlinks=disabled
+#footlinks=disabled
+
 # If you need more flexibility, use maximum-footlinks.
 # Maximum footlinks to be shown, defaults to 3, but can be set to any value 0 or greater.
 # This option cannot be used with the footlinks option; use one or the other.
 maximum-footlinks=3
+
 # Notify defaults to 'disabled', but can be set to 'enabled' to display notifications (see next section).
 notify=enabled
+
 # Color depth defaults to 256 colors, but can be set to 1 (for monochrome), 16, or 24bit.
 color-depth=256
 ```

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -134,7 +134,7 @@ def test_valid_zuliprc_but_no_connection(
     expected_lines = [
         "Loading with:",
         "   theme 'zt_dark' specified with no config.",
-        "   autohide setting 'no_autohide' specified with no config.",
+        "   layout setting 'no_autohide' specified with no config.",
         "   maximum footlinks value '3' specified with no config.",
         "   color depth setting '256' specified with no config.",
         "   notify setting 'disabled' specified with no config.",
@@ -186,7 +186,7 @@ def test_warning_regarding_incomplete_theme(
         f"   theme '{bad_theme}' specified on command line.",
         "\x1b[93m   WARNING: Incomplete theme; results may vary!",
         f"      {expected_warning}\x1b[0m",
-        "   autohide setting 'no_autohide' specified with no config.",
+        "   layout setting 'no_autohide' specified with no config.",
         "   maximum footlinks value '3' specified with no config.",
         "   color depth setting '256' specified with no config.",
         "   notify setting 'disabled' specified with no config.",
@@ -215,22 +215,22 @@ def test_zt_version(capsys: CaptureFixture[str], options: str) -> None:
 
 
 @pytest.mark.parametrize(
-    "option, autohide",
+    "option, layout",
     [
         ("--autohide", "autohide"),
         ("--no-autohide", "no_autohide"),
         ("--debug", None),  # no-autohide by default
     ],
 )
-def test_parse_args_valid_autohide_option(option: str, autohide: Optional[str]) -> None:
+def test_parse_args_valid_layout_option(option: str, layout: Optional[str]) -> None:
     args = parse_args([option])
-    assert args.autohide == autohide
+    assert args.layout == layout
 
 
 @pytest.mark.parametrize(
     "options", [["--autohide", "--no-autohide"], ["--no-autohide", "--autohide"]]
 )
-def test_main_multiple_autohide_options(
+def test_main_multiple_layout_options(
     capsys: CaptureFixture[str], options: List[str]
 ) -> None:
     with pytest.raises(SystemExit) as e:
@@ -370,6 +370,8 @@ def parameterized_zuliprc(tmp_path: Path) -> Callable[[Dict[str, str]], str]:
         "maximum-footlinks_0",
     ],
 )
+@pytest.mark.parametrize("layout_setting", ["layout", "autohide"])
+@pytest.mark.parametrize("layout_option", ["autohide", "no_autohide"])
 def test_successful_main_function_with_config(
     capsys: CaptureFixture[str],
     mocker: MockerFixture,
@@ -377,14 +379,16 @@ def test_successful_main_function_with_config(
     config_key: str,
     config_value: str,
     footlinks_output: str,
+    layout_setting: str,
+    layout_option: str,
 ) -> None:
     config = {
         "theme": "default",
-        "autohide": "autohide",
         "notify": "enabled",
         "color-depth": "256",
     }
     config[config_key] = config_value
+    config[layout_setting] = layout_option
     zuliprc = parameterized_zuliprc(config)
     mocker.patch(CONTROLLER + ".__init__", return_value=None)
     mocker.patch(CONTROLLER + ".main", return_value=None)
@@ -397,10 +401,93 @@ def test_successful_main_function_with_config(
     expected_lines = [
         "Loading with:",
         "   theme 'zt_dark' specified in zuliprc file (by alias 'default').",
-        "   autohide setting 'autohide' specified in zuliprc file.",
+        f"   layout setting '{layout_option}' specified in zuliprc file.",
         f"   maximum footlinks value {footlinks_output}",
         "   color depth setting '256' specified in zuliprc file.",
         "   notify setting 'enabled' specified in zuliprc file.",
+    ]
+    assert lines == expected_lines
+
+
+def test_cli_overrides_config(
+    capsys: CaptureFixture[str],
+    mocker: MockerFixture,
+    parameterized_zuliprc: Callable[[Dict[str, str]], str],
+) -> None:
+    config = {
+        "theme": "default",
+        "notify": "enabled",
+        "color-depth": "256",
+        "layout": "autohide",
+    }
+    zuliprc = parameterized_zuliprc(config)
+    mocker.patch(CONTROLLER + ".__init__", return_value=None)
+    mocker.patch(CONTROLLER + ".main", return_value=None)
+
+    with pytest.raises(SystemExit):
+        main(
+            [
+                "-c",
+                zuliprc,
+                "--no-autohide",
+                "--no-notify",
+                "-t",
+                "zt_light",
+                "--color-depth",
+                "24bit",
+            ]
+        )
+
+    captured = capsys.readouterr()
+    lines = captured.out.strip().split("\n")
+    expected_lines = [
+        "Loading with:",
+        "   theme 'zt_light' specified on command line.",
+        "   layout setting 'no_autohide' specified on command line.",
+        "   maximum footlinks value '3' specified with no config.",
+        "   color depth setting '24bit' specified on command line.",
+        "   notify setting 'disabled' specified on command line.",
+    ]
+    assert lines == expected_lines
+
+
+@pytest.mark.parametrize("autohide_option", ["autohide", "no_autohide", None])
+@pytest.mark.parametrize("layout_option", ["autohide", "no_autohide", None])
+def test_layout_overrides_autohide(
+    capsys: CaptureFixture[str],
+    mocker: MockerFixture,
+    parameterized_zuliprc: Callable[[Dict[str, str]], str],
+    autohide_option: Optional[str],
+    layout_option: Optional[str],
+) -> None:
+    config = {}
+    layout_source = "in zuliprc file."
+    if layout_option is not None:
+        config["layout"] = layout_option
+    if autohide_option is not None:
+        config["autohide"] = autohide_option
+        if layout_option is None:
+            layout_option = autohide_option
+    elif layout_option is None:
+        layout_option = "no_autohide"  # default
+        layout_source = "with no config."
+
+    zuliprc = parameterized_zuliprc(config)
+    mocker.patch(CONTROLLER + ".__init__", return_value=None)
+    mocker.patch(CONTROLLER + ".main", return_value=None)
+
+    with pytest.raises(SystemExit):
+        main(["-c", zuliprc])
+
+    captured = capsys.readouterr()
+    lines = captured.out.strip().split("\n")
+    expected_lines = [
+        "Loading with:",
+        "   theme 'zt_dark' specified with no config.",
+        f"   layout setting '{layout_option}' specified {layout_source}",
+        "   maximum footlinks value '3' specified with no config.",
+        "   color depth setting '256' specified with no config.",
+        "   notify setting 'disabled' specified with no config.",
     ]
     assert lines == expected_lines
 

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -88,6 +88,7 @@ def test_main_help(capsys: CaptureFixture[str], options: str) -> None:
         "--config-file CONFIG_FILE, -c CONFIG_FILE",
         "--autohide",
         "--no-autohide",
+        "--dynamic",
         "-v, --version",
         "-e, --explore",
         "--color-depth",
@@ -134,7 +135,7 @@ def test_valid_zuliprc_but_no_connection(
     expected_lines = [
         "Loading with:",
         "   theme 'zt_dark' specified with no config.",
-        "   layout setting 'no_autohide' specified with no config.",
+        "   layout setting 'dynamic' specified with no config.",
         "   maximum footlinks value '3' specified with no config.",
         "   color depth setting '256' specified with no config.",
         "   notify setting 'disabled' specified with no config.",
@@ -186,7 +187,7 @@ def test_warning_regarding_incomplete_theme(
         f"   theme '{bad_theme}' specified on command line.",
         "\x1b[93m   WARNING: Incomplete theme; results may vary!",
         f"      {expected_warning}\x1b[0m",
-        "   layout setting 'no_autohide' specified with no config.",
+        "   layout setting 'dynamic' specified with no config.",
         "   maximum footlinks value '3' specified with no config.",
         "   color depth setting '256' specified with no config.",
         "   notify setting 'disabled' specified with no config.",
@@ -219,7 +220,7 @@ def test_zt_version(capsys: CaptureFixture[str], options: str) -> None:
     [
         ("--autohide", "autohide"),
         ("--no-autohide", "no_autohide"),
-        ("--debug", None),  # no-autohide by default
+        ("--debug", None),  # dynamic by default
     ],
 )
 def test_parse_args_valid_layout_option(option: str, layout: Optional[str]) -> None:
@@ -469,7 +470,7 @@ def test_layout_overrides_autohide(
         if layout_option is None:
             layout_option = autohide_option
     elif layout_option is None:
-        layout_option = "no_autohide"  # default
+        layout_option = "dynamic"  # default
         layout_source = "with no config."
 
     zuliprc = parameterized_zuliprc(config)

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -89,6 +89,7 @@ def test_main_help(capsys: CaptureFixture[str], options: str) -> None:
         "--autohide",
         "--no-autohide",
         "--dynamic",
+        "--autohide-fluid",
         "-v, --version",
         "-e, --explore",
         "--color-depth",

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -7,7 +7,7 @@ import pytest
 from pytest_mock import MockerFixture
 
 from zulipterminal.config.themes import generate_theme
-from zulipterminal.core import Controller
+from zulipterminal.core import Controller, Layout
 from zulipterminal.helper import Index
 from zulipterminal.version import ZT_VERSION
 
@@ -42,7 +42,7 @@ class TestController:
         self.theme_name = "zt_dark"
         self.theme = generate_theme("zt_dark", 256)
         self.in_explore_mode = False
-        self.autohide = True  # FIXME Add tests for no-autohide
+        self.layout: Layout = "autohide"  # FIXME Add tests for other layouts.
         self.notify_enabled = False
         self.maximum_footlinks = 3
         result = Controller(
@@ -52,7 +52,7 @@ class TestController:
             self.theme,
             256,
             self.in_explore_mode,
-            self.autohide,
+            self.layout,
             self.notify_enabled,
         )
         result.view.message_view = mocker.Mock()  # set in View.__init__

--- a/tests/ui/test_ui.py
+++ b/tests/ui/test_ui.py
@@ -6,6 +6,7 @@ from urwid import Widget
 
 from zulipterminal.api_types import Composition
 from zulipterminal.config.keys import keys_for_command
+from zulipterminal.core import Layout
 from zulipterminal.ui import LEFT_WIDTH, RIGHT_WIDTH, TAB_WIDTH, View
 from zulipterminal.urwid_types import urwid_Box
 
@@ -186,6 +187,7 @@ class TestView:
         server_name = "Test Organization"
 
         self.controller.model = self.model
+        self.controller.layout = "autohide"
         self.model.user_full_name = full_name
         self.model.user_email = email
         self.model.server_url = server
@@ -228,17 +230,17 @@ class TestView:
         assert view.frame == frame()
         show_left_panel.assert_called_once_with(visible=True)
 
-    @pytest.mark.parametrize("autohide", [True, False])
+    @pytest.mark.parametrize("layout", ["autohide", "no_autohide"])
     @pytest.mark.parametrize("visible", [True, False])
     @pytest.mark.parametrize("test_method", ["left_panel", "right_panel"])
     def test_show_panel_methods(
         self,
         mocker: MockerFixture,
         visible: bool,
-        autohide: bool,
+        layout: Layout,
         test_method: str,
     ) -> None:
-        self.controller.autohide = autohide
+        self.controller.layout = layout
         view = View(self.controller)
         view.frame.body = view.body
 
@@ -256,7 +258,7 @@ class TestView:
 
             view.show_right_panel(visible=visible)
 
-        if autohide:
+        if layout == "autohide":
             if visible:
                 assert (expected_panel, mocker.ANY) in view.frame.body.top_w.contents
                 assert view.frame.body.bottom_w == view.body

--- a/tests/ui/test_ui.py
+++ b/tests/ui/test_ui.py
@@ -7,7 +7,7 @@ from urwid import Widget
 from zulipterminal.api_types import Composition
 from zulipterminal.config.keys import keys_for_command
 from zulipterminal.core import Layout
-from zulipterminal.ui import LEFT_WIDTH, RIGHT_WIDTH, TAB_WIDTH, View
+from zulipterminal.ui import LEFT_WIDTH, MAX_APP_WIDTH, RIGHT_WIDTH, TAB_WIDTH, View
 from zulipterminal.urwid_types import urwid_Box
 
 
@@ -509,3 +509,24 @@ class TestView:
         view.controller.current_editor().keypress.assert_called_once_with(
             (size[1],), key
         )
+
+    @pytest.mark.parametrize("maxcols", [50, MAX_APP_WIDTH, 600])
+    @pytest.mark.parametrize(
+        "has_border", [True, False], ids=["has_border", "has_no_border"]
+    )
+    def test_add_padding_and_border_to_frame(
+        self,
+        view: View,
+        mocker: MockerFixture,
+        maxcols: int,
+        has_border: bool,
+    ) -> None:
+        view.has_border = has_border
+
+        view.add_padding_and_border_to_frame(maxcols)
+
+        if maxcols > MAX_APP_WIDTH and not has_border:
+            assert view._w.align == "center"
+        elif maxcols < MAX_APP_WIDTH and has_border:
+            assert view._w == view.frame
+        assert view.has_border is False if maxcols <= MAX_APP_WIDTH else True

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1015,6 +1015,26 @@ class TestMiddleColumnView:
         assert mid_col_view.footer.focus_position == 0
         assert return_value == key
 
+    @pytest.mark.parametrize("key", keys_for_command("GO_LEFT"))
+    def test_keypress_GO_LEFT(self, mid_col_view, mocker, key, widget_size):
+        size = widget_size(mid_col_view)
+        mocker.patch(MIDCOLVIEW + ".focus_position")
+        mocker.patch(VIEWS + ".urwid.Frame")
+
+        return_value = mid_col_view.keypress(size, key)
+
+        mid_col_view.view.focus_panel == 0
+
+    @pytest.mark.parametrize("key", keys_for_command("GO_RIGHT"))
+    def test_keypress_GO_RIGHT(self, mid_col_view, mocker, key, widget_size):
+        size = widget_size(mid_col_view)
+        mocker.patch(MIDCOLVIEW + ".focus_position")
+        mocker.patch(VIEWS + ".urwid.Frame")
+
+        return_value = mid_col_view.keypress(size, key)
+
+        mid_col_view.view.focus_panel == 2
+
 
 class TestRightColumnView:
     @pytest.fixture(autouse=True)
@@ -1153,6 +1173,15 @@ class TestRightColumnView:
         right_col_view.set_body.assert_called_once_with(right_col_view.body)
         right_col_view.set_focus.assert_called_once_with("body")
         assert right_col_view.user_search.reset_search_text.called
+
+    @pytest.mark.parametrize("key", keys_for_command("GO_LEFT"))
+    def test_keypress_GO_LEFT(self, right_col_view, mocker, key, widget_size):
+        size = widget_size(right_col_view)
+        mocker.patch(VIEWS + ".urwid.Frame.keypress")
+
+        right_col_view.keypress(size, key)
+
+        assert right_col_view.view.focus_panel == 1
 
 
 class TestLeftColumnView:

--- a/tests/ui_tools/test_buttons.py
+++ b/tests/ui_tools/test_buttons.py
@@ -131,6 +131,14 @@ class TestTopButton:
         top_button.button_suffix.set_text.assert_called_once_with(expected_suffix)
         set_attr_map.assert_called_once_with({None: text_color})
 
+    def test_activate(self, mocker: MockerFixture, top_button: TopButton) -> None:
+        show_function = mocker.patch.object(top_button, "show_function")
+
+        top_button.activate("key")
+
+        assert top_button.controller.view.focus_panel == 1
+        show_function.assert_called_once_with()
+
 
 class TestStarredButton:
     def test_count_style_init_argument_value(

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -170,7 +170,7 @@ class TestAboutView:
             theme_name="zt_dark",
             color_depth=256,
             notify_enabled=False,
-            autohide_enabled=False,
+            layout="no_autohide",
             maximum_footlinks=3,
         )
 
@@ -214,7 +214,7 @@ class TestAboutView:
             theme_name="zt_dark",
             color_depth=256,
             notify_enabled=False,
-            autohide_enabled=False,
+            layout="no_autohide",
             maximum_footlinks=3,
         )
 

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -160,6 +160,14 @@ def parse_args(argv: List[str]) -> argparse.Namespace:
         const="dynamic",
         help="panels adapt based on available screen space",
     )
+    layout_group.add_argument(
+        "--autohide-fluid",
+        dest="layout",
+        default=None,
+        action="store_const",
+        const="autohide_fluid",
+        help="panels adapt based on available screen space but remains in autohide mode, unlike dynamic",
+    )
 
     parser.add_argument(
         "-d",
@@ -483,7 +491,7 @@ def main(options: Optional[List[str]] = None) -> None:
         # For binary settings
         # Specify setting in order True, False
         valid_settings = {
-            "layout": ["autohide", "no_autohide", "dynamic"],
+            "layout": ["autohide", "no_autohide", "dynamic", "autohide_fluid"],
             "notify": ["enabled", "disabled"],
             "color-depth": ["1", "16", "256", "24bit"],
         }

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -43,7 +43,7 @@ requests_logger.setLevel(logging.DEBUG)
 # These should be the defaults without config file or command-line overrides
 DEFAULT_SETTINGS = {
     "theme": "zt_dark",
-    "layout": "no_autohide",
+    "layout": "dynamic",
     "notify": "disabled",
     "footlinks": "enabled",
     "color-depth": "256",
@@ -151,6 +151,14 @@ def parse_args(argv: List[str]) -> argparse.Namespace:
         action="store_const",
         const="no_autohide",
         help="don't autohide list of users and streams",
+    )
+    layout_group.add_argument(
+        "--dynamic",
+        dest="layout",
+        default=None,
+        action="store_const",
+        const="dynamic",
+        help="panels adapt based on available screen space",
     )
 
     parser.add_argument(
@@ -475,7 +483,7 @@ def main(options: Optional[List[str]] = None) -> None:
         # For binary settings
         # Specify setting in order True, False
         valid_settings = {
-            "layout": ["autohide", "no_autohide"],
+            "layout": ["autohide", "no_autohide", "dynamic"],
             "notify": ["enabled", "disabled"],
             "color-depth": ["1", "16", "256", "24bit"],
         }

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -497,8 +497,6 @@ def main(options: Optional[List[str]] = None) -> None:
                 continue
             boolean_settings[setting] = zterm[setting][0] == valid_values[0]
 
-        boolean_settings["autohide"] = layout == "autohide"
-
         theme_data = generate_theme(theme_to_use[0], color_depth)
 
         Controller(
@@ -508,6 +506,7 @@ def main(options: Optional[List[str]] = None) -> None:
             theme_data,
             color_depth,
             args.explore,
+            layout,
             **boolean_settings,
         ).main()
     except ServerConnectionFailure as e:

--- a/zulipterminal/config/ui_sizes.py
+++ b/zulipterminal/config/ui_sizes.py
@@ -2,3 +2,6 @@ TAB_WIDTH = 3
 LEFT_WIDTH = 27
 RIGHT_WIDTH = 23
 MAX_APP_WIDTH = 200  # Controls padding
+
+MAX_SMALL_WIDTH = 102  # Controls how small is small.
+MIN_WIDE_WIDTH = 160  # Controls how wide is wide.

--- a/zulipterminal/config/ui_sizes.py
+++ b/zulipterminal/config/ui_sizes.py
@@ -1,3 +1,4 @@
 TAB_WIDTH = 3
 LEFT_WIDTH = 27
 RIGHT_WIDTH = 23
+MAX_APP_WIDTH = 200  # Controls padding

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -27,6 +27,7 @@ from zulipterminal.ui_tools.views import (
     FullRawMsgView,
     FullRenderedMsgView,
     HelpView,
+    Layout,
     MarkdownHelpView,
     MsgInfoView,
     NoticeView,
@@ -55,14 +56,14 @@ class Controller:
         theme: ThemeSpec,
         color_depth: int,
         in_explore_mode: bool,
-        autohide: bool,
+        layout: Layout,
         notify: bool,
     ) -> None:
         self.theme_name = theme_name
         self.theme = theme
         self.color_depth = color_depth
         self.in_explore_mode = in_explore_mode
-        self.autohide = autohide
+        self.layout = layout
         self.notify_enabled = notify
         self.maximum_footlinks = maximum_footlinks
 
@@ -289,7 +290,7 @@ class Controller:
                 theme_name=self.theme_name,
                 color_depth=self.color_depth,
                 notify_enabled=self.notify_enabled,
-                autohide_enabled=self.autohide,
+                layout=self.layout,
                 maximum_footlinks=self.maximum_footlinks,
             ),
             "area:help",

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -35,6 +35,7 @@ class View(urwid.WidgetWrap):
         self.palette = controller.theme
         self.model = controller.model
         self.users = self.model.users
+        self.autohide = self.controller.autohide
         self.pinned_streams = self.model.pinned_streams
         self.unpinned_streams = self.model.unpinned_streams
         self.write_box = WriteBox(self)
@@ -140,7 +141,7 @@ class View(urwid.WidgetWrap):
         self.left_panel, self.left_tab = self.left_column_view()
         self.center_panel = self.middle_column_view()
         self.right_panel, self.right_tab = self.right_column_view()
-        if self.controller.autohide:
+        if self.autohide:
             body = [
                 (TAB_WIDTH, self.left_tab),
                 ("weight", 10, self.center_panel),
@@ -187,7 +188,7 @@ class View(urwid.WidgetWrap):
         return self.frame
 
     def show_left_panel(self, *, visible: bool) -> None:
-        if not self.controller.autohide:
+        if not self.autohide:
             return
 
         if visible:
@@ -205,7 +206,7 @@ class View(urwid.WidgetWrap):
             self.frame.body = self.body
 
     def show_right_panel(self, *, visible: bool) -> None:
-        if not self.controller.autohide:
+        if not self.autohide:
             return
 
         if visible:

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -12,7 +12,12 @@ from zulipterminal.config.symbols import (
     AUTOHIDE_TAB_RIGHT_ARROW,
     COLUMN_TITLE_BAR_LINE,
 )
-from zulipterminal.config.ui_sizes import LEFT_WIDTH, RIGHT_WIDTH, TAB_WIDTH
+from zulipterminal.config.ui_sizes import (
+    LEFT_WIDTH,
+    MAX_APP_WIDTH,
+    RIGHT_WIDTH,
+    TAB_WIDTH,
+)
 from zulipterminal.helper import asynch
 from zulipterminal.platform_code import MOUSE_SELECTION_KEY, PLATFORM
 from zulipterminal.ui_tools.boxes import SearchBox, WriteBox
@@ -43,6 +48,7 @@ class View(urwid.WidgetWrap):
 
         self.message_view: Any = None
         self.displaying_selection_hint = False
+        self.has_border = False
 
         super().__init__(self.main_window())
 
@@ -357,6 +363,17 @@ class View(urwid.WidgetWrap):
             self.displaying_selection_hint = False
 
         return super().mouse_event(size, event, button, col, row, focus)
+
+    def add_padding_and_border_to_frame(self, maxcols: int) -> None:
+        if maxcols > MAX_APP_WIDTH and not self.has_border:
+            frame_line_box = urwid.LineBox(
+                self.frame, tline="", lline="▕", rline="▏", bline=""
+            )
+            self._w = urwid.Padding(frame_line_box, align="center", width=MAX_APP_WIDTH)
+            self.has_border = True
+        elif maxcols <= MAX_APP_WIDTH and self.has_border:
+            self._w = self.frame
+            self.has_border = False
 
 
 class Screen(urwid.raw_display.Screen):

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -35,7 +35,7 @@ class View(urwid.WidgetWrap):
         self.palette = controller.theme
         self.model = controller.model
         self.users = self.model.users
-        self.autohide = self.controller.autohide
+        self.layout = self.controller.layout
         self.pinned_streams = self.model.pinned_streams
         self.unpinned_streams = self.model.unpinned_streams
         self.write_box = WriteBox(self)
@@ -141,7 +141,7 @@ class View(urwid.WidgetWrap):
         self.left_panel, self.left_tab = self.left_column_view()
         self.center_panel = self.middle_column_view()
         self.right_panel, self.right_tab = self.right_column_view()
-        if self.autohide:
+        if self.layout == "autohide":
             body = [
                 (TAB_WIDTH, self.left_tab),
                 ("weight", 10, self.center_panel),
@@ -188,7 +188,7 @@ class View(urwid.WidgetWrap):
         return self.frame
 
     def show_left_panel(self, *, visible: bool) -> None:
-        if not self.autohide:
+        if self.layout != "autohide":
             return
 
         if visible:
@@ -206,7 +206,7 @@ class View(urwid.WidgetWrap):
             self.frame.body = self.body
 
     def show_right_panel(self, *, visible: bool) -> None:
-        if not self.autohide:
+        if self.layout != "autohide":
             return
 
         if visible:

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -87,9 +87,7 @@ class TopButton(urwid.Button):
         self._w.set_attr_map({None: text_color})
 
     def activate(self, key: Any) -> None:
-        self.controller.view.show_left_panel(visible=False)
-        self.controller.view.show_right_panel(visible=False)
-        self.controller.view.body.focus_col = 1
+        self.controller.view.focus_panel = 1
         self.show_function()
 
     def keypress(self, size: urwid_Size, key: str) -> Optional[str]:

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -56,7 +56,7 @@ from zulipterminal.urwid_types import urwid_Size
 MIDDLE_COLUMN_MOUSE_SCROLL_LINES = 1
 SIDE_PANELS_MOUSE_SCROLL_LINES = 5
 
-Layout = Literal["autohide", "no_autohide"]
+Layout = Literal["autohide", "no_autohide", "dynamic"]
 
 
 class ModListWalker(urwid.SimpleFocusListWalker):

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -56,6 +56,8 @@ from zulipterminal.urwid_types import urwid_Size
 MIDDLE_COLUMN_MOUSE_SCROLL_LINES = 1
 SIDE_PANELS_MOUSE_SCROLL_LINES = 5
 
+Layout = Literal["autohide", "no_autohide"]
+
 
 class ModListWalker(urwid.SimpleFocusListWalker):
     def set_focus(self, position: int) -> None:
@@ -1115,7 +1117,7 @@ class AboutView(PopUpView):
         server_feature_level: Optional[int],
         theme_name: str,
         color_depth: int,
-        autohide_enabled: bool,
+        layout: Layout,
         maximum_footlinks: int,
         notify_enabled: bool,
     ) -> None:
@@ -1131,7 +1133,7 @@ class AboutView(PopUpView):
                 "Application Configuration",
                 [
                     ("Theme", theme_name),
-                    ("Autohide", "enabled" if autohide_enabled else "disabled"),
+                    ("Layout", layout),
                     ("Maximum footlinks", str(maximum_footlinks)),
                     ("Color depth", str(color_depth)),
                     ("Notifications", "enabled" if notify_enabled else "disabled"),

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -56,7 +56,7 @@ from zulipterminal.urwid_types import urwid_Size
 MIDDLE_COLUMN_MOUSE_SCROLL_LINES = 1
 SIDE_PANELS_MOUSE_SCROLL_LINES = 5
 
-Layout = Literal["autohide", "no_autohide", "dynamic"]
+Layout = Literal["autohide", "no_autohide", "dynamic", "autohide_fluid"]
 
 
 class ModListWalker(urwid.SimpleFocusListWalker):

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -656,9 +656,9 @@ class MiddleColumnView(urwid.Frame):
             self.footer.focus_position = 0
             return key
         elif is_command_key("GO_LEFT", key):
-            self.view.show_left_panel(visible=True)
+            self.view.focus_panel = 0
         elif is_command_key("GO_RIGHT", key):
-            self.view.show_right_panel(visible=True)
+            self.view.focus_panel = 2
         return super().keypress(size, key)
 
 
@@ -787,7 +787,7 @@ class RightColumnView(urwid.Frame):
             self.view.controller.update_screen()
             return key
         elif is_command_key("GO_LEFT", key):
-            self.view.show_right_panel(visible=False)
+            self.view.focus_panel = 1
         return super().keypress(size, key)
 
 
@@ -944,7 +944,7 @@ class LeftColumnView(urwid.Pile):
                 self.view.stream_w.keypress(size, key)
             return key
         elif is_command_key("GO_RIGHT", key):
-            self.view.show_left_panel(visible=False)
+            self.view.focus_panel = 1
         return super().keypress(size, key)
 
 


### PR DESCRIPTION

<!-- Please
 see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->
This PR improves terminal width readability and support for both small and wide terminals.
<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->
Partial fix for #1005
<!-- Add a link to a discussion on chat.zulip.org, if relevant -->
[topic link](https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/Zooming)

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [x] New tests added (for any new behavior)
- [x] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

<!-- See https://github.com/zulip/zulip-terminal#commit-style -->
**Commit flow** <!-- if more than one commit; add/delete/fill-in as appropriate -->
<!-- For example:
- first commit doing some thing
- maybe multiple commits doing similar things
-->
**Commit 1**: ui: Make ZT go to into autohide mode if terminal is small.
**Commit 2**: ui: Fix center panel width and add padding for wide terminals.

**Interactions** <!-- if any; add/delete/fill-in as appropriate -->
<!-- eg.
- Waiting on #<PR>
- Blocks #<PR>
-->
Related PR #388 

**Visual changes** <!-- if any; add/delete/fill-in with screenshot/diagram as appropriate -->
To be added (many cases)