### PR TITLE
lint-and-test: Use latest default CPython on macos.

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -132,7 +132,7 @@ jobs:
           - {PYTHON: 'pypy-3.7', OS: ubuntu-latest, NAME: "PyPy 3.7 (ubuntu)"}
           - {PYTHON: 'pypy-3.8', OS: ubuntu-latest, NAME: "PyPy 3.8 (ubuntu)"}
           - {PYTHON: 'pypy-3.9', OS: ubuntu-latest, NAME: "PyPy 3.9 (ubuntu)"}
-          - {PYTHON: 3.9, OS: macos-latest, NAME: "CPython 3.9 (macos)"}
+          - {PYTHON: '3.x', OS: macos-latest, NAME: "CPython 3.x [latest] (macos)"}
     runs-on: ${{ matrix.env.OS }}
     name: Install & test - ${{ matrix.env.NAME}}
     steps:


### PR DESCRIPTION
**What does this PR do?**  <!-- Overall description goes here -->

Explore change to do tests on the macos platform against the latest available CPython.

This follows the discussion on adding support for Python 3.11 here:
https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/Python.203.2E11.20support/near/1478470

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
(CI change)

**Notes & Questions** <!-- if any; add/delete/fill-in as appropriate -->
Depends on #1276 since the latest version on macos is automatically installed properly and is actually 3.11; the last commit here can be removed after that is merged.