### PR TITLE
Apply black to tools/ and setup.py

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install with linting tools
         run: pip install .[linting]
       - name: Check code & tests meet black standards
-        run: black --check zulipterminal/ tests/
+        run: black --check zulipterminal/ tests/ setup.py tools/
 
   pytest:
     strategy:

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![GitHub Actions - Linting & tests](https://github.com/zulip/zulip-terminal/workflows/Linting%20%26%20tests/badge.svg?branch=main)](https://github.com/zulip/zulip-terminal/actions?query=workflow%3A%22Linting+%26+tests%22+branch%3Amain)
 [![Coverage status](https://img.shields.io/codecov/c/github/zulip/zulip-terminal/main.svg)](https://app.codecov.io/gh/zulip/zulip-terminal/branch/main)
 [![Checked with mypy](http://www.mypy-lang.org/static/mypy_badge.svg)](http://mypy-lang.org/)
+[![code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
 ![Screenshot](https://user-images.githubusercontent.com/9568999/106061037-b659a580-60a9-11eb-8ff8-ea1c54ac9084.png)
 

--- a/setup.py
+++ b/setup.py
@@ -9,11 +9,11 @@ from zulipterminal.version import ZT_VERSION
 
 
 class PyTest(TestCommand):
-    user_options = [('pytest-args=', 'a', "Arguments to pass to pytest")]
+    user_options = [("pytest-args=", "a", "Arguments to pass to pytest")]
 
     def initialize_options(self):
         TestCommand.initialize_options(self)
-        self.pytest_args = ''
+        self.pytest_args = ""
 
     def run_tests(self):
         import shlex
@@ -25,93 +25,93 @@ class PyTest(TestCommand):
 
 
 def long_description():
-    if not (os.path.isfile('README.md') and os.access('README.md', os.R_OK)):
-        return ''
+    if not (os.path.isfile("README.md") and os.access("README.md", os.R_OK)):
+        return ""
 
-    with codecs.open('README.md', encoding='utf8') as f:
+    with codecs.open("README.md", encoding="utf8") as f:
         source = f.read()
 
         # Skip first line (assumed to have title) to reduce duplication
-        return '\n'.join(source.splitlines()[1:])
+        return "\n".join(source.splitlines()[1:])
 
 
 testing_deps = [
-    'pytest~=6.2.3',
-    'pytest-cov~=2.11.1',
-    'pytest-mock~=3.6.0',
+    "pytest~=6.2.3",
+    "pytest-cov~=2.11.1",
+    "pytest-mock~=3.6.0",
 ]
 
 linting_deps = [
-    'isort~=5.7.0',
-    'mypy==0.812',
-    'flake8~=3.9.0',
-    'flake8-quotes~=3.2.0',
-    'flake8-continuation~=1.0.5',
-    'black>=21.5b1',
+    "isort~=5.7.0",
+    "mypy==0.812",
+    "flake8~=3.9.0",
+    "flake8-quotes~=3.2.0",
+    "flake8-continuation~=1.0.5",
+    "black>=21.5b1",
 ]
 
 dev_helper_deps = [
-    'pudb==2017.1.4',
-    'snakeviz==0.4.2',
-    'gitlint>=0.10',
-    'autopep8~=1.5.4',
-    'autoflake~=1.3.1',
+    "pudb==2017.1.4",
+    "snakeviz==0.4.2",
+    "gitlint>=0.10",
+    "autopep8~=1.5.4",
+    "autoflake~=1.3.1",
 ]
 
 setup(
-    name='zulip-term',
+    name="zulip-term",
     version=ZT_VERSION,
     description="Zulip's official terminal client",
     long_description=long_description(),
-    long_description_content_type='text/markdown',
-    url='https://github.com/zulip/zulip-terminal',
-    author='Zulip Open Source Project',
-    author_email='zulip-devel@googlegroups.com',
+    long_description_content_type="text/markdown",
+    url="https://github.com/zulip/zulip-terminal",
+    author="Zulip Open Source Project",
+    author_email="zulip-devel@googlegroups.com",
     classifiers=[
-        'Development Status :: 4 - Beta',
-        'Intended Audience :: End Users/Desktop',
-        'Topic :: Communications :: Chat',
-        'License :: OSI Approved :: Apache Software License',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: Implementation :: CPython',
-        'Programming Language :: Python :: Implementation :: PyPy',
+        "Development Status :: 4 - Beta",
+        "Intended Audience :: End Users/Desktop",
+        "Topic :: Communications :: Chat",
+        "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: Implementation :: CPython",
+        "Programming Language :: Python :: Implementation :: PyPy",
     ],
     project_urls={
-        'Changelog': 'https://github.com/zulip/zulip-terminal/blob/main/CHANGELOG.md',
-        'FAQs': 'https://github.com/zulip/zulip-terminal/blob/main/docs/FAQ.md',
-        'Issues': 'https://github.com/zulip/zulip-terminal/issues',
-        'Hot Keys': 'https://github.com/zulip/zulip-terminal/blob/main/docs/hotkeys.md',
+        "Changelog": "https://github.com/zulip/zulip-terminal/blob/main/CHANGELOG.md",
+        "FAQs": "https://github.com/zulip/zulip-terminal/blob/main/docs/FAQ.md",
+        "Issues": "https://github.com/zulip/zulip-terminal/issues",
+        "Hot Keys": "https://github.com/zulip/zulip-terminal/blob/main/docs/hotkeys.md",
     },
-    python_requires='>=3.6, <3.10',
-    keywords='',
-    packages=find_packages(exclude=['tests', 'tests.*']),
+    python_requires=">=3.6, <3.10",
+    keywords="",
+    packages=find_packages(exclude=["tests", "tests.*"]),
     zip_safe=True,
-    cmdclass={'test': PyTest},
-    test_suite='test',
+    cmdclass={"test": PyTest},
+    test_suite="test",
     entry_points={
-        'console_scripts': [
-            'zulip-term = zulipterminal.cli.run:main',
-            'zulip-term-check-symbols = zulipterminal.scripts.render_symbols:main',
+        "console_scripts": [
+            "zulip-term = zulipterminal.cli.run:main",
+            "zulip-term-check-symbols = zulipterminal.scripts.render_symbols:main",
         ],
     },
     extras_require={
-        'dev': testing_deps + linting_deps + dev_helper_deps,
-        'testing': testing_deps,
-        'linting': linting_deps,
+        "dev": testing_deps + linting_deps + dev_helper_deps,
+        "testing": testing_deps,
+        "linting": linting_deps,
     },
     tests_require=testing_deps,
     install_requires=[
-        'urwid~=2.1.2',
-        'zulip>=0.7.0',
-        'urwid_readline>=0.13',
-        'beautifulsoup4>=4.9.0',
-        'lxml>=4.6.2',
-        'typing_extensions>=3.7',
-        'python-dateutil>=2.8.1',
-        'tzlocal>=2.1',
+        "urwid~=2.1.2",
+        "zulip>=0.7.0",
+        "urwid_readline>=0.13",
+        "beautifulsoup4>=4.9.0",
+        "lxml>=4.6.2",
+        "typing_extensions>=3.7",
+        "python-dateutil>=2.8.1",
+        "tzlocal>=2.1",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ class PyTest(TestCommand):
         import shlex
 
         import pytest
+
         errno = pytest.main(shlex.split(self.pytest_args))
         sys.exit(errno)
 
@@ -68,12 +69,9 @@ setup(
     author_email='zulip-devel@googlegroups.com',
     classifiers=[
         'Development Status :: 4 - Beta',
-
         'Intended Audience :: End Users/Desktop',
         'Topic :: Communications :: Chat',
-
         'License :: OSI Approved :: Apache Software License',
-
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
@@ -83,15 +81,10 @@ setup(
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
     project_urls={
-        'Changelog':
-            'https://github.com/zulip/zulip-terminal/blob/main/CHANGELOG.md',
-        'FAQs':
-            'https://github.com/zulip/zulip-terminal/blob/main/docs/FAQ.md',
-        'Issues':
-            'https://github.com/zulip/zulip-terminal/issues',
-        'Hot Keys':
-            'https://github.com/zulip/zulip-terminal/blob/main/'
-            'docs/hotkeys.md',
+        'Changelog': 'https://github.com/zulip/zulip-terminal/blob/main/CHANGELOG.md',
+        'FAQs': 'https://github.com/zulip/zulip-terminal/blob/main/docs/FAQ.md',
+        'Issues': 'https://github.com/zulip/zulip-terminal/issues',
+        'Hot Keys': 'https://github.com/zulip/zulip-terminal/blob/main/docs/hotkeys.md',
     },
     python_requires='>=3.6, <3.10',
     keywords='',
@@ -102,8 +95,7 @@ setup(
     entry_points={
         'console_scripts': [
             'zulip-term = zulipterminal.cli.run:main',
-            'zulip-term-check-symbols = '
-            'zulipterminal.scripts.render_symbols:main',
+            'zulip-term-check-symbols = zulipterminal.scripts.render_symbols:main',
         ],
     },
     extras_require={

--- a/tools/generate_hotkeys.py
+++ b/tools/generate_hotkeys.py
@@ -6,13 +6,13 @@ from zulipterminal.config.keys import HELP_CATEGORIES, KEY_BINDINGS
 
 categories = {
     category: {
-        item['help_text']: item['keys']
+        item["help_text"]: item["keys"]
         for item in KEY_BINDINGS.values()
-        if item['key_category'] == category
+        if item["key_category"] == category
     }
     for category in HELP_CATEGORIES.keys()
 }
-OUTPUT_FILE = Path(__file__).resolve().parent.parent / 'docs' / 'hotkeys.md'
+OUTPUT_FILE = Path(__file__).resolve().parent.parent / "docs" / "hotkeys.md"
 SCRIPT_NAME = PurePath(__file__).name
 
 with open(OUTPUT_FILE, "w") as mdFile:

--- a/tools/generate_hotkeys.py
+++ b/tools/generate_hotkeys.py
@@ -6,7 +6,7 @@ from zulipterminal.config.keys import HELP_CATEGORIES, KEY_BINDINGS
 
 categories = {
     category: {
-        item['help_text']: item['keys'] 
+        item['help_text']: item['keys']
         for item in KEY_BINDINGS.values()
         if item['key_category'] == category
     }
@@ -15,21 +15,24 @@ categories = {
 OUTPUT_FILE = Path(__file__).resolve().parent.parent / 'docs' / 'hotkeys.md'
 SCRIPT_NAME = PurePath(__file__).name
 
-with open(OUTPUT_FILE,"w") as mdFile:
-    mdFile.write(f"<!--- Generated automatically by tools/{SCRIPT_NAME} -->\n"
-                  "<!--- Do not modify -->\n\n# Hot Keys\n")
+with open(OUTPUT_FILE, "w") as mdFile:
+    mdFile.write(
+        f"<!--- Generated automatically by tools/{SCRIPT_NAME} -->\n"
+        "<!--- Do not modify -->\n\n# Hot Keys\n"
+    )
     for action in categories.keys():
-        mdFile.write(f"## {HELP_CATEGORIES[action]}\n"
-                      "|Command|Key Combination|\n"
-                      "| :--- | :---: |\n")
+        mdFile.write(
+            f"## {HELP_CATEGORIES[action]}\n"
+            "|Command|Key Combination|\n"
+            "| :--- | :---: |\n"
+        )
         for help_text, key_combinations_list in categories[action].items():
-            various_key_combinations = " / ".join([
-                " + ".join([
-                    f"<kbd>{key}</kbd>"
-                    for key in key_combination.split()
-                ])
-                for key_combination in key_combinations_list
-            ])
+            various_key_combinations = " / ".join(
+                [
+                    " + ".join([f"<kbd>{key}</kbd>" for key in key_combination.split()])
+                    for key_combination in key_combinations_list
+                ]
+            )
             mdFile.write(f"|{help_text}|{various_key_combinations}|\n")
         mdFile.write("\n")
 

--- a/tools/gitlint-extra-rules.py
+++ b/tools/gitlint-extra-rules.py
@@ -19,8 +19,9 @@ class AreaFormatting(CommitRule):
     name = "area-formatting"
     id = "ZT2"
 
-    options_spec = [ListOption("exclusions", ["WIP"],
-                               "Exclusions to area lower-case rule")]
+    options_spec = [
+        ListOption("exclusions", ["WIP"], "Exclusions to area lower-case rule")
+    ]
 
     def validate(self, commit: Any) -> Optional[List[RuleViolation]]:
         title_components = commit.message.title.split(": ")
@@ -38,8 +39,10 @@ class AreaFormatting(CommitRule):
         exclusions_text = ", or ".join(exclusions)
         if exclusions_text:
             exclusions_text = " (or {})".format(exclusions_text)
-        error = (f"Areas at start of title should be lower case{exclusions_text}, "
-                 "followed by ': '")
+        error = (
+            f"Areas at start of title should be lower case{exclusions_text}, "
+            "followed by ': '"
+        )
 
         def deny_capital_text(text: str) -> bool:
             if text in exclusions:
@@ -49,8 +52,7 @@ class AreaFormatting(CommitRule):
             return False
 
         for area in title_components[:-1]:
-            if (any(deny_capital_text(word) for word in area.split('/')) or
-                    ' ' in area):
+            if any(deny_capital_text(word) for word in area.split('/')) or ' ' in area:
                 violations += [RuleViolation(self.id, error, line_nr=1)]
 
         error = "Summary of change, after area(s), should be capitalized"

--- a/tools/gitlint-extra-rules.py
+++ b/tools/gitlint-extra-rules.py
@@ -35,7 +35,7 @@ class AreaFormatting(CommitRule):
         if len(title_components) < 2:
             return [RuleViolation(self.id, error, line_nr=1)]
 
-        exclusions = self.options['exclusions'].value
+        exclusions = self.options["exclusions"].value
         exclusions_text = ", or ".join(exclusions)
         if exclusions_text:
             exclusions_text = " (or {})".format(exclusions_text)
@@ -52,7 +52,7 @@ class AreaFormatting(CommitRule):
             return False
 
         for area in title_components[:-1]:
-            if any(deny_capital_text(word) for word in area.split('/')) or ' ' in area:
+            if any(deny_capital_text(word) for word in area.split("/")) or " " in area:
                 violations += [RuleViolation(self.id, error, line_nr=1)]
 
         error = "Summary of change, after area(s), should be capitalized"

--- a/tools/gitlint-extra-rules.py
+++ b/tools/gitlint-extra-rules.py
@@ -28,8 +28,9 @@ class AreaFormatting(CommitRule):
         violations = []
 
         # Return just this violation, since latter checks assume an area
-        error = ("Title should start with at least one area, "
-                 "followed by a colon and space")
+        error = (
+            "Title should start with at least one area, followed by a colon and space"
+        )
         if len(title_components) < 2:
             return [RuleViolation(self.id, error, line_nr=1)]
 
@@ -37,8 +38,8 @@ class AreaFormatting(CommitRule):
         exclusions_text = ", or ".join(exclusions)
         if exclusions_text:
             exclusions_text = " (or {})".format(exclusions_text)
-        error = ("Areas at start of title should be lower case{}, "
-                 "followed by ': '".format(exclusions_text))
+        error = (f"Areas at start of title should be lower case{exclusions_text}, "
+                 "followed by ': '")
 
         def deny_capital_text(text: str) -> bool:
             if text in exclusions:

--- a/tools/lint-all
+++ b/tools/lint-all
@@ -8,7 +8,7 @@ tools = {
     'Import order (isort)': './tools/run-isort-check',
     'Type consistency (mypy)': './tools/run-mypy',
     'PEP8 & more (flake8)': 'flake8 zulipterminal/ tests/ setup.py'.split(),
-    'Formatting (black)': 'black --check zulipterminal/ tests/'.split(),
+    'Formatting (black)': 'black --check zulipterminal/ tests/ setup.py tools/'.split(),
 }
 
 for tool_name, command in tools.items():

--- a/tools/lister.py
+++ b/tools/lister.py
@@ -19,8 +19,10 @@ def get_ftype(fpath: str, use_shebang: bool) -> str:
             if re.search(r'^#!.*\bpython3', first_line):
                 return 'py'
             elif re.search(r'^#!', first_line):
-                print('Error: Unknown shebang in file'
-                      ' "%s":\n%s' % (fpath, first_line), file=sys.stderr)
+                print(
+                    'Error: Unknown shebang in file' ' "%s":\n%s' % (fpath, first_line),
+                    file=sys.stderr,
+                )
                 return ''
             else:
                 return ''
@@ -28,8 +30,15 @@ def get_ftype(fpath: str, use_shebang: bool) -> str:
         return ''
 
 
-def list_files(targets=[], ftypes=[], use_shebang=True, modified_only=False,
-               exclude=[], group_by_ftype=False, extless_only=False):
+def list_files(
+    targets=[],
+    ftypes=[],
+    use_shebang=True,
+    modified_only=False,
+    exclude=[],
+    group_by_ftype=False,
+    extless_only=False,
+):
     """
     List files tracked by git.
     Returns a list of files which are either in targets or in directories in
@@ -54,18 +63,23 @@ def list_files(targets=[], ftypes=[], use_shebang=True, modified_only=False,
     # Really this is all bytes -- it's a file path -- but we get paths in
     # sys.argv as str, so that battle is already lost.  Settle for hoping
     # everything is UTF-8.
-    repository_root = subprocess.check_output(
-        ['git', 'rev-parse', '--show-toplevel']).strip().decode('utf-8')
-    exclude_abspaths = [os.path.abspath(os.path.join(repository_root, fpath)
-                                        ) for fpath in exclude]
+    repository_root = (
+        subprocess.check_output(['git', 'rev-parse', '--show-toplevel'])
+        .strip()
+        .decode('utf-8')
+    )
+    exclude_abspaths = [
+        os.path.abspath(os.path.join(repository_root, fpath)) for fpath in exclude
+    ]
 
     cmdline = ['git', 'ls-files'] + targets
     if modified_only:
         cmdline.append('-m')
 
-    files_gen = (x.strip() for x in subprocess.check_output(
-                                        cmdline,
-                                        universal_newlines=True).split('\n'))
+    files_gen = (
+        x.strip()
+        for x in subprocess.check_output(cmdline, universal_newlines=True).split('\n')
+    )
     # throw away empty lines and non-files (like symlinks)
     files = list(filter(os.path.isfile, files_gen))
 
@@ -78,9 +92,10 @@ def list_files(targets=[], ftypes=[], use_shebang=True, modified_only=False,
         if extless_only and ext:
             continue
         absfpath = os.path.abspath(fpath)
-        if any(absfpath == expath or absfpath.startswith(
-                                            os.path.abspath(expath) + os.sep)
-               for expath in exclude_abspaths):
+        if any(
+            absfpath == expath or absfpath.startswith(os.path.abspath(expath) + os.sep)
+            for expath in exclude_abspaths
+        ):
             continue
 
         if ftypes or group_by_ftype:
@@ -88,8 +103,10 @@ def list_files(targets=[], ftypes=[], use_shebang=True, modified_only=False,
                 filetype = get_ftype(fpath, use_shebang)
             except (OSError, UnicodeDecodeError) as e:
                 etype = e.__class__.__name__
-                print('Error: %s while determining type of file "%s":' % (
-                                                etype, fpath), file=sys.stderr)
+                print(
+                    'Error: %s while determining type of file "%s":' % (etype, fpath),
+                    file=sys.stderr,
+                )
                 print(e, file=sys.stderr)
                 filetype = ''
             if ftypes and filetype not in ftypes_set:
@@ -107,30 +124,61 @@ def list_files(targets=[], ftypes=[], use_shebang=True, modified_only=False,
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="List files tracked by git"
-                                     "and optionally filter by type")
-    parser.add_argument('targets', nargs='*', default=[],
-                        help='''files and directories to include in the result.
+    parser = argparse.ArgumentParser(
+        description="List files tracked by git" "and optionally filter by type"
+    )
+    parser.add_argument(
+        'targets',
+        nargs='*',
+        default=[],
+        help='''files and directories to include in the result.
                         If this is not specified, the current directory is
-                         used''')
-    parser.add_argument('-m', '--modified', action='store_true', default=False,
-                        help='list only modified files')
-    parser.add_argument('-f', '--ftypes', nargs='+', default=[],
-                        help="""list of file types to filter on.
-                        All files are included if this option is absent""")
-    parser.add_argument('--ext-only', dest='extonly', action='store_true',
-                        default=False,
-                        help='only use extension to determine file type')
-    parser.add_argument('--exclude', nargs='+', default=[],
-                        help='''list of files and directories to exclude from
-                         results, relative to repo root''')
-    parser.add_argument('--extless-only', dest='extless_only',
-                        action='store_true', default=False,
-                        help='only include extensionless files in output')
+                         used''',
+    )
+    parser.add_argument(
+        '-m',
+        '--modified',
+        action='store_true',
+        default=False,
+        help='list only modified files',
+    )
+    parser.add_argument(
+        '-f',
+        '--ftypes',
+        nargs='+',
+        default=[],
+        help="""list of file types to filter on.
+                        All files are included if this option is absent""",
+    )
+    parser.add_argument(
+        '--ext-only',
+        dest='extonly',
+        action='store_true',
+        default=False,
+        help='only use extension to determine file type',
+    )
+    parser.add_argument(
+        '--exclude',
+        nargs='+',
+        default=[],
+        help='''list of files and directories to exclude from
+                         results, relative to repo root''',
+    )
+    parser.add_argument(
+        '--extless-only',
+        dest='extless_only',
+        action='store_true',
+        default=False,
+        help='only include extensionless files in output',
+    )
     args = parser.parse_args()
-    listing = list_files(targets=args.targets, ftypes=args.ftypes,
-                         use_shebang=not args.extonly,
-                         modified_only=args.modified, exclude=args.exclude,
-                         extless_only=args.extless_only)
+    listing = list_files(
+        targets=args.targets,
+        ftypes=args.ftypes,
+        use_shebang=not args.extonly,
+        modified_only=args.modified,
+        exclude=args.exclude,
+        extless_only=args.extless_only,
+    )
     for l in listing:
         print(l)

--- a/tools/lister.py
+++ b/tools/lister.py
@@ -16,18 +16,18 @@ def get_ftype(fpath: str, use_shebang: bool) -> str:
         # opening a file may throw an OSError
         with open(fpath) as f:
             first_line = f.readline()
-            if re.search(r'^#!.*\bpython3', first_line):
-                return 'py'
-            elif re.search(r'^#!', first_line):
+            if re.search(r"^#!.*\bpython3", first_line):
+                return "py"
+            elif re.search(r"^#!", first_line):
                 print(
-                    'Error: Unknown shebang in file' ' "%s":\n%s' % (fpath, first_line),
+                    "Error: Unknown shebang in file" ' "%s":\n%s' % (fpath, first_line),
                     file=sys.stderr,
                 )
-                return ''
+                return ""
             else:
-                return ''
+                return ""
     else:
-        return ''
+        return ""
 
 
 def list_files(
@@ -57,28 +57,28 @@ def list_files(
         If False, returns a flat list of files.
     extless_only - Only include extensionless files in output.
     """
-    ftypes = [x.strip('.') for x in ftypes]
+    ftypes = [x.strip(".") for x in ftypes]
     ftypes_set = set(ftypes)
 
     # Really this is all bytes -- it's a file path -- but we get paths in
     # sys.argv as str, so that battle is already lost.  Settle for hoping
     # everything is UTF-8.
     repository_root = (
-        subprocess.check_output(['git', 'rev-parse', '--show-toplevel'])
+        subprocess.check_output(["git", "rev-parse", "--show-toplevel"])
         .strip()
-        .decode('utf-8')
+        .decode("utf-8")
     )
     exclude_abspaths = [
         os.path.abspath(os.path.join(repository_root, fpath)) for fpath in exclude
     ]
 
-    cmdline = ['git', 'ls-files'] + targets
+    cmdline = ["git", "ls-files"] + targets
     if modified_only:
-        cmdline.append('-m')
+        cmdline.append("-m")
 
     files_gen = (
         x.strip()
-        for x in subprocess.check_output(cmdline, universal_newlines=True).split('\n')
+        for x in subprocess.check_output(cmdline, universal_newlines=True).split("\n")
     )
     # throw away empty lines and non-files (like symlinks)
     files = list(filter(os.path.isfile, files_gen))
@@ -108,7 +108,7 @@ def list_files(
                     file=sys.stderr,
                 )
                 print(e, file=sys.stderr)
-                filetype = ''
+                filetype = ""
             if ftypes and filetype not in ftypes_set:
                 continue
 
@@ -128,48 +128,48 @@ if __name__ == "__main__":
         description="List files tracked by git" "and optionally filter by type"
     )
     parser.add_argument(
-        'targets',
-        nargs='*',
+        "targets",
+        nargs="*",
         default=[],
-        help='''files and directories to include in the result.
+        help="""files and directories to include in the result.
                         If this is not specified, the current directory is
-                         used''',
+                         used""",
     )
     parser.add_argument(
-        '-m',
-        '--modified',
-        action='store_true',
+        "-m",
+        "--modified",
+        action="store_true",
         default=False,
-        help='list only modified files',
+        help="list only modified files",
     )
     parser.add_argument(
-        '-f',
-        '--ftypes',
-        nargs='+',
+        "-f",
+        "--ftypes",
+        nargs="+",
         default=[],
         help="""list of file types to filter on.
                         All files are included if this option is absent""",
     )
     parser.add_argument(
-        '--ext-only',
-        dest='extonly',
-        action='store_true',
+        "--ext-only",
+        dest="extonly",
+        action="store_true",
         default=False,
-        help='only use extension to determine file type',
+        help="only use extension to determine file type",
     )
     parser.add_argument(
-        '--exclude',
-        nargs='+',
+        "--exclude",
+        nargs="+",
         default=[],
-        help='''list of files and directories to exclude from
-                         results, relative to repo root''',
+        help="""list of files and directories to exclude from
+                         results, relative to repo root""",
     )
     parser.add_argument(
-        '--extless-only',
-        dest='extless_only',
-        action='store_true',
+        "--extless-only",
+        dest="extless_only",
+        action="store_true",
         default=False,
-        help='only include extensionless files in output',
+        help="only include extensionless files in output",
     )
     args = parser.parse_args()
     listing = list_files(


### PR DESCRIPTION
**What does this PR do?**  <!-- Overall description goes here -->

With tools/ and setup.py included in black linting, all python files will then be checked by black :tada:

These were originally excluded for simplicity, but to remove certain linting rules it is useful to ensure black is applied to all python files, such as for line length ie. removing flake8 rule E501 in #1084 

This is a partial fix towards #1047 

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [X] Manually
- [X] Existing tests (adapted, if necessary)
- [X] New tests added (for any new behavior)
- [X] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

<!-- See https://github.com/zulip/zulip-terminal#commit-style -->
**Commit flow** <!-- if more than one commit; add/delete/fill-in as appropriate -->
As per the original main black transition:
* adapt a few files for things black has issues with or can be handled manually simply
* apply black without quote adjustment (just structure; needs more review)
* apply black with quote adjustment (generally no need to review as black just does it fine)
* enforce black in tools

**Interactions** <!-- if any; add/delete/fill-in as appropriate -->
I'd like to merge this before #1084, since that PR currently loosens our flake8 rules based on the premise that black is being applied.