### PR TITLE
model:  added placeholder for tables in notifications.

### DIFF
--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -49,6 +49,7 @@ from zulipterminal.helper import (
     display_error_if_present,
     index_messages,
     initial_index,
+    notification_formatter,
     notify_if_message_sent_outside_narrow,
     set_count,
 )
@@ -1330,20 +1331,7 @@ class Model:
                 text = content
             else:
                 soup = BeautifulSoup(content, "lxml")
-                for spoiler_tag in soup.find_all(
-                    "div", attrs={"class": "spoiler-block"}
-                ):
-                    header = spoiler_tag.find("div", attrs={"class": "spoiler-header"})
-                    header.contents = [ele for ele in header.contents if ele != "\n"]
-                    empty_header = len(header.contents) == 0
-                    header.unwrap()
-
-                    to_hide = spoiler_tag.find(
-                        "div", attrs={"class": "spoiler-content"}
-                    )
-                    to_hide.string = "(...)" if empty_header else " (...)"
-
-                    spoiler_tag.unwrap()
+                soup = notification_formatter(soup.find(name="body"))
                 text = soup.text
 
             return notify(


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->
Added a soup_to_formatted_soup function that takes the soup and formats it so the notification doesn't contain any unwanted text.

Currently, it only handles tables (sets it to [MxN table attached]) but in the future it will handle emojis, \me, etc too.

<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->
Partially fixes issue #1174. 
<!-- Add a link to a discussion on chat.zulip.org, if relevant -->
https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/Check.20formatting.20of.20markdown.20in.20notifications.20.23T1174.20.23T1183
**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [ ] New tests added (for any new behavior)
- [x] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

<!-- See https://github.com/zulip/zulip-terminal#commit-style -->
**Commit flow** <!-- if more than one commit; add/delete/fill-in as appropriate -->
<!-- For example:
- first commit doing some thing
- maybe multiple commits doing similar things
-->
- first commit adds soup_to_formatted_soup() function to boxes.py and calls it from the notify_user function.

**Notes & Questions** <!-- if any; add/delete/fill-in as appropriate -->
<!-- For example:
- this doesn't include feature X (yet?)
- unsure about Y
- should this do Z?
-->

**Interactions** <!-- if any; add/delete/fill-in as appropriate -->
<!-- eg.
- Waiting on #<PR>
- Blocks #<PR>
-->

**Visual changes** <!-- if any; add/delete/fill-in with screenshot/diagram as appropriate -->
Present:
<img width="365" alt="image" src="https://user-images.githubusercontent.com/76529011/163799062-ee433c77-7536-4ccd-8e59-bf18e4972c62.png">
Past:
<img width="359" alt="image" src="https://user-images.githubusercontent.com/76529011/163799175-a179c5ec-4119-4763-99b7-f5f3fcaf4117.png">

For this message:
<img width="427" alt="Screenshot 2022-04-18 at 4 30 20 PM" src="https://user-images.githubusercontent.com/76529011/163799433-f44ce898-554f-42f6-b54d-ae13835a40ac.png">

