### PR TITLE
tests: conftest: Add type annotations.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import pytest
 
 from zulipterminal.api_types import Message
 from zulipterminal.config.keys import keys_for_command, primary_key_for_command
+from zulipterminal.helper import Index
 from zulipterminal.helper import initial_index as helper_initial_index
 from zulipterminal.ui_tools.boxes import MessageBox
 from zulipterminal.ui_tools.buttons import StreamButton, TopicButton, UserButton
@@ -741,34 +742,34 @@ def initial_index():
 @pytest.fixture
 def empty_index(
     stream_msg_template: Message, pm_template: Message, group_pm_template: Message
-):
+) -> Index:
     return deepcopy(
-        {
-            "pointer": defaultdict(set, {}),
-            "all_msg_ids": set(),
-            "starred_msg_ids": set(),
-            "mentioned_msg_ids": set(),
-            "private_msg_ids": set(),
-            "private_msg_ids_by_user_ids": defaultdict(set, {}),
-            "stream_msg_ids_by_stream_id": defaultdict(set, {}),
-            "topic_msg_ids": defaultdict(dict, {}),
-            "edited_messages": set(),
-            "topics": defaultdict(list),
-            "search": set(),
-            "messages": defaultdict(
-                dict,
+        Index(
+            pointer=defaultdict(set, {}),
+            all_msg_ids=set(),
+            starred_msg_ids=set(),
+            mentioned_msg_ids=set(),
+            private_msg_ids=set(),
+            private_msg_ids_by_user_ids=defaultdict(set, {}),
+            stream_msg_ids_by_stream_id=defaultdict(set, {}),
+            topic_msg_ids=defaultdict(dict, {}),
+            edited_messages=set(),
+            topics=defaultdict(list),
+            search=set(),
+            messages=defaultdict(
+                lambda: {},
                 {
                     stream_msg_template["id"]: stream_msg_template,
                     pm_template["id"]: pm_template,
                     group_pm_template["id"]: group_pm_template,
                 },
             ),
-        }
+        )
     )
 
 
 @pytest.fixture
-def index_all_messages(empty_index):
+def index_all_messages(empty_index: Index):
     """
     Expected index of `initial_data` fixture when model.narrow = []
     """
@@ -776,7 +777,7 @@ def index_all_messages(empty_index):
 
 
 @pytest.fixture
-def index_stream(empty_index):
+def index_stream(empty_index: Index):
     """
     Expected index of initial_data when model.narrow = [['stream', '7']]
     """
@@ -788,7 +789,7 @@ def index_stream(empty_index):
 
 
 @pytest.fixture
-def index_topic(empty_index):
+def index_topic(empty_index: Index):
     """
     Expected index of initial_data when model.narrow = [['stream', '7'],
                                                         ['topic', 'Test']]
@@ -798,7 +799,7 @@ def index_topic(empty_index):
 
 
 @pytest.fixture
-def index_multiple_topic_msg(empty_index, extra_stream_msg_template: Message):
+def index_multiple_topic_msg(empty_index: Index, extra_stream_msg_template: Message):
     """
     Index of initial_data with multiple message when model.narrow = [['stream, '7'],
                                                                      ['topic', 'Test']]
@@ -812,7 +813,7 @@ def index_multiple_topic_msg(empty_index, extra_stream_msg_template: Message):
 
 
 @pytest.fixture
-def index_user(empty_index):
+def index_user(empty_index: Index):
     """
     Expected index of initial_data when model.narrow = [['pm_with',
                                                          'boo@zulip.com'],
@@ -826,7 +827,7 @@ def index_user(empty_index):
 
 
 @pytest.fixture
-def index_user_multiple(empty_index):
+def index_user_multiple(empty_index: Index):
     """
     Expected index of initial_data when model.narrow = [['pm_with',
                                             'boo@zulip.com, bar@zulip.com'],
@@ -850,7 +851,7 @@ def index_user_multiple(empty_index):
         {537287, 537288},
     ]
 )
-def index_all_starred(empty_index, request):
+def index_all_starred(empty_index: Index, request):
     msgs_with_stars = request.param
     index = dict(
         empty_index, starred_msg_ids=msgs_with_stars, private_msg_ids={537287, 537288}
@@ -862,7 +863,7 @@ def index_all_starred(empty_index, request):
 
 
 @pytest.fixture()
-def index_all_mentions(empty_index, mentioned_messages_combination):
+def index_all_mentions(empty_index: Index, mentioned_messages_combination):
     mentioned_messages, wildcard_mentioned_messages = mentioned_messages_combination
     index = dict(
         empty_index,
@@ -881,7 +882,7 @@ def index_all_mentions(empty_index, mentioned_messages_combination):
 
 
 @pytest.fixture()
-def index_search_messages(empty_index):
+def index_search_messages(empty_index: Index):
     """Expected initial index when search contains the message_id 500."""
     return dict(empty_index, **{"search": {500}})
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1213,6 +1213,6 @@ def widget_size():
         elif widget_type == "flow":
             return (20,)
         else:
-            None
+            return ()
 
     return _widget_size

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -769,37 +769,41 @@ def empty_index(
 
 
 @pytest.fixture
-def index_all_messages(empty_index: Index):
+def index_all_messages(empty_index: Index) -> Index:
     """
     Expected index of `initial_data` fixture when model.narrow = []
     """
-    return dict(empty_index, **{"all_msg_ids": {537286, 537287, 537288}})
+    index = empty_index
+    index["all_msg_ids"] = {537286, 537287, 537288}
+    return index
 
 
 @pytest.fixture
-def index_stream(empty_index: Index):
+def index_stream(empty_index: Index) -> Index:
     """
     Expected index of initial_data when model.narrow = [['stream', '7']]
     """
-    diff = {
-        "stream_msg_ids_by_stream_id": defaultdict(set, {205: {537286}}),
-        "private_msg_ids": {537287, 537288},
-    }
-    return dict(empty_index, **diff)
+    index = empty_index
+    index["stream_msg_ids_by_stream_id"] = defaultdict(set, {205: {537286}})
+    index["private_msg_ids"] = {537287, 537288}
+    return index
 
 
 @pytest.fixture
-def index_topic(empty_index: Index):
+def index_topic(empty_index: Index) -> Index:
     """
     Expected index of initial_data when model.narrow = [['stream', '7'],
                                                         ['topic', 'Test']]
     """
-    diff = {"topic_msg_ids": defaultdict(dict, {205: {"Test": {537286}}})}
-    return dict(empty_index, **diff)
+    index = empty_index
+    index["topic_msg_ids"] = defaultdict(dict, {205: {"Test": {537286}}})
+    return index
 
 
 @pytest.fixture
-def index_multiple_topic_msg(empty_index: Index, extra_stream_msg_template: Message):
+def index_multiple_topic_msg(
+    empty_index: Index, extra_stream_msg_template: Message
+) -> Index:
     """
     Index of initial_data with multiple message when model.narrow = [['stream, '7'],
                                                                      ['topic', 'Test']]
@@ -808,36 +812,36 @@ def index_multiple_topic_msg(empty_index: Index, extra_stream_msg_template: Mess
     empty_index_with_multiple_topic_msg["messages"].update(
         {extra_stream_msg_template["id"]: extra_stream_msg_template}
     )
-    diff = {"topic_msg_ids": defaultdict(dict, {205: {"Test": {537286, 537289}}})}
-    return dict(empty_index_with_multiple_topic_msg, **diff)
+    empty_index_with_multiple_topic_msg["topic_msg_ids"] = defaultdict(
+        dict, {205: {"Test": {537286, 537289}}}
+    )
+    return empty_index_with_multiple_topic_msg
 
 
 @pytest.fixture
-def index_user(empty_index: Index):
+def index_user(empty_index: Index) -> Index:
     """
     Expected index of initial_data when model.narrow = [['pm_with',
                                                          'boo@zulip.com'],
     """
     user_ids = frozenset({5179, 5140})
-    diff = {
-        "private_msg_ids_by_user_ids": defaultdict(set, {user_ids: {537287}}),
-        "private_msg_ids": {537287, 537288},
-    }
-    return dict(empty_index, **diff)
+    index = empty_index
+    index["private_msg_ids_by_user_ids"] = defaultdict(set, {user_ids: {537287}})
+    index["private_msg_ids"] = {537287, 537288}
+    return index
 
 
 @pytest.fixture
-def index_user_multiple(empty_index: Index):
+def index_user_multiple(empty_index: Index) -> Index:
     """
     Expected index of initial_data when model.narrow = [['pm_with',
                                             'boo@zulip.com, bar@zulip.com'],
     """
     user_ids = frozenset({5179, 5140, 5180})
-    diff = {
-        "private_msg_ids_by_user_ids": defaultdict(set, {user_ids: {537288}}),
-        "private_msg_ids": {537287, 537288},
-    }
-    return dict(empty_index, **diff)
+    index = empty_index
+    index["private_msg_ids_by_user_ids"] = defaultdict(set, {user_ids: {537288}})
+    index["private_msg_ids"] = {537287, 537288}
+    return index
 
 
 @pytest.fixture(
@@ -851,11 +855,11 @@ def index_user_multiple(empty_index: Index):
         {537287, 537288},
     ]
 )
-def index_all_starred(empty_index: Index, request):
+def index_all_starred(empty_index: Index, request) -> Index:
     msgs_with_stars = request.param
-    index = dict(
-        empty_index, starred_msg_ids=msgs_with_stars, private_msg_ids={537287, 537288}
-    )
+    index = empty_index
+    index["starred_msg_ids"] = msgs_with_stars
+    index["private_msg_ids"] = {537287, 537288}
     for msg_id, msg in index["messages"].items():
         if msg_id in msgs_with_stars and "starred" not in msg["flags"]:
             msg["flags"].append("starred")
@@ -863,13 +867,11 @@ def index_all_starred(empty_index: Index, request):
 
 
 @pytest.fixture()
-def index_all_mentions(empty_index: Index, mentioned_messages_combination):
+def index_all_mentions(empty_index: Index, mentioned_messages_combination) -> Index:
     mentioned_messages, wildcard_mentioned_messages = mentioned_messages_combination
-    index = dict(
-        empty_index,
-        mentioned_msg_ids=(mentioned_messages | wildcard_mentioned_messages),
-        private_msg_ids={537287, 537288},
-    )
+    index = empty_index
+    index["mentioned_msg_ids"] = mentioned_messages | wildcard_mentioned_messages
+    index["private_msg_ids"] = {537287, 537288}
     for msg_id, msg in index["messages"].items():
         if msg_id in mentioned_messages and "mentioned" not in msg["flags"]:
             msg["flags"].append("mentioned")
@@ -882,9 +884,11 @@ def index_all_mentions(empty_index: Index, mentioned_messages_combination):
 
 
 @pytest.fixture()
-def index_search_messages(empty_index: Index):
+def index_search_messages(empty_index: Index) -> Index:
     """Expected initial index when search contains the message_id 500."""
-    return dict(empty_index, **{"search": {500}})
+    index = empty_index
+    index["search"] = {500}
+    return index
 
 
 @pytest.fixture

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -1118,7 +1118,7 @@ class TestModel:
             ({"timezone": "Asia/Kolkata"}, "timezone", "Asia/Kolkata"),
             ({}, "timezone", ""),
             ({"bot_type": 1}, "bot_type", 1),
-            ({}, "bot_type", 0),
+            ({}, "bot_type", None),
             ({"role": 100}, "role", 100),
             ({"role": 200}, "role", 200),
             ({"role": 300}, "role", 300),

--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -133,6 +133,7 @@ type_consistent_testfiles = [
     "test_platform_code.py",
     "test_buttons.py",
     "test_utils.py",
+    "conftest.py",
 ]
 
 for file_path in python_files:

--- a/zulipterminal/api_types.py
+++ b/zulipterminal/api_types.py
@@ -112,7 +112,7 @@ class RealmUser(TypedDict):
 
     is_bot: bool
     # These are only meaningfully (or literally) present for bots (ie. is_bot==True)
-    bot_type: int
+    bot_type: Optional[int]
     bot_owner_id: int  # NOTE: new in Zulip 3.0 (ZFL 1) - None for old bots
     bot_owner: str  # (before ZFL 1; containing email field of owner instead)
 

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -60,7 +60,7 @@ class TidiedUserInfo(TypedDict):
 
     is_bot: bool
     # Below fields are only meaningful if is_bot == True
-    bot_type: int
+    bot_type: Optional[int]
     bot_owner_name: str
 
 

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -765,7 +765,7 @@ class Model:
             is_bot=api_user_data.get("is_bot", False),
             # Role `None` for triggering servers < Zulip 4.1 (ZFL 59)
             role=api_user_data.get("role", None),
-            bot_type=api_user_data.get("bot_type", 0),
+            bot_type=api_user_data.get("bot_type", None),
             bot_owner_name="",  # Can be non-empty only if is_bot == True
             last_active="",
         )

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1196,6 +1196,7 @@ class UserInfoView(PopUpView):
             display_data["Local time"] = local_time[11:]
 
         if data["is_bot"]:
+            assert data["bot_type"] is not None
             display_data["Role"] = BOT_TYPE_BY_ID.get(
                 data["bot_type"], "Unknown Bot Type"
             )


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->
Adds type annotations to `conftest.py` and some relevant prior refactors. Also includes `conftest.py` under the list in `run-mypy`.
<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->

<!-- Add a link to a discussion on chat.zulip.org, if relevant -->

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [x] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

<!-- See https://github.com/zulip/zulip-terminal#commit-style -->
**Commit flow** <!-- if more than one commit; add/delete/fill-in as appropriate -->
<!-- For example:
- first commit doing some thing
- maybe multiple commits doing similar things
-->
- refactor: tests: conftest: Return a Message from template factory. 
This commit changes the returned object of the `msg_template_factory`
from a `Dict` to a `Message` instance, which is the appropriate type
for a message template.

- refactor: tests: conftest: Return Index instance from empty_index.
This commit returns an Index instance for the `empty_index` fixture
which previously returned a deepcopy of a Dict, as Index is the
`empty_index`'s appropriate type.

- refactor: test: conftest: Return Index instances for index_* fixtures. 
This commit returns Index instances instead of `dict`s from all the
various index fixtures present, since the appropriate type for these
fixtures is Index.

- api_types/helper/model/server_url: Replace stream_id type in Message.
This commit replaces the Message class' stream_id attribute's type
from int to Optional[int], since this attribute only has an integer
value when the message is a stream message and None when it is a
private message.

- bugfix: tests: conftest: Return empty tuple when widget isn't box/flow.
This commit fixes the `else` case of the `_widget_size` method of
the `widget_size` fixture method. Previously, the `else case did not
return anything, which has been modified to appropriately return an
empty tuple now.

- refactor: tests: conftest: Add type annotations.
This commit adds parameter and return type annotations or hints to
the `conftest.py` file, that contains custom pytest fixtures meant to
be used in the tests to make mypy checks consistent and improve code
readability.

- tools: Include conftest.py to be checked by mypy. 
This commit adds `conftest.py` to the `type_consistent_testfiles`
list to check for type consistency with mypy.

**Notes & Questions** <!-- if any; add/delete/fill-in as appropriate -->
<!-- For example:
- this doesn't include feature X (yet?)
- unsure about Y
- should this do Z?
-->
The `request` pytest fixture has no exported type, so I've typed it as `Any` for now. The only way to type it currently would be a private import otherwise.
