### PR TITLE
[WIP] Add feature to toggle subscription

### DIFF
--- a/zulipterminal/api_types.py
+++ b/zulipterminal/api_types.py
@@ -214,6 +214,8 @@ class SubscriptionEvent(TypedDict):
     value: bool
     message_ids: List[int]  # Present when subject of msg(s) is updated
 
+    subscriptions: List[Dict[str, int]]
+
 
 class TypingEvent(TypedDict):
     type: Literal["typing"]

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -289,6 +289,11 @@ KEY_BINDINGS: 'OrderedDict[str, KeyBinding]' = OrderedDict([
         'excluded_from_random_tips': True,
         'key_category': 'stream_list',
     }),
+    ('STREAM_SUBSCRIBE', {
+        'keys': ['u'],
+        'help_text': 'Subscribe/unsubscribe popup',
+        'key_category': 'stream_list',
+    }),
     ('COPY_STREAM_EMAIL', {
         'keys': ['c'],
         'help_text':

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -40,6 +40,7 @@ from zulipterminal.ui_tools.views import (
     PopUpConfirmationView,
     StreamInfoView,
     StreamMembersView,
+    SubscriptionOption,
     UserInfoView,
 )
 from zulipterminal.version import ZT_VERSION
@@ -303,6 +304,10 @@ class Controller:
     def show_stream_info(self, stream_id: int) -> None:
         show_stream_view = StreamInfoView(self, stream_id)
         self.show_pop_up(show_stream_view, "area:stream")
+
+    def show_subscription_popup(self, stream_id: int) -> None:
+        show_subscribe_popup = SubscriptionOption(self, stream_id)
+        self.show_pop_up(show_subscribe_popup, "area:stream")
 
     def show_stream_members(self, stream_id: int) -> None:
         stream_members_view = StreamMembersView(self, stream_id)

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -180,6 +180,12 @@ class Model:
 
         self._subscribe_to_streams(self.initial_data["subscriptions"])
 
+        self.unsubscribed_stream_dict: Dict[int, Any] = {}
+
+        self.unsubscribed_streams: Set[int] = set()
+        self.subscribed_streams: Set[int] = set()
+        self._unsubscribed_recently(self.initial_data["unsubscribed"])
+
         # NOTE: The date_created field of stream has been added in feature
         # level 30, server version 4. For consistency we add this field
         # on server iterations even before this with value of None.
@@ -1191,6 +1197,25 @@ class Model:
             new_visual_notified_streams
         )
 
+    def _unsubscribed_recently(self, unsubscribed_list: List[Subscription]) -> None:
+
+        new_unsubscribed_stream = set()
+
+        for unsubscribed_stream in unsubscribed_list:
+            unsubscribed_stream["color"] = canonicalize_color(
+                unsubscribed_stream["color"]
+            )
+
+            self.unsubscribed_stream_dict[
+                unsubscribed_stream["stream_id"]
+            ] = unsubscribed_stream
+            new_unsubscribed_stream.add(unsubscribed_stream["stream_id"])
+
+        if new_unsubscribed_stream:
+            self.unsubscribed_streams = self.unsubscribed_streams.union(
+                new_unsubscribed_stream
+            )
+
     def _group_info_from_realm_user_groups(
         self, groups: List[Dict[str, Any]]
     ) -> List[str]:
@@ -1221,6 +1246,22 @@ class Model:
         ]
         response = self.client.update_subscription_settings(request)
         display_error_if_present(response, self.controller)
+
+    def toggle_stream_subscription(self, stream_id: int) -> None:
+        if not self.is_user_subscribed_to_stream(stream_id):
+            stream_to_be_subscribed = {
+                "name": self.unsubscribed_stream_dict[stream_id]["name"]
+            }
+            list_of_streams = []
+            list_of_streams.append(stream_to_be_subscribed)
+            subscribe_response = self.client.add_subscriptions(streams=list_of_streams)
+            display_error_if_present(subscribe_response, self.controller)
+        else:
+            stream_to_be_unsubscribed = [self.stream_dict[stream_id]["name"]]
+            unsubscribe_response = self.client.remove_subscriptions(
+                stream_to_be_unsubscribed
+            )
+            display_error_if_present(unsubscribe_response, self.controller)
 
     def stream_id_from_name(self, stream_name: str) -> int:
         for stream_id, stream in self.stream_dict.items():
@@ -1362,6 +1403,18 @@ class Model:
                     else:
                         for user_id in user_ids:
                             subscribers.remove(user_id)
+
+        elif event["op"] == "remove":
+            if hasattr(self.controller, "view"):
+                stream_id = event["subscriptions"][0]["stream_id"]
+                self.unsubscribed_stream_dict[stream_id] = self.stream_dict[stream_id]
+                self.stream_dict.pop(stream_id)
+        elif event["op"] == "add":
+            if hasattr(self.controller, "view"):
+                stream_id = event["subscriptions"][0]["stream_id"]
+                unread_count = self.unread_counts["streams"][stream_id]
+                self.stream_dict[stream_id] = self.unsubscribed_stream_dict[stream_id]
+                self.unsubscribed_stream_dict.pop(stream_id)
 
     def _handle_typing_event(self, event: Event) -> None:
         """

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -244,8 +244,11 @@ class StreamButton(TopButton):
             )
         elif is_command_key("STREAM_INFO", key):
             self.model.controller.show_stream_info(self.stream_id)
-        return super().keypress(size, key)
 
+        elif is_command_key("STREAM_SUBSCRIBE", key):
+            self.model.controller.show_subscription_popup(self.stream_id)
+
+        return super().keypress(size, key)
 
 class UserButton(TopButton):
     def __init__(

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1480,6 +1480,29 @@ class StreamInfoView(PopUpView):
         return super().keypress(size, key)
 
 
+class SubscriptionOption(PopUpView):
+    def __init__(self, controller: Any, stream_id: int) -> None:
+        self.stream_id = stream_id
+        self.controller = controller
+
+        title = "Stream Subscription Toggle"
+
+        subscription_checkbox = urwid.CheckBox(
+            label="Subscription Status",
+            state=self.controller.model.is_user_subscribed_to_stream(stream_id),
+            checked_symbol=CHECK_MARK,
+        )
+        widgets = []
+        widgets.append(subscription_checkbox)
+        urwid.connect_signal(
+            subscription_checkbox, "change", self.toggle_subscribe_status
+        )
+        super().__init__(self.controller, widgets, "STREAM_SUBSCRIBE", 36, title)
+
+    def toggle_subscribe_status(self, button: Any, new_state: bool) -> None:
+        self.controller.model.toggle_stream_subscription(self.stream_id)
+
+
 class StreamMembersView(PopUpView):
     def __init__(self, controller: Any, stream_id: int) -> None:
         self.stream_id = stream_id


### PR DESCRIPTION
**What does this PR do?**
This PR is to add subscribe-unsubcribe toggle for all streams present in the stream. 
Currently, the commit in the PR only works for a single stream.
Partial fix for #570 


Discussion topic:
[zulip-terminal>Add provision to subscribe to streams](https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/Add.20provision.20to.20subscribe.20to.20streams)

Shifted from #1240 to here.

**Tested?**
- [ ] Manually
- [ ] Existing tests (adapted, if necessary)
- [ ] New tests added (for any new behaviour)
- [ ] Passed linting & tests (each commit)

**Commit flow**
- Popup for subscribe/unsubscribe toggle

**Notes & Questions**
- Works only for one stream and it has to be in the same session. Needs to be extended to all streams
- Does not update the stream view, nor the messages in the MiddleColumn


**Visual changes**
- To be added