### PR TITLE
Bugfix to update stream marker/color on editing stream message

### DIFF
--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -429,6 +429,9 @@ class WriteBox(urwid.Pile):
         )
         self.header_write_box.widget_list.append(self.edit_mode_button)
 
+        # Use callback to set stream marker - it shouldn't change, so don't need signal
+        self._set_stream_write_box_style(None, caption)
+
     def _set_stream_write_box_style(self, widget: ReadlineEdit, new_text: str) -> None:
         # FIXME: Refactor when we have ~ Model.is_private_stream
         stream_marker = INVALID_MARKER

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -365,15 +365,10 @@ class WriteBox(urwid.Pile):
         )
         self.title_write_box.set_completer_delims("")
 
-        stream_marker = STREAM_MARKER_PUBLIC
-        color = None
-        if caption:
-            color = self.model.stream_dict[self.stream_id]["color"]
-            if self.model.stream_dict[self.stream_id]["invite_only"]:
-                stream_marker = STREAM_MARKER_PRIVATE
+        # NOTE: stream marker should be set during initialization
         self.header_write_box = urwid.Columns(
             [
-                ("pack", urwid.Text((color, STREAM_MARKER_PUBLIC))),
+                ("pack", urwid.Text(("default", "?"))),
                 self.stream_write_box,
                 ("pack", urwid.Text(STREAM_TOPIC_SEPARATOR)),
                 self.title_write_box,


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->

If editing a message in a private stream (or soon, a web-public stream), the stream marker was not set correctly.

One commit adjusts this to do so correctly using the new helper method, while the other removes the duplicate code originally used prior to the helper method.

<!-- Add a link to a discussion on chat.zulip.org, if relevant -->

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [ ] New tests added (for any new behavior)
- [x] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

**Notes & Questions** <!-- if any; add/delete/fill-in as appropriate -->

We could add tests for the stream marker/color setting in various edit modes - we have none currently. The marker/color behavior is tested separately using a test for the common helper method.