### PR TITLE
[WIP] Highlight active stream in side panel.

### DIFF
--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -39,8 +39,6 @@ from zulipterminal.ui_tools.views import (
     UserInfoView,
 )
 from zulipterminal.version import ZT_VERSION
-from zulipterminal.platform_code import notify
-
 
 ExceptionInfo = Tuple[Type[BaseException], BaseException, TracebackType]
 

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -580,9 +580,6 @@ class Controller:
     def narrow_to_stream(
         self, *, stream_name: str, contextual_message_id: Optional[int] = None
     ) -> None:
-        # self.view.left_panel.update_stream_view_topic(stream_id)
-        # self.view.left_panel.show_stream_view()
-        notify(stream_name, stream_name)
         stream_id = self.model.stream_id_from_name(stream_name)
         self.model.update_stream_on_narrow(stream_id)
         self._narrow_to(anchor=contextual_message_id, stream=stream_name)

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -39,6 +39,7 @@ from zulipterminal.ui_tools.views import (
     UserInfoView,
 )
 from zulipterminal.version import ZT_VERSION
+from zulipterminal.platform_code import notify
 
 
 ExceptionInfo = Tuple[Type[BaseException], BaseException, TracebackType]
@@ -548,13 +549,14 @@ class Controller:
             )
 
     def _narrow_to(self, anchor: Optional[int], **narrow: Any) -> None:
+        
         already_narrowed = self.model.set_narrow(**narrow)
 
         if already_narrowed and anchor is None:
             return
 
         msg_id_list = self.model.get_message_ids_in_current_narrow()
-
+        
         # If no messages are found in the current narrow
         # OR, given anchor is not present in msg_id_list
         # then, get more messages.
@@ -578,6 +580,11 @@ class Controller:
     def narrow_to_stream(
         self, *, stream_name: str, contextual_message_id: Optional[int] = None
     ) -> None:
+        # self.view.left_panel.update_stream_view_topic(stream_id)
+        # self.view.left_panel.show_stream_view()
+        notify(stream_name, stream_name)
+        stream_id = self.model.stream_id_from_name(stream_name)
+        self.model.update_stream_on_narrow(stream_id)
         self._narrow_to(anchor=contextual_message_id, stream=stream_name)
 
     def narrow_to_topic(

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1212,7 +1212,7 @@ class Model:
                             self.unpinned_streams.append(stream)
                     sort_streams(self.unpinned_streams)
                     sort_streams(self.pinned_streams)
-                    self.controller.view.left_panel.update_stream_view()
+                    self.controller.view.left_panel.update_stream_view(stream_id)
                     self.controller.update_screen()
                 elif event.get("property", None) == "desktop_notifications":
                     stream_id = event["stream_id"]
@@ -1239,6 +1239,9 @@ class Model:
                     else:
                         for user_id in user_ids:
                             subscribers.remove(user_id)
+
+    def update_stream_on_narrow(self, stream_id: int):
+        self.controller.view.left_panel.update_stream_view(stream_id)
 
     def _handle_typing_event(self, event: Event) -> None:
         """

--- a/zulipterminal/themes/gruvbox_dark.py
+++ b/zulipterminal/themes/gruvbox_dark.py
@@ -70,6 +70,7 @@ STYLES = {
     'area:error'       : (Color.DARK0_HARD,            Color.BRIGHT_RED),
     'area:user'        : (Color.DARK0_HARD,            Color.BRIGHT_YELLOW),
     'search_error'     : (Color.BRIGHT_RED,            Color.DARK0_HARD),
+    'stream_selected'  : (Color.DARK0_HARD,            Color.BRIGHT_GREEN),
     'task:success'     : (Color.DARK0_HARD,            Color.BRIGHT_GREEN),
     'task:error'       : (Color.DARK0_HARD,            Color.BRIGHT_RED),
     'task:warning'     : (Color.DARK0_HARD,            Color.NEUTRAL_PURPLE),

--- a/zulipterminal/themes/gruvbox_dark.py
+++ b/zulipterminal/themes/gruvbox_dark.py
@@ -70,7 +70,7 @@ STYLES = {
     'area:error'       : (Color.DARK0_HARD,            Color.BRIGHT_RED),
     'area:user'        : (Color.DARK0_HARD,            Color.BRIGHT_YELLOW),
     'search_error'     : (Color.BRIGHT_RED,            Color.DARK0_HARD),
-    'stream_selected'  : (Color.DARK0_HARD,            Color.BRIGHT_GREEN),
+    'stream_active'  : (Color.DARK0_HARD,            Color.BRIGHT_GREEN),
     'task:success'     : (Color.DARK0_HARD,            Color.BRIGHT_GREEN),
     'task:error'       : (Color.DARK0_HARD,            Color.BRIGHT_RED),
     'task:warning'     : (Color.DARK0_HARD,            Color.NEUTRAL_PURPLE),

--- a/zulipterminal/themes/gruvbox_light.py
+++ b/zulipterminal/themes/gruvbox_light.py
@@ -70,6 +70,7 @@ STYLES = {
     'area:user'        : (Color.LIGHT0_HARD,            Color.FADED_YELLOW),
     'search_error'     : (Color.FADED_RED,              Color.LIGHT0_HARD),
     'task:success'     : (Color.LIGHT0_HARD,            Color.FADED_GREEN),
+    'stream_selected'  : (Color.LIGHT0_HARD,            Color.FADED_RED),
     'task:error'       : (Color.LIGHT0_HARD,            Color.FADED_RED),
     'task:warning'     : (Color.LIGHT0_HARD,            Color.NEUTRAL_PURPLE),
 }

--- a/zulipterminal/themes/gruvbox_light.py
+++ b/zulipterminal/themes/gruvbox_light.py
@@ -70,7 +70,7 @@ STYLES = {
     'area:user'        : (Color.LIGHT0_HARD,            Color.FADED_YELLOW),
     'search_error'     : (Color.FADED_RED,              Color.LIGHT0_HARD),
     'task:success'     : (Color.LIGHT0_HARD,            Color.FADED_GREEN),
-    'stream_selected'  : (Color.LIGHT0_HARD,            Color.FADED_RED),
+    'stream_active'  : (Color.LIGHT0_HARD,            Color.FADED_RED),
     'task:error'       : (Color.LIGHT0_HARD,            Color.FADED_RED),
     'task:warning'     : (Color.LIGHT0_HARD,            Color.NEUTRAL_PURPLE),
 }

--- a/zulipterminal/themes/zt_blue.py
+++ b/zulipterminal/themes/zt_blue.py
@@ -64,6 +64,7 @@ STYLES = {
     'area:error'      : (Color.WHITE,               Color.DARK_RED),
     'area:user'       : (Color.WHITE,               Color.DARK_BLUE),
     'search_error'    : (Color.LIGHT_RED,           Color.LIGHT_BLUE),
+    'stream_selected' : (Color.WHITE,               Color.DARK_GREEN),
     'task:success'    : (Color.WHITE,               Color.DARK_GREEN),
     'task:error'      : (Color.WHITE,               Color.DARK_RED),
     'task:warning'    : (Color.WHITE,               Color.BROWN),

--- a/zulipterminal/themes/zt_blue.py
+++ b/zulipterminal/themes/zt_blue.py
@@ -64,7 +64,7 @@ STYLES = {
     'area:error'      : (Color.WHITE,               Color.DARK_RED),
     'area:user'       : (Color.WHITE,               Color.DARK_BLUE),
     'search_error'    : (Color.LIGHT_RED,           Color.LIGHT_BLUE),
-    'stream_selected' : (Color.WHITE,               Color.DARK_GREEN),
+    'stream_active' : (Color.WHITE,               Color.DARK_GREEN),
     'task:success'    : (Color.WHITE,               Color.DARK_GREEN),
     'task:error'      : (Color.WHITE,               Color.DARK_RED),
     'task:warning'    : (Color.WHITE,               Color.BROWN),

--- a/zulipterminal/themes/zt_dark.py
+++ b/zulipterminal/themes/zt_dark.py
@@ -64,6 +64,7 @@ STYLES = {
     'area:error'      : (Color.WHITE,               Color.DARK_RED),
     'area:user'       : (Color.WHITE,               Color.DARK_BLUE),
     'search_error'    : (Color.LIGHT_RED,           Color.BLACK),
+    'stream_selected' : (Color.WHITE,               Color.DARK_GREEN),
     'task:success'    : (Color.WHITE,               Color.DARK_GREEN),
     'task:error'      : (Color.WHITE,               Color.DARK_RED),
     'task:warning'    : (Color.WHITE,               Color.BROWN),

--- a/zulipterminal/themes/zt_dark.py
+++ b/zulipterminal/themes/zt_dark.py
@@ -64,7 +64,7 @@ STYLES = {
     'area:error'      : (Color.WHITE,               Color.DARK_RED),
     'area:user'       : (Color.WHITE,               Color.DARK_BLUE),
     'search_error'    : (Color.LIGHT_RED,           Color.BLACK),
-    'stream_selected' : (Color.WHITE,               Color.DARK_GREEN),
+    'stream_active' : (Color.WHITE,               Color.DARK_GREEN),
     'task:success'    : (Color.WHITE,               Color.DARK_GREEN),
     'task:error'      : (Color.WHITE,               Color.DARK_RED),
     'task:warning'    : (Color.WHITE,               Color.BROWN),

--- a/zulipterminal/themes/zt_light.py
+++ b/zulipterminal/themes/zt_light.py
@@ -64,6 +64,7 @@ STYLES = {
     'area:error'      : (Color.BLACK,               Color.LIGHT_RED),
     'area:user'       : (Color.WHITE,               Color.DARK_BLUE),
     'search_error'    : (Color.LIGHT_RED,           Color.WHITE),
+    'stream_selected' : (Color.BLACK,               Color.DARK_GREEN),
     'task:success'    : (Color.BLACK,               Color.DARK_GREEN),
     'task:error'      : (Color.WHITE,               Color.DARK_RED),
     'task:warning'    : (Color.BLACK,               Color.YELLOW),

--- a/zulipterminal/themes/zt_light.py
+++ b/zulipterminal/themes/zt_light.py
@@ -64,7 +64,7 @@ STYLES = {
     'area:error'      : (Color.BLACK,               Color.LIGHT_RED),
     'area:user'       : (Color.WHITE,               Color.DARK_BLUE),
     'search_error'    : (Color.LIGHT_RED,           Color.WHITE),
-    'stream_selected' : (Color.BLACK,               Color.DARK_GREEN),
+    'stream_active' : (Color.BLACK,               Color.DARK_GREEN),
     'task:success'    : (Color.BLACK,               Color.DARK_GREEN),
     'task:error'      : (Color.WHITE,               Color.DARK_RED),
     'task:warning'    : (Color.BLACK,               Color.YELLOW),

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -13,8 +13,6 @@ from zulipterminal.config.symbols import CHECK_MARK, MUTE_MARKER
 from zulipterminal.config.ui_mappings import EDIT_MODE_CAPTIONS, STREAM_ACCESS_TYPE
 from zulipterminal.helper import Message, StreamData, hash_util_decode, process_media
 from zulipterminal.urwid_types import urwid_Size
-from zulipterminal.platform_code import notify
-
 
 class TopButton(urwid.Button):
     def __init__(

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -192,7 +192,6 @@ class StreamButton(TopButton):
         text_color = None
           
         if selected:
-            notify("stream_name", self.stream_name)
             self.stream_name = self.stream_name + " ▶▶"
             text_color = 'stream_selected'
 

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -1,3 +1,4 @@
+from cgitb import text
 import re
 from functools import partial
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union, cast
@@ -13,6 +14,7 @@ from zulipterminal.config.symbols import CHECK_MARK, MUTE_MARKER
 from zulipterminal.config.ui_mappings import EDIT_MODE_CAPTIONS, STREAM_ACCESS_TYPE
 from zulipterminal.helper import Message, StreamData, hash_util_decode, process_media
 from zulipterminal.urwid_types import urwid_Size
+from zulipterminal.platform_code import notify
 
 
 class TopButton(urwid.Button):
@@ -160,6 +162,7 @@ class StreamButton(TopButton):
         controller: Any,
         view: Any,
         count: int,
+        selected: bool,
     ) -> None:
         # FIXME Is having self.stream_id the best way to do this?
         # (self.stream_id is used elsewhere)
@@ -168,6 +171,7 @@ class StreamButton(TopButton):
         self.color = properties["color"]
         stream_access_type = properties["stream_access_type"]
         self.description = properties["description"]
+        self.selected = selected
 
         self.model = controller.model
         self.count = count
@@ -186,6 +190,12 @@ class StreamButton(TopButton):
         )
 
         stream_marker = STREAM_ACCESS_TYPE[stream_access_type]["icon"]
+        # text_color = ["white", "black"]
+          
+        if selected:
+            notify("MIL GAYA KUCH!", self.stream_name)
+            self.stream_name = self.stream_name + " ▶▶"
+            # text_color = ["white", "dark blue"]
 
         narrow_function = partial(
             controller.narrow_to_stream,
@@ -198,6 +208,7 @@ class StreamButton(TopButton):
             prefix_character=(self.color, stream_marker),
             count=count,
             count_style="unread_count",
+            # text_color= text_color
         )
 
         # Mark muted streams 'M' during button creation.

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -189,12 +189,12 @@ class StreamButton(TopButton):
         )
 
         stream_marker = STREAM_ACCESS_TYPE[stream_access_type]["icon"]
-        # text_color = ["white", "black"]
+        text_color = None
           
         if selected:
             notify("stream_name", self.stream_name)
             self.stream_name = self.stream_name + " ▶▶"
-            # text_color = ["white", "dark blue"]
+            text_color = 'stream_selected'
 
         narrow_function = partial(
             controller.narrow_to_stream,
@@ -207,7 +207,7 @@ class StreamButton(TopButton):
             prefix_character=(self.color, stream_marker),
             count=count,
             count_style="unread_count",
-            # text_color= text_color
+            text_color= text_color
         )
 
         # Mark muted streams 'M' during button creation.

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -1,4 +1,3 @@
-from cgitb import text
 import re
 from functools import partial
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union, cast

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -193,7 +193,7 @@ class StreamButton(TopButton):
         # text_color = ["white", "black"]
           
         if selected:
-            notify("MIL GAYA KUCH!", self.stream_name)
+            notify("stream_name", self.stream_name)
             self.stream_name = self.stream_name + " ▶▶"
             # text_color = ["white", "dark blue"]
 

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -191,7 +191,7 @@ class StreamButton(TopButton):
           
         if selected:
             self.stream_name = self.stream_name + " ▶▶"
-            text_color = 'stream_selected'
+            text_color = 'stream_active'
 
         narrow_function = partial(
             controller.narrow_to_stream,
@@ -288,6 +288,7 @@ class TopicButton(TopButton):
         controller: Any,
         view: Any,
         count: int,
+        in_stream_view = False,
     ) -> None:
         self.stream_name = controller.model.stream_dict[stream_id]["name"]
         self.topic_name = topic
@@ -304,6 +305,10 @@ class TopicButton(TopButton):
         # The space acts as a TopButton prefix and gives an effective 3 spaces for unresolved topics.
         topic_prefix = " "
         topic_name = self.topic_name
+
+        if in_stream_view:
+            topic_name = " ▶ " + topic_name
+
         if self.topic_name.startswith(RESOLVED_TOPIC_PREFIX):
             topic_prefix = self.topic_name[:1]
             topic_name = self.topic_name[2:]

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -831,30 +831,60 @@ class LeftColumnView(urwid.Pile):
         return w
 
     def streams_view(self, selected_stream_id = -1) -> Any:
-        streams_btn_list = [
-            StreamButton(
-                properties=stream,
-                controller=self.controller,
-                view=self.view,
-                count=self.model.unread_counts["streams"].get(stream["id"], 0),
-                selected = (selected_stream_id == stream["id"])
-            )
-            for stream in self.view.pinned_streams
-        ]
+        
+        streams_btn_list = []
+        for stream in self.view.pinned_streams:
+            streams_btn_list += [
+                StreamButton(
+                    properties=stream,
+                    controller=self.controller,
+                    view=self.view,
+                    count=self.model.unread_counts["streams"].get(stream["id"], 0),
+                    selected = (selected_stream_id == stream["id"])
+                )
+            ]
+
+            if selected_stream_id == stream["id"]:
+                 topics = self.model.topics_in_stream(stream["id"])
+                 streams_btn_list += [TopicButton(
+                     stream_id = stream["id"],
+                     topic = topic,
+                     controller=self.controller,
+                     view=self.view,
+                     count=self.model.unread_counts["unread_topics"].get(
+                         (stream["id"], topic), 0),
+                     in_stream_view=True,
+                     )
+                     for topic in topics[:3] #FIXME add constant
+                     ] 
 
         if len(streams_btn_list):
             streams_btn_list += [StreamsViewDivider()]
 
-        streams_btn_list += [
-            StreamButton(
-                properties=stream,
-                controller=self.controller,
-                view=self.view,
-                count=self.model.unread_counts["streams"].get(stream["id"], 0),
-                selected = (selected_stream_id == stream["id"]),
-            )
-            for stream in self.view.unpinned_streams
-        ]
+        for stream in self.view.unpinned_streams:
+            streams_btn_list += [
+                StreamButton(
+                    properties=stream,
+                    controller=self.controller,
+                    view=self.view,
+                    count=self.model.unread_counts["streams"].get(stream["id"], 0),
+                    selected = (selected_stream_id == stream["id"])
+                )
+            ]
+
+            if selected_stream_id == stream["id"]:
+                 topics = self.model.topics_in_stream(stream["id"])
+                 streams_btn_list += [TopicButton(
+                     stream_id = stream["id"],
+                     topic = topic,
+                     controller=self.controller,
+                     view=self.view,
+                     count=self.model.unread_counts["unread_topics"].get(
+                         (stream["id"], topic), 0),
+                     in_stream_view=True,
+                     )
+                     for topic in topics[:3] #FIXME add constant
+                     ] 
 
         self.view.stream_id_to_button = {
             stream.stream_id: stream

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -830,13 +830,14 @@ class LeftColumnView(urwid.Pile):
         w = urwid.ListBox(urwid.SimpleFocusListWalker(menu_btn_list))
         return w
 
-    def streams_view(self) -> Any:
+    def streams_view(self, selected_stream_id = -1) -> Any:
         streams_btn_list = [
             StreamButton(
                 properties=stream,
                 controller=self.controller,
                 view=self.view,
                 count=self.model.unread_counts["streams"].get(stream["id"], 0),
+                selected = (selected_stream_id == stream["id"])
             )
             for stream in self.view.pinned_streams
         ]
@@ -850,6 +851,7 @@ class LeftColumnView(urwid.Pile):
                 controller=self.controller,
                 view=self.view,
                 count=self.model.unread_counts["streams"].get(stream["id"], 0),
+                selected = (selected_stream_id == stream["id"]),
             )
             for stream in self.view.unpinned_streams
         ]
@@ -914,8 +916,8 @@ class LeftColumnView(urwid.Pile):
             and stream_id == self.view.topic_w.stream_button.stream_id
         )
 
-    def update_stream_view(self) -> None:
-        self.stream_v = self.streams_view()
+    def update_stream_view(self, selected_stream_id = -1) -> None:
+        self.stream_v = self.streams_view(selected_stream_id)
         if not self.is_in_topic_view:
             self.show_stream_view()
 


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->

In the side panel, once narrowed, the active stream is highlighted.

<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->

Partial fix for #516.

<!-- Add a link to a discussion on chat.zulip.org, if relevant -->
https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/Highlight.20currently.20narrowed.20stream.2Ftopic.20.23T516

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [ ] Existing tests (adapted, if necessary)
- [ ] New tests added (for any new behavior)
- [ ] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

<!-- See https://github.com/zulip/zulip-terminal#commit-style -->
**Commit flow** <!-- if more than one commit; add/delete/fill-in as appropriate -->
<!-- For example:
- first commit doing some thing
- maybe multiple commits doing similar things
-->

**Notes & Questions** <!-- if any; add/delete/fill-in as appropriate -->

```buttons.by``` >> ```TopButton( )``` has an attribute named text_color which is required to highlight the text in the button, but I'm unsure what format the input needs to be in. [ FIXED ]

<!-- For example:
- this doesn't include feature X (yet?)
- unsure about Y
- should this do Z?
-->

**Interactions** <!-- if any; add/delete/fill-in as appropriate -->
<!-- eg.
- Waiting on #<PR>
- Blocks #<PR>
-->

**Visual changes** <!-- if any; add/delete/fill-in with screenshot/diagram as appropriate -->
<img width="318" alt="image" src="https://user-images.githubusercontent.com/76529011/174597903-86187b67-07ce-4459-8774-9e9ec9264b34.png">

There used to be no visual indicator on the side panel showing which stream was selected.