### PR TITLE
refactor: views: Make mouse scroll-speed in side-panels consistent.

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -18,6 +18,7 @@ from zulipterminal.config.symbols import (
 from zulipterminal.helper import powerset
 from zulipterminal.ui_tools.boxes import MessageBox
 from zulipterminal.ui_tools.views import (
+    SIDE_PANELS_MOUSE_SCROLL_LINES,
     LeftColumnView,
     MessageView,
     MiddleColumnView,
@@ -546,13 +547,15 @@ class TestStreamsView:
 
     def test_mouse_event(self, mocker, stream_view, mouse_scroll_event, widget_size):
         event, button, key = mouse_scroll_event
-        mocker.patch.object(stream_view, "keypress")
+        stream_view_keypress = mocker.patch.object(stream_view, "keypress")
         size = widget_size(stream_view)
         col = 1
         row = 1
         focus = "WIDGET"
         stream_view.mouse_event(size, event, button, col, row, focus)
-        stream_view.keypress.assert_called_once_with(size, key)
+        stream_view_keypress.assert_has_calls(
+            [mocker.call(size, key)] * SIDE_PANELS_MOUSE_SCROLL_LINES
+        )
 
     @pytest.mark.parametrize("key", keys_for_command("SEARCH_STREAMS"))
     def test_keypress_SEARCH_STREAMS(self, mocker, stream_view, key, widget_size):
@@ -726,13 +729,15 @@ class TestTopicsView:
 
     def test_mouse_event(self, mocker, topic_view, mouse_scroll_event, widget_size):
         event, button, key = mouse_scroll_event
-        mocker.patch.object(topic_view, "keypress")
+        topic_view_keypress = mocker.patch.object(topic_view, "keypress")
         size = widget_size(topic_view)
         col = 1
         row = 1
         focus = "WIDGET"
         topic_view.mouse_event(size, event, button, col, row, focus)
-        topic_view.keypress.assert_called_once_with(size, key)
+        topic_view_keypress.assert_has_calls(
+            [mocker.call(size, key)] * SIDE_PANELS_MOUSE_SCROLL_LINES
+        )
 
 
 class TestUsersView:
@@ -744,13 +749,15 @@ class TestUsersView:
 
     def test_mouse_event(self, mocker, user_view, mouse_scroll_event, widget_size):
         event, button, key = mouse_scroll_event
-        mocker.patch.object(user_view, "keypress")
+        user_view_keypress = mocker.patch.object(user_view, "keypress")
         size = widget_size(user_view)
         col = 1
         row = 1
         focus = "WIDGET"
         user_view.mouse_event(size, event, button, col, row, focus)
-        user_view.keypress.assert_called_with(size, key)
+        user_view_keypress.assert_has_calls(
+            [mocker.call(size, key)] * SIDE_PANELS_MOUSE_SCROLL_LINES
+        )
 
     def test_mouse_event_left_click(
         self, mocker, user_view, widget_size, compose_box_is_open

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -51,6 +51,10 @@ from zulipterminal.ui_tools.utils import create_msg_box_list
 from zulipterminal.urwid_types import urwid_Size
 
 
+MIDDLE_COLUMN_MOUSE_SCROLL_LINES = 1
+SIDE_PANELS_MOUSE_SCROLL_LINES = 5
+
+
 class ModListWalker(urwid.SimpleFocusListWalker):
     def set_focus(self, position: int) -> None:
         # When setting focus via set_focus method.
@@ -166,10 +170,12 @@ class MessageView(urwid.ListBox):
     ) -> bool:
         if event == "mouse press":
             if button == 4:
-                self.keypress(size, primary_key_for_command("GO_UP"))
+                for _ in range(MIDDLE_COLUMN_MOUSE_SCROLL_LINES):
+                    self.keypress(size, primary_key_for_command("GO_UP"))
                 return True
             if button == 5:
-                self.keypress(size, primary_key_for_command("GO_DOWN"))
+                for _ in range(MIDDLE_COLUMN_MOUSE_SCROLL_LINES):
+                    self.keypress(size, primary_key_for_command("GO_DOWN"))
                 return True
         return super().mouse_event(size, event, button, col, row, focus)
 
@@ -366,10 +372,12 @@ class StreamsView(urwid.Frame):
     ) -> bool:
         if event == "mouse press":
             if button == 4:
-                self.keypress(size, primary_key_for_command("GO_UP"))
+                for _ in range(SIDE_PANELS_MOUSE_SCROLL_LINES):
+                    self.keypress(size, primary_key_for_command("GO_UP"))
                 return True
             elif button == 5:
-                self.keypress(size, primary_key_for_command("GO_DOWN"))
+                for _ in range(SIDE_PANELS_MOUSE_SCROLL_LINES):
+                    self.keypress(size, primary_key_for_command("GO_DOWN"))
                 return True
         return super().mouse_event(size, event, button, col, row, focus)
 
@@ -476,10 +484,12 @@ class TopicsView(urwid.Frame):
     ) -> bool:
         if event == "mouse press":
             if button == 4:
-                self.keypress(size, primary_key_for_command("GO_UP"))
+                for _ in range(SIDE_PANELS_MOUSE_SCROLL_LINES):
+                    self.keypress(size, primary_key_for_command("GO_UP"))
                 return True
             elif button == 5:
-                self.keypress(size, primary_key_for_command("GO_DOWN"))
+                for _ in range(SIDE_PANELS_MOUSE_SCROLL_LINES):
+                    self.keypress(size, primary_key_for_command("GO_DOWN"))
                 return True
         return super().mouse_event(size, event, button, col, row, focus)
 
@@ -516,11 +526,11 @@ class UsersView(urwid.ListBox):
                 if self.controller.is_in_editor_mode():
                     return True
             if button == 4:
-                for _ in range(5):
+                for _ in range(SIDE_PANELS_MOUSE_SCROLL_LINES):
                     self.keypress(size, primary_key_for_command("GO_UP"))
                 return True
             elif button == 5:
-                for _ in range(5):
+                for _ in range(SIDE_PANELS_MOUSE_SCROLL_LINES):
                     self.keypress(size, primary_key_for_command("GO_DOWN"))
         return super().mouse_event(size, event, button, col, row, focus)
 


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->
 * Adds MIDDLE_COLUMN_MOUSE_SCROLL_LINES and SIDE_PANELS_MOUSE_SCROLL_LINES
   global variables in views to store the scroll values for both columns.
 * Assigns mouse scroll values of 1 and 5 to Middle column and Side panels
   respectively.
 * Uses these values in mouse_events to skip defined number of lines on
   each scroll, making scroll lines for all side-panels consistent with each
   other.

<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->

<!-- Add a link to a discussion on chat.zulip.org, if relevant -->

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [x] New tests added (for any new behavior)
- [x] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->


**Notes & Questions** <!-- if any; add/delete/fill-in as appropriate -->
<!-- For example:
- this doesn't include feature X (yet?)
- unsure about Y
- should this do Z?
-->
Can we simplify the names of the global variables?


