### PR TITLE
Change MOUSE_SELECTION_KEY  to Fn + cmd

### DIFF
--- a/zulipterminal/platform_code.py
+++ b/zulipterminal/platform_code.py
@@ -25,7 +25,7 @@ else:
 
 
 # PLATFORM DEPENDENT HELPERS
-MOUSE_SELECTION_KEY = "Fn + Alt" if PLATFORM == "MacOS" else "Shift"
+MOUSE_SELECTION_KEY = "Fn + cmd" if PLATFORM == "MacOS" else "Shift"
 
 
 def notify(title: str, text: str) -> str:


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->

_MOUSE_SELECTION_KEY_ is changed to _**Fn + cmd**_ in MacOS platform

<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->

<!-- Add a link to a discussion on chat.zulip.org, if relevant -->

**Testing** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

Commit changes
```diff
- MOUSE_SELECTION_KEY = "Fn + Alt" if PLATFORM == "MacOS" else "Shift"
+ MOUSE_SELECTION_KEY = "Fn + cmd" if PLATFORM == "MacOS" else "Shift"
```

**Visual changes** <!-- if any; add/delete/fill-in with screenshot/diagram as appropriate -->

Before
<img width="429" alt="Screenshot 2022-10-19 at 1 28 09 PM" src="https://user-images.githubusercontent.com/69671407/196632809-b74b8f56-3d76-4d1c-a61e-8b716ec3c13a.png">

After
<img width="430" alt="Screenshot 2022-10-19 at 1 29 29 PM" src="https://user-images.githubusercontent.com/69671407/196632859-c7e58c21-ae59-4aa0-b3ea-9c0a454a9cf9.png">
> Changed to Fn+cmd is used to avoid confusion due to Mac keyboard layout
