### PR TITLE
views: Add footer to StreamsView and TopicsView

### DIFF
--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -313,6 +313,9 @@ class StreamsView(urwid.Frame):
         self.stream_search_box = PanelSearchBox(
             self, "SEARCH_STREAMS", self.update_streams
         )
+        text = urwid.Text("Press t.", align="center")
+        title_map = urwid.AttrMap(urwid.Filler(text), "area:msg")
+        title_box_adapter = urwid.BoxAdapter(title_map, height=1)
         super().__init__(
             list_box,
             header=urwid.LineBox(
@@ -321,6 +324,17 @@ class StreamsView(urwid.Frame):
                 tline="",
                 lline="",
                 trcorner="─",
+                blcorner="─",
+                rline="",
+                bline="─",
+                brcorner="─",
+            ),
+            footer=urwid.LineBox(
+                title_box_adapter,
+                title="Switch to topics view",
+                tlcorner=COLUMN_TITLE_BAR_LINE,
+                tline=COLUMN_TITLE_BAR_LINE,
+                trcorner=COLUMN_TITLE_BAR_LINE,
                 blcorner="─",
                 rline="",
                 bline="─",
@@ -419,6 +433,9 @@ class TopicsView(urwid.Frame):
         self.header_list = urwid.Pile(
             [self.stream_button, urwid.Divider("─"), self.topic_search_box]
         )
+        text = urwid.Text("Press t.", align="center")
+        title_map = urwid.AttrMap(urwid.Filler(text), "area:msg")
+        title_box_adapter = urwid.BoxAdapter(title_map, height=1)
         super().__init__(
             self.list_box,
             header=urwid.LineBox(
@@ -427,6 +444,17 @@ class TopicsView(urwid.Frame):
                 tline="",
                 lline="",
                 trcorner="─",
+                blcorner="─",
+                rline="",
+                bline="─",
+                brcorner="─",
+            ),
+            footer=urwid.LineBox(
+                title_box_adapter,
+                title="Switch to streams view",
+                tlcorner=COLUMN_TITLE_BAR_LINE,
+                tline=COLUMN_TITLE_BAR_LINE,
+                trcorner=COLUMN_TITLE_BAR_LINE,
                 blcorner="─",
                 rline="",
                 bline="─",

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -313,8 +313,8 @@ class StreamsView(urwid.Frame):
         self.stream_search_box = PanelSearchBox(
             self, "SEARCH_STREAMS", self.update_streams
         )
-        text = urwid.Text("Press t.", align="center")
-        title_map = urwid.AttrMap(urwid.Filler(text), "area:msg")
+        text = urwid.Text("Show topics [t]", align="center")
+        title_map = urwid.AttrMap(urwid.Filler(text), "popup_border")  # MARK
         title_box_adapter = urwid.BoxAdapter(title_map, height=1)
         super().__init__(
             list_box,
@@ -331,7 +331,7 @@ class StreamsView(urwid.Frame):
             ),
             footer=urwid.LineBox(
                 title_box_adapter,
-                title="Switch to topics view",
+                title="",
                 tlcorner=COLUMN_TITLE_BAR_LINE,
                 tline=COLUMN_TITLE_BAR_LINE,
                 trcorner=COLUMN_TITLE_BAR_LINE,
@@ -433,8 +433,8 @@ class TopicsView(urwid.Frame):
         self.header_list = urwid.Pile(
             [self.stream_button, urwid.Divider("─"), self.topic_search_box]
         )
-        text = urwid.Text("Press t.", align="center")
-        title_map = urwid.AttrMap(urwid.Filler(text), "area:msg")
+        text = urwid.Text("Show streams [t]", align="center")
+        title_map = urwid.AttrMap(urwid.Filler(text), "popup_border")
         title_box_adapter = urwid.BoxAdapter(title_map, height=1)
         super().__init__(
             self.list_box,
@@ -451,7 +451,7 @@ class TopicsView(urwid.Frame):
             ),
             footer=urwid.LineBox(
                 title_box_adapter,
-                title="Switch to streams view",
+                title="",
                 tlcorner=COLUMN_TITLE_BAR_LINE,
                 tline=COLUMN_TITLE_BAR_LINE,
                 trcorner=COLUMN_TITLE_BAR_LINE,


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->
Added the shortcut hint for displaying Topics to the Streams Panel and a hint to get back to Streams in the Topics Panel.
<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->
Associated with #1190. Discussed on CZO at [Stream/topic toggle hint?](https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/Stream.2Ftopic.20toggle.20hint.3F)
<!-- Add a link to a discussion on chat.zulip.org, if relevant -->

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [ ] New tests added (for any new behavior)
- [x] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

<!-- See https://github.com/zulip/zulip-terminal#commit-style -->
**Commit flow** <!-- if more than one commit; add/delete/fill-in as appropriate -->
<!-- For example:
- first commit doing some thing
- maybe multiple commits doing similar things
-->
- first commit adds the footer for the hints.
- upcoming commit will add functionality for hint to only appear when cursor is in the panel.

**Notes & Questions** <!-- if any; add/delete/fill-in as appropriate -->
<!-- For example:
- this doesn't include feature X (yet?)
- unsure about Y
- should this do Z?
-->
- Still shows hint even when not in the left panel, causing probable misunderstanding about where one has to press `t`, so have to fix that. 

**Visual changes** <!-- if any; add/delete/fill-in with screenshot/diagram as appropriate -->
<img width="256" alt="Screenshot 2022-04-15 at 4 28 32 AM" src="https://user-images.githubusercontent.com/76529011/163490778-1dbb85c1-1552-4954-8ba7-292f121a70d2.png">

