### PR TITLE
Updates documentation for 16 color names in THEMES_CONTRIBUTING.md

### DIFF
--- a/zulipterminal/themes/THEME_CONTRIBUTING.md
+++ b/zulipterminal/themes/THEME_CONTRIBUTING.md
@@ -45,7 +45,8 @@ color codes:
 
 * **16code**: Terminal's default 16 color aliases.
   * Only those used in DefaultColor are acceptable.
-  * Eg: `black, light_cyan, etc`
+  * Acceptable names: `default`, `black`, `dark red`, `dark green`, `brown`, `dark blue`, `dark magenta`, `dark cyan`, `dark gray`, `light red`, `light green`, `yellow`, `light blue`, `light magenta`, `light cyan`, `light gray`, `white`
+  * Reference link to urwid documentation: https://urwid.org/manual/displayattributes.html#standard-foreground 
 * **256code**: High color, 256 color code.
   * Acceptable formats: `#000-#fff`, `h0-h255`, `g0-g100`, `g#00-g#ff`
   * Eg: `#rgb or h255 or g19`
@@ -55,6 +56,27 @@ color codes:
 
 `'default'` is a special alias which uses the default
 foreground or background.
+
+The following table consists of the 16code equivalents of 256 color codes-
+
+| 256 color codes                                                                                                                                                                                                                                                                      | Corresponding 16 color codes | 
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------- | 
+| `h0`, `h16`, `h232`, `h233`, `h234`, `h235`, `h236`, `h237`                                                                                                                                                                                                                          | `black`                      | 
+| `h1`, `h52`, `h88`, `h124`                                                                                                                                                                                                                                                           | `dark red`                   | 
+| `h2`, `h22`, `h28`, `h34`, `h72`                                                                                                                                                                                                                                                     | `dark green`                 | 
+| `h3`, `h58`, `h64`, `h70`, `h94`, `h100`, `h106`, `h130`, `h136`, `h142`                                                                                                                                                                                                             | `brown`                      | 
+| `h4`, `h17`, `h18`, `h19`, `h60`, `h61`, `h67`, `h97`                                                                                                                                                                                                                                | `dark blue`                  | 
+| `h5`, `h53`, `h54`, `h55`, `h89`, `h90`, `h91`, `h96`, `h125`, `h126`, `h127`, `h132`, `h133`, `h139`                                                                                                                                                                                | `dark magenta`               | 
+| `h6`, `h23`, `h24`, `h25`, `h29`, `h30`, `h31`, `h35`, `h36`, `h37`, `h73`                                                                                                                                                                                                           | `dark cyan`                  | 
+| `h7`, `h71`, `h103`, `h107`, `h108`, `h109`, `h114`, `h115`, `h116`, `h131`, `h137`, `h138`, `h143`, `h144`, `h145`, `h146`, `h150`, `h151`, `h152`, `h174`, `h180`, `h181`, `h186`, `h187`, `h188`, `h248`, `h249`, `h250`, `h251`, `h252`, `h253`                                  | `light gray`                 | 
+| `h8`, `h59`, `h65`, `h66`, `h95`, `h101`, `h102`, `h238`, `h239`, `h240`, `h241`, `h242`, `h243`, `h244`, `h245`, `h246`, `h247`                                                                                                                                                     | `dark gray`                  | 
+| `h9`, `h160`, `h166`, `h167`, `h173`, `h196`, `h202`, `h203`, `h209`, `h215`                                                                                                                                                                                                         | `light red`                  | 
+| `h10`, `h40`, `h41`, `h46`, `h47`, `h76`, `h77`, `h78`, `h82`, `h83`, `h84`, `h85`, `h113`, `h119`, `h120`, `h121`, `h155`, `h156`                                                                                                                                                   | `light green`                | 
+| `h11`, `h112`, `h118`, `h148`, `h149`, `h154`, `h172`, `h178`, `h179`, `h184`, `h185`, `h190`, `h191`, `h208`, `h214`, `h220`, `h221`, `h226`, `h227`                                                                                                                                | `yellow`                     | 
+| `h12`, `h20`, `h21`, `h26`, `h27`, `h56`, `h57`, `h62`, `h63`, `h68`, `h69`, `h75`, `h98`, `h99`, `h104`, `h105`, `h110`, `h111`, `h135`, `h140`, `h141`, `h147`                                                                                                                     | `light blue`                 | 
+| `h13`, `h92`, `h93`, `h128`, `h134`, `h129`, `h161`, `h162`, `h163`, `h164`, `h165`, `h168`, `h169`, `h170`, `h171`, `h175`, `h176`, `h177`, `h182`, `h183`, `h197`, `h198`, `h199`, `h200`, `h201`, `h204`, `h205`, `h206`, `h207`, `h211`, `h212`, `h213`, `h218`, `h219`, `h225`  | `light magenta`              | 
+| `h14`, `h32`, `h33`, `h38`, `h39`, `h42`, `h43`, `h44`, `h45`, `h48`, `h49`, `h50`, `h51`, `h74`, `h79`, `h80`, `h81`, `h86`, `h87`, `h117`, `h122`, `h123`                                                                                                                          | `light cyan`                 | 
+| `h15`, `h153`, `h157`, `h158`, `h159`, `h189`, `h192`, `h193`, `h194`, `h195`, `h210`, `h216`, `h217`, `h222`, `h223`, `h224`, `h228`, `h229`, `h230`, `h231`, `h254`, `h255`                                                                                                        | `white`                      | 
 
 ### COLOR PROPERTIES
 


### PR DESCRIPTION
**What does this PR do?**  
This PR updates documentation regarding 16 color codes in THEMES_CONTRIBUTING.md 
It states the 256 color codes and its equivalent 16 color codes to fall back upon (in case of color depth 16). Also, it adds a reference to urwid documentation of accepted 16 color codes and lists the accepted colors as well

Relevant link to CZO discussion - https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/16-color.20names.20in.20themes

**Tested?** 
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [x] Passed linting & tests (each commit)

**Notes & Questions** 
None. All changes have been made in accordance with the discussion on CZO

**Interactions** 
Independent PR

**Visual changes** 
None
