### PR TITLE
Display of starred and unstarred messages enhanced

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -2300,21 +2300,38 @@ class TestMessageBox:
     @pytest.mark.parametrize(
         "to_vary_in_each_message",
         [
+            {"flags": ["starred"]},
+        ],
+        ids=[
+            "no_stars",
+        ],
+    )
+    def test_main_view_compact_output_no_star(
+        self, mocker, message_fixture, to_vary_in_each_message
+    ):
+        message_fixture.update({"id": 0})
+        varied_message = dict(message_fixture, **to_vary_in_each_message)
+        msg_box = MessageBox(varied_message, self.model, varied_message)
+        view_components = msg_box.main_view()
+        assert len(view_components) == 2
+        assert isinstance(view_components[0], Columns)
+
+    @pytest.mark.parametrize(
+        "to_vary_in_each_message",
+        [
             {"sender_full_name": "bob"},
             {"timestamp": 1532103779},
             {"timestamp": 0},
             {},
-            {"flags": ["starred"]},
         ],
         ids=[
             "common_author",
             "common_timestamp",
             "common_early_timestamp",
             "common_unchanged_message",
-            "both_starred",
         ],
     )
-    def test_main_view_compact_output(
+    def test_main_view_compact_output_common_parameters(
         self, mocker, message_fixture, to_vary_in_each_message
     ):
         message_fixture.update({"id": 4})

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -1515,7 +1515,8 @@ class MessageBox(urwid.Pile):
                 and message["this"]["time"] != message["last"]["time"]
             ),
             "star_status": (
-                message["this"]["is_starred"] != message["last"]["is_starred"]
+                (message["this"]["is_starred"])
+                or (message["this"]["is_starred"] != message["last"]["is_starred"])
             ),
         }
         any_differences = any(different.values())


### PR DESCRIPTION
**What does this PR do?**  
This PR enhances the display of consecutive starred and/or unstarred messages which have identical dates, times, and authors.
Earlier all such messages which had similar star status (whether starred or unstarred) appeared together and messages which had different star status were separated by a line. However, this led to difficulty in identifying the star status of messages (which were starred and thus appeared together). The following screenshot depicts the same-
![image](https://user-images.githubusercontent.com/75558322/148385177-f66ab2b4-12a5-4d27-84ef-b83a8743e3c5.png)

Now, all starred messages and messages which have different star statuses have been separated by a blank line whereas those which are all unstarred appear together. This leads to a better visual display and interpretation of the star status of messages.
The following screenshot demonstrates the present scenario-
![image](https://user-images.githubusercontent.com/75558322/148385598-ccf6a969-fc8f-41f3-b876-966c8efc7ed8.png)

(The first two messages are starred and the third one is unstarred in both the above screenshots)

Fixes #171 

A detailed explanation of the issue and discussion related to it can be read at - https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/Message.20merging.20-.20star.20status.20.28issue.20.23T171.29


**Tested?** 
- [x] Manually
- [x] Existing tests (adapted, if necessary)

**Notes & Questions** 
Should any other changes be made?

**Interactions** 
The changes have been made (developed on) in addition to the following PR - https://github.com/zulip/zulip-terminal/pull/335

**Visual changes** 
Earlier-
![image](https://user-images.githubusercontent.com/75558322/148386530-f99d56ff-6e0d-4ef8-a3a3-4bbddb8810d8.png)
![image](https://user-images.githubusercontent.com/75558322/148386553-e8d64b84-b88f-4083-b9a7-84022beb0824.png)
![image](https://user-images.githubusercontent.com/75558322/148386575-d96dbb71-ecd9-45ad-857b-3f77462dab18.png)

Presently-
![image](https://user-images.githubusercontent.com/75558322/148386626-bd2224ba-27d0-4f9f-b940-25a7750fe61d.png)
![image](https://user-images.githubusercontent.com/75558322/148386645-e0628a2e-b578-480a-aadf-7173f03a5379.png)
![image](https://user-images.githubusercontent.com/75558322/148386662-86a3d694-b5ba-41fe-89f7-2637f23bd612.png)
![image](https://user-images.githubusercontent.com/75558322/148386698-39c14a13-4f8c-4a01-b738-c35ba06a2ab9.png)




