### PR TITLE
FAQ/README/themes: Update documentation to reflect current themes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ key=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 site=https://realm.zulipchat.com
 
 [zterm]
-# Alternative themes are gruvbox, light and blue
-theme=default
+# Alternative themes are listed in the FAQ
+theme=zt_dark
 # Autohide defaults to 'no_autohide', but can be set to 'autohide' to hide the left & right panels except when focused.
 autohide=autohide
 # Footlinks default to 'enabled', but can be set to 'disabled' to hide footlinks.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -33,9 +33,10 @@ Please let us know if you have feedback on the success or failure in these or an
 
 ## Are there any themes available, other than the default one?
 
-Yes. There are four supported themes:
+Yes. There are five supported themes:
 - `zt_dark` (alias: `default`)
 - `gruvbox_dark` (alias: `gruvbox`)
+- `gruvbox_light`
 - `zt_light` (alias: `light`)
 - `zt_blue` (alias: `blue`)
 

--- a/zulipterminal/config/themes.py
+++ b/zulipterminal/config/themes.py
@@ -85,6 +85,7 @@ REQUIRED_META = {
 }
 # fmt: on
 
+# This is the main list of themes
 THEMES: Dict[str, Any] = {
     "gruvbox_dark": gruvbox_dark,
     "gruvbox_light": gruvbox_light,
@@ -93,6 +94,8 @@ THEMES: Dict[str, Any] = {
     "zt_blue": zt_blue,
 }
 
+# These are older aliases to some of the above, for compatibility
+# NOTE: Do not add to this section, and only modify if a theme name changes
 THEME_ALIASES = {
     "default": "zt_dark",
     "gruvbox": "gruvbox_dark",


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->

Some areas of documentation mention old theme names or do not include gruvbox_light.

This also documents the theme dicts in themes.py, to avoid future confusion over their use.