### PR TITLE
Highlight narrowed stream/topic.

### DIFF
--- a/zulipterminal/config/themes.py
+++ b/zulipterminal/config/themes.py
@@ -71,6 +71,7 @@ REQUIRED_STYLES = {
     'area:error'      : 'standout',
     'area:user'       : 'standout',
     'search_error'    : 'standout',
+    'active_narrow'   : 'standout',
     'task:success'    : 'standout',
     'task:error'      : 'standout',
     'task:warning'    : 'standout',

--- a/zulipterminal/themes/gruvbox_dark.py
+++ b/zulipterminal/themes/gruvbox_dark.py
@@ -70,6 +70,7 @@ STYLES = {
     'area:error'       : (Color.DARK0_HARD,            Color.BRIGHT_RED),
     'area:user'        : (Color.DARK0_HARD,            Color.BRIGHT_YELLOW),
     'search_error'     : (Color.BRIGHT_RED,            Color.DARK0_HARD),
+    'active_narrow'    : (Color.DARK0_HARD,            Color.BRIGHT_GREEN),
     'task:success'     : (Color.DARK0_HARD,            Color.BRIGHT_GREEN),
     'task:error'       : (Color.DARK0_HARD,            Color.BRIGHT_RED),
     'task:warning'     : (Color.DARK0_HARD,            Color.NEUTRAL_PURPLE),

--- a/zulipterminal/themes/gruvbox_light.py
+++ b/zulipterminal/themes/gruvbox_light.py
@@ -69,6 +69,7 @@ STYLES = {
     'area:error'       : (Color.LIGHT0_HARD,            Color.FADED_RED),
     'area:user'        : (Color.LIGHT0_HARD,            Color.FADED_YELLOW),
     'search_error'     : (Color.FADED_RED,              Color.LIGHT0_HARD),
+    'active_narrow'    : (Color.LIGHT0_HARD,            Color.FADED_GREEN),
     'task:success'     : (Color.LIGHT0_HARD,            Color.FADED_GREEN),
     'task:error'       : (Color.LIGHT0_HARD,            Color.FADED_RED),
     'task:warning'     : (Color.LIGHT0_HARD,            Color.NEUTRAL_PURPLE),

--- a/zulipterminal/themes/zt_blue.py
+++ b/zulipterminal/themes/zt_blue.py
@@ -64,6 +64,7 @@ STYLES = {
     'area:error'      : (Color.WHITE,               Color.DARK_RED),
     'area:user'       : (Color.WHITE,               Color.DARK_BLUE),
     'search_error'    : (Color.LIGHT_RED,           Color.LIGHT_BLUE),
+    'active_narrow'   : (Color.WHITE,               Color.DARK_GREEN),
     'task:success'    : (Color.WHITE,               Color.DARK_GREEN),
     'task:error'      : (Color.WHITE,               Color.DARK_RED),
     'task:warning'    : (Color.WHITE,               Color.BROWN),

--- a/zulipterminal/themes/zt_dark.py
+++ b/zulipterminal/themes/zt_dark.py
@@ -64,6 +64,7 @@ STYLES = {
     'area:error'      : (Color.WHITE,               Color.DARK_RED),
     'area:user'       : (Color.WHITE,               Color.DARK_BLUE),
     'search_error'    : (Color.LIGHT_RED,           Color.BLACK),
+    'active_narrow'   : (Color.WHITE,               Color.DARK_GREEN),
     'task:success'    : (Color.WHITE,               Color.DARK_GREEN),
     'task:error'      : (Color.WHITE,               Color.DARK_RED),
     'task:warning'    : (Color.WHITE,               Color.BROWN),

--- a/zulipterminal/themes/zt_light.py
+++ b/zulipterminal/themes/zt_light.py
@@ -64,6 +64,7 @@ STYLES = {
     'area:error'      : (Color.BLACK,               Color.LIGHT_RED),
     'area:user'       : (Color.WHITE,               Color.DARK_BLUE),
     'search_error'    : (Color.LIGHT_RED,           Color.WHITE),
+    'active_narrow'   : (Color.BLACK,               Color.DARK_GREEN),
     'task:success'    : (Color.BLACK,               Color.DARK_GREEN),
     'task:error'      : (Color.WHITE,               Color.DARK_RED),
     'task:warning'    : (Color.BLACK,               Color.YELLOW),

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -26,14 +26,17 @@ class TopButton(urwid.Button):
         text_color: Optional[str] = None,
         count: int = 0,
         count_style: Optional[str] = None,
+        is_active: bool = False,
     ) -> None:
         self.controller = controller
+        self.model = controller.model
         self._caption = caption
         self.show_function = show_function
         self.prefix_character = prefix_character
         self.original_color = text_color
         self.count = count
         self.count_style = count_style
+        self.is_active = is_active
 
         super().__init__("")
 
@@ -80,7 +83,8 @@ class TopButton(urwid.Button):
         self.button_prefix.set_text(prefix)
         self.set_label(self._caption)
         self.button_suffix.set_text(suffix)
-        self._w.set_attr_map({None: text_color})
+        if not self.is_active:
+            self._w.set_attr_map({None: text_color})
 
     def activate(self, key: Any) -> None:
         self.controller.view.show_left_panel(visible=False)
@@ -160,6 +164,7 @@ class StreamButton(TopButton):
         controller: Any,
         view: Any,
         count: int,
+        is_active: bool = False,
     ) -> None:
         # FIXME Is having self.stream_id the best way to do this?
         # (self.stream_id is used elsewhere)
@@ -172,6 +177,7 @@ class StreamButton(TopButton):
         self.model = controller.model
         self.count = count
         self.view = view
+        self.is_active = is_active
 
         for entry in view.palette:
             if entry[0] is None:


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->
Solves #516. Highlights the current narrow. 

<!-- Add a link to a discussion on chat.zulip.org, if relevant -->
Discussed <a href=https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/Highlight.20currently.20narrowed.20stream.2Ftopic.20.23T516.20.23T1242> here </a>.
**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [x] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

<!-- See https://github.com/zulip/zulip-terminal#commit-style -->
**Commit flow** <!-- if more than one commit; add/delete/fill-in as appropriate -->
<!-- For example:
- first commit doing some thing
- maybe multiple commits doing similar things
-->

- first commit sets theme for zt_dark. Will rebase and change for other themes.
- second commit sets functions for highlighting button
- third commit is for model.py highlight whenever narrow_to is called.

**Notes & Questions** <!-- if any; add/delete/fill-in as appropriate -->
<!-- For example:
- this doesn't include feature X (yet?)
- unsure about Y
- should this do Z?
-->

- Crashes when non-stream narrows are triggered (will fix, is fixed in last WIP PR)
- topics are not highlighted yet.
- Is the issue on linux systems fixed (related to second commit).

**Visual changes** <!-- if any; add/delete/fill-in with screenshot/diagram as appropriate -->
<img width="756" alt="image" src="https://user-images.githubusercontent.com/76529011/181395931-d59d2a83-91bc-4a57-b999-17d097ac747b.png">
