### PR TITLE
Show detected platform on startup and during CI

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -123,16 +123,18 @@ jobs:
       fail-fast: false
       matrix:
         env:
-          - {PYTHON: 3.7, OS: ubuntu-latest, NAME: "CPython 3.7 (ubuntu)"}
-          - {PYTHON: 3.8, OS: ubuntu-latest, NAME: "CPython 3.8 (ubuntu)"}
-          - {PYTHON: 3.9, OS: ubuntu-latest, NAME: "CPython 3.9 (ubuntu)", CODECOV: true}
-          - {PYTHON: "3.10", OS: ubuntu-latest, NAME: "CPython 3.10 (ubuntu)"}
-          - {PYTHON: "3.11", OS: ubuntu-latest, NAME: "CPython 3.11 (ubuntu)"}
-          - {PYTHON: 'pypy-3.6', OS: ubuntu-latest, NAME: "PyPy 3.6 (ubuntu)"}
-          - {PYTHON: 'pypy-3.7', OS: ubuntu-latest, NAME: "PyPy 3.7 (ubuntu)"}
-          - {PYTHON: 'pypy-3.8', OS: ubuntu-latest, NAME: "PyPy 3.8 (ubuntu)"}
-          - {PYTHON: 'pypy-3.9', OS: ubuntu-latest, NAME: "PyPy 3.9 (ubuntu)"}
-          - {PYTHON: '3.x', OS: macos-latest, NAME: "CPython 3.x [latest] (macos)"}
+          - {PYTHON: 3.7, OS: ubuntu-latest, NAME: "CPython 3.7 (ubuntu)", EXPECT: "Linux"}
+          - {PYTHON: 3.8, OS: ubuntu-latest, NAME: "CPython 3.8 (ubuntu)", EXPECT: "Linux"}
+          - {PYTHON: 3.9, OS: ubuntu-latest, NAME: "CPython 3.9 (ubuntu)", EXPECT: "Linux", CODECOV: true}
+          - {PYTHON: "3.10", OS: ubuntu-latest, NAME: "CPython 3.10 (ubuntu)", EXPECT: "Linux"}
+          - {PYTHON: "3.11", OS: ubuntu-latest, NAME: "CPython 3.11 (ubuntu)", EXPECT: "Linux"}
+          - {PYTHON: 'pypy-3.6', OS: ubuntu-latest, NAME: "PyPy 3.6 (ubuntu)", EXPECT: "Linux"}
+          - {PYTHON: 'pypy-3.7', OS: ubuntu-latest, NAME: "PyPy 3.7 (ubuntu)", EXPECT: "Linux"}
+          - {PYTHON: 'pypy-3.8', OS: ubuntu-latest, NAME: "PyPy 3.8 (ubuntu)", EXPECT: "Linux"}
+          - {PYTHON: 'pypy-3.9', OS: ubuntu-latest, NAME: "PyPy 3.9 (ubuntu)", EXPECT: "Linux"}
+          - {PYTHON: '3.x', OS: macos-latest, NAME: "CPython 3.x [latest] (macos)", EXPECT: "MacOS"}
+    env:
+      EXPECT: ${{ matrix.env.EXPECT }}
     runs-on: ${{ matrix.env.OS }}
     name: Install & test - ${{ matrix.env.NAME}}
     steps:
@@ -154,6 +156,8 @@ jobs:
         run: sudo apt install libxml2-dev libxslt1-dev
       - name: Ensure regular package installs from checkout
         run: pip install .
+      - name: Check we detect the platform correctly
+        run: python -c "from zulipterminal.platform_code import detected_platform; import os; e, d = os.environ['EXPECT'], detected_platform(); assert d == e, f'{d} != {e}'"
       - name: Install test dependencies
         run: pip install .[testing]
       - name: Run tests with pytest

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -24,6 +24,7 @@ from zulipterminal.config.themes import (
 )
 from zulipterminal.core import Controller
 from zulipterminal.model import ServerConnectionFailure
+from zulipterminal.platform_code import detected_platform
 from zulipterminal.version import ZT_VERSION
 
 
@@ -379,6 +380,8 @@ def main(options: Optional[List[str]] = None) -> None:
         zuliprc_path = args.config_file
     else:
         zuliprc_path = "~/zuliprc"
+
+    print(f"Detected platform: {detected_platform()}")
 
     try:
         zterm = parse_zuliprc(zuliprc_path)

--- a/zulipterminal/platform_code.py
+++ b/zulipterminal/platform_code.py
@@ -28,6 +28,10 @@ else:
 MOUSE_SELECTION_KEY = "Fn + Alt" if PLATFORM == "MacOS" else "Shift"
 
 
+def detected_platform() -> str:
+    return PLATFORM
+
+
 def notify(title: str, text: str) -> str:
     command_list = None
     if PLATFORM == "MacOS":


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->

This outputs the platform we detect, before ZT starts. The benefit of this is that it is clear if the platform is unsupported, and also should form part of the feedback we receive from users in bug reports.

This also checks the detected platform during CI, to ensure we test code paths there, as far as we can.

<!-- Add a link to a discussion on chat.zulip.org, if relevant -->

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [X] Manually **via lint-and-test adjustment, for Linux and MacOS only**
- [X] Existing tests (adapted, if necessary)
- [X] New tests added (for any new behavior) **essentially via CI, by lint-and-test**
- [X] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

**Notes & Questions (maybe further work)** <!-- if any; add/delete/fill-in as appropriate -->
- We could output an additional warning if it is unsupported, but this is a good first step to aid in helping users.
- We don't currently test on WSL to ensure we detect that correctly, or on some other unsupported platform to ensure it's flagged too.