### PR TITLE
Changing the order of message links and topic links in popup(from #1238)

### DIFF
--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -876,7 +876,7 @@ class TestMsgInfoView:
         assert self.msg_info_view.message_links == OrderedDict()
         assert self.msg_info_view.time_mentions == list()
 
-    def test_pop_up_info(self, message_fixture: Message) -> None:
+    def test_pop_up_info_order(self, message_fixture: Message) -> None:
         msg_test = MsgInfoView(
             self.controller,
             message_fixture,

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -876,18 +876,20 @@ class TestMsgInfoView:
         assert self.msg_info_view.message_links == OrderedDict()
         assert self.msg_info_view.time_mentions == list()
 
-    def test_pop_up_info(self, message_fixture):
+    def test_pop_up_info(self, message_fixture: Message) -> None:
         msg_test = MsgInfoView(
             self.controller,
             message_fixture,
             "Message Information",
             OrderedDict([("https://bar.com", ("topic", 1, True))]),
-            OrderedDict([("image.jpg", ("image", 1, True))]),
+            OrderedDict([("image", ("image", 1, True))]),
             list(),
         )
         meg_button = msg_test.button_widgets
-        assert meg_button == [OrderedDict([("https://bar.com", ("topic", 1, True))]),OrderedDict([('image.jpg', ('image', 1, True))])]
-
+        assert meg_button == [
+            OrderedDict([("image", ("image", 1, True))]),
+            OrderedDict([("https://bar.com", ("topic", 1, True))]),
+        ]
 
     def test_keypress_any_key(
         self, widget_size: Callable[[Widget], urwid_Size]

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -876,6 +876,19 @@ class TestMsgInfoView:
         assert self.msg_info_view.message_links == OrderedDict()
         assert self.msg_info_view.time_mentions == list()
 
+    def test_pop_up_info(self, message_fixture):
+        msg_test = MsgInfoView(
+            self.controller,
+            message_fixture,
+            "Message Information",
+            OrderedDict([("https://bar.com", ("topic", 1, True))]),
+            OrderedDict([("image.jpg", ("image", 1, True))]),
+            list(),
+        )
+        meg_button = msg_test.button_widgets
+        assert meg_button == [OrderedDict([("https://bar.com", ("topic", 1, True))]),OrderedDict([('image.jpg', ('image', 1, True))])]
+
+
     def test_keypress_any_key(
         self, widget_size: Callable[[Widget], urwid_Size]
     ) -> None:

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1578,10 +1578,10 @@ class MsgInfoView(PopUpView):
             keys = ", ".join(map(repr, keys_for_command("EDIT_HISTORY")))
             msg_info[0][1].append(("Edit History", f"Press {keys} to view"))
         # Render the category using the existing table methods if links exist.
-        if topic_links:
-            msg_info.append(("Topic Links", []))
         if message_links:
             msg_info.append(("Message Links", []))
+        if topic_links:
+            msg_info.append(("Topic Links", []))
         if time_mentions:
             msg_info.append(("Time mentions", time_mentions))
         if msg["reactions"]:
@@ -1604,20 +1604,6 @@ class MsgInfoView(PopUpView):
         # computing their slice indexes
         self.button_widgets = []  # type: List[Any]
 
-        if topic_links:
-            topic_link_widgets, topic_link_width = self.create_link_buttons(
-                controller, topic_links
-            )
-
-            # slice_index = Number of labels before topic links + 1 newline
-            #               + 1 'Topic Links' category label.
-            slice_index = len(msg_info[0][1]) + 2
-            slice_index += sum([len(w) + 2 for w in self.button_widgets])
-            self.button_widgets.append(topic_links)
-
-            widgets = widgets[:slice_index] + topic_link_widgets + widgets[slice_index:]
-            popup_width = max(popup_width, topic_link_width)
-
         if message_links:
             message_link_widgets, message_link_width = self.create_link_buttons(
                 controller, message_links
@@ -1633,6 +1619,20 @@ class MsgInfoView(PopUpView):
                 widgets[:slice_index] + message_link_widgets + widgets[slice_index:]
             )
             popup_width = max(popup_width, message_link_width)
+
+        if topic_links:
+            topic_link_widgets, topic_link_width = self.create_link_buttons(
+                controller, topic_links
+            )
+
+            # slice_index = Number of labels before topic links + 1 newline
+            #               + 1 'Topic Links' category label.
+            slice_index = len(msg_info[0][1]) + 2
+            slice_index += sum([len(w) + 2 for w in self.button_widgets])
+            self.button_widgets.append(topic_links)
+
+            widgets = widgets[:slice_index] + topic_link_widgets + widgets[slice_index:]
+            popup_width = max(popup_width, topic_link_width)
 
         super().__init__(controller, widgets, "MSG_INFO", popup_width, title)
 

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1602,7 +1602,7 @@ class MsgInfoView(PopUpView):
 
         # To keep track of buttons (e.g., button links) and to facilitate
         # computing their slice indexes
-        button_widgets = []  # type: List[Any]
+        self.button_widgets = []  # type: List[Any]
 
         if topic_links:
             topic_link_widgets, topic_link_width = self.create_link_buttons(
@@ -1612,8 +1612,8 @@ class MsgInfoView(PopUpView):
             # slice_index = Number of labels before topic links + 1 newline
             #               + 1 'Topic Links' category label.
             slice_index = len(msg_info[0][1]) + 2
-            slice_index += sum([len(w) + 2 for w in button_widgets])
-            button_widgets.append(topic_links)
+            slice_index += sum([len(w) + 2 for w in self.button_widgets])
+            self.button_widgets.append(topic_links)
 
             widgets = widgets[:slice_index] + topic_link_widgets + widgets[slice_index:]
             popup_width = max(popup_width, topic_link_width)
@@ -1626,8 +1626,8 @@ class MsgInfoView(PopUpView):
             # slice_index = Number of labels before message links + 1 newline
             #               + 1 'Message Links' category label.
             slice_index = len(msg_info[0][1]) + 2
-            slice_index += sum([len(w) + 2 for w in button_widgets])
-            button_widgets.append(message_links)
+            slice_index += sum([len(w) + 2 for w in self.button_widgets])
+            self.button_widgets.append(message_links)
 
             widgets = (
                 widgets[:slice_index] + message_link_widgets + widgets[slice_index:]


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  
Changed the order of message links and topic links in popup. in order to achieve this, switched if statements in MsgInfoView class in views.py 

<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->

<!-- Add a link to a discussion on chat.zulip.org, if relevant -->

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [ ] New tests added (for any new behavior)
- [ ] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->



**Visual changes** <![image](https://user-images.githubusercontent.com/101992380/176797150-c555c427-57d3-4cda-84c2-c970c60da4b6.png)>

