### PR TITLE
[WIP] Migrate message['subject'] to message['topic']

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -416,7 +416,7 @@ def msg_template_factory(
     msg_type: str,
     timestamp: int,
     *,
-    subject: str = "",
+    topic: str = "",
     stream_id: Optional[int] = None,
     recipients: Union[str, List[Dict[str, Any]]] = "PTEST",
 ) -> Message:
@@ -435,7 +435,8 @@ def msg_template_factory(
         flags=["read"],
         sender_id=5140,
         content_type="text/x-markdown",
-        subject=subject,
+        topic=topic,
+        subject=topic,
         reactions=[],
         subject_links=[],
         avatar_url="dummy_avatar_url",
@@ -459,7 +460,7 @@ def msg_template_factory(
 @pytest.fixture
 def stream_msg_template() -> Message:
     msg_template = msg_template_factory(
-        537286, "stream", 1520918722, subject="Test", stream_id=205
+        537286, "stream", 1520918722, topic="Test", stream_id=205
     )
     return msg_template
 
@@ -467,7 +468,7 @@ def stream_msg_template() -> Message:
 @pytest.fixture
 def extra_stream_msg_template() -> Message:
     msg_template = msg_template_factory(
-        537289, "stream", 1520918740, subject="Test", stream_id=205
+        537289, "stream", 1520918740, topic="Test", stream_id=205
     )
     return msg_template
 

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -951,7 +951,7 @@ class TestModel:
         old_stream_name="stream",
     ):
         self.client.update_message = mocker.Mock(return_value=response)
-        model.index["messages"][req["message_id"]]["subject"] = old_topic
+        model.index["messages"][req["message_id"]]["topic"] = old_topic
         model.index["messages"][req["message_id"]][
             "display_recipient"
         ] = old_stream_name
@@ -1487,7 +1487,7 @@ class TestModel:
         "response, narrow, recipients, log",
         [
             case(
-                {"type": "stream", "stream_id": 1, "subject": "FOO", "id": 1},
+                {"type": "stream", "stream_id": 1, "topic": "FOO", "id": 1},
                 [],
                 frozenset(),
                 ["msg_w"],
@@ -1505,7 +1505,7 @@ class TestModel:
                     "type": "stream",
                     "id": 1,
                     "stream_id": 1,
-                    "subject": "FOO",
+                    "topic": "FOO",
                     "display_recipient": "a",
                 },
                 [["stream", "a"]],
@@ -1518,7 +1518,7 @@ class TestModel:
                     "type": "stream",
                     "id": 1,
                     "stream_id": 1,
-                    "subject": "b",
+                    "topic": "b",
                     "display_recipient": "a",
                 },
                 [["stream", "a"], ["topic", "b"]],
@@ -1531,7 +1531,7 @@ class TestModel:
                     "type": "stream",
                     "id": 1,
                     "stream_id": 1,
-                    "subject": "b",
+                    "topic": "b",
                     "display_recipient": "a",
                 },
                 [["stream", "c"], ["topic", "b"]],
@@ -1573,7 +1573,7 @@ class TestModel:
                     "type": "stream",
                     "id": 1,
                     "stream_id": 1,
-                    "subject": "c",
+                    "topic": "c",
                     "display_recipient": "a",
                     "flags": ["mentioned"],
                 },
@@ -2122,7 +2122,7 @@ class TestModel:
             model.controller.update_screen.assert_called_once_with()
 
     @pytest.mark.parametrize(
-        "subject, narrow, new_log_len",
+        "topic, narrow, new_log_len",
         [
             ("foo", [["stream", "boo"], ["topic", "foo"]], 2),
             ("foo", [["stream", "boo"], ["topic", "not foo"]], 1),
@@ -2135,11 +2135,11 @@ class TestModel:
         ],
     )
     def test__update_rendered_view(
-        self, mocker, model, subject, narrow, new_log_len, msg_id=1
+        self, mocker, model, topic, narrow, new_log_len, msg_id=1
     ):
         msg_w = mocker.Mock()
         other_msg_w = mocker.Mock()
-        msg_w.original_widget.message = {"id": msg_id, "subject": subject}
+        msg_w.original_widget.message = {"id": msg_id, "topic": topic}
         model.narrow = narrow
         other_msg_w.original_widget.message = {"id": 2}
         self.controller.view.message_view = mocker.Mock(log=[msg_w, other_msg_w])
@@ -2159,7 +2159,7 @@ class TestModel:
         assert model.controller.update_screen.called
 
     @pytest.mark.parametrize(
-        "subject, narrow, narrow_changed",
+        "topic, narrow, narrow_changed",
         [
             ("foo", [["stream", "boo"], ["topic", "foo"]], False),
             ("foo", [["stream", "boo"], ["topic", "not foo"]], True),
@@ -2172,11 +2172,11 @@ class TestModel:
         ],
     )
     def test__update_rendered_view_change_narrow(
-        self, mocker, model, subject, narrow, narrow_changed, msg_id=1
+        self, mocker, model, topic, narrow, narrow_changed, msg_id=1
     ):
         msg_w = mocker.Mock()
         other_msg_w = mocker.Mock()
-        msg_w.original_widget.message = {"id": msg_id, "subject": subject}
+        msg_w.original_widget.message = {"id": msg_id, "topic": topic}
         model.narrow = narrow
         self.controller.view.message_view = mocker.Mock(log=[msg_w])
         # New msg widget generated after updating index.

--- a/tests/server_url/test_server_url.py
+++ b/tests/server_url/test_server_url.py
@@ -34,7 +34,7 @@ def test_encode_stream(
                 "type": "stream",
                 "stream_id": 23,
                 "display_recipient": "zulip terminal",
-                "subject": "#test-here #T1 #T2 #T3",
+                "topic": "#test-here #T1 #T2 #T3",
             },
             (
                 "https://chat.zulip.org/#narrow/stream/23-zulip-terminal"
@@ -48,7 +48,7 @@ def test_encode_stream(
                 "type": "stream",
                 "stream_id": 425,
                 "display_recipient": "/ in a stream name ?",
-                "subject": "abc + de = abcde",
+                "topic": "abc + de = abcde",
             },
             (
                 "https://foo-bar.co.in/#narrow/stream/425-.2F-in-a-stream-name-.3F"

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1290,7 +1290,7 @@ class TestMessageBox:
                 {"id": 7, "email": "boo@zulip.com", "full_name": "Boo is awesome"}
             ],
             stream_id=5,
-            subject="hi",
+            topic="hi",
             sender_email="foo@zulip.com",
             sender_id=4209,
             type=message_type,
@@ -1933,7 +1933,7 @@ class TestMessageBox:
                     "sender_full_name": "aaron",
                     "submessages": [],
                     "stream_id": 5,
-                    "subject": "Verona2",
+                    "topic": "Verona2",
                     "id": 37,
                     "subject_links": [],
                     "content": (
@@ -1971,7 +1971,7 @@ class TestMessageBox:
                     ],
                     "sender_full_name": "Iago",
                     "submessages": [],
-                    "subject": "",
+                    "topic": "",
                     "id": 107,
                     "subject_links": [],
                     "content": "<p>what are you planning to do this week</p>",
@@ -2005,7 +2005,7 @@ class TestMessageBox:
                 "type": "stream",
                 "display_recipient": "Verona",
                 "stream_id": 5,
-                "subject": "Test topic",
+                "topic": "Test topic",
                 "is_me_message": True,  # will be overridden by test function.
                 "flags": [],
                 "content": "",  # will be overridden by test function.
@@ -2043,7 +2043,7 @@ class TestMessageBox:
                 "type": "stream",
                 "display_recipient": "Verona",
                 "stream_id": 5,
-                "subject": "Test topic",
+                "topic": "Test topic",
                 "flags": [],
                 "is_me_message": False,
                 "content": "<p>what are you planning to do this week</p>",
@@ -2057,7 +2057,7 @@ class TestMessageBox:
         "to_vary_in_last_message",
         [
             {"display_recipient": "Verona offtopic"},
-            {"subject": "Test topic (previous)"},
+            {"topic": "Test topic (previous)"},
             {"type": "private"},
         ],
         ids=[
@@ -2218,7 +2218,7 @@ class TestMessageBox:
                 "type": "stream",
                 "display_recipient": "Verona",
                 "stream_id": 5,
-                "subject": "Test topic",
+                "topic": "Test topic",
                 "flags": [],
                 "is_me_message": False,
                 "content": "<p>what are you planning to do this week</p>",
@@ -2412,7 +2412,7 @@ class TestMessageBox:
         ],
         [
             case(
-                {"sender_id": 2, "timestamp": 45, "subject": "test"},
+                {"sender_id": 2, "timestamp": 45, "topic": "test"},
                 True,
                 60,
                 {"stream": False, "private": False},
@@ -2424,7 +2424,7 @@ class TestMessageBox:
                 id="msg_sent_by_other_user_with_topic",
             ),
             case(
-                {"sender_id": 1, "timestamp": 1, "subject": "test"},
+                {"sender_id": 1, "timestamp": 1, "topic": "test"},
                 True,
                 60,
                 {"stream": False, "private": False},
@@ -2437,7 +2437,7 @@ class TestMessageBox:
                 id="topic_edit_only_after_time_limit",
             ),
             case(
-                {"sender_id": 1, "timestamp": 45, "subject": "test"},
+                {"sender_id": 1, "timestamp": 45, "topic": "test"},
                 False,
                 60,
                 {"stream": False, "private": False},
@@ -2449,7 +2449,7 @@ class TestMessageBox:
                 id="realm_editing_not_allowed",
             ),
             case(
-                {"sender_id": 1, "timestamp": 45, "subject": "test"},
+                {"sender_id": 1, "timestamp": 45, "topic": "test"},
                 True,
                 60,
                 {"stream": True, "private": True},
@@ -2458,7 +2458,7 @@ class TestMessageBox:
                 id="realm_editing_allowed_and_within_time_limit",
             ),
             case(
-                {"sender_id": 1, "timestamp": 1, "subject": "test"},
+                {"sender_id": 1, "timestamp": 1, "topic": "test"},
                 True,
                 0,
                 {"stream": True, "private": True},
@@ -2467,7 +2467,7 @@ class TestMessageBox:
                 id="no_msg_body_edit_limit",
             ),
             case(
-                {"sender_id": 1, "timestamp": 1, "subject": "(no topic)"},
+                {"sender_id": 1, "timestamp": 1, "topic": "(no topic)"},
                 True,
                 60,
                 {"stream": False, "private": False},
@@ -2480,7 +2480,7 @@ class TestMessageBox:
                 id="msg_sent_by_me_with_no_topic",
             ),
             case(
-                {"sender_id": 2, "timestamp": 1, "subject": "(no topic)"},
+                {"sender_id": 2, "timestamp": 1, "topic": "(no topic)"},
                 True,
                 60,
                 {"stream": False, "private": False},
@@ -2493,7 +2493,7 @@ class TestMessageBox:
                 id="msg_sent_by_other_with_no_topic",
             ),
             case(
-                {"sender_id": 1, "timestamp": 1, "subject": "(no topic)"},
+                {"sender_id": 1, "timestamp": 1, "topic": "(no topic)"},
                 False,
                 60,
                 {"stream": False, "private": False},
@@ -2505,7 +2505,7 @@ class TestMessageBox:
                 id="realm_editing_not_allowed_for_no_topic",
             ),
             case(
-                {"sender_id": 1, "timestamp": 45, "subject": "(no topic)"},
+                {"sender_id": 1, "timestamp": 45, "topic": "(no topic)"},
                 True,
                 0,
                 {"stream": True, "private": True},
@@ -2529,7 +2529,7 @@ class TestMessageBox:
         key,
     ):
         if message_fixture["type"] == "private":
-            to_vary_in_each_message["subject"] = ""
+            to_vary_in_each_message["topic"] = ""
         varied_message = dict(message_fixture, **to_vary_in_each_message)
         message_type = varied_message["type"]
         msg_box = MessageBox(varied_message, self.model, message_fixture)
@@ -2551,7 +2551,7 @@ class TestMessageBox:
 
         if expect_editing_to_succeed[message_type]:
             assert write_box.msg_edit_state.message_id == varied_message["id"]
-            assert write_box.msg_edit_state.old_topic == varied_message["subject"]
+            assert write_box.msg_edit_state.old_topic == varied_message["topic"]
             write_box.msg_write_box.set_edit_text.assert_called_once_with(
                 "Edit this message"
             )

--- a/tests/ui/test_utils.py
+++ b/tests/ui/test_utils.py
@@ -59,7 +59,7 @@ MODULE = "zulipterminal.ui_tools.utils"
             {
                 "type": "stream",
                 "stream_id": 3,
-                "subject": "foo koo",
+                "topic": "foo koo",
                 # ...
             },
             [],

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -1339,6 +1339,7 @@ class TestWriteBox:
             )
         else:
             write_box.model.send_stream_message.assert_called_once_with(
+                # FIXME: This parameter is causing an error while testing
                 stream=write_box.stream_write_box.edit_text,
                 topic=topic_sent_to_server,
                 content=write_box.msg_write_box.edit_text,

--- a/zulipterminal/api_types.py
+++ b/zulipterminal/api_types.py
@@ -35,6 +35,8 @@ class Message(TypedDict, total=False):
     timestamp: int
     client: str
     subject: str  # Only for stream msgs.
+    # Changing subject -> topic as per the migration in Zulip 2.0
+    topic: str  # Only for stream msgs.
     # NOTE: new in Zulip 3.0 / ZFL 1, replacing `subject_links`
     # NOTE: API response format of `topic_links` changed in Zulip 4.0 / ZFL 46
     topic_links: List[Any]

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -165,7 +165,7 @@ def _set_count_in_model(
         if message["type"] == "stream":
             stream_id = message["stream_id"]
             update_unreads(
-                unread_counts["unread_topics"], (stream_id, message["subject"])
+                unread_counts["unread_topics"], (stream_id, message["topic"])
             )
             update_unreads(unread_counts["streams"], stream_id)
         # self-pm has only one display_recipient
@@ -217,7 +217,7 @@ def _set_count_in_view(
 
         if msg_type == "stream":
             stream_id = message["stream_id"]
-            msg_topic = message["subject"]
+            msg_topic = message["topic"]
             if controller.model.is_muted_stream(stream_id):
                 add_to_counts = False  # if muted, don't add to eg. all_msg
             else:
@@ -350,7 +350,7 @@ def index_messages(messages: List[Message], model: Any, index: Index) -> Index:
                 'sender_full_name': 'Iago',
                 'flags': [],
                 'sender_email': 'iago@zulip.com',
-                'subject': '',
+                'topic': '',
                 'subject_links': [],
                 'sender_id': 73,
                 'type': 'private',
@@ -386,7 +386,7 @@ def index_messages(messages: List[Message], model: Any, index: Index) -> Index:
                 'display_recipient': 'Verona',
                 'flags': [],
                 'reactions': [],
-                'subject': 'Verona2',
+                'topic': 'Verona2',
                 'stream_id': 32,
             },
         },
@@ -436,12 +436,12 @@ def index_messages(messages: List[Message], model: Any, index: Index) -> Index:
         if (
             msg["type"] == "stream"
             and len(narrow) == 2
-            and narrow[1][1] == msg["subject"]
+            and narrow[1][1] == msg["topic"]
         ):
             topics_in_stream = index["topic_msg_ids"][msg["stream_id"]]
-            if not topics_in_stream.get(msg["subject"]):
-                topics_in_stream[msg["subject"]] = set()
-            topics_in_stream[msg["subject"]].add(msg["id"])
+            if not topics_in_stream.get(msg["topic"]):
+                topics_in_stream[msg["topic"]] = set()
+            topics_in_stream[msg["topic"]].add(msg["id"])
 
     return index
 

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -385,7 +385,7 @@ class Model:
                     len(self.narrow) == 1  # stream
                     or (
                         len(self.narrow) == 2  # stream+topic
-                        and self.narrow[1][1] == message["subject"]
+                        and self.narrow[1][1] == message["topic"]
                     )
                 )
             )
@@ -579,7 +579,7 @@ class Model:
         if response["result"] == "success":
             message = self.index["messages"][message_id]
             stream_name = message.get("display_recipient", None)
-            old_topic = message.get("subject", None)
+            old_topic = message.get("topic", None)
             new_topic = request["topic"]
             stream_name_markup = (
                 "footer_contrast",
@@ -723,6 +723,11 @@ class Model:
             ]
             if topic_links:
                 message["topic_links"] = topic_links
+
+        # (3) `subject` param is changed to `topic` from
+        # server version 2.0
+        if "subject" in message:
+            message["topic"] = message["subject"]
 
         return message
 
@@ -1323,7 +1328,7 @@ class Model:
             if {"mentioned", "wildcard_mentioned"}.intersection(
                 set(message["flags"])
             ) or self.is_visual_notifications_enabled(stream_id):
-                recipient = "{display_recipient} -> {subject}".format(**message)
+                recipient = "{display_recipient} -> {topic}".format(**message)
 
         if recipient:
             if hidden_content:
@@ -1369,7 +1374,7 @@ class Model:
             # consecutive block independently). However, it is critical to keep
             # the topics index synchronized as it used whenever the topics list
             # view is reconstructed later.
-            self._update_topic_index(message["stream_id"], message["subject"])
+            self._update_topic_index(message["stream_id"], message["topic"])
             # If the topic view is toggled for incoming message's
             # recipient stream, then we re-arrange topic buttons
             # with most recent at the top.
@@ -1379,7 +1384,7 @@ class Model:
                     message["stream_id"]
                 ):
                     view.topic_w.update_topics_list(
-                        message["stream_id"], message["subject"], message["sender_id"]
+                        message["stream_id"], message["topic"], message["sender_id"]
                     )
                     self.controller.update_screen()
 
@@ -1453,7 +1458,7 @@ class Model:
 
     def _handle_update_message_event(self, event: Event) -> None:
         """
-        Handle updated (edited) messages (changed content/subject)
+        Handle updated (edited) messages (changed content/topic)
         """
         assert event["type"] == "update_message"
         # Update edited message status from single message id
@@ -1500,7 +1505,7 @@ class Model:
                 # Update and re-render indexed messages.
                 indexed_msg = self.index["messages"].get(msg_id)
                 if indexed_msg:
-                    indexed_msg["subject"] = new_subject
+                    indexed_msg["topic"] = new_subject
                     self._update_rendered_view(msg_id)
 
             # If topic view is open, reload list else reset cache.
@@ -1642,7 +1647,7 @@ class Model:
                 # narrow.
                 if (
                     len(self.narrow) == 2
-                    and msg_box.message["subject"] != self.narrow[1][1]
+                    and msg_box.message["topic"] != self.narrow[1][1]
                 ):
                     view.message_view.log.remove(msg_w)
                     # Change narrow if there are no messages left in the

--- a/zulipterminal/server_url.py
+++ b/zulipterminal/server_url.py
@@ -31,7 +31,7 @@ def near_stream_message_url(server_url: str, message: Message) -> str:
     message_id = str(message["id"])
     stream_id = message["stream_id"]
     stream_name = message["display_recipient"]
-    topic_name = message["subject"]
+    topic_name = message["topic"]
     encoded_stream = encode_stream(stream_id, stream_name)
     encoded_topic = hash_util_encode(topic_name)
 

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -938,7 +938,7 @@ class MessageBox(urwid.Pile):
 
             self.stream_name = self.message["display_recipient"]
             self.stream_id = self.message["stream_id"]
-            self.topic_name = self.message["subject"]
+            self.topic_name = self.message["topic"]
         elif self.message["type"] == "private":
             self.email = self.message["sender_email"]
             self.user_id = self.message["sender_id"]
@@ -983,7 +983,7 @@ class MessageBox(urwid.Pile):
         if self.message["type"] == "stream":
             return not (
                 last_msg["type"] == "stream"
-                and self.topic_name == last_msg["subject"]
+                and self.topic_name == last_msg["topic"]
                 and self.stream_name == last_msg["display_recipient"]
             )
         elif self.message["type"] == "private":
@@ -1761,7 +1761,7 @@ class MessageBox(urwid.Pile):
             elif self.message["type"] == "stream":
                 self.model.controller.view.write_box.stream_box_view(
                     caption=self.message["display_recipient"],
-                    title=self.message["subject"],
+                    title=self.message["topic"],
                     stream_id=self.stream_id,
                 )
         elif is_command_key("STREAM_MESSAGE", key):
@@ -1865,12 +1865,12 @@ class MessageBox(urwid.Pile):
             self.model.controller.view.write_box.msg_write_box.set_edit_pos(len(quote))
             self.model.controller.view.middle_column.set_focus("footer")
         elif is_command_key("EDIT_MESSAGE", key):
-            # User can't edit messages of others that already have a subject
-            # For private messages, subject = "" (empty string)
+            # User can't edit messages of others that already have a topic
+            # For private messages, topic = "" (empty string)
             # This also handles the realm_message_content_edit_limit_seconds == 0 case
             if (
                 self.message["sender_id"] != self.model.user_id
-                and self.message["subject"] != "(no topic)"
+                and self.message["topic"] != "(no topic)"
             ):
                 if self.message["type"] == "stream":
                     self.model.controller.report_error(
@@ -1919,8 +1919,8 @@ class MessageBox(urwid.Pile):
                             )
                             msg_body_edit_enabled = False
                 elif self.message["type"] == "stream":
-                    # Allow editing topic if the message has "(no topic)" subject
-                    if self.message["subject"] == "(no topic)":
+                    # Allow editing topic if the message has "(no topic)" topic
+                    if self.message["topic"] == "(no topic)":
                         self.model.controller.report_warning(
                             [
                                 " Only topic editing is allowed."
@@ -1949,14 +1949,14 @@ class MessageBox(urwid.Pile):
                 self.model.controller.view.write_box.stream_box_edit_view(
                     stream_id=self.stream_id,
                     caption=self.message["display_recipient"],
-                    title=self.message["subject"],
+                    title=self.message["topic"],
                 )
             msg_id = self.message["id"]
             response = self.model.fetch_raw_message_content(msg_id)
             msg = response if response is not None else ""
             write_box = self.model.controller.view.write_box
             write_box.msg_edit_state = _MessageEditState(
-                message_id=msg_id, old_topic=self.message["subject"]
+                message_id=msg_id, old_topic=self.message["topic"]
             )
             write_box.msg_write_box.set_edit_text(msg)
             write_box.msg_write_box.set_edit_pos(len(msg))

--- a/zulipterminal/ui_tools/utils.py
+++ b/zulipterminal/ui_tools/utils.py
@@ -61,7 +61,7 @@ def is_muted(msg: Message, model: Any) -> bool:
         return False
     elif model.is_muted_stream(msg["stream_id"]):
         return True
-    elif model.is_muted_topic(msg["stream_id"], msg["subject"]):
+    elif model.is_muted_topic(msg["stream_id"], msg["topic"]):
         return True
     return False
 


### PR DESCRIPTION
**What does this PR do?**
This commit migrates the ZT to newer API elements. Here, the migration is from message['subject'] to message['topic'].
Partial fix for #965

Discussion:
[#zulip-terminal>Update to modern API elements (support v2.1) #T965](https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/Update.20to.20modern.20API.20elements.20.28support.20v2.2E1.29.20.23T965)

**Tested?**
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [ ] New tests added (for any new behavior)
- [ ] Passed linting & tests (each commit)

**Commit flow**
- First commit updates message element from `subject` to `topic`
- Second commit refactors the tests to accommodate this migration

**Notes & Questions**
- Fixes item 4 on #965 
