### PR TITLE
Add handling for User update events

### DIFF
--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -237,6 +237,7 @@ class TestModel:
             "update_display_settings",
             "user_settings",
             "realm_emoji",
+            "realm_user",
         ]
         fetch_event_types = [
             "realm",
@@ -3345,6 +3346,48 @@ class TestModel:
         for stream_id in stream_ids:
             new_subscribers = model.stream_dict[stream_id]["subscribers"]
             assert new_subscribers == expected_subscribers
+
+    @pytest.mark.parametrize(
+        "person, changed_details",
+        [
+            (
+                {"full_name": "New Full Name"},
+                "full_name",
+            ),
+            ({"timezone": "New Timezone"}, "timezone"),
+            ({"is_billing_admin": False}, "is_billing_admin"),
+            ({"role": 10}, "role"),
+            (
+                {"avatar_url": "new_avatar_url", "avatar_version": 21},
+                "avatar_url",
+            ),
+            ({"new_email": "new_display@email.com"}, "email"),
+            (
+                {"delivery_email": "new_delivery@email.com"},
+                "delivery_email",
+            ),
+        ],
+        ids=[
+            "full_name",
+            "timezone",
+            "billing_admin_role",
+            "role",
+            "avatar",
+            "display_email",
+            "delivery_email",
+        ],
+    )
+    def test__handle_realm_user_event(
+        self, person, changed_details, model, initial_data
+    ):
+        # For testing purposes, initial_data["realm_users"][1] from the initial_data fixture is used here.
+        person["user_id"] = 11
+        event = {"type": "realm_user", "op": "update", "id": 1000, "person": person}
+        model._handle_realm_user_event(event)
+        assert (
+            initial_data["realm_users"][1][changed_details]
+            == event["person"][changed_details]
+        )
 
     @pytest.mark.parametrize("value", [True, False])
     def test__handle_user_settings_event(self, mocker, model, value):

--- a/zulipterminal/api_types.py
+++ b/zulipterminal/api_types.py
@@ -167,6 +167,37 @@ class ReactionEvent(TypedDict):
     message_id: int
 
 
+class RealmUserEventPerson(TypedDict, total=False):
+    user_id: int
+
+    full_name: str
+
+    avatar_url: str
+    avatar_source: str
+    avatar_url_medium: str
+    avatar_version: int
+
+    # NOTE: This field will be removed in future as it is redundant with the user_id
+    # email: str
+    timezone: str
+
+    role: int
+
+    email: str
+
+    new_email: str
+
+    delivery_email: str
+
+    is_billing_admin: bool
+
+
+class RealmUserEvent(TypedDict):
+    type: Literal["realm_user"]
+    op: Literal["update"]
+    person: RealmUserEventPerson
+
+
 class SubscriptionEvent(TypedDict):
     type: Literal["subscription"]
     op: str
@@ -249,4 +280,5 @@ Event = Union[
     UpdateRealmEmojiEvent,
     UpdateUserSettingsEvent,
     UpdateGlobalNotificationsEvent,
+    RealmUserEvent,
 ]

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -154,6 +154,7 @@ class Model:
                 ("update_display_settings", self._handle_update_display_settings_event),
                 ("user_settings", self._handle_user_settings_event),
                 ("realm_emoji", self._handle_update_emoji_event),
+                ("realm_user", self._handle_realm_user_event),
             ]
         )
 
@@ -1829,6 +1830,21 @@ class Model:
                 msg_w_list = create_msg_box_list(self, [msg_id], last_message=last_msg)
                 view.message_view.log[msg_pos] = msg_w_list[0]
         self.controller.update_screen()
+
+    def _handle_realm_user_event(self, event: Event) -> None:
+        """
+        Handle change to user(s) metadata (Eg: full_name, timezone, etc.)
+        """
+        assert event["type"] == "realm_user"
+        if event["op"] == "update":
+            # realm_users has 'email' attribute and not 'new_email'
+            if "new_email" in event["person"]:
+                event["person"]["email"] = event["person"].pop("new_email")
+            updated_details = event["person"]
+            for realm_user in self.initial_data["realm_users"]:
+                if realm_user["user_id"] == updated_details["user_id"]:
+                    realm_user.update(updated_details)
+                    break
 
     def _register_desired_events(self, *, fetch_data: bool = False) -> str:
         fetch_types = None if not fetch_data else self.initial_data_to_fetch

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1841,6 +1841,12 @@ class Model:
             if "new_email" in event["person"]:
                 event["person"]["email"] = event["person"].pop("new_email")
             updated_details = event["person"]
+            # Role is not present under self.initial_data,
+            # but exists only under self.initial_data["realm_users"]
+            if "role" not in event["person"]:
+                # check if the event contains details of current user or some other user in the org
+                if updated_details["user_id"] == self.user_id:
+                    self.initial_data.update(updated_details)
             for realm_user in self.initial_data["realm_users"]:
                 if realm_user["user_id"] == updated_details["user_id"]:
                     realm_user.update(updated_details)


### PR DESCRIPTION
**What does this PR do?**
The PR is for handling any changes made with respect to the users' meta data ie, meta data of the current user and that of other users.

Fixes #988 



**Tested?**
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [ ] New tests added (for any new behavior)
- [x] Passed linting & tests (each commit)

**Commit flow**
- Only one commit currently: Updates data structures in the codebase as per the events received.

**Notes & Questions**
- Yet to imbibe UI changes for the user events.
