### PR TITLE
Display 'Message sent outside current narrow' when narrowing from all_messages and all_PMs.

### DIFF
--- a/tests/helper/test_helper.py
+++ b/tests/helper/test_helper.py
@@ -339,7 +339,7 @@ def test_display_error_if_present(
         case(
             {"type": "private", "to": [1], "content": "bar"},
             [["is", "private"]],
-            False,
+            True,
             id="all_private__pm__not_notified",
         ),
         case(
@@ -386,7 +386,7 @@ def test_display_error_if_present(
                 "content": "Hi `|new_stream|`",
             },
             [],
-            False,
+            True,
             id="all_messages__stream__not_notified",
         ),
         case(

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -59,6 +59,7 @@ class TestWriteBox:
             [{"name": stream["name"]} for stream in streams_fixture],
             key=lambda stream: stream["name"].lower(),
         )
+        write_box.check_stream_topic_edit_txt_flag = False
 
         return write_box
 
@@ -76,6 +77,7 @@ class TestWriteBox:
         assert isinstance(write_box.last_key_update, datetime.datetime)
         assert write_box.idle_status_tracking is False
         assert write_box.sent_start_typing_status is False
+        assert write_box.check_stream_topic_edit_txt_flag is False
 
     def test_not_calling_typing_method_without_recipients(
         self, mocker: MockerFixture, write_box: WriteBox

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -648,11 +648,7 @@ def check_narrow_and_notify(
 ) -> None:
     current_narrow = controller.model.narrow
 
-    if (
-        current_narrow != []
-        and current_narrow != outer_narrow
-        and current_narrow != inner_narrow
-    ):
+    if current_narrow != inner_narrow:
         key = primary_key_for_command("NARROW_MESSAGE_RECIPIENT")
 
         controller.report_success(
@@ -666,7 +662,6 @@ def check_narrow_and_notify(
 def notify_if_message_sent_outside_narrow(
     message: Composition, controller: Any
 ) -> None:
-    current_narrow = controller.model.narrow
 
     if message["type"] == "stream":
         stream_narrow = [["stream", message["to"]]]


### PR DESCRIPTION
Follow up PR #1194

<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->
This PR displays ``Message sent outside current narrow`` even if narrowing from ``all_messages`` or ``all_PMs``

<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->

<!-- Add a link to a discussion on chat.zulip.org, if relevant -->

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [ ] New tests added (for any new behavior)
- [x] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

<!-- See https://github.com/zulip/zulip-terminal#commit-style -->
**Commit flow** <!-- if more than one commit; add/delete/fill-in as appropriate -->
<!-- For example:
- first commit doing some thing
- maybe multiple commits doing similar things
-->

**Notes & Questions** <!-- if any; add/delete/fill-in as appropriate -->
<!-- For example:
- this doesn't include feature X (yet?)
- unsure about Y
- should this do Z?
-->

**Interactions** <!-- if any; add/delete/fill-in as appropriate -->
<!-- eg.
- Waiting on #<PR>
- Blocks #<PR>
-->
CZO - https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/.E2.9C.94.20Support.20'Narrow.20to.20current.20compose.20box.20recipient'.20.23T1194

Cases for showing success message - https://github.com/zulip/zulip-terminal/pull/1194#discussion_r851485357

**Visual changes** <!-- if any; add/delete/fill-in with screenshot/diagram as appropriate -->
