### PR TITLE
Respect PM typing notification settings

### DIFF
--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -227,6 +227,7 @@ class TestModel:
             "typing",
             "update_message_flags",
             "update_display_settings",
+            "user_settings",
             "realm_emoji",
         ]
         fetch_event_types = [
@@ -2948,6 +2949,18 @@ class TestModel:
         for stream_id in stream_ids:
             new_subscribers = model.stream_dict[stream_id]["subscribers"]
             assert new_subscribers == expected_subscribers
+
+    @pytest.mark.parametrize("value", [True, False])
+    def test__handle_user_settings_event(self, mocker, model, value):
+        setting = "send_private_typing_notifications"
+        event = {
+            "type": "user_settings",
+            "op": "update",
+            "property": setting,
+            "value": value,
+        }
+        model._handle_user_settings_event(event)
+        assert model.user_settings()[setting] == value
 
     @pytest.mark.parametrize("setting", [True, False])
     def test_update_twenty_four_hour_format(self, mocker, model, setting):

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -705,6 +705,7 @@ class TestModel:
         mock_api_query = mocker.patch(
             CONTROLLER + ".client.set_typing_status", return_value=response
         )
+        model._user_settings["send_private_typing_notifications"] = True
 
         model.send_typing_status_by_user_ids(recipient_user_ids, status=status)
 
@@ -720,6 +721,20 @@ class TestModel:
     ):
         with pytest.raises(RuntimeError):
             model.send_typing_status_by_user_ids(recipient_user_ids, status=status)
+
+    @pytest.mark.parametrize("recipient_user_ids", [[5140], [5140, 5179]])
+    @pytest.mark.parametrize("status", ["start", "stop"])
+    def test_send_typing_status_avoided_due_to_user_setting(
+        self, mocker, model, status, recipient_user_ids
+    ):
+        model._user_settings["send_private_typing_notifications"] = False
+
+        mock_api_query = mocker.patch(CONTROLLER + ".client.set_typing_status")
+
+        model.send_typing_status_by_user_ids(recipient_user_ids, status=status)
+
+        assert not mock_api_query.called
+        assert not self.display_error_if_present.called
 
     @pytest.mark.parametrize(
         "response, return_value",

--- a/zulipterminal/api_types.py
+++ b/zulipterminal/api_types.py
@@ -217,6 +217,17 @@ class UpdateRealmEmojiEvent(TypedDict):
     realm_emoji: Dict[str, RealmEmojiData]
 
 
+# This is specifically only those supported by ZT
+SupportedUserSettings = Literal["send_private_typing_notifications"]
+
+
+class UpdateUserSettingsEvent(TypedDict):
+    type: Literal["user_settings"]
+    op: Literal["update"]
+    property: SupportedUserSettings
+    value: Any
+
+
 Event = Union[
     MessageEvent,
     UpdateMessageEvent,
@@ -226,4 +237,5 @@ Event = Union[
     UpdateMessageFlagsEvent,
     UpdateDisplaySettings,
     UpdateRealmEmojiEvent,
+    UpdateUserSettingsEvent,
 ]

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -499,6 +499,8 @@ class Model:
     def send_typing_status_by_user_ids(
         self, recipient_user_ids: List[int], *, status: Literal["start", "stop"]
     ) -> None:
+        if not self.user_settings()["send_private_typing_notifications"]:
+            return
         if recipient_user_ids:
             request = {"to": recipient_user_ids, "op": status}
             response = self.client.set_typing_status(request)

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -134,6 +134,7 @@ class Model:
                 ("typing", self._handle_typing_event),
                 ("update_message_flags", self._handle_update_message_flags_event),
                 ("update_display_settings", self._handle_update_display_settings_event),
+                ("user_settings", self._handle_user_settings_event),
                 ("realm_emoji", self._handle_update_emoji_event),
             ]
         )
@@ -1608,6 +1609,18 @@ class Model:
                         view.message_view.log[msg_pos + 1] = msg_w_list[0]
                     self.controller.update_screen()
                     return
+
+    def _handle_user_settings_event(self, event: Event) -> None:
+        """
+        Event when user settings have changed - from ZFL 89, v5.0
+        (previously "update_display_settings" and "update_global_notifications")
+        """
+        assert event["type"] == "user_settings"
+        if event["op"] == "update":  # Should always be the case
+            # Only update settings after initialization
+            if event["property"] in self._user_settings.keys():
+                setting = event["property"]
+                self._user_settings[setting] = event["value"]
 
     def _handle_update_display_settings_event(self, event: Event) -> None:
         """


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->

<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->

<!-- Add a link to a discussion on chat.zulip.org, if relevant -->

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [x] New tests added (for any new behavior)
- [x] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

<!-- See https://github.com/zulip/zulip-terminal#commit-style -->
**Commit flow** <!-- if more than one commit; add/delete/fill-in as appropriate -->

- Introduce & test new centralized user settings in model for new property (from register)
- Update the new property from events
- Use the updating property to determine whether to send typing events

**Notes & Questions** <!-- if any; add/delete/fill-in as appropriate -->

This introduces user settings, which is intended as a new central location for this. This new setting is set and updated via `user_settings`, whereas older settings may be in multiple locations dependent on parameter passed to the server (`user_settings_object`)

I have initially assumed that this setting is only available in the new structure, but that's not completely clear to me.

**Visual changes** <!-- if any; add/delete/fill-in with screenshot/diagram as appropriate -->

For servers which support this setting, ZT currently shows warning notices in the footer, returned from the server. If requested via the setting, this PR avoids sending notifications, so the server doesn't send a notice, which then isn't shown.