### PR TITLE
Add support for (un)resolving topics in ZT.

### DIFF
--- a/docs/hotkeys.md
+++ b/docs/hotkeys.md
@@ -13,6 +13,7 @@
 |Redraw screen|<kbd>ctrl</kbd> + <kbd>l</kbd>|
 |Quit|<kbd>ctrl</kbd> + <kbd>c</kbd>|
 |View user information (From Users list)|<kbd>i</kbd>|
+|Show/hide topic information & modify settings|<kbd>i</kbd>|
 
 ## Navigation
 |Command|Key Combination|

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -1097,11 +1097,11 @@ class TestModel:
                 },
                 {
                     "_": ["User not found", False],
-                    "_owner": ["Editing messages is disabled", False],
-                    "_admin": ["Editing messages is disabled", False],
-                    "_moderator": ["Editing messages is disabled", False],
-                    "_member": ["Editing messages is disabled", False],
-                    "_guest": ["Editing messages is disabled", False],
+                    "_owner": [" Editing messages is disabled", False],
+                    "_admin": [" Editing messages is disabled", False],
+                    "_moderator": [" Editing messages is disabled", False],
+                    "_member": [" Editing messages is disabled", False],
+                    "_guest": [" Editing messages is disabled", False],
                 },
                 id="editing_msg_disabled:PreZulip4.0",
             ),
@@ -1114,9 +1114,9 @@ class TestModel:
                     "_": ["User not found", False],
                     "_owner": ["", True],
                     "_admin": ["", True],
-                    "_moderator": ["Editing topic is disabled", False],
-                    "_member": ["Editing topic is disabled", False],
-                    "_guest": ["Editing topic is disabled", False],
+                    "_moderator": [" Editing topic is disabled", False],
+                    "_member": [" Editing topic is disabled", False],
+                    "_guest": [" Editing topic is disabled", False],
                 },
                 id="editing_topic_disabled:PreZulip4.0",
             ),
@@ -1136,18 +1136,6 @@ class TestModel:
                 id="editing_topic_and_msg_enabled:PreZulip4.0",
             ),
             case(
-                {"allow_message_editing": False, "edit_topic_policy": 1},
-                {
-                    "_": ["User not found", False],
-                    "_owner": ["Editing messages is disabled", False],
-                    "_admin": ["Editing messages is disabled", False],
-                    "_moderator": ["Editing messages is disabled", False],
-                    "_member": ["Editing messages is disabled", False],
-                    "_guest": ["Editing messages is disabled", False],
-                },
-                id="all_but_no_editing:Zulip4.0+:ZFL75",
-            ),
-            case(
                 {"allow_message_editing": True, "edit_topic_policy": 1},
                 {
                     "_": ["User not found", False],
@@ -1156,8 +1144,8 @@ class TestModel:
                     "_moderator": ["", True],
                     "_member": ["", True],
                     "_guest": [
-                        "Only organization administrators, moderators, full members and"
-                        " members can edit topic",
+                        "Only organization administrators, moderators, full members"
+                        " and members can edit topic",
                         False,
                     ],
                 },
@@ -1208,13 +1196,13 @@ class TestModel:
                     "_admin": ["", True],
                     "_moderator": ["", True],
                     "_member": [
-                        "Only organization administrators and moderators"
-                        " can edit topic",
+                        "Only organization administrators and moderators can edit"
+                        " topic",
                         False,
                     ],
                     "_guest": [
-                        "Only organization administrators and moderators"
-                        " can edit topic",
+                        "Only organization administrators and moderators can edit"
+                        " topic",
                         False,
                     ],
                 },
@@ -1246,9 +1234,9 @@ class TestModel:
     ):
         model.get_user_info = mocker.Mock(return_value=user_role)
         model.initial_data = initial_data
-        initial_data["realm_allow_message_editing"] = realm_editing_settings[
+        initial_data["realm_allow_message_editing"] = realm_editing_settings.get(
             "allow_message_editing"
-        ]
+        )
         allow_community_topic_editing = realm_editing_settings.get(
             "allow_community_topic_editing", None
         )

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -7,6 +7,7 @@ import pytest
 from pytest import param as case
 from zulip import Client, ZulipError
 
+from zulipterminal.api_types import RESOLVED_TOPIC_PREFIX
 from zulipterminal.config.symbols import STREAM_TOPIC_SEPARATOR
 from zulipterminal.helper import initial_index, powerset
 from zulipterminal.model import (
@@ -1258,6 +1259,87 @@ class TestModel:
             report_error.assert_not_called()
         else:
             report_error.assert_called_once_with(expected_response[user_type][0])
+
+    @pytest.mark.parametrize(
+        "topic_name, msg_response, server_feature_level, topic_editing_limit_seconds,"
+        " expected_new_topic_name, expected_footer_error",
+        [
+            case(
+                "hi!",
+                {
+                    "subject": "hi!",
+                    "timestamp": 11662271397,
+                    "id": 1,
+                },
+                12,
+                259200,
+                RESOLVED_TOPIC_PREFIX + "hi!",
+                None,
+                id="topic_resolved:Zulip2.1+:ZFL12",
+            ),
+            case(
+                "hi!",
+                {
+                    "subject": "hi!",
+                    "timestamp": 0,
+                    "id": 1,
+                },
+                None,
+                None,
+                RESOLVED_TOPIC_PREFIX + "hi!",
+                None,
+                id="no_time_limit:Zulip2.1+:None",
+            ),
+            case(
+                RESOLVED_TOPIC_PREFIX + "hi!",
+                {
+                    "subject": RESOLVED_TOPIC_PREFIX + "hi!",
+                    "timestamp": 11662271397,
+                    "id": 1,
+                },
+                10,
+                86400,
+                "hi!",
+                None,
+                id="topic_unresolved:Zulip2.1+:ZFL10",
+            ),
+        ],
+    )
+    def test_toggle_topic_resolve_status(
+        self,
+        mocker,
+        model,
+        initial_data,
+        topic_name,
+        msg_response,
+        server_feature_level,
+        topic_editing_limit_seconds,
+        expected_new_topic_name,
+        expected_footer_error,
+        stream_id=1,
+    ):
+        model.initial_data = initial_data
+        model.server_feature_level = server_feature_level
+        initial_data[
+            "realm_community_topic_editing_limit_seconds"
+        ] = topic_editing_limit_seconds
+        # If user can't edit topic, topic (un)resolve is disabled. Therefore,
+        # default return_value=True
+        model.can_user_edit_topic = mocker.Mock(return_value=True)
+        model.get_latest_message_in_topic = mocker.Mock(return_value=msg_response)
+        model.update_stream_message = mocker.Mock(return_value={"result": "success"})
+        report_error = model.controller.report_error
+
+        model.toggle_topic_resolve_status(stream_id, topic_name)
+
+        if not expected_footer_error:
+            model.update_stream_message.assert_called_once_with(
+                message_id=msg_response["id"],
+                topic=expected_new_topic_name,
+                propagate_mode="change_all",
+            )
+        else:
+            report_error.assert_called_once_with(expected_footer_error)
 
     # NOTE: This tests only getting next-unread, not a fixed anchor
     def test_success_get_messages(

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -26,6 +26,7 @@ from zulipterminal.ui_tools.views import (
     PopUpView,
     StreamInfoView,
     StreamMembersView,
+    TopicInfoView,
     UserInfoView,
 )
 from zulipterminal.urwid_types import urwid_Size
@@ -1152,6 +1153,24 @@ class TestMsgInfoView:
         assert link_w._wrapped_widget.focus_map == expected_focus_map
         assert link_w._wrapped_widget.attr_map == expected_attr_map
         assert link_width == expected_link_width
+
+
+class TestTopicInfoView:
+    @pytest.fixture(autouse=True)
+    def mock_external_classes(
+        self, mocker: MockerFixture, general_stream: Dict[str, Any], topics: List[str]
+    ) -> None:
+        self.controller = mocker.Mock()
+        mocker.patch.object(
+            self.controller, "maximum_popup_dimensions", return_value=(64, 64)
+        )
+        mocker.patch(LISTWALKER, return_value=[])
+        self.stream_id = general_stream["stream_id"]
+        self.topic = topics[0]
+
+        self.topic_info_view = TopicInfoView(
+            self.controller, self.stream_id, self.topic
+        )
 
 
 class TestStreamInfoView:

--- a/tools/lint-hotkeys
+++ b/tools/lint-hotkeys
@@ -19,7 +19,7 @@ SCRIPT_NAME = PurePath(__file__).name
 HELP_TEXT_STYLE = re.compile(r"^[a-zA-Z /()',&@#:_-]*$")
 
 # Exclude keys from duplicate keys checking
-KEYS_TO_EXCLUDE = ["q", "e", "m", "r"]
+KEYS_TO_EXCLUDE = ["q", "e", "m", "r", "i"]
 
 
 def main(fix: bool) -> None:

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -310,6 +310,11 @@ KEY_BINDINGS: Dict[str, KeyBinding] = {
         'help_text': 'View user information (From Users list)',
         'key_category': 'general',
     },
+    'TOPIC_INFO': {
+        'keys': ['i'],
+        'help_text': 'Show/hide topic information & modify settings',
+        'key_category': 'general',
+    },
     'BEGINNING_OF_LINE': {
         'keys': ['ctrl a'],
         'help_text': 'Jump to the beginning of line',

--- a/zulipterminal/config/themes.py
+++ b/zulipterminal/config/themes.py
@@ -71,6 +71,7 @@ REQUIRED_STYLES = {
     'area:help'       : 'standout',
     'area:msg'        : 'standout',
     'area:stream'     : 'standout',
+    'area:topic'      : 'standout',
     'area:error'      : 'standout',
     'area:user'       : 'standout',
     'search_error'    : 'standout',

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -43,6 +43,7 @@ from zulipterminal.ui_tools.views import (
     PopUpConfirmationView,
     StreamInfoView,
     StreamMembersView,
+    TopicInfoView,
     UserInfoView,
 )
 from zulipterminal.version import ZT_VERSION
@@ -304,6 +305,10 @@ class Controller:
     def show_stream_info(self, stream_id: int) -> None:
         show_stream_view = StreamInfoView(self, stream_id)
         self.show_pop_up(show_stream_view, "area:stream")
+
+    def show_topic_info(self, stream_id: int, topic_name: str) -> None:
+        show_topic_view = TopicInfoView(self, stream_id, topic_name)
+        self.show_pop_up(show_topic_view, "area:topic")
 
     def show_stream_members(self, stream_id: int) -> None:
         stream_members_view = StreamMembersView(self, stream_id)

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -648,7 +648,7 @@ class Model:
         user_info = self.get_user_info(self.user_id)
         if user_info is not None:
             if not self.initial_data.get("realm_allow_message_editing"):
-                self.controller.report_error("Editing messages is disabled")
+                self.controller.report_error(" Editing messages is disabled")
                 return False
             role = user_info["role"]
             if role <= 200:
@@ -661,7 +661,7 @@ class Model:
             if allow_community_topic_editing is True:
                 return True
             elif allow_community_topic_editing is False:
-                self.controller.report_error("Editing topic is disabled")
+                self.controller.report_error(" Editing topic is disabled")
                 return False
             else:
                 edit_topic_policy = self.initial_data.get("realm_edit_topic_policy")
@@ -693,7 +693,7 @@ class Model:
                     else:
                         self.controller.report_error(EDIT_TOPIC_POLICY[1])
                         return False
-                else:  # edit_topic_policy == 5 (or None)
+                else:
                     # All users including guests
                     return True
         self.controller.report_error("User not found")

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -30,6 +30,7 @@ from typing_extensions import Literal, TypedDict
 
 from zulipterminal import unicode_emojis
 from zulipterminal.api_types import (
+    RESOLVED_TOPIC_PREFIX,
     Composition,
     EditPropagateMode,
     Event,
@@ -698,6 +699,38 @@ class Model:
                     return True
         self.controller.report_error("User not found")
         return False
+
+    def toggle_topic_resolve_status(self, stream_id: int, topic_name: str) -> None:
+        if self.can_user_edit_topic():
+            latest_msg = self.get_latest_message_in_topic(stream_id, topic_name)
+            if latest_msg:
+                time_since_msg_sent = time.time() - latest_msg["timestamp"]
+                # ZFL < 11, community_topic_editing_limit_seconds
+                # was hardcoded as int value in secs eg. 86400s (1 day) or None
+                if self.server_feature_level is None or self.server_feature_level >= 11:
+                    edit_time_limit = self.initial_data.get(
+                        "realm_community_topic_editing_limit_seconds", None
+                    )
+                else:
+                    edit_time_limit = 86400
+                # Don't allow editing topic if time-limit exceeded.
+                if (
+                    edit_time_limit is not None
+                    and time_since_msg_sent >= edit_time_limit
+                ):
+                    self.controller.report_error(
+                        " Time limit for editing topic has been exceeded."
+                    )
+                else:
+                    if topic_name.startswith(RESOLVED_TOPIC_PREFIX):
+                        topic_name = topic_name[2:]
+                    else:
+                        topic_name = RESOLVED_TOPIC_PREFIX + topic_name
+                    self.update_stream_message(
+                        message_id=latest_msg["id"],
+                        topic=topic_name,
+                        propagate_mode="change_all",
+                    )
 
     def generate_all_emoji_data(
         self, custom_emoji: Dict[str, RealmEmojiData]

--- a/zulipterminal/themes/gruvbox_dark.py
+++ b/zulipterminal/themes/gruvbox_dark.py
@@ -66,6 +66,7 @@ STYLES = {
     'area:help'        : (Color.DARK0_HARD,            Color.BRIGHT_GREEN),
     'area:msg'         : (Color.DARK0_HARD,            Color.NEUTRAL_PURPLE),
     'area:stream'      : (Color.DARK0_HARD,            Color.BRIGHT_BLUE),
+    'area:topic'       : (Color.DARK0_HARD,            Color.BRIGHT_BLUE),
     'area:error'       : (Color.DARK0_HARD,            Color.BRIGHT_RED),
     'area:user'        : (Color.DARK0_HARD,            Color.BRIGHT_YELLOW),
     'search_error'     : (Color.BRIGHT_RED,            Color.DARK0_HARD),

--- a/zulipterminal/themes/gruvbox_light.py
+++ b/zulipterminal/themes/gruvbox_light.py
@@ -65,6 +65,7 @@ STYLES = {
     'area:help'        : (Color.LIGHT0_HARD,            Color.FADED_GREEN),
     'area:msg'         : (Color.LIGHT0_HARD,            Color.NEUTRAL_PURPLE),
     'area:stream'      : (Color.LIGHT0_HARD,            Color.FADED_BLUE),
+    'area:topic'       : (Color.LIGHT0_HARD,            Color.FADED_BLUE),
     'area:error'       : (Color.LIGHT0_HARD,            Color.FADED_RED),
     'area:user'        : (Color.LIGHT0_HARD,            Color.FADED_YELLOW),
     'search_error'     : (Color.FADED_RED,              Color.LIGHT0_HARD),

--- a/zulipterminal/themes/zt_blue.py
+++ b/zulipterminal/themes/zt_blue.py
@@ -59,6 +59,7 @@ STYLES = {
     'widget_disabled' : (Color.DARK_GRAY,           Color.LIGHT_BLUE),
     'area:help'       : (Color.WHITE,               Color.DARK_GREEN),
     'area:stream'     : (Color.WHITE,               Color.DARK_CYAN),
+    'area:topic'      : (Color.WHITE,               Color.DARK_CYAN),
     'area:msg'        : (Color.WHITE,               Color.BROWN),
     'area:error'      : (Color.WHITE,               Color.DARK_RED),
     'area:user'       : (Color.WHITE,               Color.DARK_BLUE),

--- a/zulipterminal/themes/zt_dark.py
+++ b/zulipterminal/themes/zt_dark.py
@@ -60,6 +60,7 @@ STYLES = {
     'area:help'       : (Color.WHITE,               Color.DARK_GREEN),
     'area:msg'        : (Color.WHITE,               Color.BROWN),
     'area:stream'     : (Color.WHITE,               Color.DARK_CYAN),
+    'area:topic'      : (Color.WHITE,               Color.DARK_CYAN),
     'area:error'      : (Color.WHITE,               Color.DARK_RED),
     'area:user'       : (Color.WHITE,               Color.DARK_BLUE),
     'search_error'    : (Color.LIGHT_RED,           Color.BLACK),

--- a/zulipterminal/themes/zt_light.py
+++ b/zulipterminal/themes/zt_light.py
@@ -59,6 +59,7 @@ STYLES = {
     'widget_disabled' : (Color.LIGHT_GRAY,          Color.WHITE),
     'area:help'       : (Color.BLACK,               Color.LIGHT_GREEN),
     'area:stream'     : (Color.BLACK,               Color.LIGHT_BLUE),
+    'area:topic'      : (Color.BLACK,               Color.LIGHT_BLUE),
     'area:msg'        : (Color.BLACK,               Color.YELLOW),
     'area:error'      : (Color.BLACK,               Color.LIGHT_RED),
     'area:user'       : (Color.WHITE,               Color.DARK_BLUE),

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -349,6 +349,8 @@ class TopicButton(TopButton):
         if is_command_key("TOGGLE_TOPIC", key):
             # Exit topic view
             self.view.left_panel.show_stream_view()
+        elif is_command_key("TOPIC_INFO", key):
+            self.model.controller.show_topic_info(self.stream_id, self.topic_name)
         return super().keypress(size, key)
 
 


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->
This PR adds support for (un)resolving topics in ZT via ``TopicInfoView`` popup menu when topic is highlighted in ``left_stream_bar`` and ``i`` key is pressed to toggle ``topic settings``.
<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->
[WIP] #1075
<!-- Add a link to a discussion on chat.zulip.org, if relevant -->

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [ ] Manually
- [ ] Existing tests (adapted, if necessary)
- [ ] New tests added (for any new behavior)
- [ ] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

<!-- See https://github.com/zulip/zulip-terminal#commit-style -->
**Commit flow** <!-- if more than one commit; add/delete/fill-in as appropriate -->
<!-- For example:
- first commit doing some thing
- maybe multiple commits doing similar things
-->
First commit adds ``TOPIC_DESC`` shortcut to ``keys.py``
Second commit adds above shorcut to ``TopicButton`` in ``buttons.py``
Third commit still figuring out a way to update topic name with ``RESOLVED_TOPIC_PREFIX`` in ``model.py``
Fourth commit  adds ``TopicInfoView`` to ``views.py``
Last commit adds ``show_topic_info`` function to ``core.py`` 

**Notes & Questions** <!-- if any; add/delete/fill-in as appropriate -->
<!-- For example:
- this doesn't include feature X (yet?)
- unsure about Y
- should this do Z?
-->
How to update the topic name by adding or removing ``RESOLVED_TOPIC_PREFIX`` when ``Topic Resolved`` checkbox is toggled?

**Interactions** <!-- if any; add/delete/fill-in as appropriate -->
<!-- eg.
- Waiting on #<PR>
- Blocks #<PR>
-->

**Visual changes** <!-- if any; add/delete/fill-in with screenshot/diagram as appropriate -->
![image](https://user-images.githubusercontent.com/53873549/174599874-a80a13e1-aa31-42df-a1fa-782a6570073b.png)
