### PR TITLE
List topics under stream-name when narrowed.

### DIFF
--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -19,6 +19,7 @@ from zulipterminal.api_types import Composition, Message
 from zulipterminal.config.themes import ThemeSpec
 from zulipterminal.helper import asynch, suppress_output
 from zulipterminal.model import Model
+from zulipterminal.platform_code import notify
 from zulipterminal.platform_code import PLATFORM
 from zulipterminal.ui import Screen, View
 from zulipterminal.ui_tools.utils import create_msg_box_list
@@ -547,6 +548,12 @@ class Controller:
     def narrow_to_stream(
         self, *, stream_name: str, contextual_message_id: Optional[int] = None
     ) -> None:
+        stream_id = self.model.stream_id_from_name(stream_name)
+        topics = self.model.topics_in_stream(stream_id=stream_id)
+        # notify(str(topics),str(topics))
+        self.view.left_panel.update_stream_view_topic(stream_id)
+        self.view.left_panel.show_stream_view()
+        # POI - stream narrow function 
         self._narrow_to(anchor=contextual_message_id, stream=stream_name)
 
     def narrow_to_topic(


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->
Shows topics under stream-name when narrowed to.

<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->
Fixes most of #1190. 

<!-- Add a link to a discussion on chat.zulip.org, if relevant -->
https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/Panel-follows-narrow.20.23T1190

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [ ] Existing tests (adapted, if necessary)
- [ ] New tests added (for any new behavior)
- [ ] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

<!-- See https://github.com/zulip/zulip-terminal#commit-style -->
**Commit flow** <!-- if more than one commit; add/delete/fill-in as appropriate -->
<!-- For example:
- first commit doing some thing
- maybe multiple commits doing similar things
-->
- first commit adds the new function for showing the view when a stream is narrowed to. 

**Notes & Questions** <!-- if any; add/delete/fill-in as appropriate -->
- doesn't include stream highlighting.
- might be difficult to discern topics from streams.
<!-- For example:
- this doesn't include feature X (yet?)
- unsure about Y
- should this do Z?
-->

**Interactions** <!-- if any; add/delete/fill-in as appropriate -->
<!-- eg.
- Waiting on #<PR>
- Blocks #<PR>
-->

**Visual changes** <!-- if any; add/delete/fill-in with screenshot/diagram as appropriate -->
<img width="360" alt="Screenshot 2022-04-10 at 5 10 18 AM" src="https://user-images.githubusercontent.com/76529011/162595150-079d12c1-4e90-4f17-970f-dc5148086859.png">

