### PR TITLE
Define and use Stream data fixture from conftest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -192,45 +192,50 @@ def logged_on_user():
     }
 
 
-general_stream = {
-    "name": "Some general stream",
-    "invite_only": False,
-    "color": "#b0a5fd",  # Color in '#xxxxxx' format
-    "pin_to_top": False,
-    "stream_id": 1000,
-    "in_home_view": True,
-    "audible_notifications": False,
-    "description": "General Stream",
-    "is_old_stream": True,
-    "desktop_notifications": False,
-    "stream_weekly_traffic": 0,
-    "push_notifications": False,
-    "email_address": "general@example.comm",
-    "subscribers": [1001, 11, 12],
-}
+@pytest.fixture
+def general_stream():
+    return {
+        "name": "Some general stream",
+        "invite_only": False,
+        "color": "#b0a5fd",  # Color in '#xxxxxx' format
+        "pin_to_top": False,
+        "stream_id": 1000,
+        "in_home_view": True,
+        "audible_notifications": False,
+        "description": "General Stream",
+        "is_old_stream": True,
+        "desktop_notifications": False,
+        "stream_weekly_traffic": 0,
+        "push_notifications": False,
+        "email_address": "general@example.comm",
+        "subscribers": [1001, 11, 12],
+    }
+
 
 # This is a private stream;
 # only description/stream_id/invite_only/name/color vary from above
-secret_stream = {
-    "description": "Some private stream",
-    "stream_id": 99,
-    "pin_to_top": False,
-    "invite_only": True,
-    "name": "Secret stream",
-    "email_address": "secret@example.com",
-    "color": "#ccc",  # Color in '#xxx' format
-    "in_home_view": True,
-    "audible_notifications": False,
-    "is_old_stream": True,
-    "desktop_notifications": False,
-    "stream_weekly_traffic": 0,
-    "push_notifications": False,
-    "subscribers": [1001, 11],
-}
+@pytest.fixture
+def secret_stream():
+    return {
+        "description": "Some private stream",
+        "stream_id": 99,
+        "pin_to_top": False,
+        "invite_only": True,
+        "name": "Secret stream",
+        "email_address": "secret@example.com",
+        "color": "#ccc",  # Color in '#xxx' format
+        "in_home_view": True,
+        "audible_notifications": False,
+        "is_old_stream": True,
+        "desktop_notifications": False,
+        "stream_weekly_traffic": 0,
+        "push_notifications": False,
+        "subscribers": [1001, 11],
+    }
 
 
 @pytest.fixture
-def streams_fixture():
+def streams_fixture(general_stream, secret_stream):
     streams = [general_stream, secret_stream]
     for i in range(1, 3):
         streams.append(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -203,6 +203,7 @@ def general_stream():
         "in_home_view": True,
         "audible_notifications": False,
         "description": "General Stream",
+        "rendered_description": "General Stream",
         "is_old_stream": True,
         "desktop_notifications": False,
         "stream_weekly_traffic": 0,
@@ -223,6 +224,7 @@ def secret_stream():
         "invite_only": True,
         "name": "Secret stream",
         "email_address": "secret@example.com",
+        "rendered_description": "Some private stream",
         "color": "#ccc",  # Color in '#xxx' format
         "in_home_view": True,
         "audible_notifications": False,
@@ -248,6 +250,7 @@ def streams_fixture(general_stream, secret_stream):
                 "in_home_view": True,
                 "audible_notifications": False,
                 "description": f"A description of stream {i}",
+                "rendered_description": f"A description of stream {i}",
                 "is_old_stream": True,
                 "desktop_notifications": False,
                 "stream_weekly_traffic": 0,


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->
This PR defines the `general_stream` and `secret_stream` dictionaries in conftest to pytest fixtures, allowing us to re-use them in tests that need stream data. The defined fixtures are currently used in tests for StreamInfo popup.
<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->

<!-- Add a link to a discussion on chat.zulip.org, if relevant -->

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [x] New tests added (for any new behavior)
- [x] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

<!-- See https://github.com/zulip/zulip-terminal#commit-style -->
**Commit flow** <!-- if more than one commit; add/delete/fill-in as appropriate -->
<!-- For example:
- first commit doing some thing
- maybe multiple commits doing similar things
-->
- refactor: conftest: Define general_stream and secret_stream as fixtures.
- conftest: Add rendered_description field to stream fixtures.
- tests: popups: Use stream fixture instead of defining custom streams.

**Interactions** <!-- if any; add/delete/fill-in as appropriate -->

- Blocks #880 


