### PR TITLE
Clarify theme contributing doc after new theme gruvbox light

### DIFF
--- a/zulipterminal/themes/THEME_CONTRIBUTING.md
+++ b/zulipterminal/themes/THEME_CONTRIBUTING.md
@@ -31,7 +31,7 @@ from zulipterminal.themes.colors_gruvbox import DefaultBoldColor
 
 ---
 
-If any of these are not enough for the theme that you want to create, the following format would give an idea of how to create a new color scheme ( Refer: `gruvbox.py` ).
+If any of these are not enough for the theme that you want to create, the following format would give an idea of how to create a new color scheme ( Refer: `colors_gruvbox.py` ).
 
 ```python
 class ThemeColor(Enum):


### PR DESCRIPTION
**What does this PR do?**  
Updates #1144 

**Tested?** 
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [x] New tests added (for any new behavior)
- [x] Passed linting & tests (each commit)

**Commit flow** 
First Commit: Refactor: config/themes: Extract gruvbox colors into common file. [Modifies THEME_CONTRIBUTING.md as well]
Second Commit:  config/themes: Add gruvbox_light theme with extra gruvbox colors.

**Interactions** 
Updates PR #1144 
https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/.E2.9C.94.20Gruvbox.20light.20.23T1144.20.28Issue.20.23T1133.29

**Visual changes** 
The screenshots of both gruvbox themes (for different color depths) are as follows-
Gruvbox light theme
1) Color depth =16
[image.png](https://chat.zulip.org/user_uploads/2/45/4VnXZ1HEtlkTs-zrIGuTV-ht/image.png)[](https://chat.zulip.org/user_uploads/2/45/4VnXZ1HEtlkTs-zrIGuTV-ht/image.png)


2) Color depth =256
[image.png](https://chat.zulip.org/user_uploads/2/4f/jIwGCwjIX1KG1x1XPDdq_SH9/image.png)[](https://chat.zulip.org/user_uploads/2/4f/jIwGCwjIX1KG1x1XPDdq_SH9/image.png)


3) Color depth =24bit
[image.png](https://chat.zulip.org/user_uploads/2/e1/1Flf-WJjj_9gKiR3fz5eVydU/image.png)[](https://chat.zulip.org/user_uploads/2/e1/1Flf-WJjj_9gKiR3fz5eVydU/image.png)


Gruvbox dark theme
1) Color depth =16
[image.png](https://chat.zulip.org/user_uploads/2/85/bpOkeRZecrBu5I1UFpfi7Pyl/image.png)[](https://chat.zulip.org/user_uploads/2/85/bpOkeRZecrBu5I1UFpfi7Pyl/image.png)


2) Color depth =256
[image.png](https://chat.zulip.org/user_uploads/2/bd/BV7qpO6hdhXc9Smx_QAClkBk/image.png)[](https://chat.zulip.org/user_uploads/2/bd/BV7qpO6hdhXc9Smx_QAClkBk/image.png)


3) Color depth =24bit
[image.png](https://chat.zulip.org/user_uploads/2/db/B1vcOM4hywVdyusREO6G-RWz/image.png)[](https://chat.zulip.org/user_uploads/2/db/B1vcOM4hywVdyusREO6G-RWz/image.png)
