### PR TITLE
bugfix: core: Do not exit editor mode when narrowing.

### DIFF
--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -542,8 +542,6 @@ class Controller:
         else:
             self.view.message_view.log.extend(w_list)
 
-        self.exit_editor_mode()
-
     def narrow_to_stream(
         self, *, stream_name: str, contextual_message_id: Optional[int] = None
     ) -> None:


### PR DESCRIPTION

<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->

These unrelated aspects being tied together was not an issue previously,
when narrowing was always done outside of compose. However, with
integration of #1194 as 2195904dd this is no longer the case, so this is
required to ensure that narrowing does not prematurely end editor mode,
since otherwise container widgets would steal keypresses.

This may be improved later through further refactoring of the keypress
handling.

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [ ] New tests added (for any new behavior)
- [x] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

**Notes & Questions** <!-- if any; add/delete/fill-in as appropriate -->

Everything appears to work fine; as per commit description, we should fix this more cleanly with the keypress refactoring. See #**zulip-terminal > Keypress refactoring**

**Interactions** <!-- if any; add/delete/fill-in as appropriate -->

This resolves an issue triggered by #1194, but which was present previously and only triggered by this situation.