### PR TITLE
Use only colors from suggested gruvbox palettes

### DIFF
--- a/zulipterminal/themes/colors_gruvbox.py
+++ b/zulipterminal/themes/colors_gruvbox.py
@@ -36,24 +36,27 @@ class GruvBoxColor(Enum):
     BRIGHT_BLUE      = 'light_blue      h109      #83a598'
     BRIGHT_GREEN     = 'light_green     h142      #b8bb26'
     BRIGHT_RED       = 'light_red       h167      #fb4934'
+    BRIGHT_YELLOW    = 'brown           h214      #fabd2f'
 
     # May be relevant to both modes
-    NEUTRAL_PURPLE   = 'light_magenta   h132      #b16286'
     NEUTRAL_BLUE     = 'dark_cyan       h66       #458588'
+    NEUTRAL_PURPLE   = 'light_magenta   h132      #b16286'
     NEUTRAL_YELLOW   = 'brown           h172      #d79921'
 
     # Light mode only - colors
     FADED_BLUE       = 'dark_blue       h24       #076678'
-    FADED_YELLOW     = 'brown           h136      #b57614'
-    FADED_RED        = 'dark_red        h88       #9d0006'
-
-    # Added for light mode; suggests light needs adjusting
-    LIGHT0_HARD      = 'white           h230      #f9f5d7'
-    GRAY_245         = 'dark_gray       h245      #928374'
-    DARK2            = 'black           h239      #504945'
-    DARK4            = 'black           h243      #7c6f64'
-    BRIGHT_YELLOW    = 'brown           h214      #fabd2f'
     FADED_GREEN      = 'dark_green      h100      #79740e'
+    FADED_RED        = 'dark_red        h88       #9d0006'
+    FADED_YELLOW     = 'brown           h136      #b57614'
+
+    # Only or primarily light version - grayscales
+    # - generally background
+    LIGHT0_HARD      = 'white           h230      #f9f5d7'
+    # - generally foreground
+    DARK2            = 'black           h239      #504945'
+    # - grays
+    GRAY_245         = 'dark_gray       h245      #928374'
+    DARK4            = 'black           h243      #7c6f64'
 
 
 # fmt: on

--- a/zulipterminal/themes/colors_gruvbox.py
+++ b/zulipterminal/themes/colors_gruvbox.py
@@ -22,19 +22,32 @@ from zulipterminal.config.color import color_properties
 class GruvBoxColor(Enum):
     # color          =  16code          256code   24code
     DEFAULT          = 'default         default   default'
+
+    # Only or primarily dark mode - grayscales
+    # - generally background
     DARK0_HARD       = 'black           h234      #1d2021'
-    GRAY_244         = 'dark_gray       h244      #928374'
+    # - generally foreground
     LIGHT2           = 'white           h250      #d5c4a1'
+    # - grays
+    GRAY_244         = 'dark_gray       h244      #928374'
     LIGHT4           = 'light_gray      h248      #bdae93'
+
+    # Dark mode only - colors
     BRIGHT_BLUE      = 'light_blue      h109      #83a598'
     BRIGHT_GREEN     = 'light_green     h142      #b8bb26'
     BRIGHT_RED       = 'light_red       h167      #fb4934'
+
+    # May be relevant to both modes
     NEUTRAL_PURPLE   = 'light_magenta   h132      #b16286'
     NEUTRAL_BLUE     = 'dark_cyan       h66       #458588'
     NEUTRAL_YELLOW   = 'brown           h172      #d79921'
+
+    # Light mode only - colors
     FADED_BLUE       = 'dark_blue       h24       #076678'
     FADED_YELLOW     = 'brown           h136      #b57614'
     FADED_RED        = 'dark_red        h88       #9d0006'
+
+    # Added for light mode; suggests light needs adjusting
     LIGHT0_HARD      = 'white           h230      #f9f5d7'
     GRAY_245         = 'dark_gray       h245      #928374'
     DARK2            = 'black           h239      #504945'

--- a/zulipterminal/themes/gruvbox_dark.py
+++ b/zulipterminal/themes/gruvbox_dark.py
@@ -19,10 +19,10 @@ from zulipterminal.themes.colors_gruvbox import DefaultBoldColor as Color
 STYLES = {
     # style_name       :  foreground                   background
     None               : (Color.LIGHT2,                Color.DARK0_HARD),
-    'selected'         : (Color.LIGHT2,                Color.FADED_BLUE),
-    'msg_selected'     : (Color.LIGHT2,                Color.FADED_BLUE),
-    'header'           : (Color.NEUTRAL_BLUE,          Color.FADED_BLUE),
-    'general_narrow'   : (Color.LIGHT2,                Color.FADED_BLUE),
+    'selected'         : (Color.DARK0_HARD,            Color.NEUTRAL_BLUE),
+    'msg_selected'     : (Color.DARK0_HARD,            Color.NEUTRAL_BLUE),
+    'header'           : (Color.NEUTRAL_BLUE,          Color.BRIGHT_BLUE),
+    'general_narrow'   : (Color.DARK0_HARD,            Color.BRIGHT_BLUE),
     'general_bar'      : (Color.LIGHT2,                Color.DARK0_HARD),
     'name'             : (Color.NEUTRAL_YELLOW__BOLD,  Color.DARK0_HARD),
     'unread'           : (Color.NEUTRAL_PURPLE,        Color.DARK0_HARD),
@@ -42,7 +42,7 @@ STYLES = {
     'msg_mention'      : (Color.BRIGHT_RED__BOLD,      Color.DARK0_HARD),
     'msg_link'         : (Color.BRIGHT_BLUE,           Color.DARK0_HARD),
     'msg_link_index'   : (Color.BRIGHT_BLUE__BOLD,     Color.DARK0_HARD),
-    'msg_quote'        : (Color.FADED_YELLOW,          Color.DARK0_HARD),
+    'msg_quote'        : (Color.NEUTRAL_YELLOW,        Color.DARK0_HARD),
     'msg_code'         : (Color.DARK0_HARD,            Color.LIGHT2),
     'msg_bold'         : (Color.LIGHT2__BOLD,          Color.DARK0_HARD),
     'msg_time'         : (Color.DARK0_HARD,            Color.LIGHT2),
@@ -65,14 +65,14 @@ STYLES = {
     'popup_important'  : (Color.BRIGHT_RED__BOLD,      Color.DARK0_HARD),
     'widget_disabled'  : (Color.GRAY_244,              Color.DARK0_HARD),
     'area:help'        : (Color.DARK0_HARD,            Color.BRIGHT_GREEN),
-    'area:msg'         : (Color.DARK0_HARD,            Color.BRIGHT_RED),
+    'area:msg'         : (Color.DARK0_HARD,            Color.NEUTRAL_PURPLE),
     'area:stream'      : (Color.DARK0_HARD,            Color.BRIGHT_BLUE),
-    'area:error'       : (Color.LIGHT2,                Color.FADED_RED),
-    'area:user'        : (Color.LIGHT2,                Color.FADED_BLUE),
+    'area:error'       : (Color.DARK0_HARD,            Color.BRIGHT_RED),
+    'area:user'        : (Color.DARK0_HARD,            Color.BRIGHT_YELLOW),
     'search_error'     : (Color.BRIGHT_RED,            Color.DARK0_HARD),
     'task:success'     : (Color.DARK0_HARD,            Color.BRIGHT_GREEN),
-    'task:error'       : (Color.LIGHT2,                Color.FADED_RED),
-    'task:warning'     : (Color.DARK0_HARD,            Color.BRIGHT_RED),
+    'task:error'       : (Color.DARK0_HARD,            Color.BRIGHT_RED),
+    'task:warning'     : (Color.DARK0_HARD,            Color.NEUTRAL_PURPLE),
 }
 
 META = {

--- a/zulipterminal/themes/gruvbox_light.py
+++ b/zulipterminal/themes/gruvbox_light.py
@@ -18,10 +18,10 @@ from zulipterminal.themes.colors_gruvbox import DefaultBoldColor as Color
 STYLES = {
     # style_name       :  foreground                   background
     None               : (Color.DARK2,                  Color.LIGHT0_HARD),
-    'selected'         : (Color.DARK2,                  Color.BRIGHT_BLUE),
-    'msg_selected'     : (Color.DARK2,                  Color.BRIGHT_BLUE),
-    'header'           : (Color.NEUTRAL_BLUE,           Color.BRIGHT_BLUE),
-    'general_narrow'   : (Color.DARK2,                  Color.BRIGHT_BLUE),
+    'selected'         : (Color.LIGHT0_HARD,            Color.NEUTRAL_BLUE),
+    'msg_selected'     : (Color.LIGHT0_HARD,            Color.NEUTRAL_BLUE),
+    'header'           : (Color.NEUTRAL_BLUE,           Color.FADED_BLUE),
+    'general_narrow'   : (Color.LIGHT0_HARD,            Color.FADED_BLUE),
     'general_bar'      : (Color.DARK2,                  Color.LIGHT0_HARD),
     'name'             : (Color.NEUTRAL_YELLOW,         Color.LIGHT0_HARD),
     'unread'           : (Color.NEUTRAL_PURPLE,         Color.LIGHT0_HARD),
@@ -41,7 +41,7 @@ STYLES = {
     'msg_mention'      : (Color.FADED_RED__BOLD,        Color.LIGHT0_HARD),
     'msg_link'         : (Color.FADED_BLUE,             Color.LIGHT0_HARD),
     'msg_link_index'   : (Color.FADED_BLUE__BOLD,       Color.LIGHT0_HARD),
-    'msg_quote'        : (Color.BRIGHT_YELLOW,          Color.LIGHT0_HARD),
+    'msg_quote'        : (Color.NEUTRAL_YELLOW,         Color.LIGHT0_HARD),
     'msg_code'         : (Color.LIGHT0_HARD,            Color.DARK2),
     'msg_bold'         : (Color.DARK2__BOLD,            Color.LIGHT0_HARD),
     'msg_time'         : (Color.LIGHT0_HARD,            Color.DARK2),
@@ -64,14 +64,14 @@ STYLES = {
     'popup_important'  : (Color.FADED_RED__BOLD,        Color.LIGHT0_HARD),
     'widget_disabled'  : (Color.GRAY_245,               Color.LIGHT0_HARD),
     'area:help'        : (Color.LIGHT0_HARD,            Color.FADED_GREEN),
-    'area:msg'         : (Color.LIGHT0_HARD,            Color.FADED_RED),
+    'area:msg'         : (Color.LIGHT0_HARD,            Color.NEUTRAL_PURPLE),
     'area:stream'      : (Color.LIGHT0_HARD,            Color.FADED_BLUE),
-    'area:error'       : (Color.DARK2,                  Color.BRIGHT_RED),
-    'area:user'        : (Color.DARK2,                  Color.BRIGHT_BLUE),
+    'area:error'       : (Color.LIGHT0_HARD,            Color.FADED_RED),
+    'area:user'        : (Color.LIGHT0_HARD,            Color.FADED_YELLOW),
     'search_error'     : (Color.FADED_RED,              Color.LIGHT0_HARD),
     'task:success'     : (Color.LIGHT0_HARD,            Color.FADED_GREEN),
-    'task:error'       : (Color.DARK2,                  Color.BRIGHT_RED),
-    'task:warning'     : (Color.LIGHT0_HARD,            Color.FADED_RED),
+    'task:error'       : (Color.LIGHT0_HARD,            Color.FADED_RED),
+    'task:warning'     : (Color.LIGHT0_HARD,            Color.NEUTRAL_PURPLE),
 }
 
 META = {


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->

When the light variant was added, we noticed that the gruvbox palettes have the faded/neutral/bright variants of colors, and it was suggested to group these. 

It is noticeable in the palettes linked below that:
- dark uses bright+neutral colors
- light uses faded+neutral colors

The existing dark variant uses some faded colors, and the light variant seems to use some bright ones. This PR is intended to address these issues, and group colors to make this usage clearer.

https://github.com/morhetz/gruvbox#palette

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [ ] Existing tests (adapted, if necessary)
- [ ] New tests added (for any new behavior)
- [x] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

<!-- See https://github.com/zulip/zulip-terminal#commit-style -->
**Commit flow** <!-- if more than one commit; add/delete/fill-in as appropriate -->

- Update dark mode, and label/group used color palette elements
- Update light mode, and label/group remaining color palette elements

**Notes & Questions** <!-- if any; add/delete/fill-in as appropriate -->

The term 'mode' is used in the color palette comments, based on the gruvbox terminology.

**Visual changes** <!-- if any; add/delete/fill-in with screenshot/diagram as appropriate -->

Please do fetch this PR for comparison, as colors can look differently in local systems.

Main elements that changed: (as evident in the diff) <-- DARK MODE
- selected elements: light-on-faded-blue -> dark-on-neutral-blue
- general narrow titles (PMs, mentions, ...): light-on-faded-blue -> dark-on-bright-blue
- quotes: faded-yellow-on-dark -> neutral-yellow-on-dark
- area:error/task:error: light-on-faded-red -> dark-on-bright-red
- area:msg: dark-on-bright-red (ok!) -> dark-on-neutral-purple (avoid area:error conflict)
- task:warning: dark-on-bright-red (ok!) -> dark-on-neutral-purple (avoid task:error conflict)
- area:user (user info): light-on-faded-blue -> dark-on-bright-yellow (bright blue already used for streams)