### PR TITLE
Display read receipts: list of people who've read the message

### DIFF
--- a/docs/hotkeys.md
+++ b/docs/hotkeys.md
@@ -64,6 +64,7 @@
 |View current message in browser (from message information)|<kbd>v</kbd>|
 |Show/hide full rendered message (from message information)|<kbd>f</kbd>|
 |Show/hide full raw message (from message information)|<kbd>r</kbd>|
+|Show/hide read receipts of message (from message information)|<kbd>ctrl</kbd> + <kbd>r</kbd>|
 
 ## Stream list actions
 |Command|Key Combination|

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -1536,6 +1536,61 @@ class TestModel:
         assert return_value == expected_raw_content
 
     @pytest.mark.parametrize(
+        "response, expected_read_receipts, feature_level",
+        [
+            case(
+                {"msg": "", "result": "success", "user_ids": [3, 7, 9]},
+                [3, 7, 9],
+                139,
+                id="valid_ZFL_with_valid_response",
+            ),
+            case(
+                {"msg": "Invalid message(s)", "result": "error"},
+                [],
+                137,
+                id="valid_ZFL_with_invalid_response",
+            ),
+        ],
+    )
+    def test_fetch_message_read_receipt_user_ids__valid_zfl(
+        self,
+        mocker,
+        model,
+        expected_read_receipts,
+        response,
+        feature_level,
+        message_id=1,
+    ):
+        model.server_feature_level = feature_level
+        self.client.call_endpoint.return_value = response
+        result = model.fetch_message_read_receipt_user_ids(message_id)
+        assert result == expected_read_receipts
+
+    @pytest.mark.parametrize(
+        "feature_level",
+        [
+            case(
+                136,
+                id="invalid_ZFL_with_response",
+            ),
+            case(
+                0,
+                id="missing_ZFL_with_response",
+            ),
+        ],
+    )
+    def test_fetch_message_read_receipt_user_ids__invalid_zfl(
+        self,
+        mocker,
+        model,
+        feature_level,
+        message_id=1,
+    ):
+        model.server_feature_level = feature_level
+        with pytest.raises(RuntimeError, match="Unsupported server feature level."):
+            model.fetch_message_read_receipt_user_ids(message_id)
+
+    @pytest.mark.parametrize(
         "initial_muted_streams, value",
         [
             ({315}, True),

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -655,6 +655,27 @@ class TestReadReceiptView:
 
         assert not self.controller.exit_popup.called
 
+    @pytest.mark.parametrize(
+        "key",
+        {
+            *keys_for_command("READ_RECEIPTS"),
+            *keys_for_command("GO_BACK"),
+        },
+    )
+    def test_keypress_show_msg_info(
+        self, key: str, widget_size: Callable[[Widget], urwid_Size]
+    ) -> None:
+        size = widget_size(self.read_receipt)
+
+        self.read_receipt.keypress(size, key)
+
+        self.controller.show_msg_info.assert_called_once_with(
+            msg=self.message,
+            topic_links=OrderedDict(),
+            message_links=OrderedDict(),
+            time_mentions=list(),
+        )
+
 
 class TestEditHistoryView:
     @pytest.fixture(autouse=True)
@@ -984,6 +1005,11 @@ class TestMsgInfoView:
             self.controller, "maximum_popup_dimensions", return_value=(64, 64)
         )
         mocker.patch(LISTWALKER, return_value=[])
+
+        # To show options based on ZFL
+        # Setting it 0 as default if it doesn't exist
+        self.controller.model.server_feature_level = 0
+
         # The subsequent patches (index and initial_data) set
         # show_edit_history_label to False for this autoused fixture.
         self.controller.model.index = {"edited_messages": set()}
@@ -1134,6 +1160,42 @@ class TestMsgInfoView:
             time_mentions=list(),
         )
 
+    @pytest.mark.parametrize("key", keys_for_command("READ_RECEIPTS"))
+    @pytest.mark.parametrize(
+        "server_feature_level",
+        [137, 135],
+        ids=[
+            "read_receipt_supported_zfl",
+            "read_receipt_unsupported_zfl",
+        ],
+    )
+    def test_keypress_read_receipts(
+        self,
+        server_feature_level: int,
+        message_fixture: Message,
+        key: str,
+        widget_size: Callable[[Widget], urwid_Size],
+    ) -> None:
+        msg_info_view = MsgInfoView(
+            self.controller,
+            message_fixture,
+            title="Message Information",
+            topic_links=OrderedDict(),
+            message_links=OrderedDict(),
+            time_mentions=list(),
+        )
+        size = widget_size(msg_info_view)
+        msg_info_view.keypress(size, key)
+        if msg_info_view.show_read_receipts_label:
+            self.controller.show_read_receipts.assert_called_once_with(
+                message=message_fixture,
+                topic_links=OrderedDict(),
+                message_links=OrderedDict(),
+                time_mentions=list(),
+            )
+        else:
+            self.controller.show_read_receipts.assert_not_called()
+
     @pytest.mark.parametrize(
         "key", {*keys_for_command("GO_BACK"), *keys_for_command("MSG_INFO")}
     )
@@ -1159,14 +1221,39 @@ class TestMsgInfoView:
 
         assert self.controller.open_in_browser.called
 
-    def test_height_noreactions(self) -> None:
-        expected_height = 8
-        # 6 = 1 (date & time) +1 (sender's name) +1 (sender's email)
-        # +1 (display group header)
+    @pytest.mark.parametrize(
+        [
+            "server_feature_level",
+            "expected_height",
+        ],
+        [
+            (137, 9),
+            (135, 8),
+        ],
+        ids=[
+            "read_receipt_supported_zfl",
+            "read_receipt_unsupported_zfl",
+        ],
+    )
+    def test_height_noreactions(
+        self, server_feature_level: int, message_fixture: Message, expected_height: int
+    ) -> None:
+        self.controller.model.server_feature_level = server_feature_level
+        self.msg_info_view = MsgInfoView(
+            self.controller,
+            message_fixture,
+            "Message Information",
+            OrderedDict(),
+            OrderedDict(),
+            list(),
+        )
+        # 9 = 1 (date & time) +1 (sender's name) +1 (sender's email)
         # +1 (whitespace column)
+        # +1 (display group header)
         # +1 (view message in browser)
         # +1 (full rendered message)
         # +1 (full raw message)
+        # +1 (read receipts) if ZFL>=137
         assert self.msg_info_view.height == expected_height
 
     # FIXME This is the same parametrize as MessageBox:test_reactions_view
@@ -1219,13 +1306,30 @@ class TestMsgInfoView:
             )
         ],
     )
+    @pytest.mark.parametrize(
+        [
+            "server_feature_level",
+            "expected_height",
+        ],
+        [
+            (137, 15),
+            (135, 14),
+        ],
+        ids=[
+            "read_receipt_supported_zfl",
+            "read_receipt_unsupported_zfl",
+        ],
+    )
     def test_height_reactions(
         self,
         message_fixture: Message,
         to_vary_in_each_message: Message,
+        server_feature_level: int,
+        expected_height: int,
     ) -> None:
         varied_message = message_fixture
         varied_message.update(to_vary_in_each_message)
+        self.controller.model.server_feature_level = server_feature_level
         self.msg_info_view = MsgInfoView(
             self.controller,
             varied_message,
@@ -1234,9 +1338,9 @@ class TestMsgInfoView:
             OrderedDict(),
             list(),
         )
-        # 12 = 7 labels + 2 blank lines + 1 'Reactions' (category)
+        # 15 = [8-9] (labels, depending on server_feature_level)
+        # + 2 blank line + 1 'Reactions' (category)
         # + 4 reactions (excluding 'Message Links').
-        expected_height = 14
         assert self.msg_info_view.height == expected_height
 
     @pytest.mark.parametrize(

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -405,6 +405,11 @@ KEY_BINDINGS: Dict[str, KeyBinding] = {
         'help_text': 'Show/hide full raw message (from message information)',
         'key_category': 'msg_actions',
     },
+    'READ_RECEIPTS': {
+        'keys': ['ctrl r'],
+        'help_text': 'Show/hide read receipts of message (from message information)',
+        'key_category': 'msg_actions',
+    },
 }
 # fmt: on
 

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -42,6 +42,7 @@ from zulipterminal.ui_tools.views import (
     MsgInfoView,
     NoticeView,
     PopUpConfirmationView,
+    ReadReceiptView,
     StreamInfoView,
     StreamMembersView,
     UserInfoView,
@@ -365,6 +366,25 @@ class Controller:
                 message_links,
                 time_mentions,
                 "Full raw message (up/down scrolls)",
+            ),
+            "area:msg",
+        )
+
+    def show_read_receipts(
+        self,
+        message: Message,
+        topic_links: "Dict[str, Tuple[str, int, bool]]",
+        message_links: "Dict[str, Tuple[str, int, bool]]",
+        time_mentions: List[Tuple[str, str]],
+    ) -> None:
+        self.show_pop_up(
+            ReadReceiptView(
+                self,
+                message,
+                topic_links,
+                message_links,
+                time_mentions,
+                "Read receipts (up/down scrolls)",
             ),
             "area:msg",
         )

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -854,6 +854,21 @@ class Model:
         display_error_if_present(response, self.controller)
         return list()
 
+    def fetch_message_read_receipt_user_ids(self, message_id: int) -> Union[List[int]]:
+        """
+        Fetches user IDs of users who've read a message using its ID.
+        If fails to fetch due to being unable to retrieve ZFL, returns None
+        """
+        if self.server_feature_level < 137:
+            raise RuntimeError("Unsupported server feature level.")
+
+        response = self.client.call_endpoint(
+            f"/messages/{message_id}/read_receipts", method="GET"
+        )
+        if response["result"] == "success":
+            return response["user_ids"]
+        return list()
+
     def fetch_raw_message_content(self, message_id: int) -> Optional[str]:
         """
         Fetches raw message content of a message using its ID.

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1603,6 +1603,16 @@ class MsgInfoView(PopUpView):
 
             keys = "[{}]".format(", ".join(map(str, keys_for_command("EDIT_HISTORY"))))
             msg_info[1][1].append(("Edit History", keys))
+
+        # ZFL >= 137 supports the option to show read receipts
+        # only show 'View read receipts' option if ZFL >= 137
+        self.show_read_receipts_label = controller.model.server_feature_level >= 137
+        if self.show_read_receipts_label:
+            read_receipt_keys = "[{}]".format(
+                ", ".join(map(str, keys_for_command("READ_RECEIPTS")))
+            )
+            msg_info[1][1].append(("View read receipts", read_receipt_keys))
+
         # Render the category using the existing table methods if links exist.
         if message_links:
             msg_info.append(("Message Links", []))
@@ -1713,6 +1723,14 @@ class MsgInfoView(PopUpView):
             return key
         elif is_command_key("FULL_RAW_MESSAGE", key):
             self.controller.show_full_raw_message(
+                message=self.msg,
+                topic_links=self.topic_links,
+                message_links=self.message_links,
+                time_mentions=self.time_mentions,
+            )
+            return key
+        elif is_command_key("READ_RECEIPTS", key) and self.show_read_receipts_label:
+            self.controller.show_read_receipts(
                 message=self.msg,
                 topic_links=self.topic_links,
                 message_links=self.message_links,


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->
As of ZFL 139, one can view all the users who have read a message. This commit allows users to see the read receipts on the message through the message information popup window where it opens another popup displaying all the names of users who've read the message.

New feature #1247 #1268
<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->

<!-- Add a link to a discussion on chat.zulip.org, if relevant -->

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [x] New tests added (for any new behavior)
- [x] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

<!-- See https://github.com/zulip/zulip-terminal#commit-style -->
**Commit flow** <!-- if more than one commit; add/delete/fill-in as appropriate -->
- First commit : Adding the function which fetches the list of users who've read the message from the endpoint
- Second commit : Adding a popup that displays the list
- Third commit : Accounting for different ZFLs and displaying messages accordingly. Also displaying the list of users in a sorted fashion, similar to StreamMembersView.
<!-- For example:
- first commit doing some thing
- maybe multiple commits doing similar things
-->

**Notes & Questions** <!-- if any; add/delete/fill-in as appropriate -->
<!-- For example:
- this doesn't include feature X (yet?)
- unsure about Y
- should this do Z?
-->

**Interactions** <!-- if any; add/delete/fill-in as appropriate -->
<!-- eg.
- Waiting on #<PR>
- Blocks #<PR>
-->

**Visual changes** <!-- if any; add/delete/fill-in with screenshot/diagram as appropriate -->
The read receipts can be accessed from the message information popup window 
<img width="373" alt="Screenshot 2024-02-08 at 11 45 32 PM" src="https://github.com/zulip/zulip-terminal/assets/71403193/233f60e5-3f3e-4f3b-9561-eb0b0e122e80">




<img width="336" alt="Screenshot 2024-02-08 at 11 46 00 PM" src="https://github.com/zulip/zulip-terminal/assets/71403193/5a1de03b-731d-4557-be45-fbdde810d061">




