### PR TITLE
Add support for keywords in searchbar

### DIFF
--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -472,15 +472,18 @@ class TestController:
         [
             ([], [["search", "FOO"]]),
             ([["search", "BOO"]], [["search", "FOO"]]),
-            ([["stream", "PTEST"]], [["stream", "PTEST"], ["search", "FOO"]]),
+            ([["stream", "Stream 1"]], [["stream", "Stream 1"], ["search", "FOO"]]),
             (
-                [["pm_with", "foo@zulip.com"], ["search", "BOO"]],
-                [["pm_with", "foo@zulip.com"], ["search", "FOO"]],
+                [["pm_with", "person1@example.com"], ["search", "BOO"]],
+                [["pm_with", "person1@example.com"], ["search", "FOO"]],
             ),
             (
-                [["stream", "PTEST"], ["topic", "RDS"]],
-                [["stream", "PTEST"], ["topic", "RDS"], ["search", "FOO"]],
+                [["stream", "Stream 1"], ["topic", "RDS"]],
+                [["stream", "Stream 1"], ["topic", "RDS"], ["search", "FOO"]],
             ),
+            ([["is", "starred"]], [["is", "starred"], ["search", "FOO"]]),
+            ([["is", "mentioned"]], [["is", "mentioned"], ["search", "FOO"]]),
+            ([["is", "private"]], [["is", "private"], ["search", "FOO"]]),
         ],
         ids=[
             "Default_all_msg_search",
@@ -488,6 +491,9 @@ class TestController:
             "search_within_stream",
             "pm_search_again",
             "search_within_topic_narrow",
+            "search_in_is_starred_narrow",
+            "search_in_is_mentioned_narrow",
+            "search_in_is_private_narrow",
         ],
     )
     @pytest.mark.parametrize("msg_ids", [({200, 300, 400}), (set()), ({100})])
@@ -498,12 +504,17 @@ class TestController:
         controller: Controller,
         mocker: MockerFixture,
         msg_ids: Set[int],
+        user_dict: Dict[str, Dict[str, Any]],
+        stream_dict: Dict[int, Dict[str, Any]],
         index_search_messages: Index,
     ) -> None:
         get_message = mocker.patch(MODEL + ".get_messages")
         create_msg = mocker.patch(MODULE + ".create_msg_box_list")
         mocker.patch(MODEL + ".get_message_ids_in_current_narrow", return_value=msg_ids)
         controller.model.index = index_search_messages  # Any initial search index
+        controller.model.user_id = 10
+        controller.model.user_dict = user_dict
+        controller.model.stream_dict = stream_dict
         controller.view.message_view = mocker.patch("urwid.ListBox")
         controller.model.narrow = initial_narrow
 

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -390,6 +390,48 @@ class TestModel:
         assert model.is_search_narrow() == is_search_narrow
 
     @pytest.mark.parametrize(
+        "search_text, expected_search_text, expected_search_narrow",
+        [
+            case("FOO", "FOO", [], id="all_messages"),
+            case(
+                "FOO stream:Stream+1",
+                "FOO",
+                [["stream", "Stream 1"]],
+                id="stream_without_spaces",
+            ),
+            case(
+                "FOO stream:Stream+1 topic:some+topic1%2Bsome+topic2",
+                "FOO",
+                [["stream", "Stream 1"], ["topic", "some topic1+some topic2"]],
+                id="stream_and_topic_without_spaces",
+            ),
+            case("FOO is:private", "FOO", [["is", "private"]], id="is_private"),
+            case("FOO is:mentioned", "FOO", [["is", "mentioned"]], id="is_mentioned"),
+            case("FOO is:starred", "FOO", [["is", "starred"]], id="is_starred"),
+            case(
+                "FOO pm_with:person1@example.com,person2@example.com",
+                "FOO",
+                [["pm_with", "person1@example.com, person2@example.com"]],
+            ),
+        ],
+    )
+    def test_extract_keywords_and_set_narrow(
+        self,
+        search_text: str,
+        model,
+        stream_dict,
+        user_dict,
+        expected_search_text: str,
+        expected_search_narrow: List[List[str]],
+    ) -> None:
+        model.stream_dict = stream_dict
+        model.narrow = []
+        model.user_dict = user_dict
+        result_query = model.extract_keywords_and_set_narrow(search_text)
+        assert model.narrow == expected_search_narrow
+        assert result_query == expected_search_text
+
+    @pytest.mark.parametrize(
         "bad_args",
         [
             dict(topic="some topic"),

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -370,6 +370,48 @@ class TestModel:
         assert model.index["pointer"][str(narrow)] == msg_id
 
     @pytest.mark.parametrize(
+        "narrow, expected_additional_text",
+        (
+            case([], "", id="all_messages"),
+            case([["stream", "PTEST"]], "stream:PTEST", id="stream_without_spaces"),
+            case(
+                [["stream", "PTEST1 PTEST2+PTEST3"]],
+                "stream:PTEST1+PTEST2%2BPTEST3",
+                id="stream_with_spaces_and_plus_symbol",
+            ),
+            case(
+                [["stream", "PTEST"], ["topic", "Test"]],
+                "stream:PTEST topic:Test",
+                id="stream_and_topic_no_spaces",
+            ),
+            case(
+                [["stream", "PTEST1 PTEST2+PTEST3"], ["topic", "Test1 Test2+Test3"]],
+                "stream:PTEST1+PTEST2%2BPTEST3 topic:Test1+Test2%2BTest3",
+                id="stream_and_topic_with_space_and_plus",
+            ),
+            case([["is", "private"]], "is:private", id="is_private"),
+            case([["is", "mentioned"]], "is:mentioned", id="is_mentioned"),
+            case([["is", "starred"]], "is:starred", id="is_starred"),
+            case(
+                [["pm_with", "some1@email.com, some2@email.com"]],
+                "pm_with:some1@email.com,some2@email.com",
+                id="group_pms",
+            ),
+        ),
+    )
+    def test_additional_search_text_for_current_narrow(
+        self,
+        model,
+        narrow: List[List[str]],
+        expected_additional_text: str,
+    ) -> None:
+        model.narrow = narrow
+        assert (
+            model.additional_search_text_for_current_narrow()
+            == expected_additional_text
+        )
+
+    @pytest.mark.parametrize(
         "narrow, is_search_narrow",
         [
             ([], False),

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -495,8 +495,11 @@ class Controller:
     def search_messages(self, text: str) -> None:
         # Search for a text in messages
         self.model.index["search"].clear()
-        self.model.set_search_narrow(text)
-
+        additional_text = self.model.additional_search_text_for_current_narrow()
+        if additional_text:
+            text = additional_text + " " + text
+        text_without_keyword = self.model.extract_keywords_and_set_narrow(text)
+        self.model.set_search_narrow(text_without_keyword)
         self.model.get_messages(num_after=0, num_before=30, anchor=10000000000)
         msg_id_list = self.model.get_message_ids_in_current_narrow()
 

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -285,6 +285,38 @@ class Model:
         """
         return "search" in [subnarrow[0] for subnarrow in self.narrow]
 
+    def extract_keywords_and_set_narrow(self, query: str) -> str:
+        """
+        This function checks for prefixes in the search string
+        and returns the query without the prefixes.
+        """
+        stream_prefix_present_flag = False
+        search_text_without_keywords = ""
+        stream = ""
+        for word in query.split(" "):
+            if word.startswith("stream:"):
+                stream_prefix_present_flag = True
+                stream = word.split(":")[1].replace("+", " ").replace("%2B", "+")
+                self.set_narrow(stream=stream)
+            elif word.startswith("topic:") and stream_prefix_present_flag:
+                topic = word.split(":")[1].replace("+", " ").replace("%2B", "+")
+                self.set_narrow(stream=stream, topic=topic)
+            elif word == "is:starred":
+                self.set_narrow(starred=True)
+            elif word == "is:mentioned":
+                self.set_narrow(mentioned=True)
+            elif word == "is:private":
+                self.set_narrow(pms=True)
+            elif word.startswith("pm_with:"):
+                recipient_id = word.split(":")[1].replace(",", ", ")
+                new_narrow = [["pm_with", recipient_id]]
+                self.set_narrow(pm_with=recipient_id)
+            elif not search_text_without_keywords:
+                search_text_without_keywords = word
+            else:
+                search_text_without_keywords += " " + word
+        return search_text_without_keywords
+
     def set_narrow(
         self,
         *,

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -278,6 +278,31 @@ class Model:
     def set_focus_in_current_narrow(self, focus_message: int) -> None:
         self.index["pointer"][repr(self.narrow)] = focus_message
 
+    def additional_search_text_for_current_narrow(self) -> str:
+        """
+        This function converts the current narrow to corresponding search text using keywords
+        """
+        # In cases where '+' is already present in stream and/or topic name, it is converted to '%2B'
+        # then the spaces in stream and topic names are converted to '+'
+        text = ""
+        if len(self.narrow) > 0:
+            if self.narrow[0][0] == "stream":
+                text += (
+                    f"stream:{self.narrow[0][1].replace('+', '%2B').replace(' ', '+')}"
+                )
+                if len(self.narrow) > 1 and self.narrow[1][0] == "topic":
+                    text += f" topic:{self.narrow[1][1].replace('+', '%2B').replace(' ', '+')}"
+            elif self.narrow[0][1] == "private":
+                text = "is:private"
+            elif self.narrow[0][0] == "pm_with":
+                pm_group_emails = self.narrow[0][1].replace(" ", "")
+                text = f"pm_with:{pm_group_emails}"
+            elif self.narrow[0][1] == "starred":
+                text = "is:starred"
+            elif self.narrow[0][1] == "mentioned":
+                text = "is:mentioned"
+        return text
+
     def is_search_narrow(self) -> bool:
         """
         Checks if the current narrow is a result of a previous search for


### PR DESCRIPTION
**What does this PR do?**
This PR is to add support for keywords in search bar.

Fixes #638 

Channel discussion:
[Expand search support #T638 #T1258](https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/Expand.20search.20support.20.23T638.20.23T1258)

**Tested?**
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [x] New tests added (for any new behavior)
- [x] Passed linting & tests (each commit)

**Commit flow**
- One commit: Support only for stream and topic keywords

**Notes & Questions**
- This is a WIP PR. It currently only has support for stream and topic name keywords.
- As per the discussions, the plan ahead would be to:
  - Extend support to other keywords for narrows supported by ZT
  - Provide auto-populated text for the current narrow in the search bar
  - Write tests

