### PR TITLE
[WIP] Disable cycling while editing a PM

### DIFF
--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -1739,6 +1739,34 @@ class TestWriteBox:
         assert isinstance(write_box.to_write_box, ReadlineEdit)
         assert write_box.to_write_box.text == "To: Human 1 <person1@example.com>"
 
+    def test_private_box_edit_view(
+        self,
+        mocker: MockerFixture,
+        user_dict: List[Dict[str, Any]],
+        user_id_email_dict: Dict[int, str],
+    ) -> None:
+        recipient_user_ids = [11]
+        write_box = WriteBox(self.view)
+        write_box.model.user_id_email_dict = user_id_email_dict
+        write_box.model.user_dict = user_dict
+        connect_signal_mock = mocker.patch.object(urwid, "connect_signal")
+        enable_autocomplete_mock = mocker.patch.object(
+            ReadlineEdit, "enable_autocomplete"
+        )
+        write_box.private_box_edit_view(recipient_user_ids=recipient_user_ids)
+        enable_autocomplete_mock.assert_has_calls(
+            [
+                mock.call(
+                    func=write_box.generic_autocomplete,
+                    key=primary_key_for_command("AUTOCOMPLETE"),
+                    key_reverse=primary_key_for_command("AUTOCOMPLETE_REVERSE"),
+                ),
+            ]
+        )
+        connect_signal_mock.assert_not_called()
+        assert isinstance(write_box.to_write_box, urwid.Text)
+        assert write_box.to_write_box.text == "To: Human 1 <person1@example.com>"
+
     def test__setup_common_private_compose(self, mocker: MockerFixture) -> None:
         write_box = WriteBox(self.view)
         write_box.to_write_box = mocker.MagicMock()

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -1680,7 +1680,10 @@ class TestWriteBox:
             else:
                 write_box.stream_box_view(stream_id)
         else:
-            write_box.private_box_view()
+            if not message_being_edited:
+                write_box.private_box_view()
+            else:
+                write_box.private_box_edit_view()
         size = widget_size(write_box)
 
         def focus_val(x: str) -> int:

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -1731,6 +1731,37 @@ class TestWriteBox:
         )
         assert write_box.focus_position == 1
 
+    @pytest.mark.parametrize(
+        "recipient_user_ids, expected_recipient_emails, expected_recipient_info",
+        [
+            (
+                [11, 12],
+                ["person1@example.com", "person2@example.com"],
+                "Human 1 <person1@example.com>, Human 2 <person2@example.com>",
+            ),
+            ([11], ["person1@example.com"], "Human 1 <person1@example.com>"),
+            ([], [], ""),
+        ],
+    )
+    def test_update_recipients_from_user_ids(
+        self,
+        recipient_user_ids: List[int],
+        expected_recipient_emails: List[str],
+        expected_recipient_info: str,
+        user_dict: List[Dict[str, Any]],
+        user_id_email_dict: Dict[int, str],
+    ) -> None:
+        write_box = WriteBox(self.view)
+        write_box.model.user_id_email_dict = user_id_email_dict
+        write_box.model.user_dict = user_dict
+
+        write_box.recipient_info = write_box.update_recipients_from_user_ids(
+            recipient_user_ids
+        )
+
+        assert write_box.recipient_emails == expected_recipient_emails
+        assert write_box.recipient_info == expected_recipient_info
+
     @pytest.mark.parametrize("key", keys_for_command("MARKDOWN_HELP"))
     def test_keypress_MARKDOWN_HELP(
         self, write_box: WriteBox, key: str, widget_size: Callable[[Widget], urwid_Size]

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -408,7 +408,7 @@ class TestWriteBox:
             ),
         ],
     )
-    def test_update_recipients(
+    def test_update_recipients_from_emails_in_widget(
         self,
         write_box: WriteBox,
         header: str,
@@ -419,7 +419,7 @@ class TestWriteBox:
         assert write_box.to_write_box is not None
         write_box.to_write_box.edit_text = header
 
-        write_box.update_recipients(write_box.to_write_box)
+        write_box.update_recipients_from_emails_in_widget(write_box.to_write_box)
 
         assert write_box.recipient_emails == expected_recipient_emails
         assert write_box.recipient_user_ids == expected_recipient_user_ids

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -227,6 +227,15 @@ class WriteBox(urwid.Pile):
             self.recipient_emails = []
             return ""
 
+    def private_box_edit_view(
+        self,
+        *,
+        recipient_user_ids: Optional[List[int]] = None,
+    ) -> None:
+        self.recipient_info = self.update_recipients_from_user_ids(recipient_user_ids)
+        self.to_write_box = urwid.Text("To: " + self.recipient_info)
+        self._setup_common_private_compose()
+
     def private_box_view(
         self,
         *,

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -280,7 +280,7 @@ class WriteBox(urwid.Pile):
 
         urwid.connect_signal(self.msg_write_box, "change", on_type_send_status)
 
-    def update_recipients(self, write_box: ReadlineEdit) -> None:
+    def update_recipients_from_emails_in_widget(self, write_box: ReadlineEdit) -> None:
         self.recipient_emails = re.findall(REGEX_RECIPIENT_EMAIL, write_box.edit_text)
         self._set_regular_and_typing_recipient_user_ids(
             [self.model.user_dict[email]["user_id"] for email in self.recipient_emails]
@@ -776,7 +776,7 @@ class WriteBox(urwid.Pile):
                     )
                     if not all_valid:
                         return key
-                    self.update_recipients(self.to_write_box)
+                    self.update_recipients_from_emails_in_widget(self.to_write_box)
                     if self.recipient_user_ids:
                         success = self.model.send_private_message(
                             recipients=self.recipient_user_ids,
@@ -830,7 +830,7 @@ class WriteBox(urwid.Pile):
                     )
                     if not all_valid:
                         return key
-                    self.update_recipients(self.to_write_box)
+                    self.update_recipients_from_emails_in_widget(self.to_write_box)
                     this_draft: Composition = PrivateComposition(
                         type="private",
                         to=self.recipient_user_ids,
@@ -905,7 +905,7 @@ class WriteBox(urwid.Pile):
                         # We extract recipients' user_ids and emails only once we know
                         # that all the recipients are valid, to avoid including any
                         # invalid ones.
-                        self.update_recipients(self.to_write_box)
+                        self.update_recipients_from_emails_in_widget(self.to_write_box)
 
             if not self.msg_body_edit_enabled:
                 return key

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -925,6 +925,13 @@ class WriteBox(urwid.Pile):
                 else:
                     header.focus_col = self.FOCUS_HEADER_BOX_STREAM
             else:
+                if self.msg_edit_state:
+                    self.model.controller.report_error(
+                        [
+                            "Recipient(s) can not be edited while editing a",
+                            "Direct Message.",
+                        ]
+                    )
                 header.focus_col = self.FOCUS_HEADER_BOX_RECIPIENT
 
         key = super().keypress(size, key)

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -896,22 +896,29 @@ class WriteBox(urwid.Pile):
                     else:
                         header.focus_col = self.FOCUS_HEADER_BOX_STREAM
                 else:
-                    all_valid = self._tidy_valid_recipients_and_notify_invalid_ones(
-                        self.to_write_box
-                    )
-                    if not all_valid:
-                        return key
-                    # We extract recipients' user_ids and emails only once we know
-                    # that all the recipients are valid, to avoid including any
-                    # invalid ones.
-                    self.update_recipients(self.to_write_box)
+                    if self.msg_edit_state is None:
+                        all_valid = self._tidy_valid_recipients_and_notify_invalid_ones(
+                            self.to_write_box
+                        )
+                        if not all_valid:
+                            return key
+                        # We extract recipients' user_ids and emails only once we know
+                        # that all the recipients are valid, to avoid including any
+                        # invalid ones.
+                        self.update_recipients(self.to_write_box)
 
             if not self.msg_body_edit_enabled:
                 return key
             if self.focus_position == self.FOCUS_CONTAINER_HEADER:
                 self.focus_position = self.FOCUS_CONTAINER_MESSAGE
             else:
-                self.focus_position = self.FOCUS_CONTAINER_HEADER
+                if self.compose_box_status == "open_with_stream":
+                    self.focus_position = self.FOCUS_CONTAINER_HEADER
+                if (
+                    self.compose_box_status == "open_with_private"
+                    and self.msg_edit_state is None
+                ):
+                    self.focus_position = self.FOCUS_CONTAINER_HEADER
             if self.compose_box_status == "open_with_stream":
                 if self.msg_edit_state is not None:
                     header.focus_col = self.FOCUS_HEADER_BOX_TOPIC

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -178,40 +178,10 @@ class WriteBox(urwid.Pile):
             self.idle_status_tracking = False
             self.sent_start_typing_status = False
 
-    def private_box_view(
-        self,
-        *,
-        recipient_user_ids: Optional[List[int]] = None,
-    ) -> None:
+    def _setup_common_private_compose(self) -> None:
         self.set_editor_mode()
 
         self.compose_box_status = "open_with_private"
-
-        if recipient_user_ids:
-            self._set_regular_and_typing_recipient_user_ids(recipient_user_ids)
-            self.recipient_emails = [
-                self.model.user_id_email_dict[user_id]
-                for user_id in self.recipient_user_ids
-            ]
-            recipient_info = ", ".join(
-                [
-                    f"{self.model.user_dict[email]['full_name']} <{email}>"
-                    for email in self.recipient_emails
-                ]
-            )
-        else:
-            self._set_regular_and_typing_recipient_user_ids(None)
-            self.recipient_emails = []
-            recipient_info = ""
-
-        self.send_next_typing_update = datetime.now()
-        self.to_write_box = ReadlineEdit("To: ", edit_text=recipient_info)
-        self.to_write_box.enable_autocomplete(
-            func=self._to_box_autocomplete,
-            key=primary_key_for_command("AUTOCOMPLETE"),
-            key_reverse=primary_key_for_command("AUTOCOMPLETE_REVERSE"),
-        )
-        self.to_write_box.set_completer_delims("")
 
         self.msg_write_box = ReadlineEdit(
             multiline=True, max_char=self.model.max_message_length
@@ -237,6 +207,37 @@ class WriteBox(urwid.Pile):
         ]
         self.focus_position = self.FOCUS_CONTAINER_MESSAGE
 
+    def private_box_view(
+        self,
+        *,
+        recipient_user_ids: Optional[List[int]] = None,
+    ) -> None:
+        if recipient_user_ids:
+            self._set_regular_and_typing_recipient_user_ids(recipient_user_ids)
+            self.recipient_emails = [
+                self.model.user_id_email_dict[user_id]
+                for user_id in self.recipient_user_ids
+            ]
+            recipient_info = ", ".join(
+                [
+                    f"{self.model.user_dict[email]['full_name']} <{email}>"
+                    for email in self.recipient_emails
+                ]
+            )
+        else:
+            self._set_regular_and_typing_recipient_user_ids(None)
+            self.recipient_emails = []
+            recipient_info = ""
+
+        self.send_next_typing_update = datetime.now()
+        self.to_write_box = ReadlineEdit("To: ", edit_text=recipient_info)
+        self.to_write_box.enable_autocomplete(
+            func=self._to_box_autocomplete,
+            key=primary_key_for_command("AUTOCOMPLETE"),
+            key_reverse=primary_key_for_command("AUTOCOMPLETE_REVERSE"),
+        )
+        self.to_write_box.set_completer_delims("")
+        self._setup_common_private_compose()
         start_period_delta = timedelta(seconds=TYPING_STARTED_WAIT_PERIOD)
         stop_period_delta = timedelta(seconds=TYPING_STOPPED_WAIT_PERIOD)
 

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -207,18 +207,16 @@ class WriteBox(urwid.Pile):
         ]
         self.focus_position = self.FOCUS_CONTAINER_MESSAGE
 
-    def private_box_view(
-        self,
-        *,
-        recipient_user_ids: Optional[List[int]] = None,
-    ) -> None:
+    def update_recipients_from_user_ids(
+        self, recipient_user_ids: Optional[List[int]] = None
+    ) -> str:
         if recipient_user_ids:
             self._set_regular_and_typing_recipient_user_ids(recipient_user_ids)
             self.recipient_emails = [
                 self.model.user_id_email_dict[user_id]
                 for user_id in self.recipient_user_ids
             ]
-            recipient_info = ", ".join(
+            return ", ".join(
                 [
                     f"{self.model.user_dict[email]['full_name']} <{email}>"
                     for email in self.recipient_emails
@@ -227,10 +225,16 @@ class WriteBox(urwid.Pile):
         else:
             self._set_regular_and_typing_recipient_user_ids(None)
             self.recipient_emails = []
-            recipient_info = ""
+            return ""
 
+    def private_box_view(
+        self,
+        *,
+        recipient_user_ids: Optional[List[int]] = None,
+    ) -> None:
+        self.recipient_info = self.update_recipients_from_user_ids(recipient_user_ids)
         self.send_next_typing_update = datetime.now()
-        self.to_write_box = ReadlineEdit("To: ", edit_text=recipient_info)
+        self.to_write_box = ReadlineEdit("To: ", edit_text=self.recipient_info)
         self.to_write_box.enable_autocomplete(
             func=self._to_box_autocomplete,
             key=primary_key_for_command("AUTOCOMPLETE"),

--- a/zulipterminal/ui_tools/messages.py
+++ b/zulipterminal/ui_tools/messages.py
@@ -1081,7 +1081,9 @@ class MessageBox(urwid.Pile):
                     )
 
             if self.message["type"] == "private":
-                self.keypress(size, primary_key_for_command("REPLY_MESSAGE"))
+                self.model.controller.view.write_box.private_box_edit_view(
+                    recipient_user_ids=self.recipient_ids,
+                )
             elif self.message["type"] == "stream":
                 self.model.controller.view.write_box.stream_box_edit_view(
                     stream_id=self.stream_id,


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->
-> Disables cycling during editing a PM by `tab` key .
->  Shows a warning if one uses tab during editing a PM.
<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->
Partial fix for #774 
<!-- Add a link to a discussion on chat.zulip.org, if relevant -->

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [X] Manually
- [X] Existing tests (adapted, if necessary)
- [x] New tests added (for any new behavior)
- [X] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

<!-- See https://github.com/zulip/zulip-terminal#commit-style -->
**Commit flow** <!-- if more than one commit; add/delete/fill-in as appropriate -->
<!-- For example:
- first commit doing some thing
- maybe multiple commits doing similar things
-->
commit 1: changes made to boxes.py
commit 2: changes made to test_boxes.py
**Notes & Questions** <!-- if any; add/delete/fill-in as appropriate -->
<!-- For example:
- this doesn't include feature X (yet?)
- unsure about Y
- should this do Z?
-->

**Interactions** <!-- if any; add/delete/fill-in as appropriate -->
<!-- eg.
- Waiting on #<PR>
- Blocks #<PR>
-->

**Visual changes** <!-- if any; add/delete/fill-in with screenshot/diagram as appropriate -->
![zt1](https://user-images.githubusercontent.com/92573882/210581649-7b23e518-dd15-4aeb-b3d7-0b2182660ed2.png)

