### PR TITLE
Keypress Rules Refactor: Boxes

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -2879,3 +2879,31 @@ class TestMessageBox:
             msg_box.keypress.assert_not_called()
         else:
             msg_box.keypress.assert_called_once_with(size, key)
+
+    @pytest.mark.parametrize(
+        "key, expected_return_value",
+        [
+            (primary_key_for_command("REPLY_MESSAGE"), None),
+            (primary_key_for_command("STREAM_MESSAGE"), None),
+            (primary_key_for_command("STREAM_NARROW"), None),
+            (primary_key_for_command("TOGGLE_NARROW"), None),
+            (primary_key_for_command("TOPIC_NARROW"), None),
+            (primary_key_for_command("ALL_MESSAGES"), None),
+            (primary_key_for_command("REPLY_AUTHOR"), None),
+            (primary_key_for_command("MENTION_REPLY"), None),
+            (primary_key_for_command("QUOTE_REPLY"), None),
+            (primary_key_for_command("EDIT_MESSAGE"), None),
+            (primary_key_for_command("MSG_INFO"), None),
+            ("k", "k"),  # Any other key is returned
+        ],
+    )
+    def test_keypress_return_value(
+        self, mocker, msg_box, key, expected_return_value, widget_size
+    ):
+        size = widget_size(msg_box)
+        mocker.patch(BOXES + ".get_unused_fence")
+        mocker.patch(BOXES + ".near_message_url")
+
+        return_value = msg_box.keypress(size, key)
+
+        assert return_value == expected_return_value

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from typing import List
+from typing import List, Optional
 
 from typing_extensions import TypedDict
 from urwid.command_map import (
@@ -405,7 +405,7 @@ class InvalidCommand(Exception):
     pass
 
 
-def is_command_key(command: str, key: str) -> bool:
+def is_command_key(command: str, key: Optional[str]) -> bool:
     """
     Returns the mapped binding for a key if mapped
     or the key otherwise.

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -232,6 +232,7 @@ class View(urwid.WidgetWrap):
         self.model.new_user_input = True
         if self.controller.is_in_editor_mode():
             return self.controller.current_editor().keypress((size[1],), key)
+
         # Redirect commands to message_view.
         elif (
             is_command_key("SEARCH_MESSAGES", key)
@@ -245,12 +246,16 @@ class View(urwid.WidgetWrap):
             self.body.focus_col = 1
             self.middle_column.keypress(size, key)
             return key
+
         elif is_command_key("ALL_PM", key):
             self.pm_button.activate(key)
+
         elif is_command_key("ALL_STARRED", key):
             self.starred_button.activate(key)
+
         elif is_command_key("ALL_MENTIONS", key):
             self.mentioned_button.activate(key)
+
         elif is_command_key("SEARCH_PEOPLE", key):
             # Start User Search if not in editor_mode
             self.show_left_panel(visible=False)
@@ -258,6 +263,7 @@ class View(urwid.WidgetWrap):
             self.body.focus_position = 2
             self.users_view.keypress(size, key)
             return key
+
         elif is_command_key("SEARCH_STREAMS", key) or is_command_key(
             "SEARCH_TOPICS", key
         ):
@@ -267,6 +273,7 @@ class View(urwid.WidgetWrap):
             self.body.focus_position = 0
             self.left_panel.keypress(size, key)
             return key
+
         elif is_command_key("OPEN_DRAFT", key):
             saved_draft = self.model.session_draft_message()
             if saved_draft:
@@ -294,16 +301,20 @@ class View(urwid.WidgetWrap):
                     "No draft message was saved in this session."
                 )
             return key
+
         elif is_command_key("ABOUT", key):
             self.controller.show_about()
             return key
+
         elif is_command_key("HELP", key):
             # Show help menu
             self.controller.show_help()
             return key
+
         elif is_command_key("MARKDOWN_HELP", key):
             self.controller.show_markdown_help()
             return key
+
         return super().keypress(size, key)
 
     def mouse_event(

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -773,15 +773,18 @@ class WriteBox(urwid.Pile):
                 if self.msg_edit_state is not None:
                     self.msg_edit_state = None
                     self.keypress(size, primary_key_for_command("GO_BACK"))
+
         elif is_command_key("GO_BACK", key):
             self.send_stop_typing_status()
             self._set_compose_attributes_to_defaults()
             self.view.controller.exit_editor_mode()
             self.main_view(False)
             self.view.middle_column.set_focus("body")
+
         elif is_command_key("MARKDOWN_HELP", key):
             self.view.controller.show_markdown_help()
             return key
+
         elif is_command_key("SAVE_AS_DRAFT", key):
             if self.msg_edit_state is None:
                 if self.compose_box_status == "open_with_private":
@@ -810,6 +813,7 @@ class WriteBox(urwid.Pile):
                     self.view.controller.save_draft_confirmation_popup(
                         this_draft,
                     )
+
         elif is_command_key("CYCLE_COMPOSE_FOCUS", key):
             if len(self.contents) == 0:
                 return key
@@ -1693,6 +1697,7 @@ class MessageBox(urwid.Pile):
                     title=self.message["subject"],
                     stream_id=self.stream_id,
                 )
+
         elif is_command_key("STREAM_MESSAGE", key):
             if len(self.model.narrow) != 0 and self.model.narrow[0][0] == "stream":
                 self.model.controller.view.write_box.stream_box_view(
@@ -1701,6 +1706,7 @@ class MessageBox(urwid.Pile):
                 )
             else:
                 self.model.controller.view.write_box.stream_box_view(0)
+
         elif is_command_key("STREAM_NARROW", key):
             if self.message["type"] == "private":
                 self.model.controller.narrow_to_user(
@@ -1712,6 +1718,7 @@ class MessageBox(urwid.Pile):
                     stream_name=self.stream_name,
                     contextual_message_id=self.message["id"],
                 )
+
         elif is_command_key("TOGGLE_NARROW", key):
             self.model.unset_search_narrow()
             if self.message["type"] == "private":
@@ -1736,6 +1743,7 @@ class MessageBox(urwid.Pile):
                         topic_name=self.topic_name,
                         contextual_message_id=self.message["id"],
                     )
+
         elif is_command_key("TOPIC_NARROW", key):
             if self.message["type"] == "private":
                 self.model.controller.narrow_to_user(
@@ -1748,15 +1756,18 @@ class MessageBox(urwid.Pile):
                     topic_name=self.topic_name,
                     contextual_message_id=self.message["id"],
                 )
+
         elif is_command_key("ALL_MESSAGES", key):
             self.model.controller.narrow_to_all_messages(
                 contextual_message_id=self.message["id"]
             )
+
         elif is_command_key("REPLY_AUTHOR", key):
             # All subscribers from recipient_ids are not needed here.
             self.model.controller.view.write_box.private_box_view(
                 recipient_user_ids=[self.message["sender_id"]],
             )
+
         elif is_command_key("MENTION_REPLY", key):
             self.keypress(size, primary_key_for_command("REPLY_MESSAGE"))
             mention = f"@**{self.message['sender_full_name']}** "
@@ -1765,6 +1776,7 @@ class MessageBox(urwid.Pile):
                 len(mention)
             )
             self.model.controller.view.middle_column.set_focus("footer")
+
         elif is_command_key("QUOTE_REPLY", key):
             self.keypress(size, primary_key_for_command("REPLY_MESSAGE"))
 
@@ -1793,6 +1805,7 @@ class MessageBox(urwid.Pile):
             self.model.controller.view.write_box.msg_write_box.set_edit_text(quote)
             self.model.controller.view.write_box.msg_write_box.set_edit_pos(len(quote))
             self.model.controller.view.middle_column.set_focus("footer")
+
         elif is_command_key("EDIT_MESSAGE", key):
             # User can't edit messages of others that already have a subject
             # For private messages, subject = "" (empty string)
@@ -1884,10 +1897,12 @@ class MessageBox(urwid.Pile):
                 write_box.header_write_box.focus_col = write_box.FOCUS_HEADER_BOX_TOPIC
 
             self.model.controller.view.middle_column.set_focus("footer")
+
         elif is_command_key("MSG_INFO", key):
             self.model.controller.show_msg_info(
                 self.message, self.topic_links, self.message_links, self.time_mentions
             )
+
         return key
 
 
@@ -1986,10 +2001,12 @@ class PanelSearchBox(urwid.Edit):
             self.reset_search_text()
             self.panel_view.set_focus("body")
             self.panel_view.keypress(size, primary_key_for_command("GO_BACK"))
+
         elif is_command_key("ENTER", key) and not self.panel_view.empty_search:
             self.panel_view.view.controller.exit_editor_mode()
             self.set_caption([("filter_results", " Search Results "), " "])
             self.panel_view.set_focus("body")
             if hasattr(self.panel_view, "log"):
                 self.panel_view.body.set_focus(0)
+
         return super().keypress(size, key)

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -92,13 +92,13 @@ class TopButton(urwid.Button):
         self.controller.view.body.focus_col = 1
         self.show_function()
 
-    def keypress(self, size: urwid_Size, key: str) -> Optional[str]:
+    def keypress(self, size: urwid_Size, key: Optional[str]) -> Optional[str]:
+        # Handle activate only for ENTER, ignore space
         if is_command_key("ENTER", key):
-            self.activate(key)
-            return None
-
-        else:  # This is in the else clause, to avoid multiple activation
             return super().keypress(size, key)
+
+        # key wasn't handled.
+        return key
 
 
 class HomeButton(TopButton):
@@ -216,19 +216,26 @@ class StreamButton(TopButton):
         self.update_count(unread_count)
         self.view.home_button.update_count(self.model.unread_counts["all_msg"])
 
-    def keypress(self, size: urwid_Size, key: str) -> Optional[str]:
+    def keypress(self, size: urwid_Size, key: Optional[str]) -> Optional[str]:
+        # Handle activation.
+        key = super().keypress(size, key)
+
         if is_command_key("TOGGLE_TOPIC", key):
             self.view.left_panel.show_topic_view(self)
+            return None
 
         elif is_command_key("TOGGLE_MUTE_STREAM", key):
             self.controller.stream_muting_confirmation_popup(
                 self.stream_id, self.stream_name
             )
+            return None
 
         elif is_command_key("STREAM_DESC", key):
             self.model.controller.show_stream_info(self.stream_id)
+            return None
 
-        return super().keypress(size, key)
+        # key wasn't handled.
+        return key
 
 
 class UserButton(TopButton):
@@ -273,11 +280,16 @@ class UserButton(TopButton):
         self._view.body.focus.original_widget.set_focus("footer")
         self._view.write_box.private_box_view(recipient_user_ids=[self.user_id])
 
-    def keypress(self, size: urwid_Size, key: str) -> Optional[str]:
+    def keypress(self, size: urwid_Size, key: Optional[str]) -> Optional[str]:
+        # Handle activation.
+        key = super().keypress(size, key)
+
         if is_command_key("USER_INFO", key):
             self.controller.show_user_info(self.user_id)
-            
-        return super().keypress(size, key)
+            return None
+
+        # key wasn't handled.
+        return key
 
 
 class TopicButton(TopButton):
@@ -318,12 +330,17 @@ class TopicButton(TopButton):
 
     # TODO: Handle event-based approach for topic-muting.
 
-    def keypress(self, size: urwid_Size, key: str) -> Optional[str]:
+    def keypress(self, size: urwid_Size, key: Optional[str]) -> Optional[str]:
+        # Handle activation.
+        key = super().keypress(size, key)
+
         if is_command_key("TOGGLE_TOPIC", key):
             # Exit topic view
             self.view.left_panel.show_stream_view()
+            return None
 
-        return super().keypress(size, key)
+        # key wasn't handled.
+        return key
 
 
 class DecodedStream(TypedDict):

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -96,6 +96,7 @@ class TopButton(urwid.Button):
         if is_command_key("ENTER", key):
             self.activate(key)
             return None
+
         else:  # This is in the else clause, to avoid multiple activation
             return super().keypress(size, key)
 
@@ -218,12 +219,15 @@ class StreamButton(TopButton):
     def keypress(self, size: urwid_Size, key: str) -> Optional[str]:
         if is_command_key("TOGGLE_TOPIC", key):
             self.view.left_panel.show_topic_view(self)
+
         elif is_command_key("TOGGLE_MUTE_STREAM", key):
             self.controller.stream_muting_confirmation_popup(
                 self.stream_id, self.stream_name
             )
+
         elif is_command_key("STREAM_DESC", key):
             self.model.controller.show_stream_info(self.stream_id)
+
         return super().keypress(size, key)
 
 
@@ -272,6 +276,7 @@ class UserButton(TopButton):
     def keypress(self, size: urwid_Size, key: str) -> Optional[str]:
         if is_command_key("USER_INFO", key):
             self.controller.show_user_info(self.user_id)
+            
         return super().keypress(size, key)
 
 
@@ -317,6 +322,7 @@ class TopicButton(TopButton):
         if is_command_key("TOGGLE_TOPIC", key):
             # Exit topic view
             self.view.left_panel.show_stream_view()
+
         return super().keypress(size, key)
 
 

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -390,6 +390,7 @@ class StreamsView(urwid.Frame):
             self.stream_search_box.set_caption(" ")
             self.view.controller.enter_editor_mode_with(self.stream_search_box)
             return key
+
         elif is_command_key("GO_BACK", key):
             self.stream_search_box.reset_search_text()
             self.log.clear()
@@ -398,6 +399,7 @@ class StreamsView(urwid.Frame):
             self.log.set_focus(self.focus_index_before_search)
             self.view.controller.update_screen()
             return key
+
         return super().keypress(size, key)
 
 
@@ -504,6 +506,7 @@ class TopicsView(urwid.Frame):
             self.topic_search_box.set_caption(" ")
             self.view.controller.enter_editor_mode_with(self.topic_search_box)
             return key
+
         elif is_command_key("GO_BACK", key):
             self.topic_search_box.reset_search_text()
             self.log.clear()
@@ -512,6 +515,7 @@ class TopicsView(urwid.Frame):
             self.log.set_focus(self.focus_index_before_search)
             self.view.controller.update_screen()
             return key
+
         return super().keypress(size, key)
 
 
@@ -639,6 +643,7 @@ class MiddleColumnView(urwid.Frame):
                 topic_name=topic,
             )
             return key
+
         elif is_command_key("NEXT_UNREAD_PM", key):
             # narrow to next unread pm
             pm = self.get_next_unread_pm()
@@ -649,16 +654,20 @@ class MiddleColumnView(urwid.Frame):
                 recipient_emails=[email],
                 contextual_message_id=pm,
             )
+
         elif is_command_key("PRIVATE_MESSAGE", key):
             # Create new PM message
             self.footer.private_box_view()
             self.set_focus("footer")
             self.footer.focus_position = 0
             return key
+
         elif is_command_key("GO_LEFT", key):
             self.view.show_left_panel(visible=True)
+
         elif is_command_key("GO_RIGHT", key):
             self.view.show_right_panel(visible=True)
+
         return super().keypress(size, key)
 
 
@@ -778,6 +787,7 @@ class RightColumnView(urwid.Frame):
             self.user_search.set_caption(" ")
             self.view.controller.enter_editor_mode_with(self.user_search)
             return key
+
         elif is_command_key("GO_BACK", key):
             self.user_search.reset_search_text()
             self.allow_update_user_list = True
@@ -786,8 +796,10 @@ class RightColumnView(urwid.Frame):
             self.set_focus("body")
             self.view.controller.update_screen()
             return key
+
         elif is_command_key("GO_LEFT", key):
             self.view.show_right_panel(visible=False)
+
         return super().keypress(size, key)
 
 
@@ -943,8 +955,10 @@ class LeftColumnView(urwid.Pile):
             else:
                 self.view.stream_w.keypress(size, key)
             return key
+
         elif is_command_key("GO_RIGHT", key):
             self.view.show_left_panel(visible=False)
+
         return super().keypress(size, key)
 
 
@@ -1296,6 +1310,7 @@ class PopUpConfirmationView(urwid.Overlay):
     def keypress(self, size: urwid_Size, key: str) -> str:
         if is_command_key("GO_BACK", key):
             self.controller.exit_popup()
+
         return super().keypress(size, key)
 
 
@@ -1450,8 +1465,10 @@ class StreamInfoView(PopUpView):
     def keypress(self, size: urwid_Size, key: str) -> str:
         if is_command_key("STREAM_MEMBERS", key):
             self.controller.show_stream_members(stream_id=self.stream_id)
+
         elif is_command_key("COPY_STREAM_EMAIL", key):
             self.controller.copy_to_clipboard(self.stream_email, "Stream email")
+
         return super().keypress(size, key)
 
 
@@ -1479,6 +1496,7 @@ class StreamMembersView(PopUpView):
         if is_command_key("GO_BACK", key) or is_command_key("STREAM_MEMBERS", key):
             self.controller.show_stream_info(stream_id=self.stream_id)
             return key
+
         return super().keypress(size, key)
 
 
@@ -1634,9 +1652,11 @@ class MsgInfoView(PopUpView):
                 message_links=self.message_links,
                 time_mentions=self.time_mentions,
             )
+
         elif is_command_key("VIEW_IN_BROWSER", key):
             url = near_message_url(self.server_url[:-1], self.msg)
             self.controller.open_in_browser(url)
+
         elif is_command_key("FULL_RENDERED_MESSAGE", key):
             self.controller.show_full_rendered_message(
                 message=self.msg,
@@ -1645,6 +1665,7 @@ class MsgInfoView(PopUpView):
                 time_mentions=self.time_mentions,
             )
             return key
+
         elif is_command_key("FULL_RAW_MESSAGE", key):
             self.controller.show_full_raw_message(
                 message=self.msg,
@@ -1653,6 +1674,7 @@ class MsgInfoView(PopUpView):
                 time_mentions=self.time_mentions,
             )
             return key
+
         return super().keypress(size, key)
 
 
@@ -1686,6 +1708,7 @@ class EditModeView(PopUpView):
         # Use space to select radio-button and exit popup too.
         if key == " ":
             key = "enter"
+
         return super().keypress(size, key)
 
 
@@ -1807,6 +1830,7 @@ class EditHistoryView(PopUpView):
                 time_mentions=self.time_mentions,
             )
             return key
+
         return super().keypress(size, key)
 
 
@@ -1851,6 +1875,7 @@ class FullRenderedMsgView(PopUpView):
                 time_mentions=self.time_mentions,
             )
             return key
+
         return super().keypress(size, key)
 
 
@@ -1901,4 +1926,5 @@ class FullRawMsgView(PopUpView):
                 time_mentions=self.time_mentions,
             )
             return key
+
         return super().keypress(size, key)


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->
This PR refactors Boxes according to urwid keypress rules.
The idea of following keypress rules is to:
* send key to inner-most widget.
* handle unhandled keys from super() and return None.
* return unhandled keys.


<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->

<!-- Add a link to a discussion on chat.zulip.org, if relevant -->

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [x] New tests added (for any new behavior)
- [x] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

**Notes & Questions** <!-- if any; add/delete/fill-in as appropriate -->
<!-- For example:
- this doesn't include feature X (yet?)
- unsure about Y
- should this do Z?
-->
The PanelSearchBox keypress may look a bit ugly but it is necessary in the transition phase of this refactor.
**Interactions** <!-- if any; add/delete/fill-in as appropriate -->
<!-- eg.
- Waiting on #<PR>
- Blocks #<PR>
-->
- Waiting on #1117 

**Visual changes** <!-- if any; add/delete/fill-in with screenshot/diagram as appropriate -->
