### PR TITLE
Hide spoiler content in notifications

### DIFF
--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -1656,6 +1656,16 @@ class TestModel:
         else:
             notify.assert_not_called
 
+    def test_notify_user_transformed_content(self, mocker, model, message_fixture):
+        mocker.patch(MODEL + ".is_visual_notifications_enabled", lambda s, id: True)
+        notify = mocker.patch(MODULE + ".notify")
+        message_fixture["content"] = "<p>hi</p>"
+        expected = "hi"
+
+        model.notify_user(message_fixture)
+
+        notify.assert_called_once_with(mocker.ANY, expected)
+
     @pytest.mark.parametrize(
         "notify_enabled, is_notify_called",
         [

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -20,6 +20,7 @@ from typing import (
 )
 from urllib.parse import urlparse
 
+import lxml.html
 import zulip
 from typing_extensions import Literal, TypedDict
 
@@ -1287,10 +1288,13 @@ class Model:
                 recipient = "{display_recipient} -> {subject}".format(**message)
 
         if recipient:
+            document = lxml.html.document_fromstring(content)
+            text = document.text_content()
+
             return notify(
                 f"{self.server_name}:\n"
                 f"{message['sender_full_name']} (to {recipient})",
-                content,
+                text,
             )
         return ""
 

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1269,6 +1269,7 @@ class Model:
 
         recipient = ""
         content = message["content"]
+        hidden_content = False
         if message["type"] == "private":
             recipient = "you"
             if len(message["display_recipient"]) > 2:
@@ -1280,6 +1281,7 @@ class Model:
                 recipient = ", ".join(extra_targets)
             if not self.user_settings()["pm_content_in_desktop_notifications"]:
                 content = f"New private message from {message['sender_full_name']}"
+                hidden_content = True
         elif message["type"] == "stream":
             stream_id = message["stream_id"]
             if {"mentioned", "wildcard_mentioned"}.intersection(
@@ -1288,8 +1290,11 @@ class Model:
                 recipient = "{display_recipient} -> {subject}".format(**message)
 
         if recipient:
-            document = lxml.html.document_fromstring(content)
-            text = document.text_content()
+            if hidden_content:
+                text = content
+            else:
+                document = lxml.html.document_fromstring(content)
+                text = document.text_content()
 
             return notify(
                 f"{self.server_name}:\n"

--- a/zulipterminal/platform_code.py
+++ b/zulipterminal/platform_code.py
@@ -1,7 +1,6 @@
 import platform
 import subprocess
 
-import lxml.html
 from typing_extensions import Literal
 
 
@@ -25,10 +24,7 @@ else:
 MOUSE_SELECTION_KEY = "Fn + Alt" if PLATFORM == "MacOS" else "Shift"
 
 
-def notify(title: str, html_text: str) -> str:
-    document = lxml.html.document_fromstring(html_text)
-    text = document.text_content()
-
+def notify(title: str, text: str) -> str:
     command_list = None
     if PLATFORM == "MacOS":
         command_list = [


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->

This is complementary to #1061, which is aimed at the message content and accessing the hidden content. #688 doesn't discuss the specifics, but hiding in notifications is one part of this. 

This PR migrates the html processing from the platform code into the model, where beautiful soup is used to translate and extract content accordingly.

Prior to this PR, spoiler text in a message gives rise to extra lines of text and doesn't hide the spoiler content. The updated output is intended to match the style from the web app, which translates a spoiler with a `title` and `content` into `title (...)` in a notification.

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [x] New tests added (for any new behavior)
- [x] Passed linting & tests (each commit)

**Notes & Questions** <!-- if any; add/delete/fill-in as appropriate -->

This provides good infrastructure for a follow-up set of work to explore how different markdown is rendered in notifications and improve it if necessary.