### PR TITLE
tests: utils: Add type annotations.

### DIFF
--- a/tests/ui/test_utils.py
+++ b/tests/ui/test_utils.py
@@ -1,5 +1,9 @@
-import pytest
+from typing import Any, Iterable, List, Optional
 
+import pytest
+from pytest_mock import MockerFixture
+
+from zulipterminal.api_types import Message
 from zulipterminal.ui_tools.utils import create_msg_box_list, is_muted
 
 
@@ -66,8 +70,13 @@ MODULE = "zulipterminal.ui_tools.utils"
     ],
 )
 def test_is_muted(
-    mocker, msg, narrow, muted_streams, is_muted_topic_return_value, muted
-):
+    mocker: MockerFixture,
+    msg: Message,
+    narrow: List[Any],
+    muted_streams: List[int],
+    is_muted_topic_return_value: bool,
+    muted: bool,
+) -> None:
     model = mocker.Mock()
     model.is_muted_stream = mocker.Mock(
         return_value=(msg.get("stream_id", "") in muted_streams)
@@ -129,8 +138,14 @@ def test_is_muted(
     ],
 )
 def test_create_msg_box_list(
-    mocker, narrow, messages, focus_msg_id, muted, unsubscribed, len_w_list
-):
+    mocker: MockerFixture,
+    narrow: List[Any],
+    messages: Optional[Iterable[Any]],
+    focus_msg_id: Optional[int],
+    muted: bool,
+    unsubscribed: bool,
+    len_w_list: int,
+) -> None:
     model = mocker.Mock()
     model.narrow = narrow
     model.index = {

--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -132,6 +132,7 @@ type_consistent_testfiles = [
     "test_color.py",
     "test_platform_code.py",
     "test_buttons.py",
+    "test_utils.py",
 ]
 
 for file_path in python_files:


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->
Adds type annotations to `test_utils.py` and adds the file to the list in `run-mypy`.
<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->

<!-- Add a link to a discussion on chat.zulip.org, if relevant -->

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [x] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

<!-- See https://github.com/zulip/zulip-terminal#commit-style -->
**Commit flow** <!-- if more than one commit; add/delete/fill-in as appropriate -->
<!-- For example:
- first commit doing some thing
- maybe multiple commits doing similar things
-->
- refactor: tests: utils: Add type annotations. 
This commit adds parameter and return type annotations or hints to the
`test_utils.py` file, that contains tests for it's counterpart
`utils.py` from  the `zulipterminal` module, to make mypy checks
consistent and improve code readability.

- tools: Include test_utils.py to be checked by mypy. 
This commit adds `test_utils.py` to the `type_consistent_testfiles`
list to check for type consistency with mypy.
