### PR TITLE
Add id to users with same name

### DIFF
--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -4263,6 +4263,21 @@ class TestModel:
         with pytest.raises(RuntimeError, match="Invalid user ID."):
             model.user_name_from_id(user_id)
 
+    @pytest.mark.parametrize(
+        "user_name, user_name_counter, is_duplicate",
+        [
+            case("Alice", {"Greg": 2}, False, id="username_does_not_exist"),
+            case("Alice", {"Alice": 1}, False, id="username_is_not_duplicate"),
+            case("Greg", {"Greg": 2}, True, id="username_is_duplicate"),
+        ],
+    )
+    def test_is_user_name_duplicate(
+        self, model, user_name, user_name_counter, is_duplicate
+    ):
+        model.user_name_counter = user_name_counter
+        return_value = model.is_user_name_duplicate(user_name)
+        assert return_value == is_duplicate
+
     def test_generate_all_emoji_data(
         self,
         mocker,

--- a/tests/ui_tools/test_messages.py
+++ b/tests/ui_tools/test_messages.py
@@ -1079,7 +1079,7 @@ class TestMessageBox:
             ([STATUS_INACTIVE, "alice", " ", "DAYDATETIME"], {"timestamp": 0}),
         ],
         ids=[
-            "show_author_as_authors_different",
+            "show_authors_with_different_name_as_different",
             "merge_messages_as_only_slightly_earlier_message",
             "dont_merge_messages_as_much_earlier_message",
         ],
@@ -1115,12 +1115,67 @@ class TestMessageBox:
         all_to_vary = dict(to_vary_in_last_message, **stars["last"])
         last_msg = dict(message, **all_to_vary)
 
+        # Marking this as false so as to not fail
+        # under the condition of same username which needs user id appended to it
+        # since that is not what we are testing here.
+        self.model.is_user_name_duplicate = mocker.Mock(return_value=False)
+
         msg_box = MessageBox(this_msg, self.model, last_msg)
 
         expected_header[2] = output_date_time
         if current_year > 2018:
             expected_header[2] = "2018 - " + expected_header[2]
         expected_header[3] = "*" if starred_msg == "this" else " "
+
+        view_components = msg_box.main_view()
+
+        assert len(view_components) == 2
+        assert isinstance(view_components[0], Columns)
+        assert [w.text for w in view_components[0].widget_list] == expected_header
+        assert isinstance(view_components[1], Padding)
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            {
+                "id": 4,
+                "sender_id": 4,
+                "type": "stream",
+                "display_recipient": "Verona",
+                "stream_id": 5,
+                "subject": "Test topic",
+                "flags": [],
+                "is_me_message": False,
+                "content": "<p>what are you planning to do this week</p>",
+                "reactions": [],
+                "sender_full_name": "alice",
+                "timestamp": 1532103879,
+            }
+        ],
+    )
+    @pytest.mark.parametrize(
+        "expected_header, to_vary_in_last_message",
+        [
+            (
+                [" ", "alice (4)", " ", " "],
+                {"sender_id": 5},
+            ),
+        ],
+        ids=[
+            "show_authors_with_same_name_different_ids_as_different",
+        ],
+    )
+    def test_main_view_content_header_without_header_for_same_name_different_user_id(
+        self,
+        mocker,
+        message,
+        expected_header,
+        to_vary_in_last_message,
+    ):
+        this_msg = dict(message)
+        last_msg = dict(message, **to_vary_in_last_message)
+
+        msg_box = MessageBox(this_msg, self.model, last_msg)
 
         view_components = msg_box.main_view()
 

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -5,7 +5,7 @@ Defines the `Model`, fetching and storing data retrieved from the Zulip server
 import itertools
 import json
 import time
-from collections import defaultdict
+from collections import Counter, defaultdict
 from concurrent.futures import Future, ThreadPoolExecutor, wait
 from copy import deepcopy
 from datetime import datetime
@@ -174,6 +174,7 @@ class Model:
 
         self.user_dict: Dict[str, MinimalUserData] = {}
         self.user_id_email_dict: Dict[int, str] = {}
+        self.user_name_counter: Dict[str, int] = {}
         self._all_users_by_id: Dict[int, RealmUser] = {}
         self._cross_realm_bots_by_id: Dict[int, RealmUser] = {}
         self.users: List[MinimalUserData] = []
@@ -1171,6 +1172,7 @@ class Model:
         # and a user-id to email mapping
         self.user_dict = dict()
         self.user_id_email_dict = dict()
+        self.user_name_counter = Counter()
         for user in self.initial_data["realm_users"]:
             if self.user_id == user["user_id"]:
                 self._all_users_by_id[self.user_id] = user
@@ -1278,6 +1280,7 @@ class Model:
         # NOTE: Do this after generating user_list to avoid current_user duplication
         self.user_dict[current_user["email"]] = current_user
         self.user_id_email_dict[self.user_id] = current_user["email"]
+        self.user_name_counter = Counter(user["full_name"] for user in user_list)
 
         self.users = user_list
 
@@ -1291,6 +1294,12 @@ class Model:
             raise RuntimeError("Invalid user ID.")
 
         return self.user_dict[user_email]["full_name"]
+
+    def is_user_name_duplicate(self, user_name: str) -> bool:
+        """
+        Returns if the count of the users with the same name is more than 1.
+        """
+        return self.user_name_counter.get(user_name, -1) > 1
 
     def _subscribe_to_streams(self, subscriptions: List[Subscription]) -> None:
         def make_reduced_stream_data(stream: Subscription) -> StreamData:

--- a/zulipterminal/ui_tools/messages.py
+++ b/zulipterminal/ui_tools/messages.py
@@ -650,6 +650,7 @@ class MessageBox(urwid.Pile):
                 "author": (
                     msg["sender_full_name"] if "sender_full_name" in msg else None
                 ),
+                "author_id": (msg["sender_id"] if "sender_id" in msg else None),
                 "time": (
                     self.model.formatted_local_time(
                         msg["timestamp"], show_seconds=False
@@ -668,6 +669,7 @@ class MessageBox(urwid.Pile):
         different = {  # How this message differs from the previous one
             "recipients": recipient_header is not None,
             "author": message["this"]["author"] != message["last"]["author"],
+            "author_id": message["this"]["author_id"] != message["last"]["author_id"],
             "24h": (
                 message["last"]["datetime"] is not None
                 and ((message["this"]["datetime"] - message["last"]["datetime"]).days)
@@ -686,7 +688,9 @@ class MessageBox(urwid.Pile):
             text_keys = ("author", "star", "time", "status")
             text: Dict[str, urwid_MarkupTuple] = {key: (None, " ") for key in text_keys}
 
-            if any(different[key] for key in ("recipients", "author", "24h")):
+            if any(
+                different[key] for key in ("recipients", "author", "author_id", "24h")
+            ):
                 text["author"] = ("msg_sender", message["this"]["author"])
 
                 # TODO: Refactor to use user ids for look up instead of emails.

--- a/zulipterminal/ui_tools/messages.py
+++ b/zulipterminal/ui_tools/messages.py
@@ -686,13 +686,23 @@ class MessageBox(urwid.Pile):
 
         if any_differences:  # Construct content_header, if needed
             text_keys = ("author", "star", "time", "status")
-            text: Dict[str, urwid_MarkupTuple] = {key: (None, " ") for key in text_keys}
+            text: Dict[str, List[urwid_MarkupTuple]] = {
+                key: [(None, " ")] for key in text_keys
+            }
 
             if any(
                 different[key] for key in ("recipients", "author", "author_id", "24h")
             ):
-                text["author"] = ("msg_sender", message["this"]["author"])
-
+                if self.model.is_user_name_duplicate(message["this"]["author"]):
+                    text["author"] = [
+                        ("msg_sender", message["this"]["author"]),
+                        (
+                            "msg_mention",
+                            f" ({message['this']['author_id']})",
+                        ),
+                    ]
+                else:
+                    text["author"] = [("msg_sender", message["this"]["author"])]
                 # TODO: Refactor to use user ids for look up instead of emails.
                 email = self.message.get("sender_email", "")
                 user = self.model.user_dict.get(email, None)
@@ -702,17 +712,17 @@ class MessageBox(urwid.Pile):
 
                 # The default text['status'] value is (None, ' ')
                 if status in STATE_ICON:
-                    text["status"] = (f"user_{status}", STATE_ICON[status])
+                    text["status"] = [(f"user_{status}", STATE_ICON[status])]
 
             if message["this"]["is_starred"]:
-                text["star"] = ("starred", "*")
+                text["star"] = [("starred", "*")]
             if any(different[key] for key in ("recipients", "author", "timestamp")):
                 this_year = date.today().year
                 msg_year = message["this"]["datetime"].year
                 if this_year != msg_year:
-                    text["time"] = ("time", f"{msg_year} - {message['this']['time']}")
+                    text["time"] = [("time", f"{msg_year} - {message['this']['time']}")]
                 else:
-                    text["time"] = ("time", message["this"]["time"])
+                    text["time"] = [("time", message["this"]["time"])]
 
             content_header = urwid.Columns(
                 [


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->
On the Zulip terminal, users with same name weren't discernable because they were considered the same users. This PR compares users based on their user id and then displays the user id beside their user name if they have the same user name.
<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->
Fixes #1151 
<!-- Add a link to a discussion on chat.zulip.org, if relevant -->

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [x] New tests added (for any new behavior)
- [x] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

<!-- See https://github.com/zulip/zulip-terminal#commit-style -->
**Commit flow** <!-- if more than one commit; add/delete/fill-in as appropriate -->
**first commit** -> comparing users based on user_id instead of name so that a separate header can be displayed


**second commit** -> displaying user_id beside all the users who have same name as more than one user in the list of all users. Adding a new style class so that the appended user_id doesn't look like a part of the username


**third commit** -> changing label from `names` to `msg_sender` in all colour themes
<!-- For example:
- first commit doing some thing
- maybe multiple commits doing similar things
-->

**Notes & Questions** <!-- if any; add/delete/fill-in as appropriate -->
This makes users with same name have different headers by appending the id to the author name and shows it as a visually separate addition.
<!-- For example:
- this doesn't include feature X (yet?)
- unsure about Y
- should this do Z?
-->

**Interactions** <!-- if any; add/delete/fill-in as appropriate -->
- Waiting on PR review 
<!-- eg.
- Waiting on PR review 
- Blocks #<PR>
-->

**Visual changes** <!-- if any; add/delete/fill-in with screenshot/diagram as appropriate -->
Before:
<img width="1055" alt="Screenshot 2022-09-13 at 7 44 25 PM" src="https://user-images.githubusercontent.com/71403193/190386027-0ca765df-39e2-4e72-8552-3893fdb0c747.png">

After:
<img width="426" alt="Screenshot 2022-10-21 at 11 48 24 AM" src="https://user-images.githubusercontent.com/71403193/197126388-5d3bdf0c-1ab8-4a48-ba12-89c488cd2725.png">


