### PR TITLE
bugfix: views: Ensure EditModeView works with new frame-based popup.

### DIFF
--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -4,6 +4,7 @@ import pytest
 from urwid import Columns, Pile, Text
 
 from zulipterminal.config.keys import is_command_key, keys_for_command
+from zulipterminal.config.ui_mappings import EDIT_MODE_CAPTIONS
 from zulipterminal.ui_tools.boxes import MessageBox
 from zulipterminal.ui_tools.views import (
     AboutView,
@@ -555,13 +556,18 @@ class TestEditHistoryView:
 
 
 class TestEditModeView:
-    @pytest.fixture()
-    def edit_mode_view(self, mocker):
+    @pytest.fixture(params=EDIT_MODE_CAPTIONS.keys())
+    def edit_mode_view(self, mocker, request):
+        button_launch_mode = request.param
+        button = mocker.Mock(mode=button_launch_mode)
+
         controller = mocker.Mock()
         controller.maximum_popup_dimensions.return_value = (64, 64)
-        mocker.patch(LISTWALKER, return_value=[])
-        button = mocker.Mock()
+
         return EditModeView(controller, button)
+
+    def test_init(self, edit_mode_view):
+        pass  # Just test init succeeds
 
     @pytest.mark.parametrize(
         "index_in_widgets, mode",
@@ -575,12 +581,15 @@ class TestEditModeView:
     def test_select_edit_mode(
         self, mocker, edit_mode_view, widget_size, index_in_widgets, mode, key
     ):
+        mode_button = edit_mode_view.edit_mode_button
+        if mode_button.mode == mode:
+            pytest.skip("button already selected")
+
         radio_button = edit_mode_view.widgets[index_in_widgets]
         size = widget_size(radio_button)
 
         radio_button.keypress(size, key)
 
-        mode_button = edit_mode_view.edit_mode_button
         mode_button.set_selected_mode.assert_called_once_with(mode)
 
 

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1548,7 +1548,7 @@ class EditModeView(PopUpView):
         # Set cursor to marked checkbox.
         for i in range(len(self.widgets)):
             if self.widgets[i].state:
-                self.set_focus(i)
+                self.body.set_focus(i)
 
     def set_selected_mode(self, button: Any, new_state: bool, mode: str) -> None:
         if new_state:


### PR DESCRIPTION
**What does this PR do?**  <!-- Overall description goes here -->

This bug was introduced by the first commit of #874 which was just cherry-picked, and hidden since the button
used in the EditModeView tests did not have any state to trigger the code in question.

Tests extended.

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [X] Manually
- [X] Existing tests (adapted, if necessary)
- [X] New tests added (for any new behavior)
- [X] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->