### PR TITLE
User friendly timestamps.

### DIFF
--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -2,6 +2,7 @@ import os
 import time
 from collections import OrderedDict, defaultdict
 from contextlib import contextmanager
+from datetime import datetime
 from functools import wraps
 from itertools import chain, combinations
 from re import ASCII, MULTILINE, findall, match
@@ -721,3 +722,53 @@ def suppress_output() -> Iterator[None]:
     finally:
         os.dup2(stdout, 1)
         os.dup2(stderr, 2)
+
+
+def user_friendly_time(time_stamp: str) -> str:  # message_info has a different format
+
+    now = datetime.now()
+    if len(time_stamp) > 22: # for message_info, year is included
+        datetime_object = datetime.strptime(
+            time_stamp, "%a %b %d %Y %I:%M:%S %p"
+        )  # Fri Apr 29 2022 05:15:12 AM is an example
+    else: # for user_info, year not included
+        datetime_object = datetime.strptime(
+            time_stamp + str(now.year), "%a %b %d %I:%M:%S %p%Y"
+        )  # Fri Apr 29 05:15:12 AM is an example
+
+    time_spent = now - datetime_object
+
+    seconds = time_spent.seconds
+    days = time_spent.days
+
+    if days < 0 or seconds < -30:
+        return ""
+
+    if days == 0:
+        if seconds < 10:
+            return "Just now"
+        if seconds < 60:
+            return str(seconds) + " seconds ago"
+        if seconds < 120:
+            return "A minute ago"
+        if seconds < 3600:
+            return str(seconds // 60) + " minutes ago"
+        if seconds < 7200:
+            return "An hour ago"
+        if seconds < 86400:  # 24 hours
+            return str(seconds // 3600) + " hours ago"
+
+    time_string = ""
+
+    if days == 1:
+        time_string = "Yesterday, "
+    if days < 7:
+        return str(days) + " days ago"
+    if days < 14:
+        return "A week ago"
+    if days < 31:
+        return str(days // 7) + " weeks ago"
+    if now.year == datetime_object.year:
+        return str(now.month - datetime_object.month) + " months ago"
+    else:
+        return str(days // 365) + " years ago"

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -37,6 +37,7 @@ from zulipterminal.helper import (
     match_emoji,
     match_stream,
     match_user,
+    user_friendly_time,
 )
 from zulipterminal.server_url import near_message_url
 from zulipterminal.ui_tools.boxes import MessageBox, PanelSearchBox
@@ -1194,7 +1195,9 @@ class UserInfoView(PopUpView):
             display_data["Role"] = ROLE_BY_ID[data["role"]]["name"]
 
             if data["last_active"]:
-                display_data["Last active"] = data["last_active"]
+                display_data[
+                    "Last active"
+                ] = f"""{data["last_active"]} \n({user_friendly_time(data["last_active"])})"""
 
         return display_data
 
@@ -1518,6 +1521,7 @@ class MsgInfoView(PopUpView):
         date_and_time = controller.model.formatted_local_time(
             msg["timestamp"], show_seconds=True, show_year=True
         )
+        pretty_date = user_friendly_time(date_and_time)
         view_in_browser_keys = ", ".join(map(repr, keys_for_command("VIEW_IN_BROWSER")))
 
         full_rendered_message_keys = ", ".join(
@@ -1530,7 +1534,7 @@ class MsgInfoView(PopUpView):
             (
                 "",
                 [
-                    ("Date & Time", date_and_time),
+                    ("Date & Time", f"""{date_and_time} \n({pretty_date})"""),
                     ("Sender", msg["sender_full_name"]),
                     ("Sender's Email ID", msg["sender_email"]),
                     (


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->
Adds user friendly times to the user and message info views. The current view just includes the timestamp, which is hard to decipher. 

<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->

<!-- Add a link to a discussion on chat.zulip.org, if relevant -->

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [ ] Existing tests (adapted, if necessary)
- [ ] New tests added (for any new behavior)
- [ ] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

<!-- See https://github.com/zulip/zulip-terminal#commit-style -->
**Commit flow** <!-- if more than one commit; add/delete/fill-in as appropriate -->
<!-- For example:
- first commit doing some thing
- maybe multiple commits doing similar things
-->
- first commit adds a helper function to friendly-fy the timestamps.
- second commit implements the helper function in views.py for message and user info popups.

**Notes & Questions** <!-- if any; add/delete/fill-in as appropriate -->
<!-- For example:
- this doesn't include feature X (yet?)
- unsure about Y
- should this do Z?
-->

**Interactions** <!-- if any; add/delete/fill-in as appropriate -->
<!-- eg.
- Waiting on #<PR>
- Blocks #<PR>
-->

**Visual changes** <!-- if any; add/delete/fill-in with screenshot/diagram as appropriate -->
For message info:
<img width="297" alt="Screenshot 2022-04-29 at 1 11 14 PM" src="https://user-images.githubusercontent.com/76529011/165903412-7c1b8ecf-e24f-4ed8-8441-bbb7efa64b4a.png">

For user info:
<img width="567" alt="Screenshot 2022-04-29 at 1 11 01 PM" src="https://user-images.githubusercontent.com/76529011/165903373-d3b5d0a8-6e6f-448a-8bb8-2484fcf8d73a.png">


