### PR TITLE
Improve print-debugging (no `flush=True` required; require `-d`/`--debug`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,13 +321,13 @@ For additional help with pytest options see `pytest -h`, or check out the [full 
 
 #### Output using `print`
 
-The stdout for zulip-terminal is redirected to `./debug.log` by default.
+The stdout (standard output) for zulip-terminal is redirected to `./debug.log` if debugging is enabled at run-time using `-d` or `--debug`.
 
-If you want to check the value of a variable, or perhaps indicate reaching a certain point in the code, you can simply use `print()`, eg.
+This means that if you want to check the value of a variable, or perhaps indicate reaching a certain point in the code, you can simply use `print()`, eg.
 ```python3
 print(f"Just about to do something with {variable}")
 ```
-and the string will be printed to `./debug.log`.
+and when running with a debugging option, the string will be printed to `./debug.log`.
 
 With a bash-like terminal, you can run something like `tail -f debug.log` in another terminal, to see the output from `print` as it happens.
 

--- a/README.md
+++ b/README.md
@@ -323,15 +323,13 @@ For additional help with pytest options see `pytest -h`, or check out the [full 
 
 The stdout for zulip-terminal is redirected to `./debug.log` by default.
 
-If you want to check the value of a variable, or perhaps indicate reaching a certain point in the code, you can simply write
+If you want to check the value of a variable, or perhaps indicate reaching a certain point in the code, you can simply use `print()`, eg.
 ```python3
-print(variable, flush=True)
+print(f"Just about to do something with {variable}")
 ```
-and the value of the variable will be printed to `./debug.log`.
+and the string will be printed to `./debug.log`.
 
-We suggest the `flush=True` to ensure it prints straight away.
-
-If you have a bash-like terminal, you can run something like `tail -f debug.log` in another terminal, to see the output from `print` as it happens.
+With a bash-like terminal, you can run something like `tail -f debug.log` in another terminal, to see the output from `print` as it happens.
 
 #### Interactive debugging using pudb & telnet
 

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -50,14 +50,16 @@ class TestController:
         self.notify_enabled = False
         self.maximum_footlinks = 3
         result = Controller(
-            self.config_file,
-            self.maximum_footlinks,
-            self.theme_name,
-            self.theme,
-            256,
-            self.in_explore_mode,
-            self.autohide,
-            self.notify_enabled,
+            config_file=self.config_file,
+            maximum_footlinks=self.maximum_footlinks,
+            theme_name=self.theme_name,
+            theme=self.theme,
+            color_depth=256,
+            in_explore_mode=self.in_explore_mode,
+            **dict(
+                autohide=self.autohide,
+                notify=self.notify_enabled,
+            ),
         )
         result.view.message_view = mocker.Mock()  # set in View.__init__
         result.model.server_url = SERVER_URL

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -56,6 +56,7 @@ class TestController:
             theme=self.theme,
             color_depth=256,
             in_explore_mode=self.in_explore_mode,
+            debug_path=None,
             **dict(
                 autohide=self.autohide,
                 notify=self.notify_enabled,

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -494,12 +494,12 @@ def main(options: Optional[List[str]] = None) -> None:
         theme_data = generate_theme(theme_to_use[0], color_depth)
 
         Controller(
-            zuliprc_path,
-            maximum_footlinks,
-            theme_to_use[0],
-            theme_data,
-            color_depth,
-            args.explore,
+            config_file=zuliprc_path,
+            maximum_footlinks=maximum_footlinks,
+            theme_name=theme_to_use[0],
+            theme=theme_data,
+            color_depth=color_depth,
+            in_explore_mode=args.explore,
             **boolean_settings,
         ).main()
     except ServerConnectionFailure as e:

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -343,14 +343,17 @@ def main(options: Optional[List[str]] = None) -> None:
     set_encoding("utf-8")
 
     if args.debug:
+        debug_path: Optional[str] = "debug.log"
+        assert isinstance(debug_path, str)
         print(
-            "NOTE: Debug mode enabled; API calls being logged to {}.".format(
-                in_color("blue", API_CALL_LOG_FILENAME)
-            )
+            "NOTE: Debug mode enabled:"
+            f"\n  API calls will be logged to {in_color('blue', API_CALL_LOG_FILENAME)}"
+            f"\n  Standard output being logged to {in_color('blue', debug_path)}"
         )
         requests_logfile_handler = logging.FileHandler(API_CALL_LOG_FILENAME)
         requests_logger.addHandler(requests_logfile_handler)
     else:
+        debug_path = None
         requests_logger.addHandler(logging.NullHandler())
 
     if args.profile:
@@ -501,6 +504,7 @@ def main(options: Optional[List[str]] = None) -> None:
             color_depth=color_depth,
             in_explore_mode=args.explore,
             **boolean_settings,
+            debug_path=debug_path,
         ).main()
     except ServerConnectionFailure as e:
         # Acts as separator between logs

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -155,7 +155,8 @@ class Controller:
             return
 
         self._stdout = sys.stdout
-        sys.stdout = open(path, "a")
+        # buffering=1 avoids need for flush=True with print() debugging
+        sys.stdout = open(path, "a", buffering=1)
 
     def restore_stdout(self) -> None:
         if not hasattr(self, "_stdout"):

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -58,6 +58,7 @@ class Controller:
         theme_name: str,
         theme: ThemeSpec,
         color_depth: int,
+        debug_path: Optional[str],
         in_explore_mode: bool,
         autohide: bool,
         notify: bool,
@@ -69,6 +70,8 @@ class Controller:
         self.autohide = autohide
         self.notify_enabled = notify
         self.maximum_footlinks = maximum_footlinks
+
+        self.debug_path = debug_path
 
         self._editor: Optional[Any] = None
 
@@ -151,13 +154,18 @@ class Controller:
 
         self.capture_stdout()
 
-    def capture_stdout(self, path: str = "debug.log") -> None:
+    def capture_stdout(self) -> None:
         if hasattr(self, "_stdout"):
             return
 
         self._stdout = sys.stdout
-        # buffering=1 avoids need for flush=True with print() debugging
-        sys.stdout = open(path, "a", buffering=1)
+
+        if self.debug_path is not None:
+            # buffering=1 avoids need for flush=True with print() debugging
+            sys.stdout = open(self.debug_path, "a", buffering=1)
+        else:
+            # Redirect stdout (print does nothing)
+            sys.stdout = open(os.devnull, "a")
 
     def restore_stdout(self) -> None:
         if not hasattr(self, "_stdout"):

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -52,6 +52,7 @@ class Controller:
 
     def __init__(
         self,
+        *,
         config_file: str,
         maximum_footlinks: int,
         theme_name: str,


### PR DESCRIPTION
**What does this PR do?**  <!-- Overall description goes here -->

This mainly improves print debugging:
* just use `print("something")` instead of `print("something", flush=True)` (README updated)
* only open the `debug.log` file that `print` is redirected to, if `-d` or `--debug` is enabled (README updated)

There is also an intermediate refactor commit to require Controller to have named arguments.

Fixes #1066 (via the second part)

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [ ] New tests added (for any new behavior)
- [x] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->