### PR TITLE
Updating version of Black in venv

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ linting_deps = [
     "flake8~=3.9.0",
     "flake8-quotes~=3.2.0",
     "flake8-continuation~=1.0.5",
-    "black>=21.5b1",
+    "black>=22.1.0",
 ]
 
 typing_deps = [

--- a/tests/config/test_themes.py
+++ b/tests/config/test_themes.py
@@ -126,7 +126,7 @@ def test_complete_and_incomplete_themes() -> None:
             ],
         ),
         (
-            2 ** 24,
+            2**24,
             [
                 ("s1", "", "", "", "#ffffff , bold", "#870087"),
                 ("s2", "", "", "", "#ffffff , bold , italics", "#870087"),

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -431,7 +431,7 @@ def main(options: Optional[List[str]] = None) -> None:
 
         color_depth_str = zterm["color-depth"][0]
         if color_depth_str == "24bit":
-            color_depth = 2 ** 24
+            color_depth = 2**24
         else:
             color_depth = int(color_depth_str)
 

--- a/zulipterminal/config/themes.py
+++ b/zulipterminal/config/themes.py
@@ -156,7 +156,7 @@ def parse_themefile(
             bg = " ".join([bg_code256] + bg_props)
             new_style = (style_name, "", "", "", fg, bg)
 
-        elif color_depth == 2 ** 24:
+        elif color_depth == 2**24:
             fg = " ".join([fg_code24] + fg_props)
             bg = " ".join([bg_code24] + bg_props)
             new_style = (style_name, "", "", "", fg, bg)


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

This PR updates the version of Black in venv when it is activated using the source zt_venv/bin/activate command

It incorporates the changes added in the new version of Black (22.1.0) in the venv (black module) and hence saves from unexpected formatting errors in the Lint test.

https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/Updating.20requirements.20for.20Black

**Tested** 
- [x] Manually

**Notes & Questions** 
Will have to run make/pip install -e .[dev] to incorporate the changes.

