### PR TITLE
tests: core: Add type annotations.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -847,6 +847,12 @@ def index_all_mentions(empty_index, mentioned_messages_combination):
     return index
 
 
+@pytest.fixture()
+def index_search_messages(empty_index):
+    """Expected initial index when search contains the message_id 500."""
+    return dict(empty_index, **{"search": {500}})
+
+
 @pytest.fixture
 def user_profile(logged_on_user):
     return {  # FIXME These should all be self-consistent with others?

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -149,42 +149,43 @@ class TestController:
         self,
         mocker,
         controller,
-        msg_box,
         index_multiple_topic_msg,
         initial_narrow,
         initial_stream_id,
         anchor,
         expected_final_focus,
-    ):
+        stream_name="PTEST",
+        topic_name="Test",
+        stream_id=205,
+    ) -> None:
         expected_narrow = [
-            ["stream", msg_box.stream_name],
-            ["topic", msg_box.topic_name],
+            ["stream", stream_name],
+            ["topic", topic_name],
         ]
         controller.model.narrow = initial_narrow
         controller.model.index = index_multiple_topic_msg
         controller.model.stream_id = initial_stream_id
         controller.view.message_view = mocker.patch("urwid.ListBox")
         controller.model.stream_dict = {
-            205: {
+            stream_id: {
                 "color": "#ffffff",
-                "name": "PTEST",
+                "name": stream_name,
             }
         }
         controller.model.muted_streams = set()
         mocker.patch(MODEL + ".is_muted_topic", return_value=False)
 
         controller.narrow_to_topic(
-            stream_name="PTEST",
-            topic_name=msg_box.topic_name,
+            stream_name=stream_name,
+            topic_name=topic_name,
             contextual_message_id=anchor,
         )
 
-        assert controller.model.stream_id == msg_box.stream_id
+        assert controller.model.stream_id == stream_id
         assert controller.model.narrow == expected_narrow
         controller.view.message_view.log.clear.assert_called_once_with()
 
         widgets, focus = controller.view.message_view.log.extend.call_args_list[0][0]
-        stream_id, topic_name = msg_box.stream_id, msg_box.topic_name
         id_list = index_multiple_topic_msg["topic_msg_ids"][stream_id][topic_name]
         msg_ids = {widget.original_widget.message["id"] for widget in widgets}
         final_focus_msg_id = widgets[focus].original_widget.message["id"]

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -114,7 +114,7 @@ class TestController:
                 "name": "PTEST",
             }
         }
-        controller.model.muted_streams = []
+        controller.model.muted_streams = set()
         controller.model.is_muted_topic = mocker.Mock(return_value=False)
 
         controller.narrow_to_stream(stream_name="PTEST")
@@ -166,7 +166,7 @@ class TestController:
                 "name": "PTEST",
             }
         }
-        controller.model.muted_streams = []
+        controller.model.muted_streams = set()
         controller.model.is_muted_topic = mocker.Mock(return_value=False)
 
         controller.narrow_to_topic(
@@ -231,7 +231,7 @@ class TestController:
                 "color": "#ffffff",
             }
         }
-        controller.model.muted_streams = []
+        controller.model.muted_streams = set()
         controller.model.is_muted_topic = mocker.Mock(return_value=False)
 
         controller.narrow_to_all_messages(contextual_message_id=anchor)

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -115,7 +115,7 @@ class TestController:
             }
         }
         controller.model.muted_streams = set()
-        controller.model.is_muted_topic = mocker.Mock(return_value=False)
+        mocker.patch(MODEL + ".is_muted_topic", return_value=False)
 
         controller.narrow_to_stream(stream_name="PTEST")
 
@@ -167,7 +167,7 @@ class TestController:
             }
         }
         controller.model.muted_streams = set()
-        controller.model.is_muted_topic = mocker.Mock(return_value=False)
+        mocker.patch(MODEL + ".is_muted_topic", return_value=False)
 
         controller.narrow_to_topic(
             stream_name="PTEST",
@@ -232,7 +232,7 @@ class TestController:
             }
         }
         controller.model.muted_streams = set()
-        controller.model.is_muted_topic = mocker.Mock(return_value=False)
+        mocker.patch(MODEL + ".is_muted_topic", return_value=False)
 
         controller.narrow_to_all_messages(contextual_message_id=anchor)
 
@@ -269,7 +269,7 @@ class TestController:
         controller.model.muted_streams = set()  # FIXME Expand upon this
         controller.model.user_id = 1
         # FIXME: Expand upon is_muted_topic().
-        controller.model.is_muted_topic = mocker.Mock(return_value=False)
+        mocker.patch(MODEL + ".is_muted_topic", return_value=False)
         controller.model.user_email = "some@email"
         controller.model.stream_dict = {
             205: {
@@ -293,7 +293,7 @@ class TestController:
         controller.model.index = index_all_mentions
         controller.model.muted_streams = set()  # FIXME Expand upon this
         # FIXME: Expand upon is_muted_topic().
-        controller.model.is_muted_topic = mocker.Mock(return_value=False)
+        mocker.patch(MODEL + ".is_muted_topic", return_value=False)
         controller.model.user_email = "some@email"
         controller.model.user_id = 1
         controller.model.stream_dict = {
@@ -324,26 +324,26 @@ class TestController:
     def test_open_in_browser_success(self, mocker, controller, url):
         # Set DISPLAY environ to be able to run test in CI
         os.environ["DISPLAY"] = ":0"
-        controller.report_success = mocker.Mock()
+        mocked_report_success = mocker.patch(MODULE + ".Controller.report_success")
         mock_get = mocker.patch(MODULE + ".webbrowser.get")
         mock_open = mock_get.return_value.open
 
         controller.open_in_browser(url)
 
         mock_open.assert_called_once_with(url)
-        controller.report_success.assert_called_once_with(
+        mocked_report_success.assert_called_once_with(
             f"The link was successfully opened using {mock_get.return_value.name}"
         )
 
     def test_open_in_browser_fail__no_browser_controller(self, mocker, controller):
         os.environ["DISPLAY"] = ":0"
         error = "No runnable browser found"
-        controller.report_error = mocker.Mock()
+        mocked_report_error = mocker.patch(MODULE + ".Controller.report_error")
         mocker.patch(MODULE + ".webbrowser.get").side_effect = webbrowser.Error(error)
 
         controller.open_in_browser("https://chat.zulip.org/#narrow/stream/test")
 
-        controller.report_error.assert_called_once_with(f"ERROR: {error}")
+        mocked_report_error.assert_called_once_with(f"ERROR: {error}")
 
     def test_main(self, mocker, controller):
         controller.view.palette = {"default": "theme_properties"}

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -398,12 +398,18 @@ class TestController:
     )
     @pytest.mark.parametrize("msg_ids", [({200, 300, 400}), (set()), ({100})])
     def test_search_message(
-        self, initial_narrow, final_narrow, controller, mocker, msg_ids
+        self,
+        initial_narrow,
+        final_narrow,
+        controller,
+        mocker,
+        msg_ids,
+        index_search_messages,
     ):
         get_message = mocker.patch(MODEL + ".get_messages")
         create_msg = mocker.patch(MODULE + ".create_msg_box_list")
         mocker.patch(MODEL + ".get_message_ids_in_current_narrow", return_value=msg_ids)
-        controller.model.index = {"search": {500}}  # Any initial search index
+        controller.model.index = index_search_messages  # Any initial search index
         controller.view.message_view = mocker.patch("urwid.ListBox")
         controller.model.narrow = initial_narrow
 
@@ -420,7 +426,9 @@ class TestController:
             num_after=0, num_before=30, anchor=10000000000
         )
         create_msg.assert_called_once_with(controller.model, msg_ids)
-        assert controller.model.index == {"search": msg_ids}
+        assert controller.model.index == dict(
+            index_search_messages, **{"search": msg_ids}
+        )
 
     @pytest.mark.parametrize(
         "screen_size, expected_popup_size",

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -103,28 +103,32 @@ class TestController:
         assert not controller.is_in_editor_mode()
 
     def test_narrow_to_stream(
-        self, mocker, controller, stream_button, index_stream
+        self,
+        mocker,
+        controller,
+        index_stream,
+        stream_id=205,
+        stream_name="PTEST",
     ) -> None:
         controller.model.narrow = []
         controller.model.index = index_stream
         controller.view.message_view = mocker.patch("urwid.ListBox")
         controller.model.stream_dict = {
-            205: {
+            stream_id: {
                 "color": "#ffffff",
-                "name": "PTEST",
+                "name": stream_name,
             }
         }
         controller.model.muted_streams = set()
         mocker.patch(MODEL + ".is_muted_topic", return_value=False)
 
-        controller.narrow_to_stream(stream_name="PTEST")
+        controller.narrow_to_stream(stream_name=stream_name)
 
-        assert controller.model.stream_id == stream_button.stream_id
-        assert controller.model.narrow == [["stream", stream_button.stream_name]]
+        assert controller.model.stream_id == stream_id
+        assert controller.model.narrow == [["stream", stream_name]]
         controller.view.message_view.log.clear.assert_called_once_with()
 
         widget = controller.view.message_view.log.extend.call_args_list[0][0][0][0]
-        stream_id = stream_button.stream_id
         id_list = index_stream["stream_msg_ids_by_stream_id"][stream_id]
         assert {widget.original_widget.message["id"]} == id_list
 

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -187,23 +187,23 @@ class TestController:
         assert msg_ids == id_list
         assert final_focus_msg_id == expected_final_focus
 
-    def test_narrow_to_user(self, mocker, controller, user_button, index_user):
+    def test_narrow_to_user(
+        self, mocker, controller, index_user, user_email="boo@zulip.com", user_id=5179
+    ):
         controller.model.narrow = []
         controller.model.index = index_user
         controller.view.message_view = mocker.patch("urwid.ListBox")
         controller.model.user_id = 5140
         controller.model.user_email = "some@email"
-        controller.model.user_dict = {
-            user_button.email: {"user_id": user_button.user_id}
-        }
+        controller.model.user_dict = {user_email: {"user_id": user_id}}
 
-        emails = [user_button.email]
+        emails = [user_email]
 
         controller.narrow_to_user(recipient_emails=emails)
 
-        assert controller.model.narrow == [["pm_with", user_button.email]]
+        assert controller.model.narrow == [["pm_with", user_email]]
         controller.view.message_view.log.clear.assert_called_once_with()
-        recipients = frozenset([controller.model.user_id, user_button.user_id])
+        recipients = frozenset([controller.model.user_id, user_id])
         assert controller.model.recipients == recipients
         widget = controller.view.message_view.log.extend.call_args_list[0][0][0][0]
         id_list = index_user["private_msg_ids_by_user_ids"][recipients]

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import pytest
 
+from zulipterminal.config.themes import generate_theme
 from zulipterminal.core import Controller
 from zulipterminal.version import ZT_VERSION
 
@@ -37,7 +38,7 @@ class TestController:
 
         self.config_file = "path/to/zuliprc"
         self.theme_name = "zt_dark"
-        self.theme = "default"
+        self.theme = generate_theme("zt_dark", 256)
         self.in_explore_mode = False
         self.autohide = True  # FIXME Add tests for no-autohide
         self.notify_enabled = False

--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -77,7 +77,7 @@ repo_python_files['zulipterminal'] = []
 repo_python_files['tests'] = []
 
 # Added incrementally as newer test files are type-annotated.
-type_consistent_testfiles = ["test_run.py"]
+type_consistent_testfiles = ["test_run.py", "test_core.py"]
 
 for file_path in python_files:
     repo = PurePath(file_path).parts[0]


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->
Adds type annotations to the test_core.py file. I've also added a few refactor/bugfix commits. 
<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->

<!-- Add a link to a discussion on chat.zulip.org, if relevant -->

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [x] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

**Commit flow**
- **bugfix: tests: core: Replace incorrect return type annotation.**
- **bugfix: tests: core: Assign ThemeSpec instance to controller theme.**
- **refactor: tests: core: Use mocker.patch for model.is_muted_topic.**
- **bugfix: tests: core: Assign a set to model's muted_streams.**
- **refactor: tests: core: Use mocker.patch for `report_*` methods.**
- **tests: conftest: Add an index_search_messages fixture.**
- **refactor: tests: core: Use index_search_messages in search tests.**
- **refactor: tests: core: Add type annotations.**

**Interactions** <!-- if any; add/delete/fill-in as appropriate -->
- Waiting on #1076 to extend the changes made to the `run-mypy` tool.

