### PR TITLE
tests: config: Add type annotations.

### DIFF
--- a/tests/config/test_color.py
+++ b/tests/config/test_color.py
@@ -3,7 +3,7 @@ from enum import Enum
 from zulipterminal.config.color import color_properties
 
 
-def test_color_properties():
+def test_color_properties() -> None:
     class Color(Enum):
         WHITE = "wh  #256  #24"
 

--- a/tests/config/test_color.py
+++ b/tests/config/test_color.py
@@ -7,9 +7,9 @@ def test_color_properties():
     class Color(Enum):
         WHITE = "wh  #256  #24"
 
-    Color = color_properties(Color, "BOLD", "ITALICS")
+    ExpandedColor = color_properties(Color, "BOLD", "ITALICS")
 
-    assert Color.WHITE in Color
-    assert Color.WHITE.value == "wh  #256  #24"
-    assert Color.WHITE__BOLD_ITALICS in Color
-    assert Color.WHITE__BOLD_ITALICS.value == "wh  #256  #24 , bold , italics"
+    assert ExpandedColor.WHITE in ExpandedColor
+    assert ExpandedColor.WHITE.value == "wh  #256  #24"
+    assert ExpandedColor.WHITE__BOLD_ITALICS in ExpandedColor
+    assert ExpandedColor.WHITE__BOLD_ITALICS.value == "wh  #256  #24 , bold , italics"

--- a/tests/config/test_keys.py
+++ b/tests/config/test_keys.py
@@ -72,21 +72,21 @@ def test_HELP_is_not_allowed_as_tip():
 def test_commands_for_random_tips(mocker):
     new_key_bindings: Dict[str, keys.KeyBinding] = {
         "ALPHA": {
-            "keys": {"a"},
+            "keys": ["a"],
             "help_text": "alpha",
             "excluded_from_random_tips": True,
         },
         "BETA": {
-            "keys": {"b"},
+            "keys": ["b"],
             "help_text": "beta",
             "excluded_from_random_tips": False,
         },
         "GAMMA": {
-            "keys": {"g"},
+            "keys": ["g"],
             "help_text": "gamma",
         },
         "DELTA": {
-            "keys": {"d"},
+            "keys": ["d"],
             "help_text": "delta",
             "excluded_from_random_tips": True,
         },

--- a/tests/config/test_keys.py
+++ b/tests/config/test_keys.py
@@ -1,6 +1,7 @@
-from typing import Dict
+from typing import Any, Dict
 
 import pytest
+from pytest_mock import MockerFixture
 
 from zulipterminal.config import keys
 
@@ -11,33 +12,33 @@ USED_KEYS = {key for values in keys.KEY_BINDINGS.values() for key in values["key
 
 
 @pytest.fixture(params=keys.KEY_BINDINGS.keys())
-def valid_command(request):
+def valid_command(request: Any) -> str:
     return request.param
 
 
 @pytest.fixture(params=["BLAH*10"])
-def invalid_command(request):
+def invalid_command(request: Any) -> str:
     return request.param
 
 
-def test_keys_for_command(valid_command):
+def test_keys_for_command(valid_command: str) -> None:
     assert keys.KEY_BINDINGS[valid_command]["keys"] == keys.keys_for_command(
         valid_command
     )
 
 
-def test_primary_key_for_command(valid_command):
+def test_primary_key_for_command(valid_command: str) -> None:
     assert keys.KEY_BINDINGS[valid_command]["keys"][0] == keys.primary_key_for_command(
         valid_command
     )
 
 
-def test_keys_for_command_invalid_command(invalid_command):
+def test_keys_for_command_invalid_command(invalid_command: str) -> None:
     with pytest.raises(keys.InvalidCommand):
         keys.keys_for_command(invalid_command)
 
 
-def test_keys_for_command_identity(valid_command):
+def test_keys_for_command_identity(valid_command: str) -> None:
     """
     Ensures that each call to keys_for_command returns the original keys in a
     new list which validates that the original keys don't get altered
@@ -48,28 +49,28 @@ def test_keys_for_command_identity(valid_command):
     )
 
 
-def test_is_command_key_matching_keys(valid_command):
+def test_is_command_key_matching_keys(valid_command: str) -> None:
     for key in keys.keys_for_command(valid_command):
         assert keys.is_command_key(valid_command, key)
 
 
-def test_is_command_key_nonmatching_keys(valid_command):
+def test_is_command_key_nonmatching_keys(valid_command: str) -> None:
     keys_to_test = USED_KEYS - set(keys.keys_for_command(valid_command))
     for key in keys_to_test:
         assert not keys.is_command_key(valid_command, key)
 
 
-def test_is_command_key_invalid_command(invalid_command):
+def test_is_command_key_invalid_command(invalid_command: str) -> None:
     with pytest.raises(keys.InvalidCommand):
         keys.is_command_key(invalid_command, "esc")  # key doesn't matter
 
 
-def test_HELP_is_not_allowed_as_tip():
+def test_HELP_is_not_allowed_as_tip() -> None:
     assert keys.KEY_BINDINGS["HELP"]["excluded_from_random_tips"] is True
     assert keys.KEY_BINDINGS["HELP"] not in keys.commands_for_random_tips()
 
 
-def test_commands_for_random_tips(mocker):
+def test_commands_for_random_tips(mocker: MockerFixture) -> None:
     new_key_bindings: Dict[str, keys.KeyBinding] = {
         "ALPHA": {
             "keys": ["a"],

--- a/tests/config/test_themes.py
+++ b/tests/config/test_themes.py
@@ -1,11 +1,14 @@
 import re
 from enum import Enum
+from typing import Dict, Optional, Tuple
 
 import pytest
+from pytest_mock import MockerFixture
 
 from zulipterminal.config.themes import (
     REQUIRED_STYLES,
     THEMES,
+    ThemeSpec,
     all_themes,
     complete_and_incomplete_themes,
     parse_themefile,
@@ -39,7 +42,7 @@ aliases_16_color = [
 ]
 
 
-def test_all_themes():
+def test_all_themes() -> None:
     assert all_themes() == list(THEMES.keys())
 
 
@@ -53,7 +56,7 @@ def test_all_themes():
         for theme in THEMES
     ],
 )
-def test_builtin_theme_completeness(theme_name):
+def test_builtin_theme_completeness(theme_name: str) -> None:
     theme = THEMES[theme_name]
     theme_styles = theme.STYLES
     theme_colors = theme.Color
@@ -88,7 +91,7 @@ def test_builtin_theme_completeness(theme_name):
         assert fg in theme_colors and bg in theme_colors
 
 
-def test_complete_and_incomplete_themes():
+def test_complete_and_incomplete_themes() -> None:
     # These are sorted to ensure reproducibility
     result = (
         sorted(list(expected_complete_themes)),
@@ -130,13 +133,15 @@ def test_complete_and_incomplete_themes():
         "24-bit-color",
     ],
 )
-def test_parse_themefile(mocker, color_depth, expected_urwid_theme):
+def test_parse_themefile(
+    mocker: MockerFixture, color_depth: int, expected_urwid_theme: ThemeSpec
+) -> None:
     class Color(Enum):
         WHITE__BOLD = "white          #fff   #ffffff , bold"
         WHITE__BOLD_ITALICS = "white  #fff   #ffffff , bold , italics"
         DARK_MAGENTA = "dark_magenta  h90    #870087"
 
-    STYLES = {
+    STYLES: Dict[Optional[str], Tuple[Color, Color]] = {
         "s1": (Color.WHITE__BOLD, Color.DARK_MAGENTA),
         "s2": (Color.WHITE__BOLD_ITALICS, Color.DARK_MAGENTA),
     }

--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -128,6 +128,7 @@ type_consistent_testfiles = [
     "test_server_url.py",
     "test_ui.py",
     "test_keys.py",
+    "test_themes.py",
 ]
 
 for file_path in python_files:

--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -129,6 +129,7 @@ type_consistent_testfiles = [
     "test_ui.py",
     "test_keys.py",
     "test_themes.py",
+    "test_color.py",
 ]
 
 for file_path in python_files:

--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -127,6 +127,7 @@ type_consistent_testfiles = [
     "test_helper.py",
     "test_server_url.py",
     "test_ui.py",
+    "test_keys.py",
 ]
 
 for file_path in python_files:


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->
Adds type annotations to the `test_keys.py`, `test_themes.py` and `test_color.py` files. Adds these files to the list in `run-mypy`.
<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->

<!-- Add a link to a discussion on chat.zulip.org, if relevant -->

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [x] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

<!-- See https://github.com/zulip/zulip-terminal#commit-style -->
**Commit flow** <!-- if more than one commit; add/delete/fill-in as appropriate -->
<!-- For example:
- first commit doing some thing
- maybe multiple commits doing similar things
-->
- bugfix: tests: keys: Use lists for keys of key bindings. 
This commits replaces the data structure used for mentioning the keys
of the various key bindings under `test_commands_for_random_tips` from
`set` to `list` which is the right structure.

- refactor: tests: keys: Add type annotations.
This commit adds parameter and return type annotations or hints
to the `test_keys.py` file, that contains tests for its counterpart
`keys.py` from  the `zulipterminal` module, to make mypy checks
consistent and improve code readability.

- tools: Include test_keys.py to be checked by mypy. 
This commit adds `test_keys.py` to the `type_consistent_testfiles`
list to check for type consistency with mypy.
Commits on Jul 25, 2021

- refactor: tests: themes: Add type annotations. 
This commit adds parameter and return type annotations or hints to the
`test_themes.py` file, that contains tests for its counterpart
`themes.py` from  the `zulipterminal` module, to make mypy
checks consistent and improve code readability.

- tools: Include test_themes.py to be checked by mypy. 
This commit adds `test_themes.py` to the `type_consistent_testfiles`
list to check for type consistency with mypy.

- refactor: tests: color: Rename variable to avoid conflict with class. 
This commit renames the `Color` variable of `test_color_properties`
to avoid conflict with the `Color` class, to the name `color`
instead.

- refactor: tests: color: Add type annotations.
This commit adds paramter and return type annotations or hints to the
`test_color.py` file, that contains tests for it's counterpart
`color.py` from  the `zulipterminal` module, to make mypy checks
consistent and improve code readability.

- tools: Include test_color.py to be checked by mypy. 
This commit adds `test_color.py` to the `type_consistent_testfiles`
list to check for type consistency with mypy.