### PR TITLE
Display names of reacting users when few users have reacted.

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -2736,55 +2736,71 @@ class TestMessageBox:
 
     # FIXME This is the same parametrize as MsgInfoView:test_height_reactions
     @pytest.mark.parametrize(
-        "to_vary_in_each_message",
+        "to_vary_in_each_message, expected_text, expected_attributes",
         [
-            {
-                "reactions": [
-                    {
-                        "emoji_name": "thumbs_up",
-                        "emoji_code": "1f44d",
-                        "user": {
-                            "email": "iago@zulip.com",
-                            "full_name": "Iago",
-                            "id": 5,
+            case(
+                {
+                    "reactions": [
+                        {
+                            "emoji_name": "thumbs_up",
+                            "emoji_code": "1f44d",
+                            "user": {
+                                "email": "iago@zulip.com",
+                                "full_name": "Iago",
+                                "id": 5,
+                            },
+                            "reaction_type": "unicode_emoji",
                         },
-                        "reaction_type": "unicode_emoji",
-                    },
-                    {
-                        "emoji_name": "zulip",
-                        "emoji_code": "zulip",
-                        "user": {
-                            "email": "iago@zulip.com",
-                            "full_name": "Iago",
-                            "id": 5,
+                        {
+                            "emoji_name": "zulip",
+                            "emoji_code": "zulip",
+                            "user": {
+                                "email": "iago@zulip.com",
+                                "full_name": "Iago",
+                                "id": 5,
+                            },
+                            "reaction_type": "zulip_extra_emoji",
                         },
-                        "reaction_type": "zulip_extra_emoji",
-                    },
-                    {
-                        "emoji_name": "zulip",
-                        "emoji_code": "zulip",
-                        "user": {
-                            "email": "AARON@zulip.com",
-                            "full_name": "aaron",
-                            "id": 1,
+                        {
+                            "emoji_name": "zulip",
+                            "emoji_code": "zulip",
+                            "user": {
+                                "email": "AARON@zulip.com",
+                                "full_name": "aaron",
+                                "id": 1,
+                            },
+                            "reaction_type": "zulip_extra_emoji",
                         },
-                        "reaction_type": "zulip_extra_emoji",
-                    },
-                    {
-                        "emoji_name": "heart",
-                        "emoji_code": "2764",
-                        "user": {
-                            "email": "iago@zulip.com",
-                            "full_name": "Iago",
-                            "id": 5,
+                        {
+                            "emoji_name": "heart",
+                            "emoji_code": "2764",
+                            "user": {
+                                "email": "iago@zulip.com",
+                                "full_name": "Iago",
+                                "id": 5,
+                            },
+                            "reaction_type": "unicode_emoji",
                         },
-                        "reaction_type": "unicode_emoji",
-                    },
-                ]
-            }
+                    ],
+                },
+                " :thumbs_up: 1   :zulip: 2   :heart: 1  ",
+                [
+                    ("reaction", 15),
+                    (None, 1),
+                    ("reaction_mine", 11),
+                    (None, 1),
+                    ("reaction", 11),
+                ],
+            ),
         ],
     )
-    def test_reactions_view(self, message_fixture, to_vary_in_each_message):
+    def test_reactions_view(
+        self,
+        message_fixture,
+        to_vary_in_each_message,
+        expected_text,
+        expected_attributes,
+    ):
         self.model.user_id = 1
         varied_message = dict(message_fixture, **to_vary_in_each_message)
         msg_box = MessageBox(varied_message, self.model, None)
@@ -2792,16 +2808,8 @@ class TestMessageBox:
 
         reactions_view = msg_box.reactions_view(reactions)
 
-        assert reactions_view.original_widget.text == (
-            " :thumbs_up: 1   :zulip: 2   :heart: 1  "
-        )
-        assert reactions_view.original_widget.attrib == [
-            ("reaction", 15),
-            (None, 1),
-            ("reaction_mine", 11),
-            (None, 1),
-            ("reaction", 11),
-        ]
+        assert reactions_view.original_widget.text == expected_text
+        assert reactions_view.original_widget.attrib == expected_attributes
 
     @pytest.mark.parametrize(
         "message_links, expected_text, expected_attrib, expected_footlinks_width",

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -2792,6 +2792,162 @@ class TestMessageBox:
                     ("reaction", 11),
                 ],
             ),
+            case(
+                {
+                    "reactions": [
+                        {
+                            "emoji_name": "thumbs_up",
+                            "emoji_code": "1f44d",
+                            "user": {
+                                "email": "iago@zulip.com",
+                                "full_name": "Iago",
+                                "id": 5,
+                            },
+                            "reaction_type": "unicode_emoji",
+                        },
+                        {
+                            "emoji_name": "zulip",
+                            "emoji_code": "zulip",
+                            "user": {
+                                "email": "AARON@zulip.com",
+                                "full_name": "aaron",
+                                "id": 1,
+                            },
+                            "reaction_type": "zulip_extra_emoji",
+                        },
+                        {
+                            "emoji_name": "heart",
+                            "emoji_code": "2764",
+                            "user": {
+                                "email": "iago@zulip.com",
+                                "full_name": "Iago",
+                                "id": 5,
+                            },
+                            "reaction_type": "unicode_emoji",
+                        },
+                    ],
+                },
+                " :thumbs_up: Iago   :zulip: You   :heart: Iago  ",
+                [
+                    ("reaction", 18),
+                    (None, 1),
+                    ("reaction_mine", 13),
+                    (None, 1),
+                    ("reaction", 14),
+                ],
+            ),
+            case(
+                {
+                    "reactions": [
+                        {
+                            "emoji_name": "zulip",
+                            "emoji_code": "zulip",
+                            "user": {
+                                "email": "iago@zulip.com",
+                                "full_name": "Iago",
+                                "id": 5,
+                            },
+                            "reaction_type": "unicode_emoji",
+                        },
+                        {
+                            "emoji_name": "zulip",
+                            "emoji_code": "zulip",
+                            "user": {
+                                "email": "AARON@zulip.com",
+                                "full_name": "aaron",
+                                "id": 1,
+                            },
+                            "reaction_type": "zulip_extra_emoji",
+                        },
+                        {
+                            "emoji_name": "zulip",
+                            "emoji_code": "zulip",
+                            "user": {
+                                "email": "shivam@zulip.com",
+                                "full_name": "Shivam",
+                                "id": 6,
+                            },
+                            "reaction_type": "unicode_emoji",
+                        },
+                    ],
+                },
+                " :zulip: Iago, Shivam, You  ",
+                [
+                    ("reaction_mine", 27),
+                ],
+            ),
+            case(
+                {
+                    "reactions": [
+                        {
+                            "emoji_name": "heart",
+                            "emoji_code": "2764",
+                            "user": {
+                                "email": "iago@zulip.com",
+                                "full_name": "Iago",
+                                "id": 5,
+                            },
+                            "reaction_type": "unicode_emoji",
+                        },
+                        {
+                            "emoji_name": "zulip",
+                            "emoji_code": "zulip",
+                            "user": {
+                                "email": "AARON@zulip.com",
+                                "full_name": "aaron",
+                                "id": 1,
+                            },
+                            "reaction_type": "zulip_extra_emoji",
+                        },
+                        {
+                            "emoji_name": "zulip",
+                            "emoji_code": "zulip",
+                            "user": {
+                                "email": "shivam@zulip.com",
+                                "full_name": "Shivam",
+                                "id": 6,
+                            },
+                            "reaction_type": "unicode_emoji",
+                        },
+                    ],
+                },
+                " :heart: Iago   :zulip: Shivam, You  ",
+                [
+                    ("reaction", 14),
+                    (None, 1),
+                    ("reaction_mine", 21),
+                ],
+            ),
+            case(
+                {
+                    "reactions": [
+                        {
+                            "emoji_name": "zulip",
+                            "emoji_code": "zulip",
+                            "user": {
+                                "email": "AARON@zulip.com",
+                                "full_name": "aaron",
+                                "id": 1,
+                            },
+                            "reaction_type": "zulip_extra_emoji",
+                        },
+                        {
+                            "emoji_name": "zulip",
+                            "emoji_code": "zulip",
+                            "user": {
+                                "email": "shivam@zulip.com",
+                                "full_name": "Shivam",
+                                "id": 6,
+                            },
+                            "reaction_type": "unicode_emoji",
+                        },
+                    ],
+                },
+                " :zulip: Shivam, You  ",
+                [
+                    ("reaction_mine", 21),
+                ],
+            ),
         ],
     )
     def test_reactions_view(


### PR DESCRIPTION
Fixes #1212

<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->
This PR displays reacting usernames besides reacting emoji in messages.

<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->

<!-- Add a link to a discussion on chat.zulip.org, if relevant -->
CZO - https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/Feature.20discussion.20-.20Show.20usernames.20adding.20emoji.20to.20message

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [ ] New tests added (for any new behavior)
- [x] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

<!-- See https://github.com/zulip/zulip-terminal#commit-style -->
**Commit flow** <!-- if more than one commit; add/delete/fill-in as appropriate -->
<!-- For example:
- first commit doing some thing
- maybe multiple commits doing similar things
-->

**Notes & Questions** <!-- if any; add/delete/fill-in as appropriate -->
<!-- For example:
- this doesn't include feature X (yet?)
- unsure about Y
- should this do Z?
-->

**Interactions** <!-- if any; add/delete/fill-in as appropriate -->
<!-- eg.
- Waiting on #<PR>
- Blocks #<PR>
-->

**Visual changes** <!-- if any; add/delete/fill-in with screenshot/diagram as appropriate -->
In Zulip web app -
![image](https://user-images.githubusercontent.com/53873549/164528377-e7dd3e7f-17f8-4764-818a-cb7c879eaa9c.png)

In ZT -
![image](https://user-images.githubusercontent.com/53873549/164529020-6f6a07e6-b50e-4b06-b619-c2984322825c.png)
