### PR TITLE
Skip muted topics and streams on n key

### DIFF
--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -3219,7 +3219,25 @@ class TestModel:
                 (2, "topic2"),
                 id="unread_present_after_previous_topic",
             ),
-            case({}, None, None, id="no_unreads"),
+            case(
+                {(1, "topic"), (2, "topic2")},
+                (2, "topic2"),
+                (1, "topic"),
+                id="unread_present_before_previous_topic",
+            ),
+            case(
+                {(1, "topic")},
+                (1, "topic"),
+                (1, "topic"),
+                id="unread_still_present_in_topic",  # TODO Should this be None?
+            ),
+            case(
+                {},
+                (1, "topic"),
+                None,
+                id="no_unreads_with_previous_topic_state",
+            ),
+            case({}, None, None, id="no_unreads_with_no_previous_topic_state"),
         ],
     )
     def test_get_next_unread_topic(

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -71,7 +71,7 @@ class TestModel:
         assert model.stream_dict == stream_dict
         assert model.recipients == frozenset()
         assert model.index == initial_index
-        assert model.last_unread_topic is None
+        assert model._last_unread_topic is None
         model.get_messages.assert_called_once_with(
             num_before=30, num_after=10, anchor=None
         )
@@ -3247,7 +3247,7 @@ class TestModel:
         model.unread_counts = {
             "unread_topics": {stream_topic: 1 for stream_topic in unread_topics}
         }
-        model.last_unread_topic = last_unread_topic
+        model._last_unread_topic = last_unread_topic
 
         unread_topic = model.get_next_unread_topic()
 

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -801,16 +801,20 @@ class Model:
     def get_next_unread_topic(self) -> Optional[Tuple[int, str]]:
         topics = sorted(self.unread_counts["unread_topics"].keys())
         next_topic = False
-        for topic in topics:
-            if next_topic is True:
+        if self._last_unread_topic not in topics:
+            next_topic = True
+        # loop over topics list twice for the case that last_unread_topic was
+        # the last valid unread_topic in topics list.
+        for topic in topics * 2:
+            if (
+                not self.is_muted_topic(stream_id=topic[0], topic=topic[1])
+                and not self.is_muted_stream(stream_id=topic[0])
+                and next_topic
+            ):
                 self._last_unread_topic = topic
                 return topic
             if topic == self._last_unread_topic:
                 next_topic = True
-        if len(topics) > 0:
-            topic = topics[0]
-            self._last_unread_topic = topic
-            return topic
         return None
 
     def _fetch_initial_data(self) -> None:

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -799,21 +799,22 @@ class Model:
         return topic_to_search in self._muted_topics.keys()
 
     def get_next_unread_topic(self) -> Optional[Tuple[int, str]]:
-        topics = sorted(self.unread_counts["unread_topics"].keys())
+        unread_topics = sorted(self.unread_counts["unread_topics"].keys())
         next_topic = False
-        if self._last_unread_topic not in topics:
+        if self._last_unread_topic not in unread_topics:
             next_topic = True
-        # loop over topics list twice for the case that last_unread_topic was
-        # the last valid unread_topic in topics list.
-        for topic in topics * 2:
+        # loop over unread_topics list twice for the case that last_unread_topic was
+        # the last valid unread_topic in unread_topics list.
+        for unread_topic in unread_topics * 2:
+            stream_id, topic_name = unread_topic
             if (
-                not self.is_muted_topic(stream_id=topic[0], topic=topic[1])
-                and not self.is_muted_stream(stream_id=topic[0])
+                not self.is_muted_topic(stream_id, topic_name)
+                and not self.is_muted_stream(stream_id)
                 and next_topic
             ):
-                self._last_unread_topic = topic
-                return topic
-            if topic == self._last_unread_topic:
+                self._last_unread_topic = unread_topic
+                return unread_topic
+            if unread_topic == self._last_unread_topic:
                 next_topic = True
         return None
 

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -102,6 +102,7 @@ class Model:
         self.stream_id: Optional[int] = None
         self.recipients: FrozenSet[Any] = frozenset()
         self.index = initial_index
+        self.last_unread_topic = None
 
         self.user_id = -1
         self.user_email = ""
@@ -796,6 +797,21 @@ class Model:
         stream_name = self.stream_dict[stream_id]["name"]
         topic_to_search = (stream_name, topic)
         return topic_to_search in self._muted_topics.keys()
+
+    def get_next_unread_topic(self) -> Optional[Tuple[int, str]]:
+        topics = sorted(self.unread_counts["unread_topics"].keys())
+        next_topic = False
+        for topic in topics:
+            if next_topic is True:
+                self.last_unread_topic = topic
+                return topic
+            if topic == self.last_unread_topic:
+                next_topic = True
+        if len(topics) > 0:
+            topic = topics[0]
+            self.last_unread_topic = topic
+            return topic
+        return None
 
     def _fetch_initial_data(self) -> None:
         # Thread Processes to reduce start time.

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -102,7 +102,7 @@ class Model:
         self.stream_id: Optional[int] = None
         self.recipients: FrozenSet[Any] = frozenset()
         self.index = initial_index
-        self.last_unread_topic = None
+        self._last_unread_topic = None
 
         self.user_id = -1
         self.user_email = ""
@@ -803,13 +803,13 @@ class Model:
         next_topic = False
         for topic in topics:
             if next_topic is True:
-                self.last_unread_topic = topic
+                self._last_unread_topic = topic
                 return topic
-            if topic == self.last_unread_topic:
+            if topic == self._last_unread_topic:
                 next_topic = True
         if len(topics) > 0:
             topic = topics[0]
-            self.last_unread_topic = topic
+            self._last_unread_topic = topic
             return topic
         return None
 

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -551,26 +551,10 @@ class MiddleColumnView(urwid.Frame):
         self.model = model
         self.controller = model.controller
         self.view = view
-        self.last_unread_topic = None
         self.last_unread_pm = None
         self.search_box = search_box
         view.message_view = message_view
         super().__init__(message_view, header=search_box, footer=write_box)
-
-    def get_next_unread_topic(self) -> Optional[Tuple[int, str]]:
-        topics = list(self.model.unread_counts["unread_topics"].keys())
-        next_topic = False
-        for topic in topics:
-            if next_topic is True:
-                self.last_unread_topic = topic
-                return topic
-            if topic == self.last_unread_topic:
-                next_topic = True
-        if len(topics) > 0:
-            topic = topics[0]
-            self.last_unread_topic = topic
-            return topic
-        return None
 
     def get_next_unread_pm(self) -> Optional[int]:
         pms = list(self.model.unread_counts["unread_pms"].keys())
@@ -631,7 +615,7 @@ class MiddleColumnView(urwid.Frame):
 
         elif is_command_key("NEXT_UNREAD_TOPIC", key):
             # narrow to next unread topic
-            stream_topic = self.get_next_unread_topic()
+            stream_topic = self.model.get_next_unread_topic()
             if stream_topic is None:
                 return key
             stream_id, topic = stream_topic


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->

This is an adjusted version of the rebuild of #442 in #1239, so if merged will supersede both of those.

The motivation for this was upon considering the test adjustments which were absent in the draft updated PR (#1239), it seemed much more natural to migrate the appropriate function into the model itself. The main logic is therefore the same as #442, but the surrounding code is quite different, including tests.

I'm strongly considering merging this promptly, but I'd welcome a read-through, and testing by anyone who looked at #T1239.

This was discussed in #**zulip-terminal > Skip muted topics and streams on 'n' #T442 #T1239**
(may update topic name given this PR)

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [x] New tests added (for any new behavior)
- [x] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

**Notes & Questions** <!-- if any; add/delete/fill-in as appropriate -->

This explicitly adds what I believe is the current behavior of ordering by stream id and then topic name. As indicated in #1239, there is likely a lot of scope for improvement beyond that, assuming we want to mimic web app use of this feature.