### PR TITLE
Restrict posting messages on streams having moderators/admins only

### DIFF
--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -808,6 +808,263 @@ class TestModel:
             )
 
     @pytest.mark.parametrize(
+        "user_role, stream_properties",
+        [
+            case(
+                {"is_admin": True},
+                {"is_announcement_only": True},
+                id="is_admin:announcement_only:Zulip2.1",
+            ),
+            case(
+                {"is_admin": True},
+                {"is_announcement_only": False},
+                id="is_admin:not_announcement_only:Zulip2.1",
+            ),
+            case(
+                {"is_admin": False},
+                {"is_announcement_only": False},
+                id="is_not_admin:not_announcement_only:Zulip2.1",
+            ),
+            case(
+                {"is_owner": True, "is_admin": True, "is_guest": False},
+                {"is_announcement_only": False, "stream_post_policy": 1},
+                id="is_owner:anyone_can_post:Zulip3.0+:ZFL8",
+            ),
+            case(
+                {"is_owner": True, "is_admin": True, "is_guest": False},
+                {"is_announcement_only": True, "stream_post_policy": 2},
+                id="is_owner:admins_only:Zulip3.0+:ZFL8",
+            ),
+            case(
+                {"is_owner": True, "is_admin": True, "is_guest": False},
+                {"is_announcement_only": False, "stream_post_policy": 3},
+                id="is_owner:members_only:Zulip3.0+:ZFL8",
+            ),
+            case(
+                {"is_owner": True, "is_admin": True, "is_guest": False},
+                {"is_announcement_only": False, "stream_post_policy": 4},
+                id="is_owner:moderators_only:Zulip3.0+:ZFL8",
+            ),
+            case(
+                {"is_owner": False, "is_admin": True, "is_guest": False},
+                {"is_announcement_only": False, "stream_post_policy": 1},
+                id="is_admin:anyone_can_post:Zulip3.0+:ZFL8",
+            ),
+            case(
+                {"is_owner": False, "is_admin": True, "is_guest": False},
+                {"is_announcement_only": True, "stream_post_policy": 2},
+                id="is_admin:admins_only:Zulip3.0+:ZFL8",
+            ),
+            case(
+                {"is_owner": False, "is_admin": True, "is_guest": False},
+                {"is_announcement_only": False, "stream_post_policy": 3},
+                id="is_admin:members_only:Zulip3.0+:ZFL8",
+            ),
+            case(
+                {"is_owner": False, "is_admin": True, "is_guest": False},
+                {"is_announcement_only": False, "stream_post_policy": 4},
+                id="is_admin:moderators_only:Zulip3.0+:ZFL8",
+            ),
+            case(
+                {"is_owner": False, "is_admin": False, "is_guest": False},
+                {"is_announcement_only": False, "stream_post_policy": 1},
+                id="is_member:anyone_can_post:Zulip3.0+:ZFL8",
+            ),
+            case(
+                {"is_owner": False, "is_admin": False, "is_guest": False},
+                {"is_announcement_only": False, "stream_post_policy": 3},
+                id="is_member:members_only:Zulip3.0+:ZFL8",
+            ),
+            case(
+                {"is_owner": False, "is_admin": False, "is_guest": True},
+                {"is_announcement_only": False, "stream_post_policy": 1},
+                id="is_guest:anyone_can_post:Zulip3.0+:ZFL8",
+            ),
+            case(
+                {"is_admin": True, "is_owner": True, "is_guest": False, "role": 100},
+                {"is_announcement_only": False, "stream_post_policy": 1},
+                id="is_owner:anyone_can_post:Zulip4.0+:ZFL59",
+            ),
+            case(
+                {"is_admin": True, "is_owner": True, "is_guest": False, "role": 100},
+                {"is_announcement_only": True, "stream_post_policy": 2},
+                id="is_owner:admins_only:Zulip4.0+:ZFL59",
+            ),
+            case(
+                {"is_admin": True, "is_owner": True, "is_guest": False, "role": 100},
+                {"is_announcement_only": False, "stream_post_policy": 3},
+                id="is_owner:members_only:Zulip4.0+:ZFL59",
+            ),
+            case(
+                {"is_admin": True, "is_owner": True, "is_guest": False, "role": 100},
+                {"is_announcement_only": False, "stream_post_policy": 4},
+                id="is_owner:moderators_only:Zulip4.0+:ZFL59",
+            ),
+            case(
+                {"is_admin": True, "is_owner": False, "is_guest": False, "role": 200},
+                {"is_announcement_only": False, "stream_post_policy": 1},
+                id="is_admin:anyone_can_post:Zulip4.0+:ZFL59",
+            ),
+            case(
+                {"is_admin": True, "is_owner": False, "is_guest": False, "role": 200},
+                {"is_announcement_only": True, "stream_post_policy": 2},
+                id="is_admin:admins_only:Zulip4.0+:ZFL59",
+            ),
+            case(
+                {"is_admin": True, "is_owner": False, "is_guest": False, "role": 200},
+                {"is_announcement_only": False, "stream_post_policy": 3},
+                id="is_admin:members_only:Zulip4.0+:ZFL59",
+            ),
+            case(
+                {"is_admin": True, "is_owner": False, "is_guest": False, "role": 200},
+                {"is_announcement_only": False, "stream_post_policy": 4},
+                id="is_admin:moderators_only:Zulip4.0+:ZFL59",
+            ),
+            case(
+                {"is_admin": False, "is_owner": False, "is_guest": False, "role": 300},
+                {"is_announcement_only": False, "stream_post_policy": 1},
+                id="is_moderator:anyone_can_post:Zulip4.0+:ZFL59",
+            ),
+            case(
+                {"is_admin": False, "is_owner": False, "is_guest": False, "role": 300},
+                {"is_announcement_only": False, "stream_post_policy": 3},
+                id="is_moderator:admins_only:Zulip4.0+:ZFL59",
+            ),
+            case(
+                {"is_admin": False, "is_owner": False, "is_guest": False, "role": 300},
+                {"is_announcement_only": False, "stream_post_policy": 4},
+                id="is_moderator:moderators_only:Zulip4.0+:ZFL59",
+            ),
+            case(
+                {"is_admin": False, "is_owner": False, "is_guest": False, "role": 400},
+                {"is_announcement_only": False, "stream_post_policy": 1},
+                id="is_member:anyone_can_post:Zulip4.0+:ZFL59",
+            ),
+            case(
+                {"is_admin": False, "is_owner": False, "is_guest": False, "role": 400},
+                {"is_announcement_only": False, "stream_post_policy": 3},
+                id="is_member:members_only:Zulip4.0+:ZFL59",
+            ),
+            case(
+                {"is_admin": False, "is_owner": False, "is_guest": True, "role": 600},
+                {"is_announcement_only": False, "stream_post_policy": 1},
+                id="is_guest:anyone_can_post:Zulip4.0+:ZFL59",
+            ),
+        ],
+    )
+    def test_is_unauthorised_to_post_in_stream_can_post(
+        self,
+        model,
+        user_dict,
+        stream_dict,
+        _all_users_by_id,
+        user_role,
+        stream_properties,
+    ):
+        _all_users_by_id[11].update(user_role)
+        model._all_users_by_id = _all_users_by_id
+        model.user_dict = user_dict
+        stream_dict[99].update(stream_properties)
+        model.user_id = 11
+        assert model.is_unauthorised_to_post_in_stream(stream_id=99) is None
+
+    @pytest.mark.parametrize(
+        "user_role, stream_properties, expected_response",
+        [
+            case(
+                {"is_admin": False},
+                {"is_announcement_only": True},
+                "Only organization administrators can send to this stream",
+                id="is_not_admin:announcement_only:Zulip2.1",
+            ),
+            case(
+                {"is_owner": False, "is_admin": False, "is_guest": False},
+                {"is_announcement_only": False, "stream_post_policy": 2},
+                "Only organization administrators can send to this stream",
+                id="is_member:admins_only:Zulip3.0+:ZFL8",
+            ),
+            case(
+                {"is_owner": False, "is_admin": False, "is_guest": False},
+                {"is_announcement_only": False, "stream_post_policy": 4},
+                "Only organization administrators and moderators can send to this stream",
+                id="is_member:moderators_only:Zulip3.0+:ZFL8",
+            ),
+            case(
+                {"is_owner": False, "is_admin": False, "is_guest": True},
+                {"is_announcement_only": False, "stream_post_policy": 2},
+                "Only organization administrators can send to this stream",
+                id="is_guest:admins_only:Zulip3.0+:ZFL8",
+            ),
+            case(
+                {"is_owner": False, "is_admin": False, "is_guest": True},
+                {"is_announcement_only": False, "stream_post_policy": 3},
+                "Only organization administrators, moderators and full members can send to this stream",
+                id="is_guest:members_only:Zulip3.0+:ZFL8",
+            ),
+            case(
+                {"is_owner": False, "is_admin": False, "is_guest": True},
+                {"is_announcement_only": False, "stream_post_policy": 4},
+                "Only organization administrators and moderators can send to this stream",
+                id="is_guest:moderators_only:Zulip3.0+:ZFL8",
+            ),
+            case(
+                {"is_admin": False, "is_owner": False, "is_guest": False, "role": 300},
+                {"is_announcement_only": False, "stream_post_policy": 2},
+                "Only organization administrators can send to this stream",
+                id="is_moderator:admins_only:Zulip4.0+:ZFL59",
+            ),
+            case(
+                {"is_admin": False, "is_owner": False, "is_guest": False, "role": 400},
+                {"is_announcement_only": False, "stream_post_policy": 2},
+                "Only organization administrators can send to this stream",
+                id="is_member:admins_only:Zulip4.0+:ZFL59",
+            ),
+            case(
+                {"is_admin": False, "is_owner": False, "is_guest": False, "role": 400},
+                {"is_announcement_only": False, "stream_post_policy": 4},
+                "Only organization administrators and moderators can send to this stream",
+                id="is_member:moderators_only:Zulip4.0+:ZFL59",
+            ),
+            case(
+                {"is_admin": False, "is_owner": False, "is_guest": True, "role": 600},
+                {"is_announcement_only": False, "stream_post_policy": 2},
+                "Only organization administrators can send to this stream",
+                id="is_guest:admins_only:Zulip4.0+:ZFL59",
+            ),
+            case(
+                {"is_admin": False, "is_owner": False, "is_guest": True, "role": 600},
+                {"is_announcement_only": False, "stream_post_policy": 3},
+                "Only organization administrators, moderators and full members can send to this stream",
+                id="is_guest:members_only:Zulip4.0+:ZFL59",
+            ),
+            case(
+                {"is_admin": False, "is_owner": False, "is_guest": True, "role": 600},
+                {"is_announcement_only": False, "stream_post_policy": 4},
+                "Only organization administrators and moderators can send to this stream",
+                id="is_guest:moderators_only:Zulip4.0+:ZFL59",
+            ),
+        ],
+    )
+    def test_is_unauthorised_to_post_in_stream_cannot_post(
+        self,
+        model,
+        user_dict,
+        stream_dict,
+        _all_users_by_id,
+        user_role,
+        stream_properties,
+        expected_response,
+    ):
+        _all_users_by_id[11].update(user_role)
+        model._all_users_by_id = _all_users_by_id
+        model.user_dict = user_dict
+        stream_dict[99].update(stream_properties)
+        model.user_id = 11
+        assert (
+            model.is_unauthorised_to_post_in_stream(stream_id=99) == expected_response
+        )
+
+    @pytest.mark.parametrize(
         "response, return_value",
         [
             ({"result": "success"}, True),

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -37,7 +37,11 @@ from zulipterminal.api_types import (
 )
 from zulipterminal.config.keys import primary_key_for_command
 from zulipterminal.config.symbols import STREAM_TOPIC_SEPARATOR
-from zulipterminal.config.ui_mappings import ROLE_BY_ID, StreamAccessType
+from zulipterminal.config.ui_mappings import (
+    ROLE_BY_ID,
+    STREAM_POST_POLICY,
+    StreamAccessType,
+)
 from zulipterminal.helper import (
     Message,
     NamedEmojiData,
@@ -549,6 +553,60 @@ class Model:
         if message_was_sent:
             notify_if_message_sent_outside_narrow(composition, self.controller)
         return message_was_sent
+
+    def is_unauthorised_to_post_in_stream(self, stream_id: int) -> Optional[str]:
+        """
+        Identify whether a user is authorised to send message to the given
+        stream or not using stream_post_policy and/or is_announcement_policy
+        and accordingly update the footer
+        """
+        if stream_id in self.stream_dict:
+            stream = self.stream_dict[stream_id]
+        else:
+            return "Stream ID is invalid"
+        user_info = self._all_users_by_id.get(self.user_id, None)
+        if user_info is None:
+            # Check whether the given user id is valid or not
+            return "User does not exist"
+
+        if "role" in user_info:
+            role = user_info["role"]
+        else:
+            if user_info.get("is_owner"):
+                role = 100
+            elif user_info.get("is_admin"):
+                role = 200
+            elif user_info.get("is_guest"):
+                role = 600
+            else:
+                role = 400
+
+        if stream.get("is_announcement_only") or stream.get("stream_post_policy") == 2:
+            # For admins and owners only (not using user role)
+            if role <= 200:
+                return None
+            else:
+                return STREAM_POST_POLICY[2]
+        elif stream.get("stream_post_policy") is not None:
+            # is_announcement_only is deprecated in Zulip 3.0+ -> stream_post_policy (ZFL 1)
+            if stream.get("stream_post_policy") == 4:
+                # Check for moderators only stream
+                if role <= 300:
+                    return None
+                else:
+                    return STREAM_POST_POLICY[4]
+            elif stream.get("stream_post_policy") == 3:
+                # Check for 'members' in the stream
+                if role <= 400:
+                    return None
+                else:
+                    return STREAM_POST_POLICY[3]
+            else:
+                # Anyone can post
+                return None
+        else:
+            # Zulip version < 3.0 and is_announcement_only == False, ie, anyone can post
+            return None
 
     def update_private_message(self, msg_id: int, content: str) -> bool:
         request = {

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -474,7 +474,11 @@ class WriteBox(urwid.Pile):
         self, text: str, state: Optional[int]
     ) -> Optional[str]:
         streams_list = self.view.pinned_streams + self.view.unpinned_streams
-        streams = [stream["name"] for stream in streams_list]
+        streams = [
+            stream["name"]
+            for stream in streams_list
+            if self.model.is_unauthorised_to_post_in_stream(stream.get("id")) is None
+        ]
 
         # match_streams takes stream names and typeaheads,
         # but we don't have typeaheads here.

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -1763,11 +1763,18 @@ class MessageBox(urwid.Pile):
                     recipient_user_ids=self.recipient_ids,
                 )
             elif self.message["type"] == "stream":
-                self.model.controller.view.write_box.stream_box_view(
-                    caption=self.message["display_recipient"],
-                    title=self.message["subject"],
-                    stream_id=self.stream_id,
+                is_unauthorised_warning = self.model.is_unauthorised_to_post_in_stream(
+                    self.message["stream_id"]
                 )
+                if is_unauthorised_warning is not None:
+                    self.model.controller.view.set_footer_text(is_unauthorised_warning, "task:warning", 8)
+                    return key
+                else:
+                    self.model.controller.view.write_box.stream_box_view(
+                        caption=self.message["display_recipient"],
+                        title=self.message["subject"],
+                        stream_id=self.stream_id,
+                    )
         elif is_command_key("STREAM_MESSAGE", key):
             if len(self.model.narrow) != 0 and self.model.narrow[0][0] == "stream":
                 self.model.controller.view.write_box.stream_box_view(
@@ -1833,7 +1840,22 @@ class MessageBox(urwid.Pile):
                 recipient_user_ids=[self.message["sender_id"]],
             )
         elif is_command_key("MENTION_REPLY", key):
-            self.keypress(size, primary_key_for_command("REPLY_MESSAGE"))
+            is_unauthorised_warning = self.model.is_unauthorised_to_post_in_stream(
+                self.message["stream_id"]
+            )
+            if is_unauthorised_warning is not None:
+                self.model.controller.view.set_footer_text(is_unauthorised_warning, "task:warning", 8)
+                self.model.controller.view.write_box.stream_box_view(
+                    caption="",
+                    title="",
+                    stream_id="",
+                )
+            else:
+                self.model.controller.view.write_box.stream_box_view(
+                        caption=self.message["display_recipient"],
+                        title=self.message["subject"],
+                        stream_id=self.stream_id,
+                    )
             mention = f"@**{self.message['sender_full_name']}** "
             self.model.controller.view.write_box.msg_write_box.set_edit_text(mention)
             self.model.controller.view.write_box.msg_write_box.set_edit_pos(
@@ -1841,7 +1863,22 @@ class MessageBox(urwid.Pile):
             )
             self.model.controller.view.middle_column.set_focus("footer")
         elif is_command_key("QUOTE_REPLY", key):
-            self.keypress(size, primary_key_for_command("REPLY_MESSAGE"))
+            is_unauthorised_warning = self.model.is_unauthorised_to_post_in_stream(
+                self.message["stream_id"]
+            )
+            if is_unauthorised_warning is not None:
+                self.model.controller.view.set_footer_text(is_unauthorised_warning, "task:warning", 8)
+                self.model.controller.view.write_box.stream_box_view(
+                    caption="",
+                    title="",
+                    stream_id="",
+                )
+            else:
+                self.model.controller.view.write_box.stream_box_view(
+                        caption=self.message["display_recipient"],
+                        title=self.message["subject"],
+                        stream_id=self.stream_id,
+                    )
 
             # To correctly quote a message that contains quote/code-blocks,
             # we need to fence quoted message containing ``` with ````,


### PR DESCRIPTION
**What does this PR do?** 
- Added `is_unauthorised_to_post()` function to verify if a user is allowed to message in the given stream or not
- If the user is not allowed, restrict compose box from opening
- Print a warning in the footer
- Test functions (can post and can-not post) for `is_unauthorised_to_post()` function
Partly fixes #682 

**Discussion on developer channel:**
[#zulip-terminal> [Restrict sending messages to streams #T1149 #T682](https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/Restrict.20sending.20messages.20to.20streams.20.23T1149.20.23T682)
[#api-documentation>stream_post_policy (API docs)](https://chat.zulip.org/#narrow/stream/412-api-documentation/topic/stream_post_policy.20.28API.20docs.29)

**Tested?**
- [x] Manually
- [x] Existing tests
- [ ] Passed linting & tests (each commit)
- [x] New tests added

**Commit flow** 
Only one commit which contains all the changes made
- Creating `is_unauthorised_to_post()` in `model.py`
- Using that function in `boxes.py`, the compose box is opened only when the user is authorised to send a message to the stream
- Two new test functions added to `test_model.py`:
  -`test_is_unauthorised_to_post_in_stream_can_post()` and 
  -`test_is_unauthorised_to_post_in_stream_cannot_post()`

**Notes & Questions**
The current changes have covered the following cases:
- Reply to a message in stream (r/enter)
- Reply quoting the current message text (>)
- Reply (in the same stream) mentioning the sender of the current message (@)

Use cases is still pending:
- New message to a stream
- Draft whose stream post policies have been changed
- _Full_ member

## Example

### Before implementing the changes
![before_changes](https://user-images.githubusercontent.com/47925568/159153149-383ff760-eeba-4449-9edb-c56b3b08746c.gif)


Here, upon pressing enter/r for replying to the message in the announce stream, the compose box opens even though the user does not have permission to post on that stream


### After implementing the changes
![after_changes](https://user-images.githubusercontent.com/47925568/159153143-2a732e35-a4db-47c0-b1bd-b39edfb16383.gif)


Upon trying to reply to the message in the stream, no compose box pops up and a warning is displayed in the footer informing the user about the restrictions due to the stream post policy.
