### PR TITLE
Overlay side-panel in autohide mode.

### DIFF
--- a/tests/ui/test_ui.py
+++ b/tests/ui/test_ui.py
@@ -311,27 +311,31 @@ class TestView:
         key: str,
         widget_size: Callable[[Widget], urwid_Box],
     ) -> None:
-        view.body = mocker.Mock()
-        view.body.focus_col = None
+        view.mentioned_button = mocker.Mock()
+        view.mentioned_button.activate = mocker.Mock()
         view.controller.is_in_editor_mode = lambda: False
         size = widget_size(view)
-        view.model.controller.narrow_to_all_mentions = mocker.Mock()
 
         view.keypress(size, key)
 
-        view.model.controller.narrow_to_all_mentions.assert_called_once_with()
-        assert view.body.focus_col == 1
+        view.mentioned_button.activate.assert_called_once_with(key)
 
     @pytest.mark.parametrize("key", keys_for_command("STREAM_MESSAGE"))
+    @pytest.mark.parametrize("autohide", [True, False], ids=["autohide", "no_autohide"])
     def test_keypress_STREAM_MESSAGE(
         self,
         view: View,
         mocker: MockerFixture,
         key: str,
+        autohide: bool,
         widget_size: Callable[[Widget], urwid_Box],
     ) -> None:
         mocked_middle_column = mocker.patch.object(view, "middle_column", create=True)
         view.body = mocker.Mock()
+        view.controller.autohide = autohide
+        view.body.contents = ["streams", "messages", "users"]
+        view.left_panel = mocker.Mock()
+        view.right_panel = mocker.Mock()
         view.controller.is_in_editor_mode = lambda: False
         size = widget_size(view)
 
@@ -414,16 +418,22 @@ class TestView:
         ],
     )
     @pytest.mark.parametrize("key", keys_for_command("OPEN_DRAFT"))
+    @pytest.mark.parametrize("autohide", [True, False], ids=["autohide", "no_autohide"])
     def test_keypress_OPEN_DRAFT(
         self,
         view: View,
         mocker: MockerFixture,
         draft: Composition,
         key: str,
+        autohide: bool,
         widget_size: Callable[[Widget], urwid_Box],
     ) -> None:
         view.body = mocker.Mock()
+        view.body.contents = ["streams", "messages", "users"]
+        view.left_panel = mocker.Mock()
         view.middle_column = mocker.Mock()
+        view.right_panel = mocker.Mock()
+        view.controller.autohide = autohide
         view.controller.report_error = mocker.Mock()
         view.controller.is_in_editor_mode = lambda: False
         view.model.stream_id_from_name.return_value = 10

--- a/tests/ui/test_ui.py
+++ b/tests/ui/test_ui.py
@@ -82,7 +82,7 @@ class TestView:
 
         view.set_footer_text()
 
-        view._w.footer.set_text.assert_called_once_with(["some help text"])
+        view.frame.footer.set_text.assert_called_once_with(["some help text"])
         view.controller.update_screen.assert_called_once_with()
 
     def test_set_footer_text_specific_text(
@@ -90,7 +90,7 @@ class TestView:
     ) -> None:
         view.set_footer_text([text])
 
-        view._w.footer.set_text.assert_called_once_with([text])
+        view.frame.footer.set_text.assert_called_once_with([text])
         view.controller.update_screen.assert_called_once_with()
 
     def test_set_footer_text_with_duration(
@@ -105,7 +105,7 @@ class TestView:
 
         view.set_footer_text([custom_text], duration=duration)
 
-        view._w.footer.set_text.assert_has_calls(
+        view.frame.footer.set_text.assert_has_calls(
             [mocker.call([custom_text]), mocker.call(["some help text"])]
         )
         mock_sleep.assert_called_once_with(duration)
@@ -226,6 +226,7 @@ class TestView:
         frame.assert_called_once_with(
             view.body, col(), focus_part="body", footer=footer_view()
         )
+        assert view.frame == frame()
         show_left_panel.assert_called_once_with(visible=True)
 
     @pytest.mark.parametrize("autohide", [True, False])

--- a/tests/ui/test_ui.py
+++ b/tests/ui/test_ui.py
@@ -179,6 +179,7 @@ class TestView:
         title_divider = mocker.patch(MODULE + ".urwid.Divider")
         text = mocker.patch(MODULE + ".urwid.Text")
         footer_view = mocker.patch(VIEW + ".footer_view")
+        show_left_panel = mocker.patch(VIEW + ".show_left_panel")
 
         full_name = "Bob James"
         email = "Bob@bob.com"
@@ -202,7 +203,7 @@ class TestView:
         expected_column_calls = [
             mocker.call(
                 [
-                    (LEFT_WIDTH, view.left_panel),
+                    (TAB_WIDTH, view.left_tab),
                     ("weight", 10, mocker.ANY),  # ANY is a center
                     (TAB_WIDTH, view.right_tab),
                 ],
@@ -225,6 +226,7 @@ class TestView:
         frame.assert_called_once_with(
             view.body, col(), focus_part="body", footer=footer_view()
         )
+        show_left_panel.assert_called_once_with(visible=True)
 
     @pytest.mark.parametrize("autohide", [True, False])
     @pytest.mark.parametrize("visible, width", [(True, LEFT_WIDTH), (False, TAB_WIDTH)])

--- a/tests/ui/test_ui.py
+++ b/tests/ui/test_ui.py
@@ -230,54 +230,40 @@ class TestView:
         show_left_panel.assert_called_once_with(visible=True)
 
     @pytest.mark.parametrize("autohide", [True, False])
-    @pytest.mark.parametrize("visible, width", [(True, LEFT_WIDTH), (False, TAB_WIDTH)])
-    def test_show_left_panel(
+    @pytest.mark.parametrize("visible", [True, False])
+    @pytest.mark.parametrize("test_method", ["left_panel", "right_panel"])
+    def test_show_panel_methods(
         self,
         mocker: MockerFixture,
         view: View,
         visible: bool,
-        width: int,
         autohide: bool,
+        test_method: str,
     ) -> None:
         view.body = mocker.Mock()
-        view.body.contents = [view.left_panel, mocker.Mock(), mocker.Mock()]
+        view.body.contents = [mocker.Mock(), mocker.Mock(), mocker.Mock()]
         view.controller.autohide = autohide
 
-        view.show_left_panel(visible=visible)
+        if test_method == "left_panel":
+            expected_width = LEFT_WIDTH
+            expected_tab = view.left_tab
+            expected_panel = view.left_panel
 
-        if autohide:
-            if visible:
-                assert view.body.contents[0][0] == view.left_panel
-            else:
-                assert view.body.contents[0][0] == view.left_tab
-            view.body.options.assert_called_once_with("given", width)
+            view.show_left_panel(visible=visible)
         else:
-            view.body.options.assert_not_called()
+            expected_width = RIGHT_WIDTH
+            expected_tab = view.right_tab
+            expected_panel = view.right_panel
 
-    @pytest.mark.parametrize("autohide", [True, False])
-    @pytest.mark.parametrize(
-        "visible, width", [(True, RIGHT_WIDTH), (False, TAB_WIDTH)]
-    )
-    def test_show_right_panel(
-        self,
-        mocker: MockerFixture,
-        view: View,
-        visible: bool,
-        width: int,
-        autohide: bool,
-    ) -> None:
-        view.body = mocker.Mock()
-        view.body.contents = [mocker.Mock(), mocker.Mock(), view.right_panel]
-        view.controller.autohide = autohide
-
-        view.show_right_panel(visible=visible)
+            view.show_right_panel(visible=visible)
 
         if autohide:
             if visible:
-                assert view.body.contents[2][0] == view.right_panel
+                assert (expected_panel, mocker.ANY) in view.body.contents
+                view.body.options.assert_called_once_with("given", expected_width)
             else:
-                assert view.body.contents[2][0] == view.right_tab
-            view.body.options.assert_called_once_with("given", width)
+                assert (expected_tab, mocker.ANY) in view.body.contents
+                view.body.options.assert_called_once_with("given", TAB_WIDTH)
         else:
             view.body.options.assert_not_called()
 

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -214,18 +214,17 @@ class View(urwid.WidgetWrap):
             or is_command_key("STREAM_MESSAGE", key)
             or is_command_key("PRIVATE_MESSAGE", key)
         ):
+            self.show_left_panel(visible=False)
+            self.show_right_panel(visible=False)
             self.body.focus_col = 1
             self.middle_column.keypress(size, key)
             return key
         elif is_command_key("ALL_PM", key):
-            self.model.controller.narrow_to_all_pm()
-            self.body.focus_col = 1
+            self.pm_button.activate(key)
         elif is_command_key("ALL_STARRED", key):
-            self.model.controller.narrow_to_all_starred()
-            self.body.focus_col = 1
+            self.starred_button.activate(key)
         elif is_command_key("ALL_MENTIONS", key):
-            self.model.controller.narrow_to_all_mentions()
-            self.body.focus_col = 1
+            self.mentioned_button.activate(key)
         elif is_command_key("SEARCH_PEOPLE", key):
             # Start User Search if not in editor_mode
             self.body.focus_position = 2
@@ -245,6 +244,8 @@ class View(urwid.WidgetWrap):
         elif is_command_key("OPEN_DRAFT", key):
             saved_draft = self.model.session_draft_message()
             if saved_draft:
+                self.show_left_panel(visible=False)
+                self.show_right_panel(visible=False)
                 if saved_draft["type"] == "stream":
                     stream_id = self.model.stream_id_from_name(saved_draft["to"])
                     self.write_box.stream_box_view(

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -107,8 +107,8 @@ class View(urwid.WidgetWrap):
             text = self.get_random_help()
         else:
             text = text_list
-        self._w.footer.set_text(text)
-        self._w.footer.set_attr_map({None: style})
+        self.frame.footer.set_text(text)
+        self.frame.footer.set_attr_map({None: style})
         self.controller.update_screen()
         if duration is not None:
             assert duration > 0
@@ -177,14 +177,14 @@ class View(urwid.WidgetWrap):
             ]
         )
 
-        w = urwid.Frame(
+        self.frame = urwid.Frame(
             self.body, title_bar, focus_part="body", footer=self.footer_view()
         )
 
         # Show left panel on startup in autohide mode
         self.show_left_panel(visible=True)
 
-        return w
+        return self.frame
 
     def show_left_panel(self, *, visible: bool) -> None:
         if not self.controller.autohide:

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -142,7 +142,7 @@ class View(urwid.WidgetWrap):
         self.right_panel, self.right_tab = self.right_column_view()
         if self.controller.autohide:
             body = [
-                (LEFT_WIDTH, self.left_panel),
+                (TAB_WIDTH, self.left_tab),
                 ("weight", 10, self.center_panel),
                 (TAB_WIDTH, self.right_tab),
             ]
@@ -180,6 +180,10 @@ class View(urwid.WidgetWrap):
         w = urwid.Frame(
             self.body, title_bar, focus_part="body", footer=self.footer_view()
         )
+
+        # Show left panel on startup in autohide mode
+        self.show_left_panel(visible=True)
+
         return w
 
     def show_left_panel(self, *, visible: bool) -> None:


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->
This commit makes the side panels to overlay the body which avoids
squashing and stretching of the message view which improves UX in
autohide mode.

<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->

<!-- Add a link to a discussion on chat.zulip.org, if relevant -->

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [x] New tests added (for any new behavior)
- [x] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

<!-- See https://github.com/zulip/zulip-terminal#commit-style -->
**Commit flow** <!-- if more than one commit; add/delete/fill-in as appropriate -->
<!-- For example:
- first commit doing some thing
- maybe multiple commits doing similar things
-->

**Notes & Questions** <!-- if any; add/delete/fill-in as appropriate -->
<!-- For example:
- this doesn't include feature X (yet?)
- unsure about Y
- should this do Z?
-->
Built on PR #1097 

**Interactions** <!-- if any; add/delete/fill-in as appropriate -->
<!-- eg.
- Waiting on #<PR>
- Blocks #<PR>
-->
Waiting on PR #1097
Blocks PR #1074 

**Visual changes** <!-- if any; add/delete/fill-in with screenshot/diagram as appropriate -->
![image](https://user-images.githubusercontent.com/64144419/126902731-48f3253d-2c6b-4caa-a950-78b10cef0566.png)
