### PR TITLE
refactor: tests: buttons: Add type annotations.

### DIFF
--- a/tests/ui_tools/test_buttons.py
+++ b/tests/ui_tools/test_buttons.py
@@ -77,11 +77,11 @@ class TestTopButton:
         self, mocker, top_button, old_count, new_count, new_count_str, text_color
     ):
         top_button.count = old_count
-        top_button.update_widget = mocker.patch(MODULE + ".TopButton.update_widget")
+        top_button_update_widget = mocker.patch(MODULE + ".TopButton.update_widget")
 
         top_button.update_count(new_count, text_color)
 
-        top_button.update_widget.assert_called_once_with(
+        top_button_update_widget.assert_called_once_with(
             (top_button.count_style, new_count_str),
             text_color,
         )
@@ -779,15 +779,17 @@ class TestMessageLinkButton:
         exit_popup_called,
     ):
         self.controller.loop.widget = mocker.Mock(spec=Overlay)
-        mocker.patch(MSGLINKBUTTON + "._parse_narrow_link")
-        mocker.patch(MSGLINKBUTTON + "._validate_narrow_link", return_value=error)
-        mocker.patch(MSGLINKBUTTON + "._switch_narrow_to")
+        mocked__parse_narrow_link = mocker.patch(MSGLINKBUTTON + "._parse_narrow_link")
+        mocked__validate_narrow_link = mocker.patch(
+            MSGLINKBUTTON + "._validate_narrow_link", return_value=error
+        )
+        mocked__switch_narrow_to = mocker.patch(MSGLINKBUTTON + "._switch_narrow_to")
         mocked_button = self.message_link_button()
 
         mocked_button.handle_narrow_link()
 
-        assert mocked_button._parse_narrow_link.called
-        assert mocked_button._validate_narrow_link.called
+        assert mocked__parse_narrow_link.called
+        assert mocked__validate_narrow_link.called
         assert mocked_button.controller.report_error.called == report_error_called
-        assert mocked_button._switch_narrow_to.called == _switch_narrow_to_called
+        assert mocked__switch_narrow_to.called == _switch_narrow_to_called
         assert mocked_button.controller.exit_popup.called == exit_popup_called

--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -131,6 +131,7 @@ type_consistent_testfiles = [
     "test_themes.py",
     "test_color.py",
     "test_platform_code.py",
+    "test_buttons.py",
 ]
 
 for file_path in python_files:


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->
Adds type annotations to test_buttons.py and adds the file to the list in run-mypy. Also has a prior refactor commit to assign `mocker.patch`s to variables.
<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->

<!-- Add a link to a discussion on chat.zulip.org, if relevant -->

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [x] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

<!-- See https://github.com/zulip/zulip-terminal#commit-style -->
**Commit flow** <!-- if more than one commit; add/delete/fill-in as appropriate -->
<!-- For example:
- first commit doing some thing
- maybe multiple commits doing similar things
-->
- refactor: tests: buttons: Assign method mocker.patchs to variables.
This commit assigns fixture method attribute `mocker.patch`s to
variables, so that the corresponding asserts can be called on the
mocked nature, as was the original intention.

- refactor: tests: buttons: Add type annotations.
This commit adds parameter and return type annotations or hints to the
`test_buttons.py` file, that contains tests for it's counterpart
`buttons.py` from  the `zulipterminal` module, to make mypy checks
consistent and improve code readability.

- tools: Include test_buttons.py to be checked by mypy.
This commit adds `test_buttons.py` to the `type_consistent_testfiles`
list to check for type consistency with mypy.

**Waiting on**:
Refactor work to improve type annotations for urwid markup.