### PR TITLE
tests: popups: Add type annotations.

### DIFF
--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -1372,10 +1372,10 @@ class TestEmojiPickerView:
     )
     def test_mouse_event(self, mocker, widget_size, event, button, keypress):
         emoji_picker = self.emoji_picker_view
-        mocker.patch.object(emoji_picker, "keypress")
+        mocked_emoji_picker_keypress = mocker.patch.object(emoji_picker, "keypress")
         size = widget_size(emoji_picker)
         emoji_picker.mouse_event(size, event, button, 0, 0, mocker.Mock())
-        emoji_picker.keypress.assert_called_once_with(size, keypress)
+        mocked_emoji_picker_keypress.assert_called_once_with(size, keypress)
 
     @pytest.mark.parametrize("key", keys_for_command("SEARCH_EMOJIS"))
     def test_keypress_search_emoji(self, key, widget_size):

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -79,7 +79,7 @@ class TestPopUpConfirmationView:
 
 class TestPopUpView:
     @pytest.fixture(autouse=True)
-    def pop_up_view(self, mocker):
+    def pop_up_view_autouse(self, mocker):
         self.controller = mocker.Mock()
         mocker.patch.object(
             self.controller, "maximum_popup_dimensions", return_value=(64, 64)

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -37,7 +37,7 @@ LISTWALKER = MODULE + ".urwid.SimpleFocusListWalker"
 
 class TestPopUpConfirmationView:
     @pytest.fixture
-    def popup_view(self, mocker, stream_button):
+    def popup_view(self, mocker):
         self.controller = mocker.Mock()
         self.callback = mocker.Mock()
         self.list_walker = mocker.patch(LISTWALKER, return_value=[])
@@ -69,7 +69,7 @@ class TestPopUpConfirmationView:
         assert self.controller.exit_popup.called
 
     @pytest.mark.parametrize("key", keys_for_command("GO_BACK"))
-    def test_exit_popup_GO_BACK(self, mocker, popup_view, key, widget_size):
+    def test_exit_popup_GO_BACK(self, popup_view, key, widget_size):
         size = widget_size(popup_view)
         popup_view.keypress(size, key)
         self.callback.assert_not_called()
@@ -332,7 +332,7 @@ class TestUserInfoView:
 
 class TestFullRenderedMsgView:
     @pytest.fixture(autouse=True)
-    def mock_external_classes(self, mocker, msg_box, initial_index):
+    def mock_external_classes(self, mocker, msg_box):
         self.controller = mocker.Mock()
         mocker.patch.object(
             self.controller, "maximum_popup_dimensions", return_value=(64, 64)
@@ -351,7 +351,7 @@ class TestFullRenderedMsgView:
             title="Full Rendered Message",
         )
 
-    def test_init(self, mocker, msg_box):
+    def test_init(self, msg_box):
         assert self.full_rendered_message.title == "Full Rendered Message"
         assert self.full_rendered_message.controller == self.controller
         assert self.full_rendered_message.message == self.message
@@ -399,7 +399,7 @@ class TestFullRenderedMsgView:
 
 class TestFullRawMsgView:
     @pytest.fixture(autouse=True)
-    def mock_external_classes(self, mocker, msg_box, initial_index):
+    def mock_external_classes(self, mocker, msg_box):
         self.controller = mocker.Mock()
         mocker.patch.object(
             self.controller, "maximum_popup_dimensions", return_value=(64, 64)
@@ -421,7 +421,7 @@ class TestFullRawMsgView:
             title="Full Raw Message",
         )
 
-    def test_init(self, mocker, msg_box):
+    def test_init(self, msg_box):
         assert self.full_raw_message.title == "Full Raw Message"
         assert self.full_raw_message.controller == self.controller
         assert self.full_raw_message.message == self.message
@@ -690,7 +690,7 @@ class TestEditModeView:
     )
     @pytest.mark.parametrize("key", keys_for_command("ENTER"))
     def test_select_edit_mode(
-        self, mocker, edit_mode_view, widget_size, index_in_widgets, mode, key
+        self, edit_mode_view, widget_size, index_in_widgets, mode, key
     ):
         mode_button = edit_mode_view.edit_mode_button
         if mode_button.mode == mode:
@@ -706,7 +706,7 @@ class TestEditModeView:
 
 class TestMarkdownHelpView:
     @pytest.fixture(autouse=True)
-    def mock_external_classes(self, mocker, monkeypatch):
+    def mock_external_classes(self, mocker):
         self.controller = mocker.Mock()
         mocker.patch.object(
             self.controller, "maximum_popup_dimensions", return_value=(64, 64)
@@ -739,7 +739,7 @@ class TestMarkdownHelpView:
 
 class TestHelpView:
     @pytest.fixture(autouse=True)
-    def mock_external_classes(self, mocker, monkeypatch):
+    def mock_external_classes(self, mocker):
         self.controller = mocker.Mock()
         mocker.patch.object(
             self.controller, "maximum_popup_dimensions", return_value=(64, 64)
@@ -764,7 +764,7 @@ class TestHelpView:
 
 class TestMsgInfoView:
     @pytest.fixture(autouse=True)
-    def mock_external_classes(self, mocker, monkeypatch, message_fixture):
+    def mock_external_classes(self, mocker, message_fixture):
         self.controller = mocker.Mock()
         mocker.patch.object(
             self.controller, "maximum_popup_dimensions", return_value=(64, 64)
@@ -903,7 +903,7 @@ class TestMsgInfoView:
         assert self.controller.exit_popup.called
 
     @pytest.mark.parametrize("key", keys_for_command("VIEW_IN_BROWSER"))
-    def test_keypress_view_in_browser(self, mocker, widget_size, message_fixture, key):
+    def test_keypress_view_in_browser(self, mocker, widget_size, key):
         size = widget_size(self.msg_info_view)
         self.msg_info_view.server_url = "https://chat.zulip.org/"
         mocker.patch(MODULE + ".near_message_url")
@@ -1239,7 +1239,7 @@ class TestStreamInfoView:
         assert self.controller.exit_popup.called
 
     @pytest.mark.parametrize("key", (*keys_for_command("ENTER"), " "))
-    def test_checkbox_toggle_mute_stream(self, mocker, key, widget_size):
+    def test_checkbox_toggle_mute_stream(self, key, widget_size):
         mute_checkbox = self.stream_info_view.widgets[-3]
         toggle_mute_status = self.controller.model.toggle_stream_muted_status
         stream_id = self.stream_info_view.stream_id
@@ -1250,7 +1250,7 @@ class TestStreamInfoView:
         toggle_mute_status.assert_called_once_with(stream_id)
 
     @pytest.mark.parametrize("key", (*keys_for_command("ENTER"), " "))
-    def test_checkbox_toggle_pin_stream(self, mocker, key, widget_size):
+    def test_checkbox_toggle_pin_stream(self, key, widget_size):
         pin_checkbox = self.stream_info_view.widgets[-2]
         toggle_pin_status = self.controller.model.toggle_stream_pinned_status
         stream_id = self.stream_info_view.stream_id
@@ -1276,7 +1276,7 @@ class TestStreamInfoView:
 
 class TestStreamMembersView:
     @pytest.fixture(autouse=True)
-    def mock_external_classes(self, mocker, monkeypatch):
+    def mock_external_classes(self, mocker):
         self.controller = mocker.Mock()
         mocker.patch.object(
             self.controller, "maximum_popup_dimensions", return_value=(64, 64)

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -4,6 +4,7 @@ import pytest
 from pytest import param as case
 from urwid import Columns, Pile, Text
 
+from zulipterminal.api_types import Message
 from zulipterminal.config.keys import is_command_key, keys_for_command
 from zulipterminal.config.ui_mappings import EDIT_MODE_CAPTIONS
 from zulipterminal.ui_tools.boxes import MessageBox
@@ -341,7 +342,7 @@ class TestFullRenderedMsgView:
         # NOTE: Given that the FullRenderedMsgView just uses the message ID from
         # the message data currently, message_fixture is not used to avoid
         # adding extra test runs unnecessarily.
-        self.message = {"id": 1}
+        self.message = Message(id=1)
         self.full_rendered_message = FullRenderedMsgView(
             controller=self.controller,
             message=self.message,
@@ -411,7 +412,7 @@ class TestFullRawMsgView:
         # NOTE: Given that the FullRawMsgView just uses the message ID from
         # the message data currently, message_fixture is not used to avoid
         # adding extra test runs unnecessarily.
-        self.message = {"id": 1}
+        self.message = Message(id=1)
         self.full_raw_message = FullRawMsgView(
             controller=self.controller,
             message=self.message,
@@ -480,7 +481,7 @@ class TestEditHistoryView:
         # NOTE: Given that the EditHistoryView just uses the message ID from
         # the message data currently, message_fixture is not used to avoid
         # adding extra test runs unnecessarily.
-        self.message = {"id": 1}
+        self.message = Message(id=1)
         self.edit_history_view = EditHistoryView(
             controller=self.controller,
             message=self.message,
@@ -924,8 +925,8 @@ class TestMsgInfoView:
     @pytest.mark.parametrize(
         "to_vary_in_each_message",
         [
-            {
-                "reactions": [
+            Message(
+                reactions=[
                     {
                         "emoji_name": "thumbs_up",
                         "emoji_code": "1f44d",
@@ -967,11 +968,12 @@ class TestMsgInfoView:
                         "reaction_type": "unicode_emoji",
                     },
                 ]
-            }
+            )
         ],
     )
     def test_height_reactions(self, message_fixture, to_vary_in_each_message):
-        varied_message = dict(message_fixture, **to_vary_in_each_message)
+        varied_message = message_fixture
+        varied_message.update(to_vary_in_each_message)
         self.msg_info_view = MsgInfoView(
             self.controller,
             varied_message,

--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -135,6 +135,7 @@ type_consistent_testfiles = [
     "test_utils.py",
     "conftest.py",
     "test_boxes.py",
+    "test_popups.py",
 ]
 
 for file_path in python_files:


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->
**What does this PR do?**  <!-- Overall description goes here -->
Adds type annotations to `test_popups.py` and adds the file to the list in `run-mypy`. Also has a few related prior refactors to ensure type consistency.

<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->

<!-- Add a link to a discussion on chat.zulip.org, if relevant -->

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [x] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

<!-- See https://github.com/zulip/zulip-terminal#commit-style -->
**Commit flow** <!-- if more than one commit; add/delete/fill-in as appropriate -->
<!-- For example:
- first commit doing some thing
- maybe multiple commits doing similar things
-->
- refactor: tests: popups: Remove unnecessary parameters. 
This commit removes the passing of parameters in test definitions
for parameters that are unused within the body of the test.

- refactor: tests: popups: Use Message instances to pass into views. 
This commit refactors the multiple `dict` assignments to View classes'
message attribute to Message instances instead to maintain type
consistency.

- refactor: tests: popups: Assign mocked keypress to a variable.
This commit assigns the mocked keypress method of the
emoji_picker_view within `test_mouse_event` of the TestEmojiPickerView
class to a variable, so that the corresponding assert method calls
are type consistent.

- refactor: tests: popups: Return a PopUpView instance from pop_up_view.
This commit refactors the pop_up_view fixture to return a PopUpView
instance for usage in further tests, instead of assigning the instance
to an attribute of the TestPopUpView class, to maintain type
consistency.

- refactor: tests: popups: Add type annotations. 
This commit adds parameter and return type annotations or hints
to the `test_popups.py` file, that contains tests for the
corresponding classes present in `views.py` from  the
`zulipterminal` module, to make mypy checks consistent and
improve code readability.

- tools: Include test_popups.py to be checked by mypy. 
This commit adds `test_popups.py` to the `type_consistent_testfiles`
list to check for type consistency with mypy.
