### PR TITLE
Ensure color codes are valid at runtime if running in 16-color mode.

### DIFF
--- a/tests/config/test_themes.py
+++ b/tests/config/test_themes.py
@@ -211,6 +211,8 @@ def test_add_pygments_style(
 def test_validate_colors(theme_name: str, color_depth: int) -> None:
     theme = THEMES[theme_name]
 
+    header_text = f"Invalid 16-color codes in theme '{theme_name}':\n"
+
     # No invalid colors
     class Color(Enum):
         # color          =  16code          256code   24code
@@ -233,10 +235,7 @@ def test_validate_colors(theme_name: str, color_depth: int) -> None:
     theme.Color = Color1
     with pytest.raises(InvalidThemeColorCode) as e:
         validate_colors(theme_name, 16)
-    assert (
-        str(e.value)
-        == f"Check 16-color-code for DARK0_HARD = (blac) in theme - {theme_name}\n"
-    )
+    assert str(e.value) == header_text + "- DARK0_HARD = blac"
 
     # Two invalid colors
     class Color2(Enum):
@@ -250,9 +249,7 @@ def test_validate_colors(theme_name: str, color_depth: int) -> None:
     with pytest.raises(InvalidThemeColorCode) as e:
         validate_colors(theme_name, 16)
     assert (
-        str(e.value)
-        == f"Check 16-color-code for DARK0_HARD = (blac) in theme - {theme_name}\n"
-        + f"Check 16-color-code for GRAY_244 = (dark_gra) in theme - {theme_name}\n"
+        str(e.value) == header_text + "- DARK0_HARD = blac\n" + "- GRAY_244 = dark_gra"
     )
 
     # Multiple invalid colors
@@ -268,8 +265,9 @@ def test_validate_colors(theme_name: str, color_depth: int) -> None:
         validate_colors(theme_name, 16)
     assert (
         str(e.value)
-        == f"Check 16-color-code for DEFAULT = (defaul) in theme - {theme_name}\n"
-        + f"Check 16-color-code for DARK0_HARD = (blac) in theme - {theme_name}\n"
-        + f"Check 16-color-code for GRAY_244 = (dark_gra) in theme - {theme_name}\n"
-        + f"Check 16-color-code for LIGHT2 = (whit) in theme - {theme_name}\n"
+        == header_text
+        + "- DEFAULT = defaul\n"
+        + "- DARK0_HARD = blac\n"
+        + "- GRAY_244 = dark_gra\n"
+        + "- LIGHT2 = whit"
     )

--- a/tests/config/test_themes.py
+++ b/tests/config/test_themes.py
@@ -16,6 +16,7 @@ from zulipterminal.config.themes import (
     all_themes,
     complete_and_incomplete_themes,
     parse_themefile,
+    valid_16_color_codes,
 )
 
 
@@ -26,27 +27,6 @@ expected_complete_themes = {
     "zt_light",
     "zt_blue",
 }
-
-# These are urwid color names with underscores instead of spaces
-valid_16_color_codes = [
-    "default",
-    "black",
-    "dark_red",
-    "dark_green",
-    "brown",
-    "dark_blue",
-    "dark_magenta",
-    "dark_cyan",
-    "dark_gray",
-    "light_red",
-    "light_green",
-    "yellow",
-    "light_blue",
-    "light_magenta",
-    "light_cyan",
-    "light_gray",
-    "white",
-]
 
 
 def test_all_themes() -> None:

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -12,6 +12,7 @@ import requests
 from urwid import display_common, set_encoding
 
 from zulipterminal.config.themes import (
+    InvalidThemeColorCode,
     aliased_themes,
     all_themes,
     complete_and_incomplete_themes,
@@ -511,6 +512,11 @@ def main(options: Optional[List[str]] = None) -> None:
         zt_logger.info(f"\n\n{e}\n\n")
         zt_logger.exception(e)
         exit_with_error(f"\nError connecting to Zulip server: {e}.")
+    except InvalidThemeColorCode as e:
+        # Acts as separator between logs
+        zt_logger.info(f"\n\n{e}\n\n")
+        zt_logger.exception(e)
+        exit_with_error(f"\n{e}")
     except (display_common.AttrSpecError, display_common.ScreenError) as e:
         # NOTE: Strictly this is not necessarily just a theme error
         # FIXME: Add test for this - once loading takes place after UI setup

--- a/zulipterminal/config/themes.py
+++ b/zulipterminal/config/themes.py
@@ -125,6 +125,10 @@ valid_16_color_codes = [
 ]
 
 
+class InvalidThemeColorCode(Exception):
+    pass
+
+
 def all_themes() -> List[str]:
     return list(THEMES.keys())
 
@@ -148,6 +152,7 @@ def complete_and_incomplete_themes() -> Tuple[List[str], List[str]]:
 
 def generate_theme(theme_name: str, color_depth: int) -> ThemeSpec:
     theme_styles = THEMES[theme_name].STYLES
+    validate_colors(theme_name, color_depth)
     urwid_theme = parse_themefile(theme_styles, color_depth)
 
     try:
@@ -157,6 +162,30 @@ def generate_theme(theme_name: str, color_depth: int) -> ThemeSpec:
         pass
 
     return urwid_theme
+
+
+def validate_colors(theme_name: str, color_depth: int) -> None:
+    """
+    This function validates color-codes for a given theme, given colors are in `Color`.
+
+    If any color is not in accordance with urwid default 16-color codes then the
+    function raises InvalidThemeColorCode with the invalid colors.
+    """
+    theme_colors = THEMES[theme_name].Color
+    failure_text = []
+    if color_depth == 16:
+        for color in theme_colors:
+            color_16code = color.value.split()[0]
+            if color_16code not in valid_16_color_codes:
+                invalid_16_color_code = str(color.name)
+                invalid_16_color_code_name = str(color.value).split()[0]
+                failure_text.append(
+                    f"Check 16-color-code for {invalid_16_color_code} = ({invalid_16_color_code_name}) in theme - {theme_name}\n"
+                )
+        if failure_text == []:
+            return
+        else:
+            raise InvalidThemeColorCode("".join(failure_text))
 
 
 def parse_themefile(

--- a/zulipterminal/config/themes.py
+++ b/zulipterminal/config/themes.py
@@ -178,14 +178,14 @@ def validate_colors(theme_name: str, color_depth: int) -> None:
             color_16code = color.value.split()[0]
             if color_16code not in valid_16_color_codes:
                 invalid_16_color_code = str(color.name)
-                invalid_16_color_code_name = str(color.value).split()[0]
-                failure_text.append(
-                    f"Check 16-color-code for {invalid_16_color_code} = ({invalid_16_color_code_name}) in theme - {theme_name}\n"
-                )
+                failure_text.append(f"- {invalid_16_color_code} = {color_16code}")
         if failure_text == []:
             return
         else:
-            raise InvalidThemeColorCode("".join(failure_text))
+            text = "\n".join(
+                [f"Invalid 16-color codes in theme '{theme_name}':"] + failure_text
+            )
+            raise InvalidThemeColorCode(text)
 
 
 def parse_themefile(

--- a/zulipterminal/config/themes.py
+++ b/zulipterminal/config/themes.py
@@ -103,6 +103,27 @@ THEME_ALIASES = {
     "blue": "zt_blue",
 }
 
+# These are urwid color names with underscores instead of spaces
+valid_16_color_codes = [
+    "default",
+    "black",
+    "dark_red",
+    "dark_green",
+    "brown",
+    "dark_blue",
+    "dark_magenta",
+    "dark_cyan",
+    "dark_gray",
+    "light_red",
+    "light_green",
+    "yellow",
+    "light_blue",
+    "light_magenta",
+    "light_cyan",
+    "light_gray",
+    "white",
+]
+
 
 def all_themes() -> List[str]:
     return list(THEMES.keys())


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->
In ``/zulip-terminal/zulipterminal/config/themes.py`` code is added in ``generate_theme`` function to check if valid color codes are used in color files for specific themes. For eg. (``colors_gruvbox.py`` for ``gruvbox_dark.py`` theme)

<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->
Fixes #1158 

<!-- Add a link to a discussion on chat.zulip.org, if relevant -->

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [x] New tests added (for any new behavior)
- [x] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

<!-- See https://github.com/zulip/zulip-terminal#commit-style -->
**Commit flow** <!-- if more than one commit; add/delete/fill-in as appropriate -->
<!-- For example:
- first commit doing some thing
- maybe multiple commits doing similar things
-->

**Notes & Questions** <!-- if any; add/delete/fill-in as appropriate -->
<!-- For example:
- this doesn't include feature X (yet?)
- unsure about Y
- should this do Z?
-->

**Interactions** <!-- if any; add/delete/fill-in as appropriate -->
<!-- eg.
- Waiting on #<PR>
- Blocks #<PR>
-->

**Visual changes** <!-- if any; add/delete/fill-in with screenshot/diagram as appropriate -->
