### PR TITLE
Upgrade mypy to 0.960 & use new typing features

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -122,7 +122,7 @@ setup(
         "beautifulsoup4>=4.10.0",
         "lxml>=4.7.1",
         "pygments>=2.11.2",
-        "typing_extensions>=3.7",
+        "typing_extensions~=4.0.0",
         "python-dateutil>=2.8.2",
         "pytz>=2022.1",
         "tzlocal>=2.1",

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ linting_deps = [
 
 typing_deps = [
     "lxml-stubs",
-    "mypy==0.942",
+    "mypy==0.961",
     "types-pygments",
     "types-python-dateutil",
     "types-tzlocal",

--- a/tests/config/test_keys.py
+++ b/tests/config/test_keys.py
@@ -75,20 +75,24 @@ def test_commands_for_random_tips(mocker: MockerFixture) -> None:
         "ALPHA": {
             "keys": ["a"],
             "help_text": "alpha",
+            "key_category": "category 1",
             "excluded_from_random_tips": True,
         },
         "BETA": {
             "keys": ["b"],
             "help_text": "beta",
+            "key_category": "category 1",
             "excluded_from_random_tips": False,
         },
         "GAMMA": {
             "keys": ["g"],
             "help_text": "gamma",
+            "key_category": "category 1",
         },
         "DELTA": {
             "keys": ["d"],
             "help_text": "delta",
+            "key_category": "category 2",
             "excluded_from_random_tips": True,
         },
     }

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 from typing import List
 
-from typing_extensions import TypedDict
+from typing_extensions import NotRequired, TypedDict
 from urwid.command_map import (
     CURSOR_DOWN,
     CURSOR_LEFT,
@@ -14,10 +14,10 @@ from urwid.command_map import (
 )
 
 
-class KeyBinding(TypedDict, total=False):
+class KeyBinding(TypedDict):
     keys: List[str]
     help_text: str
-    excluded_from_random_tips: bool
+    excluded_from_random_tips: NotRequired[bool]
     key_category: str
 
 

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -26,7 +26,7 @@ from typing import (
 from urllib.parse import unquote
 
 import requests
-from typing_extensions import TypedDict
+from typing_extensions import ParamSpec, TypedDict
 
 from zulipterminal.api_types import Composition, EmojiType, Message
 from zulipterminal.config.keys import primary_key_for_command
@@ -119,13 +119,16 @@ class UnreadCounts(TypedDict):
     streams: Dict[int, int]  # stream_id
 
 
-def asynch(func: Callable[..., None]) -> Callable[..., None]:
+ParamT = ParamSpec("ParamT")
+
+
+def asynch(func: Callable[ParamT, None]) -> Callable[ParamT, None]:
     """
     Decorator for executing a function in a separate :class:`threading.Thread`.
     """
 
     @wraps(func)
-    def wrapper(*args: Any, **kwargs: Any) -> Any:
+    def wrapper(*args: ParamT.args, **kwargs: ParamT.kwargs) -> None:
         # If calling when pytest is running simply return the function
         # to avoid running in asynch mode.
         if os.environ.get("PYTEST_CURRENT_TEST"):
@@ -133,7 +136,7 @@ def asynch(func: Callable[..., None]) -> Callable[..., None]:
 
         thread = Thread(target=func, args=args, kwargs=kwargs)
         thread.daemon = True
-        return thread.start()
+        thread.start()
 
     return wrapper
 


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->

- upgrade typing-extensions (for mypy + new features)
- upgrade mypy
- migrate away from total=False with the KeyBinding TypedDict, using NotRequired
- migrate asynch to use ParamSpec and clarify the return type

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [ ] New tests added (for any new behavior)
- [x] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

<!-- See https://github.com/zulip/zulip-terminal#commit-style -->
**Commit flow** <!-- if more than one commit; add/delete/fill-in as appropriate -->

`typing-extensions` is upgraded first due to the mypy dependency, though is used in the application as a whole, rather than just development.

Similarly, the features depend upon the names being available, and mypy won't recognize the syntax in earlier commits if it is upgraded last.

**Notes & Questions** <!-- if any; add/delete/fill-in as appropriate -->

There are a few other TypedDicts which total=False could be removed from, but these are potentially more complex (Message) or may have related open PRs.