### PR TITLE
Add "$(PYTHON) -m pip install wheel" to makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -47,4 +47,4 @@ venv: $(ZT_VENV)/bin/activate
 $(ZT_VENV)/bin/activate: setup.py
 	@echo "=== Installing development environment ==="
 	test -d $(ZT_VENV) || $(BASEPYTHON) -m venv $(ZT_VENV)
-	$(PYTHON) -m pip install -U pip && $(PYTHON) -m pip install -e .[dev] && touch $(ZT_VENV)/bin/activate
+	$(PYTHON) -m pip install wheel && $(PYTHON) -m pip install -U pip && $(PYTHON) -m pip install -e .[dev] && touch $(ZT_VENV)/bin/activate


### PR DESCRIPTION
Adds "$(PYTHON) -m pip install wheel" to the makefile, so as to install wheel if it isn't on the host system


(https://chat.zulip.org/#narrow/stream/2-general)

- [x ] Manually
- [x] Existing tests (adapted, if necessary)
- [x] New tests added (for any new behavior)
- [x] Passed linting & tests (each commit)

 See https://github.com/zulip/zulip-terminal#commit-style
