### PR TITLE
gruvbox: Change background of selected to dark blue.

### DIFF
--- a/zulipterminal/themes/gruvbox.py
+++ b/zulipterminal/themes/gruvbox.py
@@ -37,8 +37,8 @@ Color = color_properties(GruvBoxColor, 'BOLD')
 STYLES = {
     # style_name       :  foreground                   background
     None               : (Color.LIGHT2,                Color.DARK0_HARD),
-    'selected'         : (Color.DARK0_HARD,            Color.LIGHT2),
-    'msg_selected'     : (Color.DARK0_HARD,            Color.LIGHT2),
+    'selected'         : (Color.LIGHT2,                Color.FADED_BLUE),
+    'msg_selected'     : (Color.LIGHT2,                Color.FADED_BLUE),
     'header'           : (Color.NEUTRAL_BLUE,          Color.FADED_BLUE),
     'general_narrow'   : (Color.LIGHT2,                Color.FADED_BLUE),
     'general_bar'      : (Color.LIGHT2,                Color.DARK0_HARD),


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->
To make it consistent with zt_dark. We could deviate and use green instead. But the current Zulip logo is blue, so it's good to have more blue in the screen.
<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->

<!-- Add a link to a discussion on chat.zulip.org, if relevant -->

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [ ] Existing tests (adapted, if necessary)
- [ ] New tests added (for any new behavior)
- [ ] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

<!-- See https://github.com/zulip/zulip-terminal#commit-style -->
**Commit flow** <!-- if more than one commit; add/delete/fill-in as appropriate -->
<!-- For example:
- first commit doing some thing
- maybe multiple commits doing similar things
-->

**Notes & Questions** <!-- if any; add/delete/fill-in as appropriate -->
<!-- For example:
- this doesn't include feature X (yet?)
- unsure about Y
- should this do Z?
-->

**Interactions** <!-- if any; add/delete/fill-in as appropriate -->
<!-- eg.
- Waiting on #<PR>
- Blocks #<PR>
-->

**Visual changes** <!-- if any; add/delete/fill-in with screenshot/diagram as appropriate -->
