### PR TITLE
tests: run: Add type annotations.

### DIFF
--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -74,9 +74,18 @@ python_files = [fpath for fpath in files_dict['py']
 
 repo_python_files = {}
 repo_python_files['zulipterminal'] = []
+repo_python_files['tests'] = []
+
+# Added incrementally as newer test files are type-annotated.
+type_consistent_testfiles = ["test_run.py"]
+
 for file_path in python_files:
     repo = PurePath(file_path).parts[0]
-    if repo in repo_python_files:
+    filename = PurePath(file_path).parts[-1]
+    if (
+        repo == "zulipterminal" or
+        (repo == 'tests' and filename in type_consistent_testfiles)
+    ):
         repo_python_files[repo].append(file_path)
 
 mypy_command = "mypy"


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->
Adds type annotations to the `test_run.py` file. Includes this file under the `run-mypy` tool to type-check.
<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->

<!-- Add a link to a discussion on chat.zulip.org, if relevant -->

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [x] New tests added (for any new behavior)
- [x] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

<!-- See https://github.com/zulip/zulip-terminal#commit-style -->
**Commit flow** <!-- if more than one commit; add/delete/fill-in as appropriate -->
<!-- For example:
- first commit doing some thing
- maybe multiple commits doing similar things
-->
- **refactor: tests: run: Add type annotations.**
This commit adds paramter and return type annotations or hints to the
`test_run.py` file, that contains tests for it's counterpart `run.py`
from  the `zulipterminal` module, to make mypy checks consistent and
improve code readability.
- **tools: Include test_run.py under files to be type-checked with mypy.**
This commit adds a new "tests" key to the `repo_python_files` dict to
let mypy know which files to type check. A new list,
`type_consistent_testfiles` is also added, to hold the list of test
files that have been type-annotated incrementally till all the test
files are consistent.

**Notes & Questions** <!-- if any; add/delete/fill-in as appropriate -->
<!-- For example:
- this doesn't include feature X (yet?)
- unsure about Y
- should this do Z?
-->
I've referred to the `pytest` and `pytest-mock` docs for the type annotations on some of the fixtures, is a reference link in the commit necessary? (one reference would then be to a CHANGELOG)