### PR TITLE
bugfix: views: ZT crashes on muting a stream.

### DIFF
--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -36,7 +36,6 @@ class TestPopUpConfirmationView:
     @pytest.fixture
     def popup_view(self, mocker, stream_button):
         self.controller = mocker.Mock()
-        self.controller.view.LEFT_WIDTH = 27
         self.callback = mocker.Mock()
         self.list_walker = mocker.patch(LISTWALKER, return_value=[])
         self.divider = mocker.patch(MODULE + ".urwid.Divider")

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -54,6 +54,8 @@ from zulipterminal.urwid_types import urwid_Size
 MIDDLE_COLUMN_MOUSE_SCROLL_LINES = 1
 SIDE_PANELS_MOUSE_SCROLL_LINES = 5
 
+LEFT_WIDTH = 27
+
 
 class ModListWalker(urwid.SimpleFocusListWalker):
     def set_focus(self, position: int) -> None:
@@ -1249,7 +1251,7 @@ class PopUpConfirmationView(urwid.Overlay):
             self.controller.view,
             align="left",
             valign="top",
-            width=self.controller.view.LEFT_WIDTH + 1,
+            width=LEFT_WIDTH + 1,
             height=8,
         )
 


### PR DESCRIPTION


Tests updated.

<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->
ZT crashes because LEFT_WIDTH is no longer stored as a View constant.
This happened because of the recent merge of Autohide Tabs.

<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->

<!-- Add a link to a discussion on chat.zulip.org, if relevant -->

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [x] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

**Notes & Questions** <!-- if any; add/delete/fill-in as appropriate -->
<!-- For example:
- this doesn't include feature X (yet?)
- unsure about Y
- should this do Z?
-->
LEFT_WIDTH is redefined and used in views.py to fix the issue as
importing from ui.py would cause a cyclic import error.
