### PR TITLE
refactor: views: Moved message links above topic links.

### DIFF
--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -884,6 +884,32 @@ class TestMsgInfoView:
         self.msg_info_view.keypress(size, key)
         assert not self.controller.exit_popup.called
 
+    @pytest.mark.parametrize(
+        "topic_links, message_links",
+        [
+            (
+                OrderedDict([("image", ("image", 1, True))]),
+                OrderedDict([("https://bar.com", ("topic", 1, True))]),
+            ),
+        ],
+    )
+    def test_pop_up_info_order(
+        self,
+        message_fixture: Message,
+        topic_links: "OrderedDict[str, Tuple[str, int, bool]]",
+        message_links: "OrderedDict[str, Tuple[str, int, bool]]",
+    ) -> None:
+        msg_info_view = MsgInfoView(
+            self.controller,
+            message_fixture,
+            title="Message Information",
+            topic_links=topic_links,
+            message_links=message_links,
+            time_mentions=list(),
+        )
+        msg_links = msg_info_view.button_widgets
+        assert msg_links == [message_links, topic_links]
+
     @pytest.mark.parametrize("key", keys_for_command("EDIT_HISTORY"))
     @pytest.mark.parametrize("realm_allow_edit_history", [True, False])
     @pytest.mark.parametrize(

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1566,10 +1566,10 @@ class MsgInfoView(PopUpView):
             keys = ", ".join(map(repr, keys_for_command("EDIT_HISTORY")))
             msg_info[0][1].append(("Edit History", f"Press {keys} to view"))
         # Render the category using the existing table methods if links exist.
-        if topic_links:
-            msg_info.append(("Topic Links", []))
         if message_links:
             msg_info.append(("Message Links", []))
+        if topic_links:
+            msg_info.append(("Topic Links", []))
         if time_mentions:
             msg_info.append(("Time mentions", time_mentions))
         if msg["reactions"]:
@@ -1590,21 +1590,7 @@ class MsgInfoView(PopUpView):
 
         # To keep track of buttons (e.g., button links) and to facilitate
         # computing their slice indexes
-        button_widgets = []  # type: List[Any]
-
-        if topic_links:
-            topic_link_widgets, topic_link_width = self.create_link_buttons(
-                controller, topic_links
-            )
-
-            # slice_index = Number of labels before topic links + 1 newline
-            #               + 1 'Topic Links' category label.
-            slice_index = len(msg_info[0][1]) + 2
-            slice_index += sum([len(w) + 2 for w in button_widgets])
-            button_widgets.append(topic_links)
-
-            widgets = widgets[:slice_index] + topic_link_widgets + widgets[slice_index:]
-            popup_width = max(popup_width, topic_link_width)
+        self.button_widgets = []  # type: List[Any]
 
         if message_links:
             message_link_widgets, message_link_width = self.create_link_buttons(
@@ -1614,13 +1600,27 @@ class MsgInfoView(PopUpView):
             # slice_index = Number of labels before message links + 1 newline
             #               + 1 'Message Links' category label.
             slice_index = len(msg_info[0][1]) + 2
-            slice_index += sum([len(w) + 2 for w in button_widgets])
-            button_widgets.append(message_links)
+            slice_index += sum([len(w) + 2 for w in self.button_widgets])
+            self.button_widgets.append(message_links)
 
             widgets = (
                 widgets[:slice_index] + message_link_widgets + widgets[slice_index:]
             )
             popup_width = max(popup_width, message_link_width)
+
+        if topic_links:
+            topic_link_widgets, topic_link_width = self.create_link_buttons(
+                controller, topic_links
+            )
+
+            # slice_index = Number of labels before topic links + 1 newline
+            #               + 1 'Topic Links' category label.
+            slice_index = len(msg_info[0][1]) + 2
+            slice_index += sum([len(w) + 2 for w in self.button_widgets])
+            self.button_widgets.append(topic_links)
+
+            widgets = widgets[:slice_index] + topic_link_widgets + widgets[slice_index:]
+            popup_width = max(popup_width, topic_link_width)
 
         super().__init__(controller, widgets, "MSG_INFO", popup_width, title)
 


### PR DESCRIPTION
Fixes #1238

<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->
refactored code such as topic_links are now below message_links so that when displayed in the information popup, message link is shown above topic link. 

<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->

<!-- Add a link to a discussion on chat.zulip.org, if relevant -->

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [ ] Existing tests (adapted, if necessary)
- [x] New tests added (for any new behavior)
- [x] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

<!-- See https://github.com/zulip/zulip-terminal#commit-style -->
**Commit flow** <!-- if more than one commit; add/delete/fill-in as appropriate -->
Single commit- Moved message links above topic links in message information popup

<!-- For example:
- first commit doing some thing
- maybe multiple commits doing similar things
-->

**Notes & Questions** <!-- if any; add/delete/fill-in as appropriate -->
<!-- For example:
- this doesn't include feature X (yet?)
- unsure about Y
- should this do Z?
-->

**Interactions** <!-- if any; add/delete/fill-in as appropriate -->
<!-- eg.
- Waiting on #<PR>
- Blocks #<PR>
-->

**Visual changes** <!-- if any; add/delete/fill-in with screenshot/diagram as appropriate -->
Before:
<img width="758" alt="Screenshot 2022-10-12 at 6 21 17 PM" src="https://user-images.githubusercontent.com/71403193/195347228-c2f5e025-8844-478a-a96c-6942c879f99e.png">

After: 
<img width="755" alt="Screenshot 2022-10-12 at 6 07 19 PM" src="https://user-images.githubusercontent.com/71403193/195346611-8afea38d-1ade-47d5-b7d7-9e8ebc7f4dc5.png">
