### PR TITLE
tools: Add check-branch to run 'make check' on all branch commits

### DIFF
--- a/tools/check-branch
+++ b/tools/check-branch
@@ -11,4 +11,22 @@ fi
 
 main_branch=${1:-"upstream/main"}
 
+if [ ! "$1" ]; then
+    echo "Using default main branch '$main_branch'"
+    if ! git diff --quiet "$main_branch" main; then
+        set +x
+        echo "Branch '$main_branch' appears to differ from 'main'; please specify one!"
+        exit 1
+    fi
+else
+    echo "Specified main branch as '$main_branch'"
+fi
+
+if git diff --quiet "$main_branch" HEAD; then
+    set +x
+    echo "No changes! Nothing to do!"
+    exit 1
+fi
+
+echo "Checking commits..."
 git rebase $(git merge-base "$main_branch" @) --exec 'git --no-pager log -1 && make check'

--- a/tools/check-branch
+++ b/tools/check-branch
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+if ! git diff-index --quiet HEAD; then
+    set +x
+    echo "There are uncommitted changes:"
+    git status --short
+    echo "Doing nothing to avoid losing your work."
+    exit 1
+fi
+
+main_branch=${1:-"upstream/main"}
+
+git rebase $(git merge-base "$main_branch" @) --exec 'git --no-pager log -1 && make check'

--- a/tools/python_tools.py
+++ b/tools/python_tools.py
@@ -11,6 +11,7 @@ tools_exclusions = {
         "push-to-pull-request",
         "release",
         "__pycache__",
+        "check-branch",
     }
 }
 

--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -10,7 +10,12 @@ from typing import Dict, List, cast
 import lister
 
 
-EXCLUDE_FILES = ["tools/fetch-pull-request", "tools/fetch-rebase-pull-request"]
+# This could use tools/python_tools.py in future?
+EXCLUDE_FILES = [
+    "tools/fetch-pull-request",
+    "tools/fetch-rebase-pull-request",
+    "tools/check-branch",
+]
 
 TOOLS_DIR = os.path.dirname(os.path.abspath(__file__))
 os.chdir(os.path.dirname(TOOLS_DIR))


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->

This is a first pass at a script to ensure a branch has commits which individually pass `make check`.

<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->

<!-- Add a link to a discussion on chat.zulip.org, if relevant -->

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Passed linting & tests (each commit)

^ checked with this script!
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

**Notes & Questions** <!-- if any; add/delete/fill-in as appropriate -->

This may become integrated into CI at some point, but an initial try at this turned out to be more complex than expected, so working with something we can easily run locally first.

I've not added documentation yet, since I'd like to let this get some simple testing first.

This script passes if it leaves you back at your branch; if it fails it leaves you at the failed commit, at which point you can `git rebase --abort` and explore it more yourself, or use the rebase interactively.