### PR TITLE
tests: boxes: Add type annotations.

### DIFF
--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -274,6 +274,7 @@ class TestWriteBox:
     ):
         write_box.model.is_valid_private_recipient = mocker.Mock(return_value=True)
         write_box.private_box_view()
+        assert write_box.to_write_box is not None
         write_box.focus_position = write_box.FOCUS_CONTAINER_HEADER
         write_box.header_write_box.focus_col = write_box.FOCUS_HEADER_BOX_RECIPIENT
 
@@ -312,6 +313,7 @@ class TestWriteBox:
 
         write_box.model.is_valid_private_recipient = mocker.Mock(return_value=False)
         write_box.private_box_view()
+        assert write_box.to_write_box is not None
         write_box.focus_position = write_box.FOCUS_CONTAINER_HEADER
         write_box.header_write_box.focus_col = write_box.FOCUS_HEADER_BOX_RECIPIENT
 
@@ -358,6 +360,7 @@ class TestWriteBox:
         self, write_box, header, expected_recipient_emails, expected_recipient_user_ids
     ):
         write_box.private_box_view()
+        assert write_box.to_write_box is not None
         write_box.to_write_box.edit_text = header
 
         write_box.update_recipients(write_box.to_write_box)
@@ -828,6 +831,7 @@ class TestWriteBox:
     ):
         write_box.model.user_id_email_dict = user_id_email_dict
         write_box.private_box_view(recipient_user_ids=[1])
+        assert write_box.to_write_box is not None
         write_box.to_write_box.set_edit_text(text)
         write_box.to_write_box.set_edit_pos(len(text))
         write_box.focus_position = write_box.FOCUS_CONTAINER_HEADER

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -209,7 +209,7 @@ class TestWriteBox:
     def test__compose_attributes_reset_for_stream_compose(
         self, key, mocker, write_box, widget_size
     ):
-        write_box._set_stream_write_box_style = mocker.Mock()
+        mocker.patch(WRITEBOX + "._set_stream_write_box_style")
         write_box.stream_box_view(stream_id=1)
         write_box.msg_write_box.edit_text = "random text"
 

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -120,7 +120,6 @@ class TestWriteBox:
         self,
         write_box,
         text,
-        mocker,
         state,
         is_valid_stream,
         required_typeahead,
@@ -373,7 +372,7 @@ class TestWriteBox:
             ("Plain Text", 1),
         ],
     )
-    def test_generic_autocomplete_no_prefix(self, mocker, write_box, text, state):
+    def test_generic_autocomplete_no_prefix(self, write_box, text, state):
         return_val = write_box.generic_autocomplete(text, state)
         assert return_val == text
         write_box.view.set_typeahead_footer.assert_not_called()
@@ -773,7 +772,7 @@ class TestWriteBox:
         ],
     )
     def test_generic_autocomplete_emojis(
-        self, write_box, text, mocker, state, required_typeahead
+        self, write_box, text, state, required_typeahead
     ):
         typeahead_string = write_box.generic_autocomplete(text, state)
         assert typeahead_string == required_typeahead
@@ -993,7 +992,6 @@ class TestWriteBox:
         is_valid_stream,
         expected_marker,
         stream_dict,
-        mocker,
         expected_color,
     ):
         # FIXME: Refactor when we have ~ Model.is_private_stream
@@ -1191,7 +1189,6 @@ class TestWriteBox:
     )
     def test_keypress_typeahead_mode_autocomplete_key(
         self,
-        mocker,
         write_box,
         widget_size,
         current_typeahead_mode,
@@ -1388,7 +1385,7 @@ class TestWriteBox:
             )
 
     @pytest.mark.parametrize("key", keys_for_command("MARKDOWN_HELP"))
-    def test_keypress_MARKDOWN_HELP(self, mocker, write_box, key, widget_size):
+    def test_keypress_MARKDOWN_HELP(self, write_box, key, widget_size):
         size = widget_size(write_box)
 
         write_box.keypress(size, key)

--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -134,6 +134,7 @@ type_consistent_testfiles = [
     "test_buttons.py",
     "test_utils.py",
     "conftest.py",
+    "test_boxes.py",
 ]
 
 for file_path in python_files:


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->
Adds type annotations to `test_boxes.py` and adds the file to the list in `run-mypy`. Also has a prior refactor commit to remove unnecessary `mocker` parameters.
<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->

<!-- Add a link to a discussion on chat.zulip.org, if relevant -->

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [x] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

<!-- See https://github.com/zulip/zulip-terminal#commit-style -->
**Commit flow** <!-- if more than one commit; add/delete/fill-in as appropriate -->
<!-- For example:
- first commit doing some thing
- maybe multiple commits doing similar things
-->
- refactor: tests: boxes: Remove mocker as parameter where unnecessary.
This commit removes the `mocker` fixture as a parameter from tests
where it isn't used.

- refactor: tests: boxes: Add type annotations. 
This commit adds parameter and return type annotations or hints to the
`test_boxes.py` file, that contains tests for it's counterpart
`boxes.py` from  the `zulipterminal` module, to make mypy checks
consistent and improve code readability.

- tools: Include test_boxes.py to be checked by mypy.
This commit adds `test_boxes.py` to the `type_consistent_testfiles`
list to check for type consistency with mypy.