### PR TITLE
Add support for is_muted event

### DIFF
--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -3031,8 +3031,31 @@ class TestModel:
                 },
                 {15, 19, 30},
             ),
+            (
+                {
+                    "property": "is_muted",
+                    "op": "update",
+                    "stream_id": 19,
+                    "value": False,
+                },
+                {15},
+            ),
+            (
+                {
+                    "property": "is_muted",
+                    "op": "update",
+                    "stream_id": 30,
+                    "value": True,
+                },
+                {15, 19, 30},
+            ),
         ],
-        ids=["remove_19", "add_30"],
+        ids=[
+            "remove_19_in_home_view:ZFLNone",
+            "add_30_in_home_view:ZFLNone",
+            "remove_19_is_muted:ZFL139",
+            "add_30_is_muted:ZFL139",
+        ],
     )
     def test__handle_subscription_event_mute_streams(
         self, model, mocker, stream_button, event, final_muted_streams
@@ -3054,7 +3077,10 @@ class TestModel:
         model._handle_subscription_event(event)
 
         assert model.muted_streams == final_muted_streams
-        if event["value"]:
+        # This condition is to check if the stream is unmuted or not
+        if (event["value"] and event["property"] == "in_home_view") or (
+            not event["value"] and event["property"] == "is_muted"
+        ):
             mark_unmuted.assert_called_once_with(99)
             assert model.unread_counts["all_msg"] == 399
         else:


### PR DESCRIPTION
This commit contains changes made to _handle_subscription_event() for handling is_muted events added under ZFL 139. Fixes #1251.

**What does this PR do?**
This PR adds support for `is_muted` events as a consequence of ZFL 139.

Fixes #1251 

[Update to modern API elements #T965 #T1236 #T1237](https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/Update.20to.20modern.20API.20elements.20.23T965.20.23T1236.20.23T1237)

**Tested?**
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [x] New tests added (for any new behavior)
- [x] Passed linting & tests (each commit)


**Commit flow**
- This commit adds support for `is_muted` event

**Notes & Questions**
- Currently, `in_home_view` and `is_muted` are being supported by the server. However, as per ZFL 139, `in_home_view` shall be deprecated in the future.
