### PR TITLE
refactor: buttons/core: Avoid using StreamButton as a popup parameter.

### DIFF
--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -9,7 +9,6 @@ from pytest_mock import MockerFixture
 from zulipterminal.config.themes import generate_theme
 from zulipterminal.core import Controller
 from zulipterminal.helper import Index
-from zulipterminal.ui_tools.buttons import StreamButton
 from zulipterminal.version import ZT_VERSION
 
 
@@ -392,9 +391,10 @@ class TestController:
         self,
         mocker: MockerFixture,
         controller: Controller,
-        stream_button: StreamButton,
         muted_streams: Set[int],
         action: str,
+        stream_id: int = 205,
+        stream_name: str = "PTEST",
     ) -> None:
         pop_up = mocker.patch(MODULE + ".PopUpConfirmationView")
         text = mocker.patch(MODULE + ".urwid.Text")
@@ -402,9 +402,10 @@ class TestController:
         controller.model.muted_streams = muted_streams
         controller.loop = mocker.Mock()
 
-        controller.stream_muting_confirmation_popup(stream_button)
+        controller.stream_muting_confirmation_popup(stream_id, stream_name)
+
         text.assert_called_with(
-            ("bold", f"Confirm {action} of stream '{stream_button.stream_name}' ?"),
+            ("bold", f"Confirm {action} of stream '{stream_name}' ?"),
             "center",
         )
         pop_up.assert_called_once_with(controller, text(), partial())

--- a/tests/ui_tools/test_buttons.py
+++ b/tests/ui_tools/test_buttons.py
@@ -137,13 +137,21 @@ class TestStreamButton:
         )
 
     @pytest.mark.parametrize("key", keys_for_command("TOGGLE_MUTE_STREAM"))
-    def test_keypress_TOGGLE_MUTE_STREAM(self, mocker, stream_button, key, widget_size):
+    def test_keypress_TOGGLE_MUTE_STREAM(
+        self,
+        mocker,
+        key,
+        widget_size,
+        stream_button,
+        stream_id=205,
+        stream_name="PTEST",
+    ):
         size = widget_size(stream_button)
         pop_up = mocker.patch(
             "zulipterminal.core.Controller.stream_muting_confirmation_popup"
         )
         stream_button.keypress(size, key)
-        pop_up.assert_called_once_with(stream_button)
+        pop_up.assert_called_once_with(stream_id, stream_name)
 
 
 class TestUserButton:

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -379,16 +379,16 @@ class Controller:
         save_draft = partial(self.model.save_draft, draft)
         self.loop.widget = PopUpConfirmationView(self, question, save_draft)
 
-    def stream_muting_confirmation_popup(self, button: Any) -> None:
-        currently_muted = self.model.is_muted_stream(button.stream_id)
+    def stream_muting_confirmation_popup(
+        self, stream_id: int, stream_name: str
+    ) -> None:
+        currently_muted = self.model.is_muted_stream(stream_id)
         type_of_action = "unmuting" if currently_muted else "muting"
         question = urwid.Text(
-            ("bold", f"Confirm {type_of_action} of stream '{button.stream_name}' ?"),
+            ("bold", f"Confirm {type_of_action} of stream '{stream_name}' ?"),
             "center",
         )
-        mute_this_stream = partial(
-            self.model.toggle_stream_muted_status, button.stream_id
-        )
+        mute_this_stream = partial(self.model.toggle_stream_muted_status, stream_id)
         self.loop.widget = PopUpConfirmationView(self, question, mute_this_stream)
 
     def _narrow_to(self, anchor: Optional[int], **narrow: Any) -> None:

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -216,7 +216,9 @@ class StreamButton(TopButton):
         if is_command_key("TOGGLE_TOPIC", key):
             self.view.left_panel.show_topic_view(self)
         elif is_command_key("TOGGLE_MUTE_STREAM", key):
-            self.controller.stream_muting_confirmation_popup(self)
+            self.controller.stream_muting_confirmation_popup(
+                self.stream_id, self.stream_name
+            )
         elif is_command_key("STREAM_DESC", key):
             self.model.controller.show_stream_info(self.stream_id)
         return super().keypress(size, key)


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->
Prior to this PR, the `stream_muting_confirmation_popup` required
a `StreamButton` instance as a parameter to mute/unmute it and show
it to the user to request for confirmation. This PR refactors
the parameters to require the `stream_name` and `stream_id` instead
to abstract the StreamButton from this method.

<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->

<!-- Add a link to a discussion on chat.zulip.org, if relevant -->

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [x] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

<!-- See https://github.com/zulip/zulip-terminal#commit-style -->
**Commit flow** <!-- if more than one commit; add/delete/fill-in as appropriate -->
<!-- For example:
- first commit doing some thing
- maybe multiple commits doing similar things
-->
- refactor: buttons/core: Avoid using StreamButton as a popup parameter.
Prior to this commit, the `stream_muting_confirmation_popup` required
a `StreamButton` instance as a parameter to mute/unmute it and show
it to the user to request for confirmation. This commit refactors
the parameters to require the `stream_name` and `stream_id` instead
to abstract the StreamButton from this method.
Tests updated.
