### PR TITLE
bugfix: boxes/ui: Display mouse selection_hint for entire `View`.

### DIFF
--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -1,6 +1,7 @@
 import random
 import re
 import time
+from sys import platform
 from typing import Any, List, Optional
 
 import urwid
@@ -39,6 +40,7 @@ class View(urwid.WidgetWrap):
         self.search_box = SearchBox(self.controller)
 
         self.message_view: Any = None
+        self.displaying_selection_hint = False
 
         super().__init__(self.main_window())
 
@@ -296,6 +298,26 @@ class View(urwid.WidgetWrap):
         elif is_command_key("GO_TO_BOTTOM", key):
             key = "end"
         return super().keypress(size, key)
+
+    def mouse_event(
+        self, size: urwid_Box, event: str, button: int, col: int, row: int, focus: bool
+    ) -> bool:
+        if event == "mouse drag":
+            selection_key = "Fn + Alt" if platform == "darwin" else "Shift"
+            self.model.controller.view.set_footer_text(
+                [
+                    "Try pressing ",
+                    ("footer_contrast", f" {selection_key} "),
+                    " and dragging to select text.",
+                ],
+                "task:warning",
+            )
+            self.displaying_selection_hint = True
+        elif event == "mouse release" and self.displaying_selection_hint:
+            self.model.controller.view.set_footer_text()
+            self.displaying_selection_hint = False
+
+        return super().mouse_event(size, event, button, col, row, focus)
 
 
 class Screen(urwid.raw_display.Screen):

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -3,7 +3,6 @@ import typing
 import unicodedata
 from collections import Counter, OrderedDict, defaultdict
 from datetime import date, datetime, timedelta
-from sys import platform
 from time import sleep, time
 from typing import Any, Callable, Dict, List, NamedTuple, Optional, Tuple, Union
 from urllib.parse import urljoin, urlparse
@@ -837,9 +836,6 @@ class MessageBox(urwid.Pile):
                     if recipient["id"] != self.model.user_id
                 ]
 
-        # mouse_event helper variable
-        self.displaying_selection_hint = False
-
         super().__init__(self.main_view())
 
     def need_recipient_header(self) -> bool:
@@ -1575,20 +1571,6 @@ class MessageBox(urwid.Pile):
                     return True
                 self.keypress(size, primary_key_for_command("ENTER"))
                 return True
-        elif event == "mouse drag":
-            selection_key = "Fn + Alt" if platform == "darwin" else "Shift"
-            self.model.controller.view.set_footer_text(
-                [
-                    "Try pressing ",
-                    ("footer_contrast", f" {selection_key} "),
-                    " and dragging to select text.",
-                ],
-                "task:warning",
-            )
-            self.displaying_selection_hint = True
-        elif event == "mouse release" and self.displaying_selection_hint:
-            self.model.controller.view.set_footer_text()
-            self.displaying_selection_hint = False
 
         return super().mouse_event(size, event, button, col, row, focus)
 


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->
This commit fixes 2 bugs related to displaying selection_hint on mouse_drag
events. This migrates the mouse_event from MessageBox to the entire View
so that the selection_hint is displayed even when the user tries to perform
mouse_drag events outside of MessageBox i.e. anywhere in View.

This also fixes selection_hint getting stuck in the footer if the mouse is
dragged in the MessageView but released outside of it.

Thanks to @Rohitth007 for reporting this bug in [#zulip terminal>Drag-to-select-text](https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/Drag-to-select-text)

<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->

<!-- Add a link to a discussion on chat.zulip.org, if relevant -->

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [x] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->
