### PR TITLE
views: Avoid sending GO_BACK to duplicate child widgets unnecessarily.

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -870,20 +870,6 @@ class TestMiddleColumnView:
         assert return_value is None
         assert mid_col_view.last_unread_pm is None
 
-    @pytest.mark.parametrize("key", keys_for_command("GO_BACK"))
-    def test_keypress_GO_BACK(self, mid_col_view, mocker, key, widget_size):
-        size = widget_size(mid_col_view)
-        mocker.patch(MIDCOLVIEW + ".header")
-        mocker.patch(MIDCOLVIEW + ".footer")
-        mocker.patch(MIDCOLVIEW + ".set_focus")
-
-        mid_col_view.keypress(size, key)
-
-        mid_col_view.header.keypress.assert_called_once_with(size, key)
-        mid_col_view.footer.keypress.assert_called_once_with(size, key)
-        mid_col_view.set_focus.assert_called_once_with("body")
-        self.super_keypress.assert_called_once_with(size, key)
-
     @pytest.mark.parametrize("key", keys_for_command("SEARCH_MESSAGES"))
     def test_keypress_focus_header(self, mid_col_view, mocker, key, widget_size):
         size = widget_size(mid_col_view)

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -592,12 +592,7 @@ class MiddleColumnView(urwid.Frame):
         self.controller.update_screen()
 
     def keypress(self, size: urwid_Size, key: str) -> Optional[str]:
-        if is_command_key("GO_BACK", key):
-            self.header.keypress(size, key)
-            self.footer.keypress(size, key)
-            self.set_focus("body")
-
-        elif self.focus_position in ["footer", "header"]:
+        if self.focus_position in ["footer", "header"]:
             return super().keypress(size, key)
 
         elif is_command_key("SEARCH_MESSAGES", key):


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->

This conditional appears unnecessary, and interception here can cause multiple triggers of the keypress in corner cases.

Test removed.

Discussed in #**zulip-terminal > Avoid double Esc keypress #T1201**

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [ ] New tests added (for any new behavior)
- [x] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

**Interactions** <!-- if any; add/delete/fill-in as appropriate -->

This appears to also resolve the outstanding issue with #1194.