### PR TITLE
Improve PyPy coverage in CI & Note supported Python versions in README

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -70,6 +70,7 @@ jobs:
           - {PYTHON: 'pypy-3.6', OS: ubuntu-latest, NAME: "PyPy 3.6 (ubuntu)"}
           - {PYTHON: 'pypy-3.7', OS: ubuntu-latest, NAME: "PyPy 3.7 (ubuntu)"}
           - {PYTHON: 'pypy-3.8', OS: ubuntu-latest, NAME: "PyPy 3.8 (ubuntu)"}
+          - {PYTHON: 'pypy-3.9', OS: ubuntu-latest, NAME: "PyPy 3.9 (ubuntu)"}
           - {PYTHON: 3.9, OS: macos-latest, NAME: "CPython 3.9 (macos)"}
     runs-on: ${{ matrix.env.OS }}
     name: Install & test - ${{ matrix.env.NAME}}
@@ -83,8 +84,8 @@ jobs:
         run: python --version
       - name: Upgrade pip
         run: python -m pip install --upgrade pip
-      - name: Ensure libxml-related libraries are installed (pypy-3.6 only)
-        if: matrix.env.PYTHON == 'pypy-3.6'
+      - name: Ensure libxml-related libraries are installed (some pypy versions don't have wheels)
+        if: startsWith(matrix.env.PYTHON, 'pypy-')
         run: sudo apt install libxml2-dev libxslt1-dev
       - name: Ensure regular package installs from checkout
         run: pip install .

--- a/README.md
+++ b/README.md
@@ -49,6 +49,23 @@ our open [Issues](https://github.com/zulip/zulip-terminal/issues/), or sign up o
 
 The minimum server version that Zulip Terminal supports is [`2.1.0`](https://zulip.readthedocs.io/en/latest/overview/changelog.html#id7). It may still work with earlier versions.
 
+### Supported Python Versions
+
+Version 0.6.0 was the last release with support for Python 3.5.
+
+Later releases and the main development branch are currently tested (on Ubuntu) with:
+- CPython 3.6-3.10
+- PyPy 3.6-3.9
+
+Since our automated testing does not cover interactive testing of the UI, there
+may be issues with some Python versions, though generally we have not found
+this to be the case.
+
+Please note that generally we limit each release to between a lower and upper
+Python version, so it is possible that for example if you have a newer version
+of Python installed, then some releases (or `main`) may not install correctly.
+In some cases this can give rise to the symptoms in issue #1145.
+
 ## Installation
 
 We recommend installing in a dedicated python virtual environment (see below) or using an automated option such as [pipx](https://pypi.python.org/pypi/pipx)


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->

We currently test PyPy 3.6-3.8; the first commit adds PyPy 3.9. Since it doesn't always have an lxml wheel available, these are installed manually in all cases of PyPy.

Given that supported Python versions are not clear from the icons or even `setup.py` exactly, a section is added to the README to note this, as well as a reference to #1145.

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Existing tests (adapted, if necessary)