### PR TITLE
ci: Provide initial Python 3.11 testing support.

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -9,7 +9,7 @@ on:
 
 # Cancel previous runs within same workflow and if within a PR (all branch runs complete)
 # (head_ref [branch name] is unique to and only for PRs, otherwise use always-unique run_id)
-concurrency: 
+concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
@@ -128,6 +128,7 @@ jobs:
           - {PYTHON: 3.8, OS: ubuntu-latest, NAME: "CPython 3.8 (ubuntu)"}
           - {PYTHON: 3.9, OS: ubuntu-latest, NAME: "CPython 3.9 (ubuntu)", CODECOV: true}
           - {PYTHON: "3.10", OS: ubuntu-latest, NAME: "CPython 3.10 (ubuntu)"}
+          - {PYTHON: "3.11", OS: ubuntu-latest, NAME: "CPython 3.11 (ubuntu)"}
           - {PYTHON: 'pypy-3.6', OS: ubuntu-latest, NAME: "PyPy 3.6 (ubuntu)"}
           - {PYTHON: 'pypy-3.7', OS: ubuntu-latest, NAME: "PyPy 3.7 (ubuntu)"}
           - {PYTHON: 'pypy-3.8', OS: ubuntu-latest, NAME: "PyPy 3.8 (ubuntu)"}

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ setup(
         "Issues": "https://github.com/zulip/zulip-terminal/issues",
         "Hot Keys": "https://github.com/zulip/zulip-terminal/blob/main/docs/hotkeys.md",
     },
-    python_requires=">=3.6, <3.11",
+    python_requires=">=3.6, <3.12",
     keywords="",
     packages=find_packages(exclude=["tests", "tests.*"]),
     zip_safe=True,


### PR DESCRIPTION
Initial local testing with Pipenv on x86_64 glibc seems to indicate the application runs on Python 3.11, so let's enable CI to (start to) prove it.

Follow-up from [CZO thread](https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/Python.203.2E11.20support/near/1478433)