### PR TITLE
User-friendly date and time formatting.

### DIFF
--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -345,7 +345,10 @@ class TestUserInfoView:
 
         display_data = self.user_info_view._fetch_user_data(self.controller, 1)
 
-        assert display_data.get(expected_key, None) == expected_value
+        try:
+            assert expected_value in display_data.get(expected_key, None)
+        except TypeError:
+            assert display_data.get(expected_key, None) == expected_value
 
     def test__fetch_user_data_USER_NOT_FOUND(self, mocker: MockerFixture) -> None:
         mocker.patch.object(self.controller.model, "get_user_info", return_value=dict())
@@ -1013,7 +1016,7 @@ class TestMsgInfoView:
         assert self.controller.open_in_browser.called
 
     def test_height_noreactions(self) -> None:
-        expected_height = 6
+        expected_height = 7
         # 6 = 1 (date & time) +1 (sender's name) +1 (sender's email)
         # +1 (view message in browser)
         # +1 (full rendered message)
@@ -1087,7 +1090,7 @@ class TestMsgInfoView:
         )
         # 12 = 6 labels + 1 blank line + 1 'Reactions' (category)
         # + 4 reactions (excluding 'Message Links').
-        expected_height = 12
+        expected_height = 13
         assert self.msg_info_view.height == expected_height
 
     @pytest.mark.parametrize(

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -3,6 +3,7 @@ import subprocess
 import time
 from collections import OrderedDict, defaultdict
 from contextlib import contextmanager
+from datetime import datetime
 from functools import partial, wraps
 from itertools import chain, combinations
 from re import ASCII, MULTILINE, findall, match
@@ -819,3 +820,61 @@ def open_media(controller: Any, tool: str, media_path: str) -> None:
 
     if error:
         controller.report_error(error)
+
+
+def user_friendly_time(time_stamp: str) -> str:  # message_info has a different format
+
+    now = datetime.now()
+
+    if len(time_stamp) > 22:  # for message_info, year is included
+        datetime_object = datetime.strptime(
+            time_stamp, "%a %b %d %Y %I:%M:%S %p"
+        )  # Fri Apr 29 2022 05:15:12 AM is an example
+    elif len(time_stamp) > 0:  # for user_info, year not included
+        if time_stamp[-1] == "M":  # AM or PM
+            datetime_object = datetime.strptime(
+                time_stamp + str(now.year), "%a %b %d %I:%M:%S %p%Y"
+            )  # Fri Apr 29 05:15:12 AM is an example
+        else:
+            datetime_object = datetime.strptime(
+                time_stamp + str(now.year), "%a %b %d %H:%M:%S%Y"
+            )  # Fri Apr 29 15:15:12 is an example
+    else:
+        return ""  # return blank string if input is "" or similar
+
+    time_spent = now - datetime_object
+
+    seconds = time_spent.seconds
+    days = time_spent.days
+
+    if days < 0 or seconds < -30:
+        return ""
+
+    if days == 0:
+        if seconds < 10:
+            return "Just now"
+        if seconds < 60:
+            return str(seconds) + " seconds ago"
+        if seconds < 120:
+            return "A minute ago"
+        if seconds < 3600:
+            return str(seconds // 60) + " minutes ago"
+        if seconds < 7200:
+            return "An hour ago"
+        if seconds < 86400:  # 24 hours
+            return str(seconds // 3600) + " hours ago"
+
+    time_string = ""
+
+    if days == 1:
+        time_string = "Yesterday, "
+    if days < 7:
+        return str(days) + " days ago"
+    if days < 14:
+        return "A week ago"
+    if days < 31:
+        return str(days // 7) + " weeks ago"
+    if now.year == datetime_object.year:
+        return str(now.month - datetime_object.month) + " months ago"
+    else:
+        return str(days // 365) + " years ago"

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -37,6 +37,7 @@ from zulipterminal.helper import (
     match_emoji,
     match_stream,
     match_user,
+    user_friendly_time,
 )
 from zulipterminal.server_url import near_message_url
 from zulipterminal.ui_tools.boxes import MessageBox, PanelSearchBox
@@ -1162,6 +1163,10 @@ class UserInfoView(PopUpView):
             }
             return display_data
 
+        try:
+            pretty_date = user_friendly_time(data["last_active"])
+        except TypeError:
+            pretty_date = "Over two weeks ago."
         # Style the data obtained to make it displayable
         display_data = {"Name": data["full_name"]}
 
@@ -1194,7 +1199,9 @@ class UserInfoView(PopUpView):
             display_data["Role"] = ROLE_BY_ID[data["role"]]["name"]
 
             if data["last_active"]:
-                display_data["Last active"] = data["last_active"]
+                display_data[
+                    "Last active"
+                ] = f"""{data["last_active"]} \n({pretty_date})"""
 
         return display_data
 
@@ -1545,11 +1552,12 @@ class MsgInfoView(PopUpView):
         full_raw_message_keys = ", ".join(
             map(repr, keys_for_command("FULL_RAW_MESSAGE"))
         )
+        pretty_date = user_friendly_time(date_and_time)
         msg_info = [
             (
                 "",
                 [
-                    ("Date & Time", date_and_time),
+                    ("Date & Time", f"""{date_and_time} \n({pretty_date})"""),
                     ("Sender", msg["sender_full_name"]),
                     ("Sender's Email ID", msg["sender_email"]),
                     (
@@ -1573,7 +1581,10 @@ class MsgInfoView(PopUpView):
             and controller.model.initial_data["realm_allow_edit_history"]
         )
         if self.show_edit_history_label:
-            msg_info[0][1][0] = ("Date & Time (Original)", date_and_time)
+            msg_info[0][1][0] = (
+                "Date & Time (Original)",
+                f"""{date_and_time} \n({pretty_date})""",
+            )
 
             keys = ", ".join(map(repr, keys_for_command("EDIT_HISTORY")))
             msg_info[0][1].append(("Edit History", f"Press {keys} to view"))


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->
Adds user friendly times to the user and message info views. The current view just includes the timestamp, which is hard to decipher.

<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->

Partial fix for issues #1211  and addresses #1086

<!-- Add a link to a discussion on chat.zulip.org, if relevant -->

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [x] New tests added (for any new behavior)
- [x] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

<!-- See https://github.com/zulip/zulip-terminal#commit-style -->
**Commit flow** <!-- if more than one commit; add/delete/fill-in as appropriate -->
<!-- For example:
- first commit doing some thing
- maybe multiple commits doing similar things
-->
- first commit adds a helper function to friendly-fy the timestamps.
- second commit implements the helper function in views.py for message and user info popups.

**Notes & Questions** <!-- if any; add/delete/fill-in as appropriate -->
<!-- For example:
- this doesn't include feature X (yet?)
- unsure about Y
- should this do Z?
-->

**Interactions** <!-- if any; add/delete/fill-in as appropriate -->
<!-- eg.
- Waiting on #<PR>
- Blocks #<PR>
-->

**Visual changes** <!-- if any; add/delete/fill-in with screenshot/diagram as appropriate -->
For message info:
<img width="297" alt="Screenshot 2022-04-29 at 1 11 14 PM" src="https://user-images.githubusercontent.com/76529011/165903412-7c1b8ecf-e24f-4ed8-8441-bbb7efa64b4a.png">

For user info:
<img width="567" alt="Screenshot 2022-04-29 at 1 11 01 PM" src="https://user-images.githubusercontent.com/76529011/165903373-d3b5d0a8-6e6f-448a-8bb8-2484fcf8d73a.png">


