### PR TITLE
Add support for copying code snippets

### DIFF
--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -391,6 +391,7 @@ class TestFullRenderedMsgView:
             message=self.message,
             topic_links=OrderedDict(),
             message_links=OrderedDict(),
+            code_snippets=list(),
             time_mentions=list(),
             title="Full Rendered Message",
         )
@@ -467,6 +468,7 @@ class TestFullRawMsgView:
             message=self.message,
             topic_links=OrderedDict(),
             message_links=OrderedDict(),
+            code_snippets=list(),
             time_mentions=list(),
             title="Full Raw Message",
         )
@@ -542,6 +544,7 @@ class TestEditHistoryView:
             message=self.message,
             topic_links=OrderedDict(),
             message_links=OrderedDict(),
+            code_snippets=list(),
             time_mentions=list(),
             title="Edit History",
         )
@@ -868,6 +871,7 @@ class TestMsgInfoView:
             OrderedDict(),
             OrderedDict(),
             list(),
+            list(),
         )
 
     def test_init(self, message_fixture: Message) -> None:
@@ -933,6 +937,7 @@ class TestMsgInfoView:
             title="Message Information",
             topic_links=OrderedDict(),
             message_links=OrderedDict(),
+            code_snippets=list(),
             time_mentions=list(),
         )
         size = widget_size(msg_info_view)
@@ -962,6 +967,7 @@ class TestMsgInfoView:
             title="Message Information",
             topic_links=OrderedDict(),
             message_links=OrderedDict(),
+            code_snippets=list(),
             time_mentions=list(),
         )
         size = widget_size(msg_info_view)
@@ -988,6 +994,7 @@ class TestMsgInfoView:
             title="Message Information",
             topic_links=OrderedDict(),
             message_links=OrderedDict(),
+            code_snippets=list(),
             time_mentions=list(),
         )
         size = widget_size(msg_info_view)
@@ -1097,6 +1104,7 @@ class TestMsgInfoView:
             "Message Information",
             OrderedDict(),
             OrderedDict(),
+            list(),
             list(),
         )
         # 12 = 6 labels + 1 blank line + 1 'Reactions' (category)

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -280,6 +280,7 @@ class Controller:
         msg: Message,
         topic_links: "OrderedDict[str, Tuple[str, int, bool]]",
         message_links: "OrderedDict[str, Tuple[str, int, bool]]",
+        code_snippets: List[Tuple[str, List[Tuple[str, str]]]],
         time_mentions: List[Tuple[str, str]],
     ) -> None:
         msg_info_view = MsgInfoView(
@@ -288,6 +289,7 @@ class Controller:
             "Message Information (up/down scrolls)",
             topic_links,
             message_links,
+            code_snippets,
             time_mentions,
         )
         self.show_pop_up(msg_info_view, "area:msg")
@@ -341,14 +343,17 @@ class Controller:
         message: Message,
         topic_links: "OrderedDict[str, Tuple[str, int, bool]]",
         message_links: "OrderedDict[str, Tuple[str, int, bool]]",
+        code_snippets: List[Tuple[str, List[Tuple[str, str]]]],
         time_mentions: List[Tuple[str, str]],
     ) -> None:
+        print(1, code_snippets)
         self.show_pop_up(
             FullRenderedMsgView(
                 self,
                 message,
                 topic_links,
                 message_links,
+                code_snippets,
                 time_mentions,
                 "Full rendered message (up/down scrolls)",
             ),
@@ -360,6 +365,7 @@ class Controller:
         message: Message,
         topic_links: "OrderedDict[str, Tuple[str, int, bool]]",
         message_links: "OrderedDict[str, Tuple[str, int, bool]]",
+        code_snippets: List[Tuple[str, List[Tuple[str, str]]]],
         time_mentions: List[Tuple[str, str]],
     ) -> None:
         self.show_pop_up(
@@ -368,6 +374,7 @@ class Controller:
                 message,
                 topic_links,
                 message_links,
+                code_snippets,
                 time_mentions,
                 "Full raw message (up/down scrolls)",
             ),
@@ -379,6 +386,7 @@ class Controller:
         message: Message,
         topic_links: "OrderedDict[str, Tuple[str, int, bool]]",
         message_links: "OrderedDict[str, Tuple[str, int, bool]]",
+        code_snippets: List[Tuple[str, List[Tuple[str, str]]]],
         time_mentions: List[Tuple[str, str]],
     ) -> None:
         self.show_pop_up(
@@ -387,6 +395,7 @@ class Controller:
                 message,
                 topic_links,
                 message_links,
+                code_snippets,
                 time_mentions,
                 "Edit History (up/down scrolls)",
             ),

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -647,6 +647,40 @@ class MessageLinkButton(urwid.Button):
                 self.controller.exit_popup()
 
 
+class CodeSnippetButton(urwid.Text):
+    _selectable = True
+
+    signals = ["click"]
+
+    def keypress(self, size: Tuple[int, None], key: str) -> Optional[str]:
+        """
+        Send 'click' signal on 'activate' command.
+        """
+        if self._command_map[key] != urwid.ACTIVATE:
+            return key
+
+        self._emit("click")
+        return None
+
+    def mouse_event(
+        self,
+        size: Tuple[int, None],
+        event: str,
+        button: float,
+        x: int,
+        y: int,
+        focus: bool,
+    ) -> bool:
+        """
+        Send 'click' signal on button 1 press.
+        """
+        if button != 1 or not urwid.util.is_mouse_press(event):
+            return False
+
+        self._emit("click")
+        return True
+
+
 class EditModeButton(urwid.Button):
     def __init__(self, *, controller: Any, width: int) -> None:
         self.controller = controller


### PR DESCRIPTION
**What does this PR do?**  <!-- Overall description goes here -->
This adds a feature to copy code snippets as mentioned in [#1123 ](https://github.com/zulip/zulip-terminal/issues/1123)

![copy_code_snippet](https://user-images.githubusercontent.com/69108486/132318750-8c14ff2e-2b58-4752-bf07-429209e1ff67.gif)

Work in progress
**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [ ] Manually
- [ ] Existing tests (adapted, if necessary)
- [ ] New tests added (for any new behavior)
- [ ] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->
