### PR TITLE
Use urwid's CommandMap to manage navigational keys.

### DIFF
--- a/tests/config/test_keys.py
+++ b/tests/config/test_keys.py
@@ -97,3 +97,14 @@ def test_commands_for_random_tips(mocker: MockerFixture) -> None:
     assert len(result) == 2
     assert new_key_bindings["BETA"] in result
     assert new_key_bindings["GAMMA"] in result
+
+
+def test_updated_urwid_command_map() -> None:
+    urwid_to_zt_mapping = {v: k for k, v in keys.ZT_TO_URWID_CMD_MAPPING.items()}
+    # Check if keys in command map are actually the ones in KEY_BINDINGS
+    for key, urwid_cmd in keys.command_map._command.items():
+        try:
+            zt_cmd = urwid_to_zt_mapping[urwid_cmd]
+            assert key in keys.keys_for_command(zt_cmd)
+        except KeyError:
+            pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,11 @@ from pytest_mock import MockerFixture
 from urwid import Widget
 
 from zulipterminal.api_types import Message
-from zulipterminal.config.keys import keys_for_command, primary_key_for_command
+from zulipterminal.config.keys import (
+    ZT_TO_URWID_CMD_MAPPING,
+    keys_for_command,
+    primary_key_for_command,
+)
 from zulipterminal.helper import Index, TidiedUserInfo
 from zulipterminal.helper import initial_index as helper_initial_index
 from zulipterminal.ui_tools.boxes import MessageBox
@@ -1203,24 +1207,13 @@ def mouse_scroll_event(request: Any) -> Tuple[Any]:
 
 
 @pytest.fixture(
-    params=[
-        (key, expected_key)
-        for keys, expected_key in [
-            (keys_for_command("GO_UP"), "up"),
-            (keys_for_command("GO_DOWN"), "down"),
-            (keys_for_command("SCROLL_UP"), "page up"),
-            (keys_for_command("SCROLL_DOWN"), "page down"),
-            (keys_for_command("GO_TO_BOTTOM"), "end"),
-        ]
-        for key in keys
-    ],
-    ids=lambda param: "key:{}-expected_key:{}".format(*param),
+    params=[key for cmd in ZT_TO_URWID_CMD_MAPPING for key in keys_for_command(cmd)],
+    ids=lambda param: "nav-key:{}".format(*param),
 )
-def navigation_key_expected_key_pair(request: Any) -> Tuple[str, str]:
+def navigation_key(request: Any) -> str:
     """
-    Fixture to generate pairs of navigation keys with their respective
-    expected key.
-    The expected key is the one which is passed to the super `keypress` calls.
+    Fixture to generate navigation keys.
+    This key is passed to the super `keypress` calls as is.
     """
     return request.param
 

--- a/tests/ui/test_ui.py
+++ b/tests/ui/test_ui.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, List, Optional, Tuple
+from typing import Any, Callable, List, Optional
 
 import pytest
 from pytest_mock import MockerFixture
@@ -275,9 +275,8 @@ class TestView:
         mocker: MockerFixture,
         # TODO: Improve `widget_size`'s return type, likely via Protocols.
         widget_size: Callable[[Widget], urwid_Box],
-        navigation_key_expected_key_pair: Tuple[str, str],
+        navigation_key: str,
     ) -> None:
-        key, expected_key = navigation_key_expected_key_pair
         view.users_view = mocker.Mock()
         view.body = mocker.Mock()
         view.user_search = mocker.Mock()
@@ -287,9 +286,9 @@ class TestView:
 
         view.controller.is_in_editor_mode = lambda: False
 
-        view.keypress(size, key)
+        view.keypress(size, navigation_key)
 
-        super_keypress.assert_called_once_with(size, expected_key)
+        super_keypress.assert_called_once_with(size, navigation_key)
 
     @pytest.mark.parametrize("key", keys_for_command("ALL_MENTIONS"))
     def test_keypress_ALL_MENTIONS(

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -132,10 +132,7 @@ class TestPopUpView:
         self.pop_up_view.keypress(size, "cmd_key")
         assert self.controller.exit_popup.called
 
-    def test_keypress_navigation(
-        self, mocker, widget_size, navigation_key_expected_key_pair
-    ):
-        key, expected_key = navigation_key_expected_key_pair
+    def test_keypress_navigation(self, mocker, navigation_key, widget_size):
         size = widget_size(self.pop_up_view)
         # Patch `is_command_key` to not raise an 'Invalid Command' exception
         # when its parameters are (self.command, key) as there is no
@@ -148,8 +145,10 @@ class TestPopUpView:
                 else is_command_key(command, key)
             ),
         )
-        self.pop_up_view.keypress(size, key)
-        self.super_keypress.assert_called_once_with(size, expected_key)
+
+        self.pop_up_view.keypress(size, navigation_key)
+
+        self.super_keypress.assert_called_once_with(size, navigation_key)
 
 
 class TestAboutView:
@@ -188,15 +187,6 @@ class TestAboutView:
         size = widget_size(self.about_view)
         self.about_view.keypress(size, key)
         assert not self.controller.exit_popup.called
-
-    def test_keypress_navigation(
-        self, mocker, widget_size, navigation_key_expected_key_pair
-    ):
-        key, expected_key = navigation_key_expected_key_pair
-        size = widget_size(self.about_view)
-        super_keypress = mocker.patch(MODULE + ".urwid.Frame.keypress")
-        self.about_view.keypress(size, key)
-        super_keypress.assert_called_once_with(size, expected_key)
 
     def test_feature_level_content(self, mocker, zulip_version):
         self.controller = mocker.Mock()
@@ -338,15 +328,6 @@ class TestUserInfoView:
         self.user_info_view.keypress(size, key)
         assert not self.controller.exit_popup.called
 
-    def test_keypress_navigation(
-        self, mocker, widget_size, navigation_key_expected_key_pair
-    ):
-        key, expected_key = navigation_key_expected_key_pair
-        size = widget_size(self.user_info_view)
-        super_keypress = mocker.patch(MODULE + ".urwid.Frame.keypress")
-        self.user_info_view.keypress(size, key)
-        super_keypress.assert_called_once_with(size, expected_key)
-
 
 class TestFullRenderedMsgView:
     @pytest.fixture(autouse=True)
@@ -413,17 +394,6 @@ class TestFullRenderedMsgView:
             message_links=OrderedDict(),
             time_mentions=list(),
         )
-
-    def test_keypress_navigation(
-        self, mocker, widget_size, navigation_key_expected_key_pair
-    ):
-        size = widget_size(self.full_rendered_message)
-        key, expected_key = navigation_key_expected_key_pair
-        super_keypress = mocker.patch(MODULE + ".urwid.Frame.keypress")
-
-        self.full_rendered_message.keypress(size, key)
-
-        super_keypress.assert_called_once_with(size, expected_key)
 
 
 class TestFullRawMsgView:
@@ -495,17 +465,6 @@ class TestFullRawMsgView:
             time_mentions=list(),
         )
 
-    def test_keypress_navigation(
-        self, mocker, widget_size, navigation_key_expected_key_pair
-    ):
-        size = widget_size(self.full_raw_message)
-        key, expected_key = navigation_key_expected_key_pair
-        super_keypress = mocker.patch(MODULE + ".urwid.Frame.keypress")
-
-        self.full_raw_message.keypress(size, key)
-
-        super_keypress.assert_called_once_with(size, expected_key)
-
 
 class TestEditHistoryView:
     @pytest.fixture(autouse=True)
@@ -570,17 +529,6 @@ class TestEditHistoryView:
             message_links=OrderedDict(),
             time_mentions=list(),
         )
-
-    def test_keypress_navigation(
-        self, mocker, widget_size, navigation_key_expected_key_pair
-    ):
-        size = widget_size(self.edit_history_view)
-        key, expected_key = navigation_key_expected_key_pair
-        super_keypress = mocker.patch(MODULE + ".urwid.Frame.keypress")
-
-        self.edit_history_view.keypress(size, key)
-
-        super_keypress.assert_called_once_with(size, expected_key)
 
     @pytest.mark.parametrize(
         "snapshot",
@@ -787,17 +735,6 @@ class TestMarkdownHelpView:
 
         assert self.controller.exit_popup.called
 
-    def test_keypress_body_navigation(
-        self, mocker, widget_size, navigation_key_expected_key_pair
-    ):
-        key, expected_key = navigation_key_expected_key_pair
-        size = widget_size(self.markdown_help_view)
-        super_keypress = mocker.patch(MODULE + ".urwid.Frame.keypress")
-
-        self.markdown_help_view.keypress(size, key)
-
-        super_keypress.assert_called_once_with(size, expected_key)
-
 
 class TestHelpView:
     @pytest.fixture(autouse=True)
@@ -822,15 +759,6 @@ class TestHelpView:
         size = widget_size(self.help_view)
         self.help_view.keypress(size, key)
         assert self.controller.exit_popup.called
-
-    def test_keypress_navigation(
-        self, mocker, widget_size, navigation_key_expected_key_pair
-    ):
-        key, expected_key = navigation_key_expected_key_pair
-        size = widget_size(self.help_view)
-        super_keypress = mocker.patch(MODULE + ".urwid.Frame.keypress")
-        self.help_view.keypress(size, key)
-        super_keypress.assert_called_once_with(size, expected_key)
 
 
 class TestMsgInfoView:
@@ -1103,15 +1031,6 @@ class TestMsgInfoView:
         assert link_w._wrapped_widget.attr_map == expected_attr_map
         assert link_width == expected_link_width
 
-    def test_keypress_navigation(
-        self, mocker, widget_size, navigation_key_expected_key_pair
-    ):
-        key, expected_key = navigation_key_expected_key_pair
-        size = widget_size(self.msg_info_view)
-        super_keypress = mocker.patch(MODULE + ".urwid.Frame.keypress")
-        self.msg_info_view.keypress(size, key)
-        super_keypress.assert_called_once_with(size, expected_key)
-
 
 class TestStreamInfoView:
     @pytest.fixture(autouse=True)
@@ -1318,15 +1237,6 @@ class TestStreamInfoView:
         self.stream_info_view.keypress(size, key)
         assert self.controller.exit_popup.called
 
-    def test_keypress_navigation(
-        self, mocker, widget_size, navigation_key_expected_key_pair
-    ):
-        key, expected_key = navigation_key_expected_key_pair
-        size = widget_size(self.stream_info_view)
-        super_keypress = mocker.patch(MODULE + ".urwid.Frame.keypress")
-        self.stream_info_view.keypress(size, key)
-        super_keypress.assert_called_once_with(size, expected_key)
-
     @pytest.mark.parametrize("key", (*keys_for_command("ENTER"), " "))
     def test_checkbox_toggle_mute_stream(self, mocker, key, widget_size):
         mute_checkbox = self.stream_info_view.widgets[-3]
@@ -1386,12 +1296,3 @@ class TestStreamMembersView:
         self.controller.show_stream_info.assert_called_once_with(
             stream_id=stream_id,
         )
-
-    def test_keypress_navigation(
-        self, mocker, widget_size, navigation_key_expected_key_pair
-    ):
-        key, expected_key = navigation_key_expected_key_pair
-        size = widget_size(self.stream_members_view)
-        super_keypress = mocker.patch(MODULE + ".urwid.Frame.keypress")
-        self.stream_members_view.keypress(size, key)
-        super_keypress.assert_called_once_with(size, expected_key)

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -2,6 +2,16 @@ from collections import OrderedDict
 from typing import List
 
 from typing_extensions import TypedDict
+from urwid.command_map import (
+    CURSOR_DOWN,
+    CURSOR_LEFT,
+    CURSOR_MAX_RIGHT,
+    CURSOR_PAGE_DOWN,
+    CURSOR_PAGE_UP,
+    CURSOR_RIGHT,
+    CURSOR_UP,
+    command_map,
+)
 
 
 class KeyBinding(TypedDict, total=False):
@@ -380,6 +390,16 @@ HELP_CATEGORIES = OrderedDict(
     ]
 )
 
+ZT_TO_URWID_CMD_MAPPING = {
+    "GO_UP": CURSOR_UP,
+    "GO_DOWN": CURSOR_DOWN,
+    "GO_LEFT": CURSOR_LEFT,
+    "GO_RIGHT": CURSOR_RIGHT,
+    "SCROLL_UP": CURSOR_PAGE_UP,
+    "SCROLL_DOWN": CURSOR_PAGE_DOWN,
+    "GO_TO_BOTTOM": CURSOR_MAX_RIGHT,
+}
+
 
 class InvalidCommand(Exception):
     pass
@@ -422,3 +442,10 @@ def commands_for_random_tips() -> List[KeyBinding]:
         for key_binding in KEY_BINDINGS.values()
         if not key_binding.get("excluded_from_random_tips", False)
     ]
+
+
+# Refer urwid/command_map.py
+# Adds alternate keys for standard urwid navigational commands.
+for zt_cmd, urwid_cmd in ZT_TO_URWID_CMD_MAPPING.items():
+    for key in keys_for_command(zt_cmd):
+        command_map[key] = urwid_cmd

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -304,23 +304,6 @@ class View(urwid.WidgetWrap):
         elif is_command_key("MARKDOWN_HELP", key):
             self.controller.show_markdown_help()
             return key
-        # replace alternate keys with arrow/functional keys
-        # This is needed for navigating in widgets
-        # other than message_view.
-        elif is_command_key("GO_UP", key):
-            key = "up"
-        elif is_command_key("GO_DOWN", key):
-            key = "down"
-        elif is_command_key("GO_LEFT", key):
-            key = "left"
-        elif is_command_key("GO_RIGHT", key):
-            key = "right"
-        elif is_command_key("SCROLL_UP", key):
-            key = "page up"
-        elif is_command_key("SCROLL_DOWN", key):
-            key = "page down"
-        elif is_command_key("GO_TO_BOTTOM", key):
-            key = "end"
         return super().keypress(size, key)
 
     def mouse_event(

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1079,16 +1079,7 @@ class PopUpView(urwid.Frame):
     def keypress(self, size: urwid_Size, key: str) -> str:
         if is_command_key("GO_BACK", key) or is_command_key(self.command, key):
             self.controller.exit_popup()
-        elif is_command_key("GO_UP", key):
-            key = "up"
-        elif is_command_key("GO_DOWN", key):
-            key = "down"
-        elif is_command_key("SCROLL_UP", key):
-            key = "page up"
-        elif is_command_key("SCROLL_DOWN", key):
-            key = "page down"
-        elif is_command_key("GO_TO_BOTTOM", key):
-            key = "end"
+
         return super().keypress(size, key)
 
 


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->
This PR modifies urwid's `CommandMap` class object `command_map`
to map alternate navigational keys to standard urwid navigational
aliases. This is used in `ui.py` and `PopupView`.

Users can also now add custom nav-keys by adding it to KEY_BINDINGS.

<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->

<!-- Add a link to a discussion on chat.zulip.org, if relevant -->

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [x] New tests added (for any new behavior)
- [x] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->