### PR TITLE
Simplify Topbutton attributes

### DIFF
--- a/tests/ui_tools/test_buttons.py
+++ b/tests/ui_tools/test_buttons.py
@@ -77,6 +77,48 @@ class TestTopButton:
             top_button, "click", top_button.activate
         )
 
+    def test_style_properties(self, top_button: TopButton) -> None:
+        top_button._prefix_markup = ("prefix-style", "prefix-text")
+        top_button._label_markup = ("label-style", "label-text")
+        top_button._suffix_markup = ("suffix-style", "suffix-text")
+
+        # Test getter
+        prefix_style = top_button.prefix_style
+        assert prefix_style == "prefix-style"
+        label_style = top_button.label_style
+        assert label_style == "label-style"
+        suffix_style = top_button.suffix_style
+        assert suffix_style == "suffix-style"
+
+        # Test setter
+        top_button.prefix_style = "prefix-style2"
+        assert top_button.prefix_style == "prefix-style2"
+        top_button.label_style = "label-style2"
+        assert top_button.label_style == "label-style2"
+        top_button.suffix_style = "suffix-style2"
+        assert top_button.suffix_style == "suffix-style2"
+
+    def test_text_properties(self, top_button: TopButton) -> None:
+        top_button._prefix_markup = ("prefix-style", "prefix-text")
+        top_button._label_markup = ("label-style", "label-text")
+        top_button._suffix_markup = ("suffix-style", "suffix-text")
+
+        # Test getter
+        prefix_text = top_button.prefix_text
+        assert prefix_text == "prefix-text"
+        label_text = top_button.label_text
+        assert label_text == "label-text"
+        suffix_text = top_button.suffix_text
+        assert suffix_text == "suffix-text"
+
+        # Test setter
+        top_button.prefix_text = "prefix-text2"
+        assert top_button.prefix_text == "prefix-text2"
+        top_button.label_text = "label-text2"
+        assert top_button.label_text == "label-text2"
+        top_button.suffix_text = "suffix-text2"
+        assert top_button.suffix_text == "suffix-text2"
+
     @pytest.mark.parametrize("text_color", ["color", None])
     @pytest.mark.parametrize(
         "old_count, new_count, new_count_str",

--- a/tests/ui_tools/test_buttons.py
+++ b/tests/ui_tools/test_buttons.py
@@ -195,6 +195,7 @@ class TestStreamButton:
 
         stream_button.mark_muted()
 
+        assert stream_button.prefix_style == "muted"
         assert stream_button.label_style == "muted"
         assert stream_button.suffix_style == "muted"
         assert stream_button.suffix_text == MUTE_MARKER
@@ -209,6 +210,7 @@ class TestStreamButton:
 
         stream_button.mark_unmuted(unread_count)
 
+        assert stream_button.prefix_style == stream_button.color
         assert stream_button.label_style is None
         assert stream_button.suffix_style == "unread_count"
         update_count.assert_called_once_with(unread_count)

--- a/tests/ui_tools/test_buttons.py
+++ b/tests/ui_tools/test_buttons.py
@@ -125,14 +125,11 @@ class TestTopButton:
         new_count: int,
         new_count_str: str,
     ) -> None:
-        top_button.label_style = "style"
         top_button_update_widget = mocker.patch(MODULE + ".TopButton.update_widget")
 
         top_button.update_count(new_count)
 
-        top_button_update_widget.assert_called_once_with(
-            top_button._suffix_markup, top_button.label_style
-        )
+        top_button_update_widget.assert_called_once_with()
         assert top_button.suffix_text == new_count_str
 
     @pytest.mark.parametrize(
@@ -170,7 +167,7 @@ class TestTopButton:
         top_button.button_suffix = mocker.patch(MODULE + ".urwid.Text")
         set_attr_map = mocker.patch.object(top_button._w, "set_attr_map")
 
-        top_button.update_widget(suffix_markup, label_markup[0])
+        top_button.update_widget()
 
         top_button.button_prefix.set_text.assert_called_once_with(
             expected_prefix_markup
@@ -198,7 +195,10 @@ class TestStreamButton:
 
         stream_button.mark_muted()
 
-        update_widget.assert_called_once_with(("muted", MUTE_MARKER), "muted")
+        assert stream_button.label_style == "muted"
+        assert stream_button.suffix_style == "muted"
+        assert stream_button.suffix_text == MUTE_MARKER
+        update_widget.assert_called_once_with()
 
     def test_mark_unmuted(
         self, mocker: MockerFixture, stream_button: StreamButton
@@ -209,6 +209,8 @@ class TestStreamButton:
 
         stream_button.mark_unmuted(unread_count)
 
+        assert stream_button.label_style is None
+        assert stream_button.suffix_style == "unread_count"
         update_count.assert_called_once_with(unread_count)
 
     @pytest.mark.parametrize("key", keys_for_command("TOGGLE_TOPIC"))
@@ -490,7 +492,10 @@ class TestTopicButton:
 
         topic_button.mark_muted()
 
-        update_widget.assert_called_once_with(("muted", MUTE_MARKER), "muted")
+        assert topic_button.label_style == "muted"
+        assert topic_button.suffix_style == "muted"
+        assert topic_button.suffix_text == MUTE_MARKER
+        update_widget.assert_called_once_with()
 
     @pytest.mark.parametrize("key", keys_for_command("TOGGLE_TOPIC"))
     def test_keypress_EXIT_TOGGLE_TOPIC(

--- a/tests/ui_tools/test_buttons.py
+++ b/tests/ui_tools/test_buttons.py
@@ -317,7 +317,7 @@ class TestEmojiButton:
     ) -> None:
         controller = mocker.Mock()
         controller.model.has_user_reacted_to_message = mocker.Mock(return_value=False)
-        update_widget = mocker.patch(MODULE + ".EmojiButton.update_widget")
+        update_widget = mocker.patch(MODULE + ".EmojiButton.update_check_mark")
         top_button = mocker.patch(MODULE + ".TopButton.__init__")
         label = ", ".join([emoji_unit[0], *emoji_unit[2]])
         message_fixture["reactions"] = to_vary_in_message["reactions"]

--- a/tests/ui_tools/test_buttons.py
+++ b/tests/ui_tools/test_buttons.py
@@ -56,9 +56,7 @@ class TestTopButton:
         assert top_button._caption == "label"
         assert top_button.show_function == self.show_function
         assert top_button.prefix_character == ("style", "-")
-        assert top_button.original_color is None
         assert top_button.count == 0
-        assert top_button.count_style is None
 
         assert top_button._label.wrap == "ellipsis"
         assert top_button._label.get_cursor_coords("size") is None
@@ -119,29 +117,25 @@ class TestTopButton:
         top_button.suffix_text = "suffix-text2"
         assert top_button.suffix_text == "suffix-text2"
 
-    @pytest.mark.parametrize("text_color", ["color", None])
     @pytest.mark.parametrize(
-        "old_count, new_count, new_count_str",
-        [(10, 11, "11"), (0, 1, "1"), (11, 10, "10"), (1, 0, "")],
+        "new_count, new_count_str", [(11, "11"), (1, "1"), (10, "10"), (0, "")]
     )
     def test_update_count(
         self,
         mocker: MockerFixture,
         top_button: TopButton,
-        old_count: int,
         new_count: int,
         new_count_str: str,
-        text_color: Optional[str],
     ) -> None:
-        top_button.count = old_count
+        top_button.label_style = "style"
         top_button_update_widget = mocker.patch(MODULE + ".TopButton.update_widget")
 
-        top_button.update_count(new_count, text_color)
+        top_button.update_count(new_count)
 
         top_button_update_widget.assert_called_once_with(
-            (top_button.count_style, new_count_str),
-            text_color,
+            top_button._suffix_markup, top_button.label_style
         )
+        assert top_button.suffix_text == new_count_str
 
     @pytest.mark.parametrize(
         "prefix, expected_prefix",
@@ -189,7 +183,7 @@ class TestStarredButton:
         self, mocker: MockerFixture, count: int = 10
     ) -> None:
         starred_button = StarredButton(controller=mocker.Mock(), count=count)
-        assert starred_button.count_style == "starred_count"
+        assert starred_button.suffix_style == "starred_count"
 
 
 class TestStreamButton:

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -31,12 +31,10 @@ class TopButton(urwid.Button):
         count: int = 0,
     ) -> None:
         self.controller = controller
-        self._caption = label_markup[1]  # kept for easier transition.
         self._prefix_markup = prefix_markup
         self._label_markup = label_markup
         self._suffix_markup = suffix_markup
         self.show_function = show_function
-        self.prefix_character = prefix_markup  # kept for easier transition.
         self.count = count
 
         super().__init__("")
@@ -93,18 +91,20 @@ class TopButton(urwid.Button):
     def update_widget(
         self, count_text: urwid_MarkupTuple, text_color: Optional[str]
     ) -> Any:
-        if self.prefix_character[1]:
-            prefix = [" ", self.prefix_character, " "]
+        self._suffix_markup = count_text  # kept for easier transition
+        self.label_style = text_color  # kept for easier transition
+        if self.prefix_text:
+            prefix = [" ", self._prefix_markup, " "]
         else:
             prefix = [" "]
-        if count_text[1]:
-            suffix = [" ", count_text, " "]
+        if self.suffix_text:
+            suffix = [" ", self._suffix_markup, " "]
         else:
             suffix = ["  "]
         self.button_prefix.set_text(prefix)
-        self.set_label(self._caption)
+        self.set_label(self.label_text)
         self.button_suffix.set_text(suffix)
-        self._w.set_attr_map({None: text_color})
+        self._w.set_attr_map({None: self.label_style})
 
     def activate(self, key: Any) -> None:
         self.controller.view.show_left_panel(visible=False)

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -221,6 +221,7 @@ class StreamButton(TopButton):
             self.mark_muted()
 
     def mark_muted(self) -> None:
+        self.prefix_style = "muted"
         self.label_style = "muted"
         self.suffix_style = "muted"
         self.suffix_text = MUTE_MARKER
@@ -228,6 +229,7 @@ class StreamButton(TopButton):
         self.view.home_button.update_count(self.model.unread_counts["all_msg"])
 
     def mark_unmuted(self, unread_count: int) -> None:
+        self.prefix_style = self.color
         self.label_style = None
         self.suffix_style = "unread_count"
         self.update_count(unread_count)

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -86,13 +86,9 @@ class TopButton(urwid.Button):
     def update_count(self, count: int) -> None:
         self.count = count
         self.suffix_text = "" if count == 0 else str(count)
-        self.update_widget(self._suffix_markup, self.label_style)
+        self.update_widget()
 
-    def update_widget(
-        self, count_text: urwid_MarkupTuple, text_color: Optional[str]
-    ) -> Any:
-        self._suffix_markup = count_text  # kept for easier transition
-        self.label_style = text_color  # kept for easier transition
+    def update_widget(self) -> Any:
         if self.prefix_text:
             prefix = [" ", self._prefix_markup, " "]
         else:
@@ -225,10 +221,15 @@ class StreamButton(TopButton):
             self.mark_muted()
 
     def mark_muted(self) -> None:
-        self.update_widget(("muted", MUTE_MARKER), "muted")
+        self.label_style = "muted"
+        self.suffix_style = "muted"
+        self.suffix_text = MUTE_MARKER
+        self.update_widget()
         self.view.home_button.update_count(self.model.unread_counts["all_msg"])
 
     def mark_unmuted(self, unread_count: int) -> None:
+        self.label_style = None
+        self.suffix_style = "unread_count"
         self.update_count(unread_count)
         self.view.home_button.update_count(self.model.unread_counts["all_msg"])
 
@@ -274,7 +275,9 @@ class UserButton(TopButton):
             count=count,
         )
         if is_current_user:
-            self.update_widget(("current_user", "(you)"), color)
+            self.suffix_style = "current_user"
+            self.suffix_text = "(you)"
+            self.update_widget()
 
     def _narrow_with_compose(self) -> None:
         # Switches directly to composing with user
@@ -333,7 +336,10 @@ class TopicButton(TopButton):
             self.mark_muted()
 
     def mark_muted(self) -> None:
-        self.update_widget(("muted", MUTE_MARKER), "muted")
+        self.label_style = "muted"
+        self.suffix_style = "muted"
+        self.suffix_text = MUTE_MARKER
+        self.update_widget()
 
     # TODO: Handle event-based approach for topic-muting.
 
@@ -380,7 +386,8 @@ class EmojiButton(TopButton):
     def update_check_mark(self, user_reacted: bool) -> None:
         count_text = str(self.reaction_count) if self.reaction_count > 0 else ""
         reacted_check_mark = CHECK_MARK if user_reacted else ""
-        self.update_widget((None, f" {reacted_check_mark} {count_text} "), None)
+        self.suffix_text = f" {reacted_check_mark} {count_text} "
+        self.update_widget()
 
     def mouse_event(
         self, size: urwid_Size, event: str, button: int, col: int, row: int, focus: int

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -61,6 +61,32 @@ class TopButton(urwid.Button):
 
         urwid.connect_signal(self, "click", self.activate)
 
+    def _set_prefix_style(self, style: str) -> None:
+        self._prefix_markup = (style, self._prefix_markup[1])
+
+    def _set_label_style(self, style: str) -> None:
+        self._label_markup = (style, self._label_markup[1])
+
+    def _set_suffix_style(self, style: str) -> None:
+        self._suffix_markup = (style, self._suffix_markup[1])
+
+    prefix_style = property(lambda self: self._prefix_markup[0], _set_prefix_style)
+    label_style = property(lambda self: self._label_markup[0], _set_label_style)
+    suffix_style = property(lambda self: self._suffix_markup[0], _set_suffix_style)
+
+    def _set_prefix_text(self, text: str) -> None:
+        self._prefix_markup = (self._prefix_markup[0], text)
+
+    def _set_label_text(self, text: str) -> None:
+        self._label_markup = (self._label_markup[0], text)
+
+    def _set_suffix_text(self, text: str) -> None:
+        self._suffix_markup = (self._suffix_markup[0], text)
+
+    prefix_text = property(lambda self: self._prefix_markup[1], _set_prefix_text)
+    label_text = property(lambda self: self._label_markup[1], _set_label_text)
+    suffix_text = property(lambda self: self._suffix_markup[1], _set_suffix_text)
+
     def update_count(self, count: int, text_color: Optional[str] = None) -> None:
         new_color = self.original_color if text_color is None else text_color
 

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -37,9 +37,7 @@ class TopButton(urwid.Button):
         self._suffix_markup = suffix_markup
         self.show_function = show_function
         self.prefix_character = prefix_markup  # kept for easier transition.
-        self.original_color = label_markup[0]  # kept for easier transition.
         self.count = count
-        self.count_style = suffix_markup[0]  # kept for easier transition.
 
         super().__init__("")
 
@@ -57,7 +55,7 @@ class TopButton(urwid.Button):
         )
         self._w = urwid.AttrMap(cols, None, "selected")
 
-        self.update_count(count, label_markup[0])
+        self.update_count(count)
 
         urwid.connect_signal(self, "click", self.activate)
 
@@ -87,16 +85,10 @@ class TopButton(urwid.Button):
     label_text = property(lambda self: self._label_markup[1], _set_label_text)
     suffix_text = property(lambda self: self._suffix_markup[1], _set_suffix_text)
 
-    def update_count(self, count: int, text_color: Optional[str] = None) -> None:
-        new_color = self.original_color if text_color is None else text_color
-
+    def update_count(self, count: int) -> None:
         self.count = count
-        if count == 0:
-            count_text = ""
-        else:
-            count_text = str(count)
-
-        self.update_widget((self.count_style, count_text), new_color)
+        self.suffix_text = "" if count == 0 else str(count)
+        self.update_widget(self._suffix_markup, self.label_style)
 
     def update_widget(
         self, count_text: urwid_MarkupTuple, text_color: Optional[str]

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -370,17 +370,17 @@ class EmojiButton(TopButton):
         )
 
         has_check_mark = self._has_user_reacted_to_msg() or is_selected(self.emoji_name)
-        self.update_widget((None, self.get_update_widget_text(has_check_mark)), None)
+        self.update_check_mark(has_check_mark)
 
     def _has_user_reacted_to_msg(self) -> bool:
         return self.controller.model.has_user_reacted_to_message(
             self.message, emoji_code=self.emoji_code
         )
 
-    def get_update_widget_text(self, user_reacted: bool) -> str:
+    def update_check_mark(self, user_reacted: bool) -> None:
         count_text = str(self.reaction_count) if self.reaction_count > 0 else ""
         reacted_check_mark = CHECK_MARK if user_reacted else ""
-        return f" {reacted_check_mark} {count_text} "
+        self.update_widget((None, f" {reacted_check_mark} {count_text} "), None)
 
     def mouse_event(
         self, size: urwid_Size, event: str, button: int, col: int, row: int, focus: int
@@ -401,7 +401,7 @@ class EmojiButton(TopButton):
             if is_reaction_added
             else (self.reaction_count - 1)
         )
-        self.update_widget((None, self.get_update_widget_text(is_reaction_added)), None)
+        self.update_check_mark(is_reaction_added)
 
 
 class DecodedStream(TypedDict):


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->
This PR creates TopButton attributes `prefix_markup`,
`label_markup` and `suffix_markup` with Type `urwidMarkupTuple`.
All of the other attributes can be written in terms of these
which simplifies the logic in various methods ad reads better.
<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->
This PR formed after splitting of the last commit of #1064 and is a follow-up to it.
<!-- Add a link to a discussion on chat.zulip.org, if relevant -->

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [x] New tests added (for any new behavior)
- [x] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

<!-- See https://github.com/zulip/zulip-terminal#commit-style -->
**Commit flow** <!-- if more than one commit; add/delete/fill-in as appropriate -->
<!-- For example:
- first commit doing some thing
- maybe multiple commits doing similar things
-->
**Commit 1-3**: refactors TopButton attributes.
**Commit 4**: button: Add muted style to stream prefix. 

**Notes & Questions** <!-- if any; add/delete/fill-in as appropriate -->
<!-- For example:
- this doesn't include feature X (yet?)
- unsure about Y
- should this do Z?
-->
The old attributes are kept and deleted in the following commits to keep the diffs cleaner and have separate commits.
I haven't handled the count Exception that happens because of `self.count`. I realize I shouldn't have removed it.

**Visual changes** <!-- if any; add/delete/fill-in with screenshot/diagram as appropriate -->
![image](https://user-images.githubusercontent.com/64144419/126071952-3cff2b38-b2c0-476d-bcc3-b61688841786.png)
![image](https://user-images.githubusercontent.com/64144419/126072018-5894981b-0f74-4ec4-b46a-2d7130f976b0.png)
