### PR TITLE
tests: ui: Add type annotations. 

### DIFF
--- a/tests/ui/test_ui.py
+++ b/tests/ui/test_ui.py
@@ -361,17 +361,21 @@ class TestView:
             "foo@zulip.com": {"user_id": 1},
             "bar@gmail.com": {"user_id": 2},
         }
+        mocked_stream_box_view = mocker.patch.object(view.write_box, "stream_box_view")
+        mocked_private_box_view = mocker.patch.object(
+            view.write_box, "private_box_view"
+        )
 
         size = widget_size(view)
         view.keypress(size, key)
 
         if draft:
             if draft["type"] == "stream":
-                view.write_box.stream_box_view.assert_called_once_with(
+                mocked_stream_box_view.assert_called_once_with(
                     caption=draft["to"], title=draft["subject"], stream_id=10
                 )
             else:
-                view.write_box.private_box_view.assert_called_once_with(
+                mocked_private_box_view.assert_called_once_with(
                     emails=draft["to"], recipient_user_ids=[1, 2]
                 )
 

--- a/tests/ui/test_ui.py
+++ b/tests/ui/test_ui.py
@@ -266,21 +266,21 @@ class TestView:
 
     @pytest.mark.parametrize("key", keys_for_command("STREAM_MESSAGE"))
     def test_keypress_STREAM_MESSAGE(self, view, mocker, key, widget_size):
-        view.middle_column = mocker.Mock()
+        mocked_middle_column = mocker.patch.object(view, "middle_column", create=True)
         view.body = mocker.Mock()
         view.controller.is_in_editor_mode = lambda: False
         size = widget_size(view)
 
         returned_key = view.keypress(size, key)
 
-        view.middle_column.keypress.assert_called_once_with(size, key)
+        mocked_middle_column.keypress.assert_called_once_with(size, key)
         assert returned_key == key
         assert view.body.focus_col == 1
 
     @pytest.mark.parametrize("key", keys_for_command("SEARCH_PEOPLE"))
     @pytest.mark.parametrize("autohide", [True, False], ids=["autohide", "no_autohide"])
     def test_keypress_autohide_users(self, view, mocker, autohide, key, widget_size):
-        view.users_view = mocker.Mock()
+        mocked_users_view = mocker.patch.object(view, "users_view", create=True)
         view.body = mocker.Mock()
         view.controller.autohide = autohide
         view.body.contents = ["streams", "messages", mocker.Mock()]
@@ -289,14 +289,13 @@ class TestView:
         view.right_panel = mocker.Mock()
         size = widget_size(view)
 
-        super_view = mocker.patch(MODULE + ".urwid.WidgetWrap.keypress")
         view.controller.is_in_editor_mode = lambda: False
 
         view.body.focus_position = None
 
         view.keypress(size, key)
 
-        view.users_view.keypress.assert_called_once_with(size, key)
+        mocked_users_view.keypress.assert_called_once_with(size, key)
         assert view.body.focus_position == 2
         view.controller.enter_editor_mode_with.assert_called_once_with(view.user_search)
 

--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -79,7 +79,7 @@ repo_python_files['tests'] = []
 # Added incrementally as newer test files are type-annotated.
 type_consistent_testfiles = [
     "test_run.py", "test_core.py", "test_emoji_data.py", "test_helper.py",
-    "test_server_url.py"
+    "test_server_url.py", "test_ui.py"
 ]
 
 for file_path in python_files:


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->
Adds type annotations to `test_ui.py` and includes it under files to be checked by mypy in the run-mypy tool. Also added a couple of prior commits to use appropriate patches.
<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->

<!-- Add a link to a discussion on chat.zulip.org, if relevant -->

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [x] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

<!-- See https://github.com/zulip/zulip-terminal#commit-style -->
**Commit flow** <!-- if more than one commit; add/delete/fill-in as appropriate -->
<!-- For example:
- first commit doing some thing
- maybe multiple commits doing similar things
-->
- refactor: ui: Patch *_box_views in OPEN_DRAFT tests.
This commit assigns patches `stream_box_view` and `private_box_view`
using `mocker.patch.object` to maintain type consistency since their
mocked nature's assert methods are being called.

- refactor: ui: Use patch for non-existent attributes instead of Mock.
This commit uses `mocker.patch` with the `create` parameter set as
True for attributes of the `View` fixture instance that don't exist
without their corresponding generation methods being called. `View`'s
`middle_column` is generated by the `middle_column_view()` method
and `users_view` is generated by the `right_column_view()` method.

- refactor: tests: ui: Add type annotations.
This commit adds parameter and return type annotations or hints to the
`test_ui.py` file, that contains tests for its counterpart `ui.py`
from the `zulipterminal` module, to make mypy checks consistent and
improve code readability.

- tools: Include test_ui.py to be checked by mypy.
This commit adds `test_ui.py` to the `type_consistent_testfiles`
list to check for type consistency with mypy.