### PR TITLE
Run mypy on tools/ & close down list of checked tests/

### DIFF
--- a/tools/font-styles-test
+++ b/tools/font-styles-test
@@ -3,7 +3,7 @@
 import urwid
 
 
-def exit_on_q(key):
+def exit_on_q(key: str) -> None:
     if key in ("q", "Q"):
         raise urwid.ExitMainLoop()
 

--- a/tools/gitlint-extra-rules.py
+++ b/tools/gitlint-extra-rules.py
@@ -12,6 +12,7 @@ class EndsWithDot(CommitRule):
         error = "Title does not end with a '.' character"
         if not commit.message.title.endswith("."):
             return [RuleViolation(self.id, error, line_nr=1)]
+        return None
 
 
 class AreaFormatting(CommitRule):

--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -15,6 +15,7 @@ EXCLUDE_FILES = [
     "tools/fetch-pull-request",
     "tools/fetch-rebase-pull-request",
     "tools/check-branch",
+    "tools/lister.py",  # Came from zulip/zulip, now in zulint?
 ]
 
 TOOLS_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -120,9 +121,9 @@ python_files = [
     if not fpath.endswith(".py") or fpath + "i" not in pyi_files
 ]
 
-repo_python_files = {}
-repo_python_files["zulipterminal"] = []
-repo_python_files["tests"] = []
+repo_python_files: Dict[str, List[str]] = {
+    folder: [] for folder in ["zulipterminal", "tests", "tools"]
+}
 
 # Added incrementally as newer test files are type-annotated.
 type_consistent_testfiles = [
@@ -146,8 +147,10 @@ type_consistent_testfiles = [
 for file_path in python_files:
     repo = PurePath(file_path).parts[0]
     filename = PurePath(file_path).parts[-1]
-    if repo == "zulipterminal" or (
-        repo == "tests" and filename in type_consistent_testfiles
+    if (
+        repo == "zulipterminal"
+        or repo == "tools"
+        or (repo == "tests" and filename in type_consistent_testfiles)
     ):
         repo_python_files[repo].append(file_path)
 

--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -21,6 +21,8 @@ EXCLUDE_FILES = [
     "tests/ui/test_ui_tools.py",
 ]
 
+python_project_folders = ["zulipterminal", "tests", "tools"]
+
 TOOLS_DIR = os.path.dirname(os.path.abspath(__file__))
 os.chdir(os.path.dirname(TOOLS_DIR))
 
@@ -125,13 +127,13 @@ python_files = [
 ]
 
 repo_python_files: Dict[str, List[str]] = {
-    folder: [] for folder in ["zulipterminal", "tests", "tools"]
+    folder: [] for folder in python_project_folders
 }
 
 for file_path in python_files:
     repo = PurePath(file_path).parts[0]
     filename = PurePath(file_path).parts[-1]
-    if repo == "zulipterminal" or repo == "tools" or repo == "tests":
+    if repo in repo_python_files:
         repo_python_files[repo].append(file_path)
 
 mypy_command = "mypy"

--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -16,6 +16,9 @@ EXCLUDE_FILES = [
     "tools/fetch-rebase-pull-request",
     "tools/check-branch",
     "tools/lister.py",  # Came from zulip/zulip, now in zulint?
+    # Remaining test files to have types applied:
+    "tests/model/test_model.py",
+    "tests/ui/test_ui_tools.py",
 ]
 
 TOOLS_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -125,33 +128,10 @@ repo_python_files: Dict[str, List[str]] = {
     folder: [] for folder in ["zulipterminal", "tests", "tools"]
 }
 
-# Added incrementally as newer test files are type-annotated.
-type_consistent_testfiles = [
-    "test_run.py",
-    "test_core.py",
-    "test_emoji_data.py",
-    "test_helper.py",
-    "test_server_url.py",
-    "test_ui.py",
-    "test_keys.py",
-    "test_themes.py",
-    "test_color.py",
-    "test_platform_code.py",
-    "test_buttons.py",
-    "test_utils.py",
-    "conftest.py",
-    "test_boxes.py",
-    "test_popups.py",
-]
-
 for file_path in python_files:
     repo = PurePath(file_path).parts[0]
     filename = PurePath(file_path).parts[-1]
-    if (
-        repo == "zulipterminal"
-        or repo == "tools"
-        or (repo == "tests" and filename in type_consistent_testfiles)
-    ):
+    if repo == "zulipterminal" or repo == "tools" or repo == "tests":
         repo_python_files[repo].append(file_path)
 
 mypy_command = "mypy"


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->

- Run mypy on python tools/ by default (with exclusions)
- Switches the explicitly included running of mypy on test files to check into a shorter list of remaining test files to add typing for
- Refactoring

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [x] New tests added (for any new behavior)
- [x] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

**Notes & Questions** <!-- if any; add/delete/fill-in as appropriate -->

@prah23 Down to only two test files needing typing after last Summer :)
@mounilKshah This will affect the tool for docstrings in #1208; there are some types in that PR, but they won't be checked in CI until this is merged.