### PR TITLE
tests: emoji_data: Add type annotations.

### DIFF
--- a/tests/emoji_data/test_emoji_data.py
+++ b/tests/emoji_data/test_emoji_data.py
@@ -1,11 +1,14 @@
 from collections import OrderedDict
+from typing import Dict
 
 from zulipterminal.unicode_emojis import EMOJI_DATA
 
 
-def test_generated_emoji_list_sorted():
+def test_generated_emoji_list_sorted() -> None:
     assert EMOJI_DATA == OrderedDict(sorted(EMOJI_DATA.items()))
 
 
-def test_unicode_emojis_fixture_sorted(unicode_emojis):
+def test_unicode_emojis_fixture_sorted(
+    unicode_emojis: "OrderedDict[str, Dict[str, str]]",
+) -> None:
     assert unicode_emojis == OrderedDict(sorted(unicode_emojis.items()))

--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -77,7 +77,7 @@ repo_python_files['zulipterminal'] = []
 repo_python_files['tests'] = []
 
 # Added incrementally as newer test files are type-annotated.
-type_consistent_testfiles = ["test_run.py", "test_core.py"]
+type_consistent_testfiles = ["test_run.py", "test_core.py", "test_emoji_data.py"]
 
 for file_path in python_files:
     repo = PurePath(file_path).parts[0]


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->
Adds type annotations to the `test_emoji_data.py` file. Also updates the `run-mypy` tool to run mypy on it.
<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->

<!-- Add a link to a discussion on chat.zulip.org, if relevant -->

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [x] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

<!-- See https://github.com/zulip/zulip-terminal#commit-style -->
**Commit flow** <!-- if more than one commit; add/delete/fill-in as appropriate -->
<!-- For example:
- first commit doing some thing
- maybe multiple commits doing similar things
-->
- **refactor: tests: emoji_data: Add type annotations.**
- **tools: Include test_emoji_data.py to be checked by mypy.**
