### PR TITLE
Indicate web-public streams differently

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,7 +54,7 @@ def stream_button(mocker: MockerFixture) -> StreamButton:
             "name": "PTEST",
             "id": 205,
             "color": "#bfd56f",
-            "invite_only": False,
+            "stream_access_type": "public",
             "description": "Test stream description",
         },
         controller=mocker.patch("zulipterminal.core.Controller"),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -253,11 +253,39 @@ def secret_stream() -> Dict[str, Any]:
     }
 
 
+# Like public stream but with is_web_public=True
+@pytest.fixture
+def web_public_stream() -> Dict[str, Any]:
+    return {
+        "description": "Some web public stream",
+        "stream_id": 999,
+        "pin_to_top": False,
+        "invite_only": False,
+        "name": "Web public stream",
+        "date_created": 1472047124,
+        "email_address": "web_public@example.com",
+        "rendered_description": "Some web public stream",
+        "color": "#ddd",  # Color in '#xxx' format
+        "in_home_view": True,
+        "audible_notifications": False,
+        "is_old_stream": True,
+        "desktop_notifications": False,
+        "stream_weekly_traffic": 0,
+        "message_retention_days": -1,
+        "push_notifications": False,
+        "subscribers": [1001, 11],
+        "history_public_to_subscribers": False,
+        "is_web_public": True,
+    }
+
+
 @pytest.fixture
 def streams_fixture(
-    general_stream: Dict[str, Any], secret_stream: Dict[str, Any]
+    general_stream: Dict[str, Any],
+    secret_stream: Dict[str, Any],
+    web_public_stream: Dict[str, Any],
 ) -> List[Dict[str, Any]]:
-    streams = [general_stream, secret_stream]
+    streams = [general_stream, secret_stream, web_public_stream]
     for i in range(1, 3):
         streams.append(
             {
@@ -1129,6 +1157,13 @@ def streams() -> List[Dict[str, Any]]:
             "color": "#baf",
             "invite_only": False,
             "description": "A description of stream 2",
+        },
+        {
+            "name": "Web public stream",
+            "id": 999,
+            "color": "#ddd",
+            "invite_only": False,
+            "description": "Some web public stream",
         },
     ]
 

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -1152,9 +1152,12 @@ class TestModel:
         model.client.update_subscription_settings.assert_called_once_with(request)
         self.display_error_if_present.assert_called_once_with(response, self.controller)
 
-    def test_stream_access_type(self, model, general_stream, secret_stream):
+    def test_stream_access_type(
+        self, model, general_stream, secret_stream, web_public_stream
+    ):
         assert model.stream_access_type(general_stream["stream_id"]) == "public"
         assert model.stream_access_type(secret_stream["stream_id"]) == "private"
+        assert model.stream_access_type(web_public_stream["stream_id"]) == "web-public"
 
     @pytest.mark.parametrize(
         "flags_before, expected_operator",

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -1152,6 +1152,10 @@ class TestModel:
         model.client.update_subscription_settings.assert_called_once_with(request)
         self.display_error_if_present.assert_called_once_with(response, self.controller)
 
+    def test_stream_access_type(self, model, general_stream, secret_stream):
+        assert model.stream_access_type(general_stream["stream_id"]) == "public"
+        assert model.stream_access_type(secret_stream["stream_id"]) == "private"
+
     @pytest.mark.parametrize(
         "flags_before, expected_operator",
         [

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1200,7 +1200,7 @@ class TestLeftColumnView:
             controller=left_col_view.controller, count=3
         )
 
-    @pytest.mark.parametrize("pinned", powerset([1, 2, 99, 1000]))
+    @pytest.mark.parametrize("pinned", powerset([1, 2, 99, 999, 1000]))
     def test_streams_view(self, mocker, streams, pinned):
         self.view.unpinned_streams = [s for s in streams if s["id"] not in pinned]
         self.view.pinned_streams = [s for s in streams if s["id"] in pinned]
@@ -1222,7 +1222,7 @@ class TestLeftColumnView:
                     properties=stream,
                     controller=self.view.controller,
                     view=self.view,
-                    count=1,
+                    count=mocker.ANY,
                 )
                 for stream in (self.view.pinned_streams + self.view.unpinned_streams)
             ]

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -509,18 +509,36 @@ class TestWriteBox:
             (
                 "#Stream",
                 0,
-                ["Stream 1", "Stream 2", "Secret stream", "Some general stream"],
+                [
+                    "Stream 1",
+                    "Stream 2",
+                    "Secret stream",
+                    "Some general stream",
+                    "Web public stream",
+                ],
             ),
             ("#*Stream", None, []),  # NOTE: Optional single star fails
             (
                 "#**Stream",
                 0,
-                ["Stream 1", "Stream 2", "Secret stream", "Some general stream"],
+                [
+                    "Stream 1",
+                    "Stream 2",
+                    "Secret stream",
+                    "Some general stream",
+                    "Web public stream",
+                ],
             ),  # Optional 2-stars
             (
                 "#Stream",
                 None,
-                ["Stream 1", "Stream 2", "Secret stream", "Some general stream"],
+                [
+                    "Stream 1",
+                    "Stream 2",
+                    "Secret stream",
+                    "Some general stream",
+                    "Web public stream",
+                ],
             ),
             ("#NoMatch", None, []),
             # emojis
@@ -735,11 +753,13 @@ class TestWriteBox:
             ("#S", 1, "#**Some general stream**", []),  # 1st-word startswith.
             ("#S", 2, "#**Stream 1**", []),  # 1st-word startswith match.
             ("#S", 3, "#**Stream 2**", []),  # 1st-word startswith match.
-            ("#S", -1, "#**Stream 2**", []),
-            ("#S", -2, "#**Stream 1**", []),
-            ("#S", -3, "#**Some general stream**", []),
-            ("#S", -4, "#**Secret stream**", []),
-            ("#S", -5, None, []),
+            ("#S", 4, "#**Web public stream**", []),  # 1st-word startswith match.
+            ("#S", -1, "#**Web public stream**", []),
+            ("#S", -2, "#**Stream 2**", []),
+            ("#S", -3, "#**Stream 1**", []),
+            ("#S", -4, "#**Some general stream**", []),
+            ("#S", -5, "#**Secret stream**", []),
+            ("#S", -6, None, []),
             ("#So", 0, "#**Some general stream**", []),
             ("#So", 1, None, []),
             ("#Se", 0, "#**Secret stream**", []),
@@ -1013,25 +1033,49 @@ class TestWriteBox:
                 "",
                 1,
                 [],
-                ["Secret stream", "Some general stream", "Stream 1", "Stream 2"],
+                [
+                    "Secret stream",
+                    "Some general stream",
+                    "Stream 1",
+                    "Stream 2",
+                    "Web public stream",
+                ],
             ),
             (
                 "",
                 1,
                 ["Stream 2"],
-                ["Stream 2", "Secret stream", "Some general stream", "Stream 1"],
+                [
+                    "Stream 2",
+                    "Secret stream",
+                    "Some general stream",
+                    "Stream 1",
+                    "Web public stream",
+                ],
             ),
             (
                 "St",
                 1,
                 [],
-                ["Stream 1", "Stream 2", "Secret stream", "Some general stream"],
+                [
+                    "Stream 1",
+                    "Stream 2",
+                    "Secret stream",
+                    "Some general stream",
+                    "Web public stream",
+                ],
             ),
             (
                 "St",
                 1,
                 ["Stream 2"],
-                ["Stream 2", "Stream 1", "Secret stream", "Some general stream"],
+                [
+                    "Stream 2",
+                    "Stream 1",
+                    "Secret stream",
+                    "Some general stream",
+                    "Web public stream",
+                ],
             ),
         ],
         ids=[

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -12,6 +12,7 @@ from zulipterminal.config.symbols import (
     INVALID_MARKER,
     STREAM_MARKER_PRIVATE,
     STREAM_MARKER_PUBLIC,
+    STREAM_MARKER_WEB_PUBLIC,
 )
 from zulipterminal.config.ui_mappings import StreamAccessType
 from zulipterminal.helper import Index
@@ -1109,11 +1110,20 @@ class TestWriteBox:
     @pytest.mark.parametrize(
         "stream_name, stream_id, is_valid_stream, stream_access_type, expected_marker, expected_color",
         [
+            (
+                "Web public stream",
+                999,
+                True,
+                "web-public",
+                STREAM_MARKER_WEB_PUBLIC,
+                "#ddd",
+            ),
             ("Secret stream", 99, True, "private", STREAM_MARKER_PRIVATE, "#ccc"),
             ("Stream 1", 1, True, "public", STREAM_MARKER_PUBLIC, "#b0a5fd"),
             ("Stream 0", 0, False, None, INVALID_MARKER, "general_bar"),
         ],
         ids=[
+            "web_public_stream",
             "private_stream",
             "public_stream",
             "invalid_stream_name",

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -13,6 +13,7 @@ from zulipterminal.config.symbols import (
     STREAM_MARKER_PRIVATE,
     STREAM_MARKER_PUBLIC,
 )
+from zulipterminal.config.ui_mappings import StreamAccessType
 from zulipterminal.helper import Index
 from zulipterminal.ui_tools.boxes import PanelSearchBox, WriteBox, _MessageEditState
 from zulipterminal.urwid_types import urwid_Size
@@ -1062,11 +1063,11 @@ class TestWriteBox:
         )
 
     @pytest.mark.parametrize(
-        "stream_name, stream_id, is_valid_stream, expected_marker, expected_color",
+        "stream_name, stream_id, is_valid_stream, stream_access_type, expected_marker, expected_color",
         [
-            ("Secret stream", 99, True, STREAM_MARKER_PRIVATE, "#ccc"),
-            ("Stream 1", 1, True, STREAM_MARKER_PUBLIC, "#b0a5fd"),
-            ("Stream 0", 0, False, INVALID_MARKER, "general_bar"),
+            ("Secret stream", 99, True, "private", STREAM_MARKER_PRIVATE, "#ccc"),
+            ("Stream 1", 1, True, "public", STREAM_MARKER_PUBLIC, "#b0a5fd"),
+            ("Stream 0", 0, False, None, INVALID_MARKER, "general_bar"),
         ],
         ids=[
             "private_stream",
@@ -1080,6 +1081,7 @@ class TestWriteBox:
         stream_id: int,
         stream_name: str,
         is_valid_stream: bool,
+        stream_access_type: StreamAccessType,
         expected_marker: str,
         stream_dict: Dict[int, Any],
         expected_color: str,
@@ -1088,6 +1090,7 @@ class TestWriteBox:
         write_box.model.stream_dict = stream_dict
         write_box.model.is_valid_stream.return_value = is_valid_stream
         write_box.model.stream_id_from_name.return_value = stream_id
+        write_box.model.stream_access_type.return_value = stream_access_type
 
         write_box.stream_box_view(stream_id)
 

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -1155,7 +1155,10 @@ class TestStreamInfoView:
         self.stream_id = general_stream["stream_id"]
         self.controller.model.server_feature_level = 40
         self.controller.model.cached_retention_text = {self.stream_id: "10"}
+
         self.controller.model.stream_dict = {self.stream_id: general_stream}
+        self.controller.model.stream_access_type.return_value = "public"
+
         self.stream_info_view = StreamInfoView(self.controller, self.stream_id)
 
     def test_keypress_any_key(

--- a/zulipterminal/config/symbols.py
+++ b/zulipterminal/config/symbols.py
@@ -1,6 +1,7 @@
 INVALID_MARKER = "✗"
 STREAM_MARKER_PRIVATE = "P"
 STREAM_MARKER_PUBLIC = "#"
+STREAM_MARKER_WEB_PUBLIC = "⊚"
 STREAM_TOPIC_SEPARATOR = "▶"
 # Used as a separator between messages and 'EDITED'
 MESSAGE_CONTENT_MARKER = "▒"  # Options are '█', '▓', '▒', '░'

--- a/zulipterminal/config/ui_mappings.py
+++ b/zulipterminal/config/ui_mappings.py
@@ -27,7 +27,7 @@ STATE_ICON = {
 }
 
 
-StreamAccessType = Literal["public", "private"]
+StreamAccessType = Literal["public", "private", "web-public"]
 
 
 BOT_TYPE_BY_ID = {

--- a/zulipterminal/config/ui_mappings.py
+++ b/zulipterminal/config/ui_mappings.py
@@ -29,6 +29,12 @@ STATE_ICON = {
 
 StreamAccessType = Literal["public", "private", "web-public"]
 
+STREAM_ACCESS_TYPE = {
+    "public": {"description": "Public"},
+    "private": {"description": "Private"},
+    "web-public": {"description": "Web public"},
+}
+
 
 BOT_TYPE_BY_ID = {
     1: "Generic Bot",

--- a/zulipterminal/config/ui_mappings.py
+++ b/zulipterminal/config/ui_mappings.py
@@ -8,6 +8,9 @@ from zulipterminal.config.symbols import (
     STATUS_IDLE,
     STATUS_INACTIVE,
     STATUS_OFFLINE,
+    STREAM_MARKER_PRIVATE,
+    STREAM_MARKER_PUBLIC,
+    STREAM_MARKER_WEB_PUBLIC,
 )
 
 
@@ -30,9 +33,9 @@ STATE_ICON = {
 StreamAccessType = Literal["public", "private", "web-public"]
 
 STREAM_ACCESS_TYPE = {
-    "public": {"description": "Public"},
-    "private": {"description": "Private"},
-    "web-public": {"description": "Web public"},
+    "public": {"description": "Public", "icon": STREAM_MARKER_PUBLIC},
+    "private": {"description": "Private", "icon": STREAM_MARKER_PRIVATE},
+    "web-public": {"description": "Web public", "icon": STREAM_MARKER_WEB_PUBLIC},
 }
 
 

--- a/zulipterminal/config/ui_mappings.py
+++ b/zulipterminal/config/ui_mappings.py
@@ -1,5 +1,7 @@
 from typing import Dict, Optional
 
+from typing_extensions import Literal
+
 from zulipterminal.api_types import EditPropagateMode
 from zulipterminal.config.symbols import (
     STATUS_ACTIVE,
@@ -23,6 +25,9 @@ STATE_ICON = {
     "offline": STATUS_OFFLINE,
     "inactive": STATUS_INACTIVE,
 }
+
+
+StreamAccessType = Literal["public", "private"]
 
 
 BOT_TYPE_BY_ID = {

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -31,13 +31,14 @@ from zulipterminal.config.regexes import (
     REGEX_COLOR_6_DIGIT,
     REGEX_QUOTED_FENCE_LENGTH,
 )
+from zulipterminal.config.ui_mappings import StreamAccessType
 
 
 class StreamData(TypedDict):
     name: str
     id: int
     color: str
-    invite_only: bool
+    stream_access_type: StreamAccessType
     description: str
 
 

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1096,7 +1096,10 @@ class Model:
     def stream_access_type(self, stream_id: int) -> StreamAccessType:
         if stream_id not in self.stream_dict:
             raise RuntimeError("Invalid stream id.")
-        if self.stream_dict[stream_id]["invite_only"]:
+        stream = self.stream_dict[stream_id]
+        if stream.get("is_web_public", False):
+            return "web-public"
+        if stream["invite_only"]:
             return "private"
         return "public"
 

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -36,7 +36,7 @@ from zulipterminal.api_types import (
     Subscription,
 )
 from zulipterminal.config.keys import primary_key_for_command
-from zulipterminal.config.ui_mappings import ROLE_BY_ID
+from zulipterminal.config.ui_mappings import ROLE_BY_ID, StreamAccessType
 from zulipterminal.helper import (
     Message,
     NamedEmojiData,
@@ -1092,6 +1092,13 @@ class Model:
             if stream["name"] == stream_name:
                 return stream_id
         raise RuntimeError("Invalid stream name.")
+
+    def stream_access_type(self, stream_id: int) -> StreamAccessType:
+        if stream_id not in self.stream_dict:
+            raise RuntimeError("Invalid stream id.")
+        if self.stream_dict[stream_id]["invite_only"]:
+            return "private"
+        return "public"
 
     def is_pinned_stream(self, stream_id: int) -> bool:
         return stream_id in [stream["id"] for stream in self.pinned_streams]

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1018,7 +1018,7 @@ class Model:
                     "name": stream["name"],
                     "id": stream["stream_id"],
                     "color": stream["color"],
-                    "invite_only": stream["invite_only"],
+                    "stream_access_type": self.stream_access_type(stream["stream_id"]),
                     "description": stream["description"],
                 }
             )

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -35,6 +35,7 @@ from zulipterminal.config.symbols import (
     QUOTED_TEXT_MARKER,
     STREAM_MARKER_PRIVATE,
     STREAM_MARKER_PUBLIC,
+    STREAM_MARKER_WEB_PUBLIC,
     STREAM_TOPIC_SEPARATOR,
     TIME_MENTION_MARKER,
 )
@@ -433,8 +434,11 @@ class WriteBox(urwid.Pile):
         color = "general_bar"
         if self.model.is_valid_stream(new_text):
             stream_id = self.model.stream_id_from_name(new_text)
-            if self.model.stream_access_type(stream_id) == "private":
+            stream_access_type = self.model.stream_access_type(stream_id)
+            if stream_access_type == "private":
                 stream_marker = STREAM_MARKER_PRIVATE
+            elif stream_access_type == "web-public":
+                stream_marker = STREAM_MARKER_WEB_PUBLIC
             else:
                 stream_marker = STREAM_MARKER_PUBLIC
             stream = self.model.stream_dict[stream_id]

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -432,11 +432,12 @@ class WriteBox(urwid.Pile):
         stream_marker = INVALID_MARKER
         color = "general_bar"
         if self.model.is_valid_stream(new_text):
-            stream = self.model.stream_dict[self.model.stream_id_from_name(new_text)]
-            if stream["invite_only"]:
+            stream_id = self.model.stream_id_from_name(new_text)
+            if self.model.stream_access_type(stream_id) == "private":
                 stream_marker = STREAM_MARKER_PRIVATE
             else:
                 stream_marker = STREAM_MARKER_PUBLIC
+            stream = self.model.stream_dict[stream_id]
             color = stream["color"]
         self.header_write_box[self.FOCUS_HEADER_PREFIX_STREAM].set_text(
             (color, stream_marker)

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -33,13 +33,10 @@ from zulipterminal.config.symbols import (
     MESSAGE_CONTENT_MARKER,
     MESSAGE_HEADER_DIVIDER,
     QUOTED_TEXT_MARKER,
-    STREAM_MARKER_PRIVATE,
-    STREAM_MARKER_PUBLIC,
-    STREAM_MARKER_WEB_PUBLIC,
     STREAM_TOPIC_SEPARATOR,
     TIME_MENTION_MARKER,
 )
-from zulipterminal.config.ui_mappings import STATE_ICON
+from zulipterminal.config.ui_mappings import STATE_ICON, STREAM_ACCESS_TYPE
 from zulipterminal.helper import (
     Message,
     asynch,
@@ -435,12 +432,7 @@ class WriteBox(urwid.Pile):
         if self.model.is_valid_stream(new_text):
             stream_id = self.model.stream_id_from_name(new_text)
             stream_access_type = self.model.stream_access_type(stream_id)
-            if stream_access_type == "private":
-                stream_marker = STREAM_MARKER_PRIVATE
-            elif stream_access_type == "web-public":
-                stream_marker = STREAM_MARKER_WEB_PUBLIC
-            else:
-                stream_marker = STREAM_MARKER_PUBLIC
+            stream_marker = STREAM_ACCESS_TYPE[stream_access_type]["icon"]
             stream = self.model.stream_dict[stream_id]
             color = stream["color"]
         self.header_write_box[self.FOCUS_HEADER_PREFIX_STREAM].set_text(

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -9,14 +9,8 @@ from typing_extensions import TypedDict
 from zulipterminal.api_types import RESOLVED_TOPIC_PREFIX, EditPropagateMode
 from zulipterminal.config.keys import is_command_key, primary_key_for_command
 from zulipterminal.config.regexes import REGEX_INTERNAL_LINK_STREAM_ID
-from zulipterminal.config.symbols import (
-    CHECK_MARK,
-    MUTE_MARKER,
-    STREAM_MARKER_PRIVATE,
-    STREAM_MARKER_PUBLIC,
-    STREAM_MARKER_WEB_PUBLIC,
-)
-from zulipterminal.config.ui_mappings import EDIT_MODE_CAPTIONS
+from zulipterminal.config.symbols import CHECK_MARK, MUTE_MARKER
+from zulipterminal.config.ui_mappings import EDIT_MODE_CAPTIONS, STREAM_ACCESS_TYPE
 from zulipterminal.helper import Message, StreamData, hash_util_decode
 from zulipterminal.urwid_types import urwid_Size
 
@@ -191,12 +185,7 @@ class StreamButton(TopButton):
             ("s" + self.color, "", "", "standout", inverse_text, self.color)
         )
 
-        if stream_access_type == "private":
-            stream_marker = STREAM_MARKER_PRIVATE
-        elif stream_access_type == "web-public":
-            stream_marker = STREAM_MARKER_WEB_PUBLIC
-        else:
-            stream_marker = STREAM_MARKER_PUBLIC
+        stream_marker = STREAM_ACCESS_TYPE[stream_access_type]["icon"]
 
         narrow_function = partial(
             controller.narrow_to_stream,

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -14,6 +14,7 @@ from zulipterminal.config.symbols import (
     MUTE_MARKER,
     STREAM_MARKER_PRIVATE,
     STREAM_MARKER_PUBLIC,
+    STREAM_MARKER_WEB_PUBLIC,
 )
 from zulipterminal.config.ui_mappings import EDIT_MODE_CAPTIONS
 from zulipterminal.helper import Message, StreamData, hash_util_decode
@@ -171,7 +172,7 @@ class StreamButton(TopButton):
         self.stream_name = properties["name"]
         self.stream_id = properties["id"]
         self.color = properties["color"]
-        is_private = properties["invite_only"]
+        stream_access_type = properties["stream_access_type"]
         self.description = properties["description"]
 
         self.model = controller.model
@@ -190,7 +191,13 @@ class StreamButton(TopButton):
             ("s" + self.color, "", "", "standout", inverse_text, self.color)
         )
 
-        stream_marker = STREAM_MARKER_PRIVATE if is_private else STREAM_MARKER_PUBLIC
+        if stream_access_type == "private":
+            stream_marker = STREAM_MARKER_PRIVATE
+        elif stream_access_type == "web-public":
+            stream_marker = STREAM_MARKER_WEB_PUBLIC
+        else:
+            stream_marker = STREAM_MARKER_PUBLIC
+
         narrow_function = partial(
             controller.narrow_to_stream,
             stream_name=self.stream_name,

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1339,7 +1339,15 @@ class StreamInfoView(PopUpView):
                 stream_policy = STREAM_POST_POLICY[1]
 
         total_members = len(stream["subscribers"])
-        type_of_stream = "Private" if stream["invite_only"] else "Public"
+
+        stream_access_type = controller.model.stream_access_type(stream_id)
+        if stream_access_type == "private":
+            type_of_stream = "Private"
+            stream_marker = STREAM_MARKER_PRIVATE
+        else:
+            type_of_stream = "Public"
+            stream_marker = STREAM_MARKER_PUBLIC
+
         availability_of_history = (
             "Public to Users"
             if stream["history_public_to_subscribers"]
@@ -1354,9 +1362,6 @@ class StreamInfoView(PopUpView):
             "Stream created recently" if weekly_traffic is None else str(weekly_traffic)
         )
 
-        stream_marker = (
-            STREAM_MARKER_PRIVATE if stream["invite_only"] else STREAM_MARKER_PUBLIC
-        )
         title = f"{stream_marker} {stream['name']}"
         rendered_desc = stream["rendered_description"]
         self.markup_desc, message_links, _ = MessageBox.transform_content(

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -20,9 +20,6 @@ from zulipterminal.config.symbols import (
     CHECK_MARK,
     COLUMN_TITLE_BAR_LINE,
     PINNED_STREAMS_DIVIDER,
-    STREAM_MARKER_PRIVATE,
-    STREAM_MARKER_PUBLIC,
-    STREAM_MARKER_WEB_PUBLIC,
 )
 from zulipterminal.config.ui_mappings import (
     BOT_TYPE_BY_ID,
@@ -1344,12 +1341,7 @@ class StreamInfoView(PopUpView):
 
         stream_access_type = controller.model.stream_access_type(stream_id)
         type_of_stream = STREAM_ACCESS_TYPE[stream_access_type]["description"]
-        if stream_access_type == "private":
-            stream_marker = STREAM_MARKER_PRIVATE
-        elif stream_access_type == "web-public":
-            stream_marker = STREAM_MARKER_WEB_PUBLIC
-        else:
-            stream_marker = STREAM_MARKER_PUBLIC
+        stream_marker = STREAM_ACCESS_TYPE[stream_access_type]["icon"]
 
         availability_of_history = (
             "Public to Users"

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -29,6 +29,7 @@ from zulipterminal.config.ui_mappings import (
     EDIT_MODE_CAPTIONS,
     ROLE_BY_ID,
     STATE_ICON,
+    STREAM_ACCESS_TYPE,
     STREAM_POST_POLICY,
 )
 from zulipterminal.config.ui_sizes import LEFT_WIDTH
@@ -1342,14 +1343,12 @@ class StreamInfoView(PopUpView):
         total_members = len(stream["subscribers"])
 
         stream_access_type = controller.model.stream_access_type(stream_id)
+        type_of_stream = STREAM_ACCESS_TYPE[stream_access_type]["description"]
         if stream_access_type == "private":
-            type_of_stream = "Private"
             stream_marker = STREAM_MARKER_PRIVATE
         elif stream_access_type == "web-public":
-            type_of_stream = "Web-public"
             stream_marker = STREAM_MARKER_WEB_PUBLIC
         else:
-            type_of_stream = "Public"
             stream_marker = STREAM_MARKER_PUBLIC
 
         availability_of_history = (

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -22,6 +22,7 @@ from zulipterminal.config.symbols import (
     PINNED_STREAMS_DIVIDER,
     STREAM_MARKER_PRIVATE,
     STREAM_MARKER_PUBLIC,
+    STREAM_MARKER_WEB_PUBLIC,
 )
 from zulipterminal.config.ui_mappings import (
     BOT_TYPE_BY_ID,
@@ -1344,6 +1345,9 @@ class StreamInfoView(PopUpView):
         if stream_access_type == "private":
             type_of_stream = "Private"
             stream_marker = STREAM_MARKER_PRIVATE
+        elif stream_access_type == "web-public":
+            type_of_stream = "Web-public"
+            stream_marker = STREAM_MARKER_WEB_PUBLIC
         else:
             type_of_stream = "Public"
             stream_marker = STREAM_MARKER_PUBLIC


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->

This is intended to fix most of #712 (#1135)

See #**zulip-terminal > Web public marker #T1135/#T712**

<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->

<!-- Add a link to a discussion on chat.zulip.org, if relevant -->

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [X] Manually
- [x] Existing tests (adapted, if necessary)
- [x] New tests added (for any new behavior)
- [x] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

<!-- See https://github.com/zulip/zulip-terminal#commit-style -->
**Commit flow** <!-- if more than one commit; add/delete/fill-in as appropriate -->

- Add model accessor for stream type, given stream id
- Use new accessor outside of model (in UI)
- Add fixtures for a web public stream & adjust existing tests
- Add symbol and extend existing code minimally to indicate symbol in most cases
- Add symbol rendering in stream list
- Refactor duplicated if/elif blocks to use new common dict in ui_mappings (descriptions)
- Refactor if/elif blocks to use same dict for icons too

**Notes & Questions** <!-- if any; add/delete/fill-in as appropriate -->

This needs some tests fixed and I'm planning an additional refactor, but pushing now to get feedback.

**update** Tests are now fixed and extended.

**Visual changes** <!-- if any; add/delete/fill-in with screenshot/diagram as appropriate -->

Currently, web-public streams are shown as `A`. This is not ideal, but I've not found a reliable symbol/character yet (`W` in bold was very full/blocky). If you fetch the PR you can play with variations by changing the character in `symbols.py`.

**update** After debate on the stream, we currently have `⊚` as an approximation to a narrow (1-character-wide) circular symbol. We can explore this further when we explore symbol themes #938 (maybe #1114)