### PR TITLE
ui/boxes: Improve stream sorting for stream typeahead in compose box.

### DIFF
--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -829,7 +829,7 @@ class TestWriteBox:
                     3: "#**Web public stream**",
                     4: "#**Secret stream**",
                 },
-                {"muted": {99}},
+                {"muted": ["Secret stream"]},
             ),
             # With 'Stream 1' and 'Secret stream' muted.
             (
@@ -841,7 +841,7 @@ class TestWriteBox:
                     3: "#**Stream 1**",
                     4: "#**Secret stream**",
                 },
-                {"muted": {99, 1}},
+                {"muted": ["Secret stream", "Stream 1"]},
             ),
             # With 'Stream 1' and 'Secret stream' pinned, 'Secret stream' muted.
             (
@@ -853,7 +853,7 @@ class TestWriteBox:
                     3: "#**Some general stream**",
                     4: "#**Web public stream**",
                 },
-                {"pinned": ["Secret stream", "Stream 1"], "muted": {99}},
+                {"pinned": ["Secret stream", "Stream 1"], "muted": ["Secret stream"]},
             ),
             # With 'Stream 1' and 'Secret stream' pinned, 'Some general stream' and 'Stream 2' muted.
             (
@@ -865,7 +865,10 @@ class TestWriteBox:
                     3: "#**Stream 2**",
                     4: "#**Some general stream**",
                 },
-                {"pinned": ["Secret stream", "Stream 1"], "muted": {1000, 2}},
+                {
+                    "pinned": ["Secret stream", "Stream 1"],
+                    "muted": ["Some general stream", "Stream 2"],
+                },
             ),
             # With 'Stream 1' and 'Secret stream' pinned, 'Secret stream' and 'Stream 2' muted.
             (
@@ -877,7 +880,10 @@ class TestWriteBox:
                     3: "#**Web public stream**",
                     4: "#**Stream 2**",
                 },
-                {"pinned": ["Secret stream", "Stream 1"], "muted": {99, 2}},
+                {
+                    "pinned": ["Secret stream", "Stream 1"],
+                    "muted": ["Secret stream", "Stream 2"],
+                },
             ),
             # With 'Stream 1' as current stream.
             (
@@ -903,7 +909,7 @@ class TestWriteBox:
                 },
                 {
                     "pinned": ["Secret stream", "Stream 1"],
-                    "muted": {99, 2},
+                    "muted": ["Secret stream", "Stream 2"],
                     "current_stream": 2,
                 },
             ),
@@ -927,7 +933,11 @@ class TestWriteBox:
         write_box.view.pinned_streams = streams_to_pin
         write_box.stream_id = stream_categories.get("current_stream", None)
         write_box.model.stream_dict = stream_dict
-        write_box.model.muted_streams = stream_categories.get("muted", set())
+        write_box.model.muted_streams = set(
+            stream["stream_id"]
+            for stream in stream_dict.values()
+            if stream["name"] in stream_categories.get("muted", set())
+        )
         for state, required_typeahead in state_and_required_typeahead.items():
             typeahead_string = write_box.generic_autocomplete(text, state)
             assert typeahead_string == required_typeahead

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -938,9 +938,12 @@ class TestWriteBox:
             for stream in stream_dict.values()
             if stream["name"] in stream_categories.get("muted", set())
         )
-        for state, required_typeahead in state_and_required_typeahead.items():
-            typeahead_string = write_box.generic_autocomplete(text, state)
-            assert typeahead_string == required_typeahead
+        states = state_and_required_typeahead.keys()
+        required_typeaheads = list(state_and_required_typeahead.values())
+        typeahead_strings = [
+            write_box.generic_autocomplete(text, state) for state in states
+        ]
+        assert typeahead_strings == required_typeaheads
 
     @pytest.mark.parametrize(
         "text, state, required_typeahead",

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -660,6 +660,13 @@ class WriteBox(urwid.Pile):
             else:
                 matched_streams.append(matching_muted_stream)
 
+        current_stream = self.model.stream_dict.get(self.stream_id, None)
+        if current_stream is not None:
+            current_stream_name = current_stream["name"]
+            if current_stream_name in matched_streams:
+                matched_streams.remove(current_stream_name)
+                matched_streams.insert(0, current_stream_name)
+
         matched_stream_typeaheads = format_string(matched_streams, "#**{}**")
         return matched_stream_typeaheads, matched_streams
 


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->
This PR improves stream sorting for stream typeahead in compose box stream results in footer in the following order -

1) current stream (if matching)
2) pinned and unmuted
3) unpinned and unmuted
4) pinned and muted
5) unpinned and muted

<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->

<!-- Add a link to a discussion on chat.zulip.org, if relevant -->
CZO - https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/Improve.20stream.20sorting.20for.20stream.20typeahead.20in.20compose.20box.2E

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [ ] Existing tests (adapted, if necessary)
- [ ] New tests added (for any new behavior)
- [ ] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->
Passing all lint tests.

``test_generic_autocomplete_streams`` test to be updated in ``test_boxes.py``
<!-- See https://github.com/zulip/zulip-terminal#commit-style -->
**Commit flow** <!-- if more than one commit; add/delete/fill-in as appropriate -->
<!-- For example:
- first commit doing some thing
- maybe multiple commits doing similar things
-->

**Notes & Questions** <!-- if any; add/delete/fill-in as appropriate -->
<!-- For example:
- this doesn't include feature X (yet?)
- unsure about Y
- should this do Z?
-->

**Interactions** <!-- if any; add/delete/fill-in as appropriate -->
<!-- eg.
- Waiting on #<PR>
- Blocks #<PR>
-->

**Visual changes** <!-- if any; add/delete/fill-in with screenshot/diagram as appropriate -->
Stream sorting for stream typeahead before -
![image](https://user-images.githubusercontent.com/53873549/162564960-639f268c-b160-426d-8ab6-e4309806a59a.png)

Stream sorting for stream typeahead after -
![image](https://user-images.githubusercontent.com/53873549/162964508-31b452df-8ffd-4d3d-b4e7-a847d8f92f6c.png)