### PR TITLE
model: checking 'code' field instead of 'msg' field

### DIFF
--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1903,7 +1903,7 @@ class Model:
             )
 
             if "error" in response["result"]:
-                if response["msg"].startswith("Bad event queue id:"):
+                if response.get("code") == "BAD_EVENT_QUEUE_ID":
                     # Our event queue went away, probably because
                     # we were asleep or the server restarted
                     # abnormally.  We may have missed some


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->
Currently, zulip-terminal is checking for the string "Bad event queue id:" to check whether an error is due to a bad event queue ID. This is not the correct algorithm; as documented on https://zulip.com/api/register-queue, it should be checking the code on the response object, not the msg field.

Fixes #1272
<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->

<!-- Add a link to a discussion on chat.zulip.org, if relevant -->
https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/events.20error.20handling

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [ ] Manually
- [x] Existing tests (adapted, if necessary)
- [ ] New tests added (for any new behavior)
- [x] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

<!-- See https://github.com/zulip/zulip-terminal#commit-style -->
**Commit flow** <!-- if more than one commit; add/delete/fill-in as appropriate -->
- First commit, changed `msg` field to `code` field in response object and changed matching text accordingly
<!-- For example:
- first commit doing some thing
- maybe multiple commits doing similar things
-->

**Notes & Questions** <!-- if any; add/delete/fill-in as appropriate -->
<!-- For example:
- this doesn't include feature X (yet?)
- unsure about Y
- should this do Z?
-->
- Not sure how I'd test the working of this manually. 
**Interactions** <!-- if any; add/delete/fill-in as appropriate -->
<!-- eg.
- Waiting on #<PR>
- Blocks #<PR>
-->

**Visual changes** <!-- if any; add/delete/fill-in with screenshot/diagram as appropriate -->
