### PR TITLE
CI: Update to CPython 3.10 release and add specific PyPy versions (3.6, 3.7, 3.8)

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -66,7 +66,7 @@ jobs:
           - {PYTHON: 3.7, OS: ubuntu-latest, NAME: "CPython 3.7 (ubuntu)"}
           - {PYTHON: 3.8, OS: ubuntu-latest, NAME: "CPython 3.8 (ubuntu)"}
           - {PYTHON: 3.9, OS: ubuntu-latest, NAME: "CPython 3.9 (ubuntu)", CODECOV: true}
-          - {PYTHON: "3.10.0-rc.1", OS: ubuntu-latest, NAME: "CPython 3.10RC1 (ubuntu)"}
+          - {PYTHON: "3.10", OS: ubuntu-latest, NAME: "CPython 3.10 (ubuntu)"}
           - {PYTHON: 'pypy3', OS: ubuntu-latest, NAME: "PyPy 3 (ubuntu)"}
           - {PYTHON: 3.9, OS: macos-latest, NAME: "CPython 3.9 (macos)"}
     runs-on: ${{ matrix.env.OS }}

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -67,7 +67,9 @@ jobs:
           - {PYTHON: 3.8, OS: ubuntu-latest, NAME: "CPython 3.8 (ubuntu)"}
           - {PYTHON: 3.9, OS: ubuntu-latest, NAME: "CPython 3.9 (ubuntu)", CODECOV: true}
           - {PYTHON: "3.10", OS: ubuntu-latest, NAME: "CPython 3.10 (ubuntu)"}
-          - {PYTHON: 'pypy3', OS: ubuntu-latest, NAME: "PyPy 3 (ubuntu)"}
+          - {PYTHON: 'pypy-3.6', OS: ubuntu-latest, NAME: "PyPy 3.6 (ubuntu)"}
+          - {PYTHON: 'pypy-3.7', OS: ubuntu-latest, NAME: "PyPy 3.7 (ubuntu)"}
+          - {PYTHON: 'pypy-3.8', OS: ubuntu-latest, NAME: "PyPy 3.8 (ubuntu)"}
           - {PYTHON: 3.9, OS: macos-latest, NAME: "CPython 3.9 (macos)"}
     runs-on: ${{ matrix.env.OS }}
     name: Install & test - ${{ matrix.env.NAME}}
@@ -81,8 +83,8 @@ jobs:
         run: python --version
       - name: Upgrade pip
         run: python -m pip install --upgrade pip
-      - name: Ensure libxml-related libraries are installed (pypy3 only)
-        if: matrix.env.PYTHON == 'pypy3'
+      - name: Ensure libxml-related libraries are installed (pypy-3.6 only)
+        if: matrix.env.PYTHON == 'pypy-3.6'
         run: sudo apt install libxml2-dev libxslt1-dev
       - name: Ensure regular package installs from checkout
         run: pip install .


### PR DESCRIPTION
**What does this PR do?**  <!-- Overall description goes here -->

We recently added CI support for a release-candidate version of CPython 3.10 - this is now released and available in Github Actions, so can be updated and should track later releases too.

PyPy support has been present for some time, but different python versions appeared to be challenging in the past - this seems more straightforward now, so we have separate tests under 3.6, 3.7 and 3.8.
(Note that more generally 3.6 will be end-of-life soon, so this will make updating specific python versions more explicit when we remove support too)

<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->

<!-- Add a link to a discussion on chat.zulip.org, if relevant -->

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->

CI has been updated.