### PR TITLE
Isolate typing testing dependencies and upgrade to mypy 0.910

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -11,8 +11,8 @@ jobs:
       - uses: actions/setup-python@v1
         with:
           python-version: 3.7
-      - name: Install with linting tools
-        run: pip install .[linting]
+      - name: Install with type-checking tools
+        run: pip install .[typing]
       - name: Run mypy
         run: ./tools/run-mypy
 

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,11 @@ linting_deps = [
 ]
 
 typing_deps = [
-    "mypy==0.812",
+    "mypy==0.910",
+    "types-python-dateutil",
+    "types-tzlocal",
+    "types-pytz",
+    "types-requests",
 ]
 
 dev_helper_deps = [

--- a/setup.py
+++ b/setup.py
@@ -43,11 +43,14 @@ testing_deps = [
 
 linting_deps = [
     "isort~=5.7.0",
-    "mypy==0.812",
     "flake8~=3.9.0",
     "flake8-quotes~=3.2.0",
     "flake8-continuation~=1.0.5",
     "black>=21.5b1",
+]
+
+typing_deps = [
+    "mypy==0.812",
 ]
 
 dev_helper_deps = [
@@ -99,9 +102,10 @@ setup(
         ],
     },
     extras_require={
-        "dev": testing_deps + linting_deps + dev_helper_deps,
+        "dev": testing_deps + linting_deps + typing_deps + dev_helper_deps,
         "testing": testing_deps,
         "linting": linting_deps,
+        "typing": typing_deps,
     },
     tests_require=testing_deps,
     install_requires=[


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->

This is essentially an upgrade to mypy 0.910.

However, from ~0.901, type annotations for libraries not in the standard library are expected to be pulled in externally. For this reason a separate extra is added to `setup.py` for use by CI when running mypy (first commit) and to group the dependencies together in the second commit when mypy is upgraded.

NOTE: I've provisionally used a `[dev]` in the commit area to indicate this is a dev-only change, which we can discuss.

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [X] Manually
- [X] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->