### PR TITLE
buttons: Ensure muted button text color is adjusted when selected.

### DIFF
--- a/tests/ui_tools/test_buttons.py
+++ b/tests/ui_tools/test_buttons.py
@@ -111,12 +111,14 @@ class TestTopButton:
         top_button.button_prefix = mocker.patch(MODULE + ".urwid.Text")
         top_button.set_label = mocker.patch(MODULE + ".urwid.Button.set_label")
         top_button.button_suffix = mocker.patch(MODULE + ".urwid.Text")
+        set_attr_map = mocker.patch.object(top_button._w, "set_attr_map")
 
         top_button.update_widget(count_text, text_color)
 
         top_button.button_prefix.set_text.assert_called_once_with(expected_prefix)
-        top_button.set_label.assert_called_once_with((text_color, top_button._caption))
+        top_button.set_label.assert_called_once_with(top_button._caption)
         top_button.button_suffix.set_text.assert_called_once_with(expected_suffix)
+        set_attr_map.assert_called_once_with({None: text_color})
 
 
 class TestStarredButton:

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -81,8 +81,9 @@ class TopButton(urwid.Button):
         else:
             suffix = ["  "]
         self.button_prefix.set_text(prefix)
-        self.set_label((text_color, self._caption))
+        self.set_label(self._caption)
         self.button_suffix.set_text(suffix)
+        self._w.set_attr_map({None: text_color})
 
     def activate(self, key: Any) -> None:
         self.controller.view.show_left_panel(visible=False)


### PR DESCRIPTION
**What does this PR do?**  <!-- Overall description goes here -->

This fixes a minor regression in selection of buttons with colored text after the refactoring to use more internal button features.

Without this fix then muted streambuttons and userbuttons don't appear as strongly selected when the cursor is on them, as the main text does not highlight.

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [X] Manually
- [X] Existing tests (adapted, if necessary)
- [X] New tests added (for any new behavior)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

@Rohitth007 I'd welcome your feedback here - this seems like an appropriate minimal solution?