### PR TITLE
Remove support for Subscription["in_home_view"]

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -212,7 +212,7 @@ def general_stream() -> Dict[str, Any]:
         "color": "#b0a5fd",  # Color in '#xxxxxx' format
         "pin_to_top": False,
         "stream_id": 1000,
-        "in_home_view": True,
+        "is_muted": False,
         "audible_notifications": False,
         "description": "General Stream",
         "rendered_description": "General Stream",
@@ -241,7 +241,7 @@ def secret_stream() -> Dict[str, Any]:
         "email_address": "secret@example.com",
         "rendered_description": "Some private stream",
         "color": "#ccc",  # Color in '#xxx' format
-        "in_home_view": True,
+        "is_muted": False,
         "audible_notifications": False,
         "is_old_stream": True,
         "desktop_notifications": False,
@@ -266,7 +266,7 @@ def web_public_stream() -> Dict[str, Any]:
         "email_address": "web_public@example.com",
         "rendered_description": "Some web public stream",
         "color": "#ddd",  # Color in '#xxx' format
-        "in_home_view": True,
+        "is_muted": False,
         "audible_notifications": False,
         "is_old_stream": True,
         "desktop_notifications": False,
@@ -295,7 +295,7 @@ def streams_fixture(
                 "color": "#b0a5fd",
                 "pin_to_top": False,
                 "stream_id": i,
-                "in_home_view": True,
+                "is_muted": False,
                 "audible_notifications": False,
                 "description": f"A description of stream {i}",
                 "rendered_description": f"A description of stream {i}",
@@ -645,7 +645,7 @@ def initial_data(
                 "push_notifications": False,
                 "email_address": "",
                 "color": "#bfd56f",
-                "in_home_view": True,
+                "is_muted": False,
                 "history_public_to_subscribers": True,
             }
         ],

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -1386,7 +1386,7 @@ class TestModel:
         subs = [
             dict(
                 entry,
-                in_home_view=entry["stream_id"] not in muted,
+                is_muted=entry["stream_id"] in muted,
                 desktop_notifications=entry["stream_id"] in visual_notification_enabled,
             )
             for entry in initial_data["subscriptions"]

--- a/zulipterminal/api_types.py
+++ b/zulipterminal/api_types.py
@@ -79,8 +79,7 @@ class Subscription(TypedDict):
     pin_to_top: bool
     email_address: str
 
-    is_muted: bool  # NOTE: new in Zulip 2.1 (in_home_view still present)
-    in_home_view: bool  # TODO: Migrate to is_muted (note inversion)
+    is_muted: bool
 
     is_announcement_only: bool  # Deprecated in Zulip 3.0 -> stream_post_policy
     stream_post_policy: int  # NOTE: new in Zulip 3.0 / ZFL 1
@@ -92,6 +91,9 @@ class Subscription(TypedDict):
     history_public_to_subscribers: bool
     first_message_id: Optional[int]
     stream_weekly_traffic: Optional[int]
+
+    # Deprecated fields
+    # in_home_view: bool  # Replaced by is_muted in Zulip 2.1; still present in updates
 
 
 class RealmUser(TypedDict):

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1065,7 +1065,7 @@ class Model:
                 new_pinned_streams.append(streamData)
             else:
                 new_unpinned_streams.append(streamData)
-            if not subscription["in_home_view"]:
+            if subscription["is_muted"]:
                 new_muted_streams.add(subscription["stream_id"])
             if subscription["desktop_notifications"]:
                 new_visual_notified_streams.add(subscription["stream_id"])
@@ -1178,6 +1178,8 @@ class Model:
 
         if event["op"] == "update":
             if hasattr(self.controller, "view"):
+                # NOTE: Currently, the response from the API still contains in_home_view
+                # and not is_muted, hence, the conditional is left unaltered, for now.
                 if event.get("property", None) == "in_home_view":
                     stream_id = event["stream_id"]
 


### PR DESCRIPTION
**What does this PR do?**
Migrates `in_home_view` to `is_muted` for Subscription.
Partially fix towards #965.

[#zulip-terminal>Update to modern API elements (support v2.1) #T965](https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/Update.20to.20modern.20API.20elements.20.28support.20v2.2E1.29.20.23T965)


**Tested?**
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [ ] New tests added (for any new behavior)
- [x] Passed linting & tests (each commit)

**Commit flow**
- First commit contains the UI changes for the migration
- Second commit contains changes made to the test functions