### PR TITLE
Skip muted streams and topics using `n` (from #442)

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -832,56 +832,70 @@ class TestMiddleColumnView:
             "MSG_LIST", header=self.search_box, footer=self.write_box
         )
 
-    @pytest.mark.parametrize('last_unread_topic, next_unread_topic', [
-        ((1, 'stream muted & unmuted topic'), (2, 'unmuted topic 1')),
-        ((2, 'unmuted topic 1'), (2, 'unmuted topic 2')),
-        ((2, 'unmuted topic 2'), (2, 'unmuted topic 3')),
-        ((2, 'unmuted topic 3'), (2, 'unmuted topic 1')),
-    ])
-    def test_get_next_unread_topic(self, mid_col_view, last_unread_topic,
-                                   next_unread_topic, stream_dict,
-                                   model_fixture):
+    @pytest.mark.parametrize(
+        "last_unread_topic, next_unread_topic",
+        [
+            ((1, "stream muted & unmuted topic"), (2, "unmuted topic 1")),
+            ((2, "unmuted topic 1"), (2, "unmuted topic 2")),
+            ((2, "unmuted topic 2"), (2, "unmuted topic 3")),
+            ((2, "unmuted topic 3"), (2, "unmuted topic 1")),
+        ],
+    )
+    def test_get_next_unread_topic(
+        self,
+        mid_col_view,
+        last_unread_topic,
+        next_unread_topic,
+        stream_dict,
+        model_fixture,
+    ):
         mid_col_view.model = model_fixture
         mid_col_view.model.unread_counts = dict()
         unread_topics = OrderedDict()
-        unread_topics[(1, 'stream muted & unmuted topic')] = 1,
-        unread_topics[(1, 'muted stream muted topic')] = 1,
-        unread_topics[(2, 'muted topic')] = 1,
-        unread_topics[(2, 'unmuted topic 1')] = 1,
-        unread_topics[(2, 'unmuted topic 2')] = 1,
-        unread_topics[(2, 'unmuted topic 3')] = 1,
-        mid_col_view.model.unread_counts['unread_topics'] = unread_topics
+        unread_topics[(1, "stream muted & unmuted topic")] = (1,)
+        unread_topics[(1, "muted stream muted topic")] = (1,)
+        unread_topics[(2, "muted topic")] = (1,)
+        unread_topics[(2, "unmuted topic 1")] = (1,)
+        unread_topics[(2, "unmuted topic 2")] = (1,)
+        unread_topics[(2, "unmuted topic 3")] = (1,)
+        mid_col_view.model.unread_counts["unread_topics"] = unread_topics
         mid_col_view.model.stream_dict = stream_dict
         mid_col_view.model.muted_streams = [1]
         mid_col_view.model.muted_topics = [
-            ('Stream 2', 'muted topic'),
-            ('Stream 1', 'muted stream muted topic'),
+            ("Stream 2", "muted topic"),
+            ("Stream 1", "muted stream muted topic"),
         ]
         mid_col_view.last_unread_topic = last_unread_topic
         assert mid_col_view.get_next_unread_topic() == next_unread_topic
 
-    @pytest.mark.parametrize('last_unread_topic, next_unread_topic', [
-        ((1, 'stream muted & unmuted topic'), None),
-        ((2, 'muted topic'), None),
-        (None, None),
-    ])
-    def test_get_next_unread_topic_no_unread(self, mid_col_view,
-                                             stream_dict,
-                                             last_unread_topic,
-                                             next_unread_topic,
-                                             model_fixture):
+    @pytest.mark.parametrize(
+        "last_unread_topic, next_unread_topic",
+        [
+            ((1, "stream muted & unmuted topic"), None),
+            ((2, "muted topic"), None),
+            (None, None),
+        ],
+    )
+    def test_get_next_unread_topic_no_unread(
+        self,
+        mid_col_view,
+        stream_dict,
+        last_unread_topic,
+        next_unread_topic,
+        model_fixture,
+    ):
         mid_col_view.model = model_fixture
         mid_col_view.model.unread_counts = dict()
-        mid_col_view.model.unread_counts['unread_topics'] = {
-            (1, 'stream muted & unmuted topic'): 1,
-            (1, 'muted stream muted topic'): 1,
-            (2, 'muted topic'): 1,
+        mid_col_view.model.unread_counts["unread_topics"] = {
+            (1, "stream muted & unmuted topic"): 1,
+            (1, "muted stream muted topic"): 1,
+            (2, "muted topic"): 1,
         }
         mid_col_view.model.stream_dict = stream_dict
         mid_col_view.model.muted_streams = [1]
         mid_col_view.model.muted_topics = [
-            ('Stream 2', 'muted topic'),
-            ('Stream 1', 'muted stream muted topic'),
+            ("Stream 2", "muted topic"),
+            ("Stream 1", "muted stream muted topic"),
         ]
         assert mid_col_view.get_next_unread_topic() == next_unread_topic
 

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -556,16 +556,18 @@ class MiddleColumnView(urwid.Frame):
     def get_next_unread_topic(self) -> Optional[Tuple[int, str]]:
         topics = list(self.model.unread_counts["unread_topics"].keys())
         next_topic = False
-        for topic in topics:
-            if next_topic is True:
+        if self.last_unread_topic not in topics:
+            next_topic = True
+        # loop over topics list twice
+        # for the case that last_unread_topic was
+        # the last valid unread_topic in topics list.
+        for topic in topics*2:
+            if not self.model.is_muted_topic(stream_id=topic[0],
+                                             topic=topic[1]) and next_topic:
                 self.last_unread_topic = topic
                 return topic
             if topic == self.last_unread_topic:
                 next_topic = True
-        if len(topics) > 0:
-            topic = topics[0]
-            self.last_unread_topic = topic
-            return topic
         return None
 
     def get_next_unread_pm(self) -> Optional[int]:

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -561,9 +561,11 @@ class MiddleColumnView(urwid.Frame):
         # loop over topics list twice
         # for the case that last_unread_topic was
         # the last valid unread_topic in topics list.
-        for topic in topics*2:
-            if not self.model.is_muted_topic(stream_id=topic[0],
-                                             topic=topic[1]) and next_topic:
+        for topic in topics * 2:
+            if (
+                not self.model.is_muted_topic(stream_id=topic[0], topic=topic[1])
+                and next_topic
+            ):
                 self.last_unread_topic = topic
                 return topic
             if topic == self.last_unread_topic:

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -564,6 +564,7 @@ class MiddleColumnView(urwid.Frame):
         for topic in topics * 2:
             if (
                 not self.model.is_muted_topic(stream_id=topic[0], topic=topic[1])
+                and not self.model.is_muted_stream(stream_id=topic[0])
                 and next_topic
             ):
                 self.last_unread_topic = topic

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -554,22 +554,23 @@ class MiddleColumnView(urwid.Frame):
         super().__init__(message_view, header=search_box, footer=write_box)
 
     def get_next_unread_topic(self) -> Optional[Tuple[int, str]]:
-        topics = list(self.model.unread_counts["unread_topics"].keys())
+        unread_topics = list(self.model.unread_counts["unread_topics"].keys())
         next_topic = False
-        if self.last_unread_topic not in topics:
+        if self.last_unread_topic not in unread_topics:
             next_topic = True
         # loop over topics list twice
         # for the case that last_unread_topic was
         # the last valid unread_topic in topics list.
-        for topic in topics * 2:
+        for unread_topic in unread_topics * 2:
+            stream_id, topic = unread_topic
             if (
-                not self.model.is_muted_topic(stream_id=topic[0], topic=topic[1])
-                and not self.model.is_muted_stream(stream_id=topic[0])
+                not self.model.is_muted_topic(stream_id, topic)
+                and not self.model.is_muted_stream(stream_id)
                 and next_topic
             ):
-                self.last_unread_topic = topic
-                return topic
-            if topic == self.last_unread_topic:
+                self.last_unread_topic = unread_topic
+                return unread_topic
+            if unread_topic == self.last_unread_topic:
                 next_topic = True
         return None
 


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->

This is a WIP taking the last commit of #442, rebasing, reformatting and correcting for how that PR treats is_muted_topic as also incorporating if the stream is muted (which the model method we have now doesn't do).

This was brought up again recently in #**zulip-terminal > ZT impressions** by @rht but I'm continuing the discussion in #**zulip-terminal > Skip muted topics and streams on 'n' #T442 #T1239**.

I tested this in explore mode and toggled muted streams and topics. For example, where it starts on #general (id=2) for me, and will skip #backend (id=3) next if muted, and then also skips #test here just fine.

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [ ] Existing tests (adapted, if necessary)
- [ ] New tests added (for any new behavior)
- [ ] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

<!-- See https://github.com/zulip/zulip-terminal#commit-style -->
**Commit flow** <!-- if more than one commit; add/delete/fill-in as appropriate -->

The flow is very WIP; this is just for functional testing and broad feedback. I've reformatted and it should be functional, but I've not adapted the tests from #442 so far.

**Notes & Questions** <!-- if any; add/delete/fill-in as appropriate -->

Would appreciate feedback from anyone who uses the `n` shortcut regularly.

Refactor in last commit improves clarity?

This doesn't fix various other factors regarding this feature, including:
- order of unreads is stream via stream id, and topic alphabetically, neither of which match the left panel list order (which is likely desirable)
- I've not dug into if the unreads get updated cleanly when messages get read or new messages are received