### PR TITLE
feature: Add presence markers to PM compose.

### DIFF
--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -247,35 +247,35 @@ class TestWriteBox:
     @pytest.mark.parametrize(
         ["raw_recipients", "tidied_recipients"],
         [
-            ("Human 1 person1@example.com", "Human 1 <person1@example.com>"),
+            ("• Human 1 person1@example.com", "• Human 1 <person1@example.com>"),
             (
-                "Human 2 person2@example.com random text",
-                "Human 2 <person2@example.com>",
+                "• Human 2 person2@example.com random text",
+                "• Human 2 <person2@example.com>",
             ),
             (
-                "Human Myself FOOBOO@gmail.com random, Human 1 <person1@example.com>",
-                "Human Myself <FOOBOO@gmail.com>, Human 1 <person1@example.com>",
+                "● Human Myself FOOBOO@gmail.com random, • Human 1 <person1@example.com>",
+                "● Human Myself <FOOBOO@gmail.com>, • Human 1 <person1@example.com>",
             ),
             (
-                "Human Myself <FOOBOO@gmail.com>, Human 1 person1@example.com random",
-                "Human Myself <FOOBOO@gmail.com>, Human 1 <person1@example.com>",
+                "● Human Myself <FOOBOO@gmail.com>, • Human 1 person1@example.com random",
+                "● Human Myself <FOOBOO@gmail.com>, • Human 1 <person1@example.com>",
             ),
             (
-                "Human Myself FOOBOO@gmail.com random,"
-                "Human 1 person1@example.com random",
-                "Human Myself <FOOBOO@gmail.com>, Human 1 <person1@example.com>",
+                "● Human Myself FOOBOO@gmail.com random,"
+                "• Human 1 person1@example.com random",
+                "● Human Myself <FOOBOO@gmail.com>, • Human 1 <person1@example.com>",
             ),
             (
-                "Human Myself FOOBOO@gmail.com random, Human 1 person1@example.com "
-                "random, Human 2 person2@example.com random",
-                "Human Myself <FOOBOO@gmail.com>, Human 1 <person1@example.com>, "
-                "Human 2 <person2@example.com>",
+                "● Human Myself FOOBOO@gmail.com random, • Human 1 person1@example.com "
+                "random, • Human 2 person2@example.com random",
+                "● Human Myself <FOOBOO@gmail.com>, • Human 1 <person1@example.com>, "
+                "• Human 2 <person2@example.com>",
             ),
             (
-                "Human Myself FOOBOO@gmail.com, Human 1 person1@example.com random, "
-                "Human 2 person2@example.com",
-                "Human Myself <FOOBOO@gmail.com>, Human 1 <person1@example.com>, "
-                "Human 2 <person2@example.com>",
+                "● Human Myself FOOBOO@gmail.com, • Human 1 person1@example.com random, "
+                "• Human 2 person2@example.com",
+                "● Human Myself <FOOBOO@gmail.com>, • Human 1 <person1@example.com>, "
+                "• Human 2 <person2@example.com>",
             ),
         ],
         ids=[
@@ -320,7 +320,7 @@ class TestWriteBox:
     @pytest.mark.parametrize(
         ["raw_recipients", "invalid_recipients"],
         [
-            ("Human 1 <person2@example.com>", "Human 1 <person2@example.com>"),
+            ("• Human 1 <person2@example.com>", "• Human 1 <person2@example.com>"),
             ("person1@example.com", "person1@example.com"),
             ("Human 1", "Human 1"),
         ],
@@ -374,13 +374,13 @@ class TestWriteBox:
         "header, expected_recipient_emails, expected_recipient_user_ids",
         [
             case(
-                "Human 1 <person1@example.com>",
+                "• Human 1 <person1@example.com>",
                 ["person1@example.com"],
                 [11],
                 id="single_recipient",
             ),
             case(
-                "Human 1 <person1@example.com>, Human 2 <person2@example.com>",
+                "• Human 1 <person1@example.com>, • Human 2 <person2@example.com>",
                 ["person1@example.com", "person2@example.com"],
                 [11, 12],
                 id="multiple_recipients",
@@ -878,14 +878,14 @@ class TestWriteBox:
                     "Human Duplicate",
                 ],
                 [
-                    "Human Myself <FOOBOO@gmail.com>",
-                    "Human 1 <person1@example.com>",
-                    "Human 2 <person2@example.com>",
+                    "● Human Myself <FOOBOO@gmail.com>",
+                    "• Human 1 <person1@example.com>",
+                    "• Human 2 <person2@example.com>",
                     "Human Duplicate <personduplicate1@example.com>",
                     "Human Duplicate <personduplicate2@example.com>",
                 ],
             ),
-            ("My", ["Human Myself"], ["Human Myself <FOOBOO@gmail.com>"]),
+            ("My", ["Human Myself"], ["● Human Myself <FOOBOO@gmail.com>"]),
         ],
         ids=[
             "no_search_text",
@@ -912,9 +912,9 @@ class TestWriteBox:
     @pytest.mark.parametrize(
         "text, expected_text",
         [
-            ("Hu", "Human Myself <FOOBOO@gmail.com>"),
-            ("Human M", "Human Myself <FOOBOO@gmail.com>"),
-            ("Human Myself <FOOBOO", "Human Myself <FOOBOO@gmail.com>"),
+            ("Hu", "● Human Myself <FOOBOO@gmail.com>"),
+            ("Human M", "● Human Myself <FOOBOO@gmail.com>"),
+            ("● Human Myself <FOOBOO", "● Human Myself <FOOBOO@gmail.com>"),
         ],
     )
     def test__to_box_autocomplete_with_spaces(
@@ -951,11 +951,11 @@ class TestWriteBox:
                 ],
                 [
                     "Welcome Bot <welcome-bot@zulip.com>, "
-                    "Human Myself <FOOBOO@gmail.com>",
+                    "● Human Myself <FOOBOO@gmail.com>",
                     "Welcome Bot <welcome-bot@zulip.com>, "
-                    "Human 1 <person1@example.com>",
+                    "• Human 1 <person1@example.com>",
                     "Welcome Bot <welcome-bot@zulip.com>, "
-                    "Human 2 <person2@example.com>",
+                    "• Human 2 <person2@example.com>",
                     "Welcome Bot <welcome-bot@zulip.com>, "
                     "Human Duplicate <personduplicate1@example.com>",
                     "Welcome Bot <welcome-bot@zulip.com>, "
@@ -968,7 +968,7 @@ class TestWriteBox:
                 ["Human 2"],
                 [
                     "Welcome Bot <welcome-bot@zulip.com>, Notification Bot "
-                    "<notification-bot@zulip.com>, Human 2 <person2@example.com>"
+                    "<notification-bot@zulip.com>, • Human 2 <person2@example.com>"
                 ],
             ),
             (
@@ -982,11 +982,11 @@ class TestWriteBox:
                 ],
                 [
                     "Email Gateway <emailgateway@zulip.com>, "
-                    "Human Myself <FOOBOO@gmail.com>",
+                    "● Human Myself <FOOBOO@gmail.com>",
                     "Email Gateway <emailgateway@zulip.com>, "
-                    "Human 1 <person1@example.com>",
+                    "• Human 1 <person1@example.com>",
                     "Email Gateway <emailgateway@zulip.com>, "
-                    "Human 2 <person2@example.com>",
+                    "• Human 2 <person2@example.com>",
                     "Email Gateway <emailgateway@zulip.com>, "
                     "Human Duplicate <personduplicate1@example.com>",
                     "Email Gateway <emailgateway@zulip.com>, "
@@ -994,12 +994,12 @@ class TestWriteBox:
                 ],
             ),
             (
-                "Human 1 <person1@example.com>, Notification Bot "
+                "• Human 1 <person1@example.com>, Notification Bot "
                 "<notification-bot@zulip.com>,person2",
                 ["Human 2"],
                 [
-                    "Human 1 <person1@example.com>, Notification Bot "
-                    "<notification-bot@zulip.com>, Human 2 <person2@example.com>"
+                    "• Human 1 <person1@example.com>, Notification Bot "
+                    "<notification-bot@zulip.com>, • Human 2 <person2@example.com>"
                 ],
             ),
         ],

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -201,7 +201,7 @@ class WriteBox(urwid.Pile):
             ]
             recipient_info = ", ".join(
                 [
-                    f"""{self.model.user_dict[email]['full_name']} <{email}>"""
+                    f"""{STATE_ICON[self.model.user_dict.get(email, None).get("status","inactive") if self.model.user_dict.get(email,None) else "inactive"]}""" + " " + f"""{self.model.user_dict[email]['full_name']} <{email}>"""
                     for email in self.recipient_emails
                 ]
             )
@@ -219,7 +219,7 @@ class WriteBox(urwid.Pile):
 
         self.send_next_typing_update = datetime.now()
         self.to_write_box = ReadlineEdit(
-            "To: " + recipient_markers + " ", edit_text=recipient_info
+            "To: ", edit_text=recipient_info
         )
         self.to_write_box.enable_autocomplete(
             func=self._to_box_autocomplete,

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -200,10 +200,12 @@ class WriteBox(urwid.Pile):
                 for user_id in self.recipient_user_ids
             ]
             # In the format "{state marker} {recipient name} <{recipient email}> for all recipients.
-            # Avoids issue where all state markers appear back-to-back. 
+            # Avoids issue where all state markers appear back-to-back.
             recipient_info = ", ".join(
                 [
-                    f"""{STATE_ICON[self.model.user_dict.get(email, None).get("status","inactive") if self.model.user_dict.get(email,None) else "inactive"]}""" + " " + f"""{self.model.user_dict[email]['full_name']} <{email}>"""
+                    f"""{STATE_ICON[self.model.user_dict.get(email, None).get("status","inactive") if self.model.user_dict.get(email,None) else "inactive"]}"""
+                    + " "
+                    + f"""{self.model.user_dict[email]['full_name']} <{email}>"""
                     for email in self.recipient_emails
                 ]
             )
@@ -214,9 +216,7 @@ class WriteBox(urwid.Pile):
             recipient_markers = ""
 
         self.send_next_typing_update = datetime.now()
-        self.to_write_box = ReadlineEdit(
-            "To: ", edit_text=recipient_info
-        )
+        self.to_write_box = ReadlineEdit("To: ", edit_text=recipient_info)
         self.to_write_box.enable_autocomplete(
             func=self._to_box_autocomplete,
             key=primary_key_for_command("AUTOCOMPLETE"),
@@ -299,7 +299,7 @@ class WriteBox(urwid.Pile):
     ) -> bool:
         tidied_recipients = list()
         invalid_recipients = list()
-    
+
         recipients = [
             recipient.strip()
             for recipient in write_box.edit_text.split(",")
@@ -307,20 +307,22 @@ class WriteBox(urwid.Pile):
         ]
 
         for recipient in recipients:
-            
+
             cleaned_recipient_list = re.findall(REGEX_CLEANED_RECIPIENT, recipient)
             recipient_name, recipient_email, invalid_text = cleaned_recipient_list[0]
             marked_recipient_name = recipient_name
             # Remove the state marker from the recipient name.
             for status in STATE_ICON:
-                recipient_name = recipient_name.replace(f"{STATE_ICON[status]} ", "") 
+                recipient_name = recipient_name.replace(f"{STATE_ICON[status]} ", "")
             # Discard invalid_text as part of tidying up the recipient.
 
             if recipient_email and self.model.is_valid_private_recipient(
                 recipient_email, recipient_name
             ):
-            # Put state marker back in when rendering on screen after key is pressed.
-                tidied_recipients.append(f"""{STATE_ICON[self.model.user_dict.get(recipient_email, None).get("status","inactive") if self.model.user_dict.get(recipient_email,None) else "inactive"]} {recipient_name} <{recipient_email}>""")
+                # Put state marker back in when rendering on screen after key is pressed.
+                tidied_recipients.append(
+                    f"""{STATE_ICON[self.model.user_dict.get(recipient_email, None).get("status","inactive") if self.model.user_dict.get(recipient_email,None) else "inactive"]} {recipient_name} <{recipient_email}>"""
+                )
             else:
                 invalid_recipients.append(recipient)
                 tidied_recipients.append(recipient)

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -201,7 +201,7 @@ class WriteBox(urwid.Pile):
             ]
             recipient_info = ", ".join(
                 [
-                    f"{self.model.user_dict[email]['full_name']} <{email}>"
+                    f"""{STATE_ICON[self.model.user_dict.get(email, None).get("status","inactive") if self.model.user_dict.get(email,None) else "inactive"]} {self.model.user_dict[email]['full_name']} <{email}>"""
                     for email in self.recipient_emails
                 ]
             )
@@ -209,8 +209,6 @@ class WriteBox(urwid.Pile):
             self._set_regular_and_typing_recipient_user_ids(None)
             self.recipient_emails = []
             recipient_info = ""
-
-        self.send_next_typing_update = datetime.now()
         self.to_write_box = ReadlineEdit("To: ", edit_text=recipient_info)
         self.to_write_box.enable_autocomplete(
             func=self._to_box_autocomplete,

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -215,9 +215,12 @@ class WriteBox(urwid.Pile):
             self._set_regular_and_typing_recipient_user_ids(None)
             self.recipient_emails = []
             recipient_info = ""
+            recipient_markers = ""
 
         self.send_next_typing_update = datetime.now()
-        self.to_write_box = ReadlineEdit("To: "+recipient_markers+" ", edit_text= recipient_info)
+        self.to_write_box = ReadlineEdit(
+            "To: " + recipient_markers + " ", edit_text=recipient_info
+        )
         self.to_write_box.enable_autocomplete(
             func=self._to_box_autocomplete,
             key=primary_key_for_command("AUTOCOMPLETE"),

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -199,15 +199,11 @@ class WriteBox(urwid.Pile):
                 self.model.user_id_email_dict[user_id]
                 for user_id in self.recipient_user_ids
             ]
+            # In the format "{state marker} {recipient name} <{recipient email}> for all recipients.
+            # Avoids issue where all state markers appear back-to-back. 
             recipient_info = ", ".join(
                 [
                     f"""{STATE_ICON[self.model.user_dict.get(email, None).get("status","inactive") if self.model.user_dict.get(email,None) else "inactive"]}""" + " " + f"""{self.model.user_dict[email]['full_name']} <{email}>"""
-                    for email in self.recipient_emails
-                ]
-            )
-            recipient_markers = ", ".join(
-                [
-                    f"""{STATE_ICON[self.model.user_dict.get(email, None).get("status","inactive") if self.model.user_dict.get(email,None) else "inactive"]}"""
                     for email in self.recipient_emails
                 ]
             )
@@ -303,7 +299,7 @@ class WriteBox(urwid.Pile):
     ) -> bool:
         tidied_recipients = list()
         invalid_recipients = list()
-
+    
         recipients = [
             recipient.strip()
             for recipient in write_box.edit_text.split(",")
@@ -311,17 +307,24 @@ class WriteBox(urwid.Pile):
         ]
 
         for recipient in recipients:
+            
             cleaned_recipient_list = re.findall(REGEX_CLEANED_RECIPIENT, recipient)
             recipient_name, recipient_email, invalid_text = cleaned_recipient_list[0]
+            marked_recipient_name = recipient_name
+            # Remove the state marker from the recipient name.
+            for status in STATE_ICON:
+                recipient_name = recipient_name.replace(f"{STATE_ICON[status]} ", "") 
             # Discard invalid_text as part of tidying up the recipient.
 
             if recipient_email and self.model.is_valid_private_recipient(
                 recipient_email, recipient_name
             ):
-                tidied_recipients.append(f"{recipient_name} <{recipient_email}>")
+            # Put state marker back in when rendering on screen after key is pressed.
+                tidied_recipients.append(f"""{STATE_ICON[self.model.user_dict.get(recipient_email, None).get("status","inactive") if self.model.user_dict.get(recipient_email,None) else "inactive"]} {recipient_name} <{recipient_email}>""")
             else:
                 invalid_recipients.append(recipient)
                 tidied_recipients.append(recipient)
+            recipient_name = marked_recipient_name
 
         write_box.edit_text = ", ".join(tidied_recipients)
         write_box.edit_pos = len(write_box.edit_text)

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -201,7 +201,13 @@ class WriteBox(urwid.Pile):
             ]
             recipient_info = ", ".join(
                 [
-                    f"""{STATE_ICON[self.model.user_dict.get(email, None).get("status","inactive") if self.model.user_dict.get(email,None) else "inactive"]} {self.model.user_dict[email]['full_name']} <{email}>"""
+                    f"""{self.model.user_dict[email]['full_name']} <{email}>"""
+                    for email in self.recipient_emails
+                ]
+            )
+            recipient_markers = ", ".join(
+                [
+                    f"""{STATE_ICON[self.model.user_dict.get(email, None).get("status","inactive") if self.model.user_dict.get(email,None) else "inactive"]}"""
                     for email in self.recipient_emails
                 ]
             )
@@ -209,7 +215,9 @@ class WriteBox(urwid.Pile):
             self._set_regular_and_typing_recipient_user_ids(None)
             self.recipient_emails = []
             recipient_info = ""
-        self.to_write_box = ReadlineEdit("To: ", edit_text=recipient_info)
+
+        self.send_next_typing_update = datetime.now()
+        self.to_write_box = ReadlineEdit("To: "+recipient_markers+" ", edit_text= recipient_info)
         self.to_write_box.enable_autocomplete(
             func=self._to_box_autocomplete,
             key=primary_key_for_command("AUTOCOMPLETE"),


### PR DESCRIPTION

<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->

Adds presence markers to PM compose.

Previously the only way to know if the person on the other side was online was to check through the info window or through the sidebar, which are big hassles. In the future, for non-group PMs, we could add a good last-seen implementation that doesn't take up unnecessary space. 


<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->

Partial fix for #1155.

<!-- Add a link to a discussion on chat.zulip.org, if relevant -->

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [ ] Existing tests (adapted, if necessary)
- [ ] New tests added (for any new behavior)
- [ ] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

<!-- See https://github.com/zulip/zulip-terminal#commit-style -->
**Commit flow** <!-- if more than one commit; add/delete/fill-in as appropriate -->
<!-- For example:
- maybe multiple commits doing similar things
-->
- Add presence markers to PM compose


**Notes & Questions** <!-- if any; add/delete/fill-in as appropriate -->
<!-- For example:
- this doesn't include feature X (yet?)
- unsure about Y
- should this do Z?
-->
- markers don't have colours yet. 

**Visual changes** <!-- if any; add/delete/fill-in with screenshot/diagram as appropriate -->
<img width="369" alt="Screenshot 2022-04-07 at 7 24 27 PM" src="https://user-images.githubusercontent.com/76529011/162218059-f64da147-da17-4d98-96fc-3bcbf169ff9c.png">

