### PR TITLE
bugfix: model: Avoid creating empty messages from reaction events.

### DIFF
--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -2041,9 +2041,7 @@ class TestModel:
         def _factory(msgs: MsgsType):
             return {
                 "messages": {
-                    message_id: {}
-                    if reactions is None
-                    else {
+                    message_id: {
                         "id": message_id,
                         "content": f"message content {message_id}",
                         "reactions": [
@@ -2061,6 +2059,7 @@ class TestModel:
                         ],
                     }
                     for message_id, reactions in msgs
+                    if reactions is not None
                 }
             }
 
@@ -2082,7 +2081,7 @@ class TestModel:
         )
         model.index = reaction_event_index_factory(
             [
-                (unindexed_message_id, None),
+                (unindexed_message_id, None),  # explicitly exclude
                 (2, [(1, "unicode_emoji", "1232", "thumbs_up")]),
                 (3, []),
             ]

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1427,7 +1427,7 @@ class Model:
         assert event["type"] == "reaction"
         message_id = event["message_id"]
         # If the message is indexed
-        if self.index["messages"][message_id] != {}:
+        if message_id in self.index["messages"]:
 
             message = self.index["messages"][message_id]
             if event["op"] == "add":


### PR DESCRIPTION
**What does this PR do?**  <!-- Overall description goes here -->

This updates an approach taken in the original reaction implementation.

Since locally cached messages are currently stored in a `defaultdict`,
direct indexing with a non-present message-id creates an empty message.
Such messages then generate `KeyError`s when flags are updated later
(eg. marking read, toggling star status), if the message has not been
fetched.

Tests updated to explicitly exclude generation of empty index for
reaction events.

Fixes #920.

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [x] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

**Notes & Questions** <!-- if any; add/delete/fill-in as appropriate -->

This suggests we should move away from `defaultdict` for at least this data structure, as access masks generation of invalid data.

**Interactions** <!-- if any; add/delete/fill-in as appropriate -->

This is purely a bugfix. This prompts thoughts on further refactoring, but an outstanding branch for improving reaction handling may conflict with that, so this is left for now.