### PR TITLE
Support 'Narrow to current compose box recipient'.

### DIFF
--- a/docs/hotkeys.md
+++ b/docs/hotkeys.md
@@ -80,6 +80,7 @@
 |Save current message as a draft|<kbd>meta</kbd> + <kbd>s</kbd>|
 |Autocomplete @mentions, #stream_names, :emoji: and topics|<kbd>ctrl</kbd> + <kbd>f</kbd>|
 |Cycle through autocomplete suggestions in reverse|<kbd>ctrl</kbd> + <kbd>r</kbd>|
+|Narrow to compose box message recipient|<kbd>meta</kbd> + <kbd>.</kbd>|
 |Jump to the beginning of line|<kbd>ctrl</kbd> + <kbd>a</kbd>|
 |Jump to the end of line|<kbd>ctrl</kbd> + <kbd>e</kbd>|
 |Jump backward one word|<kbd>meta</kbd> + <kbd>b</kbd>|

--- a/tests/helper/test_helper.py
+++ b/tests/helper/test_helper.py
@@ -5,6 +5,7 @@ from pytest import param as case
 from pytest_mock import MockerFixture
 
 from zulipterminal.api_types import Composition
+from zulipterminal.config.keys import primary_key_for_command
 from zulipterminal.helper import (
     Index,
     canonicalize_color,
@@ -428,8 +429,10 @@ def test_notify_if_message_sent_outside_narrow(
     notify_if_message_sent_outside_narrow(req, controller)
 
     if footer_updated:
+        key = primary_key_for_command("NARROW_MESSAGE_RECIPIENT")
         report_success.assert_called_once_with(
-            "Message is sent outside of current narrow."
+            f"Message is sent outside of current narrow. Press [{key}] to narrow to conversation.",
+            duration=6,
         )
     else:
         report_success.assert_not_called()

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -164,6 +164,11 @@ KEY_BINDINGS: 'OrderedDict[str, KeyBinding]' = OrderedDict([
         'help_text': 'Narrow to the topic of the current message',
         'key_category': 'msg_actions',
     }),
+    ('NARROW_MESSAGE_RECIPIENT', {
+        'keys': ['meta .'],
+        'help_text': 'Narrow to compose box message recipient',
+        'key_category': 'msg_compose',
+    }),
     ('TOGGLE_NARROW', {
         'keys': ['z'],
         'help_text':

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -26,6 +26,7 @@ from urllib.parse import unquote
 from typing_extensions import TypedDict
 
 from zulipterminal.api_types import Composition, EmojiType, Message
+from zulipterminal.config.keys import primary_key_for_command
 from zulipterminal.config.regexes import (
     REGEX_COLOR_3_DIGIT,
     REGEX_COLOR_6_DIGIT,
@@ -652,7 +653,12 @@ def check_narrow_and_notify(
         and current_narrow != outer_narrow
         and current_narrow != inner_narrow
     ):
-        controller.report_success("Message is sent outside of current narrow.")
+        key = primary_key_for_command("NARROW_MESSAGE_RECIPIENT")
+
+        controller.report_success(
+            f"Message is sent outside of current narrow. Press [{key}] to narrow to conversation.",
+            duration=6,
+        )
 
 
 def notify_if_message_sent_outside_narrow(

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -773,6 +773,27 @@ class WriteBox(urwid.Pile):
                 if self.msg_edit_state is not None:
                     self.keypress(size, primary_key_for_command("GO_BACK"))
                     assert self.msg_edit_state is None
+        elif is_command_key("NARROW_MESSAGE_RECIPIENT", key):
+            if self.compose_box_status == "open_with_stream":
+                self.model.controller.narrow_to_topic(
+                    stream_name=self.stream_write_box.edit_text,
+                    topic_name=self.title_write_box.edit_text,
+                    contextual_message_id=None,
+                )
+            elif self.compose_box_status == "open_with_private":
+                self.recipient_emails = [
+                    self.model.user_id_email_dict[user_id]
+                    for user_id in self.recipient_user_ids
+                ]
+                if self.recipient_user_ids:
+                    self.model.controller.narrow_to_user(
+                        recipient_emails=self.recipient_emails,
+                        contextual_message_id=None,
+                    )
+                else:
+                    self.view.controller.report_error(
+                        "Cannot narrow to message without specifying recipients."
+                    )
         elif is_command_key("GO_BACK", key):
             self.send_stop_typing_status()
             self._set_compose_attributes_to_defaults()


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->
This PR adds support to 'Narrow to current compose box recipient' after sending a message outside current narrow.
Shortcut - ``ctrl``+``.``
<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->
Fixes #1182 
<!-- Add a link to a discussion on chat.zulip.org, if relevant -->
CZO - https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/Support.20'Narrow.20to.20current.20compose.20box.20recipient'

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [ ] New tests added (for any new behavior)
- [x] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

<!-- See https://github.com/zulip/zulip-terminal#commit-style -->
**Commit flow** <!-- if more than one commit; add/delete/fill-in as appropriate -->
<!-- For example:
- first commit doing some thing
- maybe multiple commits doing similar things
-->

**Notes & Questions** <!-- if any; add/delete/fill-in as appropriate -->
<!-- For example:
- this doesn't include feature X (yet?)
- unsure about Y
- should this do Z?
-->
Currently I have used shortcut - `.` instead of ``ctrl``+``.`` as ``ctrl``+``.`` doesn't seem to work in my local development environment (WSL2 Windows 10) 

**Interactions** <!-- if any; add/delete/fill-in as appropriate -->
<!-- eg.
- Waiting on #<PR>
- Blocks #<PR>
-->

**Visual changes** <!-- if any; add/delete/fill-in with screenshot/diagram as appropriate -->
