### PR TITLE
Blacken/lint rest of tools/

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install with linting tools
         run: pip install .[linting]
       - name: Run flake8
-        run: flake8
+        run: flake8 zulipterminal/ tests/ setup.py `tools/python_tools.py`
 
   isort:
     runs-on: ubuntu-latest
@@ -54,7 +54,7 @@ jobs:
       - name: Install with linting tools
         run: pip install .[linting]
       - name: Check code & tests meet black standards
-        run: black --check zulipterminal/ tests/ setup.py tools/
+        run: black --check zulipterminal/ tests/ setup.py `tools/python_tools.py`
 
   pytest:
     strategy:

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ ignore=
   Q000,
 inline-quotes = "
 multiline-quotes = """
-exclude=.git,__pycache__,build,dist,tools
+exclude=.git,__pycache__,build,dist,zt_venv
 
 [mypy]
 python_version = 3.6

--- a/tools/convert-unicode-emoji-data
+++ b/tools/convert-unicode-emoji-data
@@ -26,8 +26,8 @@ emoji_dict = EMOJI_NAME_MAPS
 
 emoji_map = {}
 for emoji_code, emoji_names in emoji_dict.items():
-    emoji_map[emoji_names['canonical_name']] = emoji_code
-    for emoji in emoji_names['aliases']:
+    emoji_map[emoji_names["canonical_name"]] = emoji_code
+    for emoji in emoji_names["aliases"]:
         emoji_map[emoji] = emoji_code
 
 ordered_emojis = OrderedDict(sorted(emoji_map.items()))

--- a/tools/fetch-unicode-emoji-data
+++ b/tools/fetch-unicode-emoji-data
@@ -5,10 +5,13 @@ import requests
 OUTPUT_FILE = "zulipterminal/unicode_emoji_dict.py"
 
 # download emojis dictionary
-URL = "https://raw.githubusercontent.com/zulip/zulip/master/tools/setup/emoji/emoji_names.py"
+URL = (
+    "https://raw.githubusercontent.com/zulip/zulip/master/"
+    "tools/setup/emoji/emoji_names.py"
+)
 r = requests.get(URL)
 
-with open(OUTPUT_FILE, 'w') as f:
+with open(OUTPUT_FILE, "w") as f:
     f.write(r.text)
 print("Emoji dictionary saved in {}".format(OUTPUT_FILE))
 print("Run tools/convert-unicode-emoji-data to convert dictionary to a list")

--- a/tools/font-styles-test
+++ b/tools/font-styles-test
@@ -4,18 +4,18 @@ import urwid
 
 
 def exit_on_q(key):
-    if key in ('q', 'Q'):
+    if key in ("q", "Q"):
         raise urwid.ExitMainLoop()
 
+
 palette = [
-    ('normal         ', 'white', 'black'),
-    ('bold_only      ', 'white, bold', 'black'),
-    ('italic_only    ', 'white, italics', 'black'),
-    ('bold_and_italic', 'white, bold, italics', 'black'),
+    ("normal         ", "white", "black"),
+    ("bold_only      ", "white, bold", "black"),
+    ("italic_only    ", "white, italics", "black"),
+    ("bold_and_italic", "white, bold, italics", "black"),
 ]
 
-text = 'Hello world'
-pile = urwid.Pile([urwid.Text([st[0] + u' : ', (st[0], text)])
-                   for st in palette])
+text = "Hello world"
+pile = urwid.Pile([urwid.Text([st[0] + " : ", (st[0], text)]) for st in palette])
 loop = urwid.MainLoop(urwid.Filler(pile), palette, unhandled_input=exit_on_q)
 loop.run()

--- a/tools/gitlint-extra-rules.py
+++ b/tools/gitlint-extra-rules.py
@@ -1,6 +1,5 @@
 from typing import Any, List, Optional
 
-import gitlint
 from gitlint.options import ListOption
 from gitlint.rules import CommitRule, RuleViolation
 

--- a/tools/lint-all
+++ b/tools/lint-all
@@ -4,11 +4,18 @@ import subprocess
 import sys
 
 
+python_sources = [
+    "zulipterminal/",
+    "tests/",
+    "setup.py",
+    "tools/",
+]
+
 tools = {
     'Import order (isort)': './tools/run-isort-check',
     'Type consistency (mypy)': './tools/run-mypy',
-    'PEP8 & more (flake8)': 'flake8 zulipterminal/ tests/ setup.py'.split(),
-    'Formatting (black)': 'black --check zulipterminal/ tests/ setup.py tools/'.split(),
+    'PEP8 & more (flake8)': ['flake8'] + python_sources,
+    'Formatting (black)': ['black', '--check'] + python_sources,
 }
 
 for tool_name, command in tools.items():

--- a/tools/lint-all
+++ b/tools/lint-all
@@ -12,21 +12,21 @@ python_sources = [
 ]
 
 tools = {
-    'Import order (isort)': './tools/run-isort-check',
-    'Type consistency (mypy)': './tools/run-mypy',
-    'PEP8 & more (flake8)': ['flake8'] + python_sources,
-    'Formatting (black)': ['black', '--check'] + python_sources,
+    "Import order (isort)": "./tools/run-isort-check",
+    "Type consistency (mypy)": "./tools/run-mypy",
+    "PEP8 & more (flake8)": ["flake8"] + python_sources,
+    "Formatting (black)": ["black", "--check"] + python_sources,
 }
 
 for tool_name, command in tools.items():
-    print(80*"=")
+    print(80 * "=")
     print(tool_name)
-    print(80*"-")
+    print(80 * "-")
     result = subprocess.call(command)
     if result != 0:
-        print(80*"=")
+        print(80 * "=")
         print("LINTING FAILED")
         sys.exit(1)
 
-print(80*"=")
+print(80 * "=")
 print("LINTING SUCCESSFUL")

--- a/tools/lint-all
+++ b/tools/lint-all
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import glob
 import subprocess
 import sys
 
@@ -8,8 +9,21 @@ python_sources = [
     "zulipterminal/",
     "tests/",
     "setup.py",
-    "tools/",
 ]
+
+tools_exclusions = {
+    f"tools/{name}"
+    for name in {
+        "fetch-pull-request",
+        "fetch-rebase-pull-request",
+        "push-to-pull-request",
+        "release",
+        "__pycache__",
+    }
+}
+
+lintable_tools_files = set(glob.glob("tools/*")).difference(tools_exclusions)
+python_sources += lintable_tools_files
 
 tools = {
     "Import order (isort)": "./tools/run-isort-check",

--- a/tools/lint-all
+++ b/tools/lint-all
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 
-import glob
 import subprocess
 import sys
+
+from tools.python_tools import lintable_tools_files
 
 
 python_sources = [
@@ -11,18 +12,6 @@ python_sources = [
     "setup.py",
 ]
 
-tools_exclusions = {
-    f"tools/{name}"
-    for name in {
-        "fetch-pull-request",
-        "fetch-rebase-pull-request",
-        "push-to-pull-request",
-        "release",
-        "__pycache__",
-    }
-}
-
-lintable_tools_files = set(glob.glob("tools/*")).difference(tools_exclusions)
 python_sources += lintable_tools_files
 
 tools = {

--- a/tools/lister.py
+++ b/tools/lister.py
@@ -6,6 +6,7 @@ import re
 import subprocess
 import sys
 from collections import defaultdict
+from typing import Dict, List
 
 
 def get_ftype(fpath: str, use_shebang: bool) -> str:
@@ -180,5 +181,5 @@ if __name__ == "__main__":
         exclude=args.exclude,
         extless_only=args.extless_only,
     )
-    for l in listing:
-        print(l)
+    for entry in listing:
+        print(entry)

--- a/tools/python_tools.py
+++ b/tools/python_tools.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+
+import glob
+
+
+tools_exclusions = {
+    f"tools/{name}"
+    for name in {
+        "fetch-pull-request",
+        "fetch-rebase-pull-request",
+        "push-to-pull-request",
+        "release",
+        "__pycache__",
+    }
+}
+
+lintable_tools_files = set(glob.glob("tools/*")).difference(tools_exclusions)
+
+
+if __name__ == "__main__":
+    for f in lintable_tools_files:
+        print(f)

--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -17,25 +17,23 @@ os.chdir(os.path.dirname(TOOLS_DIR))
 
 sys.path.append(os.path.dirname(TOOLS_DIR))
 
-parser = argparse.ArgumentParser(description="Run mypy on files tracked"
-                                             " by git.")
+parser = argparse.ArgumentParser(description="Run mypy on files tracked by git.")
 
 parser.add_argument('targets', nargs='*', default=[],
-                    help="""files and directories to include in the result.
-                    If this is not specified, the current directory is used""")
+    help="""files and directories to include in the result.
+            If this is not specified, the current directory is used""")
 
 parser.add_argument('-m', '--modified', action='store_true', default=False,
                     help='list only modified files')
 
 parser.add_argument('-a', '--all', dest='all', action='store_true',
                     default=False, help="""run mypy on all python files,
-                    ignoring the exclude list. This is useful if you have to 
-                    find out which files fail mypy check.""")
+            ignoring the exclude list. This is useful if you have to
+            find out which files fail mypy check.""")
 
 parser.add_argument('--no-disallow-untyped-defs', dest='disallow_untyped_defs',
                     action='store_false', default=True,
-                    help="""Don't throw errors when functions are not
-                    annotated""")
+                    help="""Don't throw errors when functions are not annotated""")
 
 parser.add_argument('--scripts-only', dest='scripts_only',
                     action='store_true', default=False,
@@ -51,8 +49,8 @@ parser.add_argument('--warn-unused-ignores', dest='warn_unused_ignores',
 
 parser.add_argument('--no-ignore-missing-imports',
                     dest='ignore_missing_imports', action='store_false',
-                    default=True, help="""Don't use the
-                     --ignore-missing-imports flag with mypy""")
+                    default=True,
+                    help="""Don't use the --ignore-missing-imports flag with mypy""")
 
 parser.add_argument('--quick', action='store_true', default=False,
                     help="""Use the --quick flag with mypy""")

--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -19,56 +19,101 @@ sys.path.append(os.path.dirname(TOOLS_DIR))
 
 parser = argparse.ArgumentParser(description="Run mypy on files tracked by git.")
 
-parser.add_argument('targets', nargs='*', default=[],
+parser.add_argument(
+    'targets',
+    nargs='*',
+    default=[],
     help="""files and directories to include in the result.
-            If this is not specified, the current directory is used""")
+            If this is not specified, the current directory is used""",
+)
 
-parser.add_argument('-m', '--modified', action='store_true', default=False,
-                    help='list only modified files')
+parser.add_argument(
+    '-m',
+    '--modified',
+    action='store_true',
+    default=False,
+    help='list only modified files',
+)
 
-parser.add_argument('-a', '--all', dest='all', action='store_true',
-                    default=False, help="""run mypy on all python files,
+parser.add_argument(
+    '-a',
+    '--all',
+    dest='all',
+    action='store_true',
+    default=False,
+    help="""run mypy on all python files,
             ignoring the exclude list. This is useful if you have to
-            find out which files fail mypy check.""")
+            find out which files fail mypy check.""",
+)
 
-parser.add_argument('--no-disallow-untyped-defs', dest='disallow_untyped_defs',
-                    action='store_false', default=True,
-                    help="""Don't throw errors when functions are not annotated""")
+parser.add_argument(
+    '--no-disallow-untyped-defs',
+    dest='disallow_untyped_defs',
+    action='store_false',
+    default=True,
+    help="""Don't throw errors when functions are not annotated""",
+)
 
-parser.add_argument('--scripts-only', dest='scripts_only',
-                    action='store_true', default=False,
-                    help="""Only type check extensionless python scripts""")
+parser.add_argument(
+    '--scripts-only',
+    dest='scripts_only',
+    action='store_true',
+    default=False,
+    help="""Only type check extensionless python scripts""",
+)
 
-parser.add_argument('--no-strict-optional', dest='strict_optional',
-                    action='store_false', default=True,
-                    help="""Don't use the --strict-optional flag with mypy""")
+parser.add_argument(
+    '--no-strict-optional',
+    dest='strict_optional',
+    action='store_false',
+    default=True,
+    help="""Don't use the --strict-optional flag with mypy""",
+)
 
-parser.add_argument('--warn-unused-ignores', dest='warn_unused_ignores',
-                    action='store_true', default=False,
-                    help="""Use the --warn-unused-ignores flag with mypy""")
+parser.add_argument(
+    '--warn-unused-ignores',
+    dest='warn_unused_ignores',
+    action='store_true',
+    default=False,
+    help="""Use the --warn-unused-ignores flag with mypy""",
+)
 
-parser.add_argument('--no-ignore-missing-imports',
-                    dest='ignore_missing_imports', action='store_false',
-                    default=True,
-                    help="""Don't use the --ignore-missing-imports flag with mypy""")
+parser.add_argument(
+    '--no-ignore-missing-imports',
+    dest='ignore_missing_imports',
+    action='store_false',
+    default=True,
+    help="""Don't use the --ignore-missing-imports flag with mypy""",
+)
 
-parser.add_argument('--quick', action='store_true', default=False,
-                    help="""Use the --quick flag with mypy""")
+parser.add_argument(
+    '--quick',
+    action='store_true',
+    default=False,
+    help="""Use the --quick flag with mypy""",
+)
 
 args = parser.parse_args()
 
-files_dict = cast(Dict[str, List[str]],
-                  lister.list_files(targets=args.targets, ftypes=['py'],
-                                    use_shebang=True,
-                                    modified_only=args.modified,
-                                    group_by_ftype=True,
-                                    exclude=EXCLUDE_FILES,
-                                    ))
+files_dict = cast(
+    Dict[str, List[str]],
+    lister.list_files(
+        targets=args.targets,
+        ftypes=['py'],
+        use_shebang=True,
+        modified_only=args.modified,
+        group_by_ftype=True,
+        exclude=EXCLUDE_FILES,
+    ),
+)
 
 
 pyi_files = set(files_dict['pyi'])
-python_files = [fpath for fpath in files_dict['py']
-                if not fpath.endswith('.py') or fpath + 'i' not in pyi_files]
+python_files = [
+    fpath
+    for fpath in files_dict['py']
+    if not fpath.endswith('.py') or fpath + 'i' not in pyi_files
+]
 
 repo_python_files = {}
 repo_python_files['zulipterminal'] = []
@@ -76,26 +121,31 @@ repo_python_files['tests'] = []
 
 # Added incrementally as newer test files are type-annotated.
 type_consistent_testfiles = [
-    "test_run.py", "test_core.py", "test_emoji_data.py", "test_helper.py",
-    "test_server_url.py", "test_ui.py"
+    "test_run.py",
+    "test_core.py",
+    "test_emoji_data.py",
+    "test_helper.py",
+    "test_server_url.py",
+    "test_ui.py",
 ]
 
 for file_path in python_files:
     repo = PurePath(file_path).parts[0]
     filename = PurePath(file_path).parts[-1]
-    if (
-        repo == "zulipterminal" or
-        (repo == 'tests' and filename in type_consistent_testfiles)
+    if repo == "zulipterminal" or (
+        repo == 'tests' and filename in type_consistent_testfiles
     ):
         repo_python_files[repo].append(file_path)
 
 mypy_command = "mypy"
 
-extra_args = ["--check-untyped-defs",
-              "--follow-imports=silent",
-              "--scripts-are-modules",
-              "--disallow-any-generics",
-              "-i"]
+extra_args = [
+    "--check-untyped-defs",
+    "--follow-imports=silent",
+    "--scripts-are-modules",
+    "--disallow-any-generics",
+    "-i",
+]
 if args.disallow_untyped_defs:
     extra_args.append("--disallow-untyped-defs")
 if args.warn_unused_ignores:

--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -10,7 +10,7 @@ from typing import Dict, List, cast
 import lister
 
 
-EXCLUDE_FILES = ['tools/fetch-pull-request', 'tools/fetch-rebase-pull-request']
+EXCLUDE_FILES = ["tools/fetch-pull-request", "tools/fetch-rebase-pull-request"]
 
 TOOLS_DIR = os.path.dirname(os.path.abspath(__file__))
 os.chdir(os.path.dirname(TOOLS_DIR))
@@ -20,26 +20,26 @@ sys.path.append(os.path.dirname(TOOLS_DIR))
 parser = argparse.ArgumentParser(description="Run mypy on files tracked by git.")
 
 parser.add_argument(
-    'targets',
-    nargs='*',
+    "targets",
+    nargs="*",
     default=[],
     help="""files and directories to include in the result.
             If this is not specified, the current directory is used""",
 )
 
 parser.add_argument(
-    '-m',
-    '--modified',
-    action='store_true',
+    "-m",
+    "--modified",
+    action="store_true",
     default=False,
-    help='list only modified files',
+    help="list only modified files",
 )
 
 parser.add_argument(
-    '-a',
-    '--all',
-    dest='all',
-    action='store_true',
+    "-a",
+    "--all",
+    dest="all",
+    action="store_true",
     default=False,
     help="""run mypy on all python files,
             ignoring the exclude list. This is useful if you have to
@@ -47,48 +47,48 @@ parser.add_argument(
 )
 
 parser.add_argument(
-    '--no-disallow-untyped-defs',
-    dest='disallow_untyped_defs',
-    action='store_false',
+    "--no-disallow-untyped-defs",
+    dest="disallow_untyped_defs",
+    action="store_false",
     default=True,
     help="""Don't throw errors when functions are not annotated""",
 )
 
 parser.add_argument(
-    '--scripts-only',
-    dest='scripts_only',
-    action='store_true',
+    "--scripts-only",
+    dest="scripts_only",
+    action="store_true",
     default=False,
     help="""Only type check extensionless python scripts""",
 )
 
 parser.add_argument(
-    '--no-strict-optional',
-    dest='strict_optional',
-    action='store_false',
+    "--no-strict-optional",
+    dest="strict_optional",
+    action="store_false",
     default=True,
     help="""Don't use the --strict-optional flag with mypy""",
 )
 
 parser.add_argument(
-    '--warn-unused-ignores',
-    dest='warn_unused_ignores',
-    action='store_true',
+    "--warn-unused-ignores",
+    dest="warn_unused_ignores",
+    action="store_true",
     default=False,
     help="""Use the --warn-unused-ignores flag with mypy""",
 )
 
 parser.add_argument(
-    '--no-ignore-missing-imports',
-    dest='ignore_missing_imports',
-    action='store_false',
+    "--no-ignore-missing-imports",
+    dest="ignore_missing_imports",
+    action="store_false",
     default=True,
     help="""Don't use the --ignore-missing-imports flag with mypy""",
 )
 
 parser.add_argument(
-    '--quick',
-    action='store_true',
+    "--quick",
+    action="store_true",
     default=False,
     help="""Use the --quick flag with mypy""",
 )
@@ -99,7 +99,7 @@ files_dict = cast(
     Dict[str, List[str]],
     lister.list_files(
         targets=args.targets,
-        ftypes=['py'],
+        ftypes=["py"],
         use_shebang=True,
         modified_only=args.modified,
         group_by_ftype=True,
@@ -108,16 +108,16 @@ files_dict = cast(
 )
 
 
-pyi_files = set(files_dict['pyi'])
+pyi_files = set(files_dict["pyi"])
 python_files = [
     fpath
-    for fpath in files_dict['py']
-    if not fpath.endswith('.py') or fpath + 'i' not in pyi_files
+    for fpath in files_dict["py"]
+    if not fpath.endswith(".py") or fpath + "i" not in pyi_files
 ]
 
 repo_python_files = {}
-repo_python_files['zulipterminal'] = []
-repo_python_files['tests'] = []
+repo_python_files["zulipterminal"] = []
+repo_python_files["tests"] = []
 
 # Added incrementally as newer test files are type-annotated.
 type_consistent_testfiles = [
@@ -133,7 +133,7 @@ for file_path in python_files:
     repo = PurePath(file_path).parts[0]
     filename = PurePath(file_path).parts[-1]
     if repo == "zulipterminal" or (
-        repo == 'tests' and filename in type_consistent_testfiles
+        repo == "tests" and filename in type_consistent_testfiles
     ):
         repo_python_files[repo].append(file_path)
 


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->

This is a follow-up to #1087, which did not fully achieve its aim since python scripts without a `.py` ending were not identified.

Other scripts are now updated to be covered, with an additional script providing a list of tools in python, given certain known exclusions. This script is used as a module in `tools/lint-all`, and separately in CI to explicitly include those files.

A broader approach is likely possible with zulint or using lister.py in future, but having these files covered and tested, and not accidentally losing compliance is the intent here.

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [X] Manually
- [X] Existing tests (adapted, if necessary)
- [X] New tests added (for any new behavior)
- [X] Passed linting & tests (each commit) **within limited local test ability right now**
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->