### PR TITLE
tests: server_url: Add type annotations.

### DIFF
--- a/tests/server_url/test_server_url.py
+++ b/tests/server_url/test_server_url.py
@@ -1,5 +1,6 @@
 import pytest
 
+from zulipterminal.api_types import Message
 from zulipterminal.server_url import encode_stream, near_message_url
 
 
@@ -15,7 +16,9 @@ from zulipterminal.server_url import encode_stream, near_message_url
         (374, "/ in a stream name ?", "374-.2F-in-a-stream-name-.3F"),
     ],
 )
-def test_encode_stream(stream_id, stream_name, expected_encoded_string):
+def test_encode_stream(
+    stream_id: int, stream_name: str, expected_encoded_string: str
+) -> None:
     encoded_string = encode_stream(stream_id=stream_id, stream_name=stream_name)
 
     assert encoded_string == expected_encoded_string
@@ -73,7 +76,9 @@ def test_encode_stream(stream_id, stream_name, expected_encoded_string):
         ),
     ],
 )
-def test_near_message_url(server_url, msg, expected_message_url):
+def test_near_message_url(
+    server_url: str, msg: Message, expected_message_url: str
+) -> None:
     message_url = near_message_url(server_url=server_url, message=msg)
 
     assert message_url == expected_message_url

--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -78,7 +78,8 @@ repo_python_files['tests'] = []
 
 # Added incrementally as newer test files are type-annotated.
 type_consistent_testfiles = [
-    "test_run.py", "test_core.py", "test_emoji_data.py", "test_helper.py"
+    "test_run.py", "test_core.py", "test_emoji_data.py", "test_helper.py",
+    "test_server_url.py"
 ]
 
 for file_path in python_files:


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->
Adds type annotations to `test_server_url.py` and includes it under files to be checked by mypy in the `run-mypy` tool.
<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->

<!-- Add a link to a discussion on chat.zulip.org, if relevant -->

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [x] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

<!-- See https://github.com/zulip/zulip-terminal#commit-style -->
**Commit flow** <!-- if more than one commit; add/delete/fill-in as appropriate -->
<!-- For example:
- first commit doing some thing
- maybe multiple commits doing similar things
-->
- refactor: tests: server_url: Add type annotations.
This commit adds parameter and return type annotations or hints
to the `test_server_url.py` file, that contains tests for its
counterpart `server_url.py` from  the `zulipterminal` module, to
make mypy checks consistent and improve code readability.
- tools: Include test_server_url.py to be checked by mypy.
This commit adds `test_server_url.py` to the
`type_consistent_testfiles` list to check for type consistency
with mypy.
