### PR TITLE
Docs: Improve autocomplete docs & expand PMs to Private Messages

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -179,6 +179,7 @@ Since each of the stream (1), topic (2) and private message recipients (3) areas
 ![Stream header](https://user-images.githubusercontent.com/55916430/118403323-8e5b7580-b68b-11eb-9c8a-734c2fe6b774.png)
 
 **NOTE:** The stream box prefix is automatic:
+* `⊚` (with stream color) if the stream is valid and web-public,
 * `#` (with stream color) if the stream is valid and public,
 * `P` (with stream color) if the stream is valid and private,
 * `✗` if the stream is invalid.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -204,7 +204,7 @@ Since each of the stream (1), topic (2) and private message recipients (3) areas
 
 ![PM recipients header](https://user-images.githubusercontent.com/55916430/118403345-9d422800-b68b-11eb-9005-6d2af74adab9.png)
 
-**NOTE:** If a PM recipient's name contains comma(s) (`,`), they are currently treated as comma-separated recipients.
+**NOTE:** If a private message recipient's name contains comma(s) (`,`), they are currently treated as comma-separated recipients.
 
 ## Unable to render symbols
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -139,9 +139,27 @@ Since we expect the above to be straightforward for most users and it allows the
 However, we are certainly likely to move towards a system to make access of the different servers simpler, which should be made easier through work such as [zulip-terminal#678](https://github.com/zulip/zulip-terminal/issues/678).
 In the longer term we may move to multiple servers per session, which is tracked in [zulip-terminal#961](https://github.com/zulip/zulip-terminal/issues/961).
 
-## How do I use autocompletes in ZT?
+## What is autocomplete? Why is it useful?
 
-Composing messages could be a tiring task when you have to type all things by yourself. Autocompletes come to the rescue here! ZT currently supports some basic autocompletes, for different compose boxes.
+Autocomplete can be used to request matching options, and cycle through each option in turn, including:
+- helping to specify users for new private messages (eg. after <kbd>x</kbd>)
+- helping to specify streams and existing topics for new stream messages (eg. after <kbd>c</kbd>)
+- mentioning a user or user-group (in message content)
+- linking to a stream or existing topic (in message content)
+- emojis (in message content)
+
+This helps ensure that:
+- messages are sent to valid users, streams, and matching existing topics if appropriate - so they
+  are sent to the correct location;
+- message content has references to valid users, user-groups, streams, topics and emojis, with
+  correct syntax - so is rendered well in all Zulip clients.
+
+> Note that if using the left or right panels of the application to search for
+> streams, topics or users, this is **not** part of the autocomplete system. In
+> those cases, as you type, the results of these searches are shown
+> automatically by limiting what is displayed in the existing area, until the
+> search is cleared. Autocomplete operates differently, and uses the bottom
+> line(s) of the screen to show a limited set of matches.
 
 ### Hotkeys triggering autocomplete
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -163,9 +163,9 @@ This helps ensure that:
 
 ### Hotkeys triggering autocomplete
 
-We use `ctrl` + **`f`** and `ctrl` + **`r`** for cycling through autocompletes (**forward** & **reverse** respectively).
+We use <kbd>ctrl</kbd>+<kbd>**f**</kbd> and <kbd>ctrl</kbd>+<kbd>**r**</kbd> for cycling through autocompletes (**forward** & **reverse** respectively).
 
-**NOTE:** We don't use `tab`/`shift tab` (although it is widely used elsewhere) for cycling through matches. However, recall that we do use `tab` to cycle through recipient and content boxes. (See [hotkeys for composing a message](https://github.com/zulip/zulip-terminal/blob/main/docs/hotkeys.md#composing-a-message))
+**NOTE:** We don't use <kbd>tab</kbd>/<kbd>shift</kbd>+<kbd>tab</kbd> (although it is widely used elsewhere) for cycling through matches. However, recall that we do use <kbd>tab</kbd> to cycle through recipient and content boxes. (See [hotkeys for composing a message](https://github.com/zulip/zulip-terminal/blob/main/docs/hotkeys.md#composing-a-message))
 
 ### Example: Using autocomplete to add a recognized emoji in your message content
 

--- a/docs/developer-feature-tutorial.md
+++ b/docs/developer-feature-tutorial.md
@@ -103,8 +103,8 @@ You can view these events in the `type` file in your `zulip-terminal` home direc
 
 Now to display if user is typing in the view, we need to check few things:
 * The `op` is `start`.
-* User is narrowed into PM with a user.
-* The `user_id` of the person is present in the narrowed PM recipients.
+* User is narrowed into private message conversation with a user.
+* The `user_id` of the person is present in the narrowed private message conversation recipients.
 
 If all the above conditions are satisfied we can successfully update the footer to display `X is typing` until we receive
 a `stop` event for typing.

--- a/docs/developer-file-overview.md
+++ b/docs/developer-file-overview.md
@@ -30,7 +30,7 @@ Zulip Terminal uses [Zulip's API](https://zulip.com/api/) to store and retrieve 
 |                        | ui_sizes.py         | Fixed sizes of UI elements                                                                             |
 |                        |                     |                                                                                                        |
 | zulipterminal/ui_tools | boxes.py            | UI boxes for displaying messages and entering text, such as `MessageBox`, `SearchBox`, `WriteBox`, etc.|
-|                        | buttons.py          | UI buttons for 'narrowing' and showing unread counts, such as Stream, PM, Topic, Home, Starred, etc    |
+|                        | buttons.py          | UI buttons for 'narrowing' & showing unread counts, eg. All, Stream, Private message, Topic, Starred   |
 |                        | tables.py           | Helper functions which render tables in the UI                                                         |
 |                        | utils.py            | The `MessageBox` for every message displayed is created here                                           |
 |                        | views.py            | UI views for larger elements such as Streams, Messages, Topics, Help, etc                              |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,7 +2,7 @@
 
 # Zulip Terminal User Tutorial
 
-Hi, are you new to [Zulip](https://github.com/zulip/zulip)? If so, we recommend trying out our [web-client](https://chat.zulip.org) first to understand the concept of [streams/topics/PMs](https://zulip.com/help/about-streams-and-topics) in the world of Zulip. Please read through our [community docs](https://zulip.readthedocs.io/en/latest/contributing/chat-zulip-org.html) to get a feel for how things work. Just sending a message or two in the [#test here](https://chat.zulip.org/#narrow/stream/7-test-here) stream should help you get started. If you don't already have a Zulip account, you'll also have to use our [web-client](https://chat.zulip.org) to sign up because currently you can't create an account using Zulip Terminal.
+Hi, are you new to [Zulip](https://github.com/zulip/zulip)? If so, we recommend trying out our [web-client](https://chat.zulip.org) first to understand the concept of [streams and topics](https://zulip.com/help/about-streams-and-topics) in the world of Zulip. Please read through our [community docs](https://zulip.readthedocs.io/en/latest/contributing/chat-zulip-org.html) to get a feel for how things work. Just sending a message or two in the [#test here](https://chat.zulip.org/#narrow/stream/7-test-here) stream should help you get started. If you don't already have a Zulip account, you'll also have to use our [web-client](https://chat.zulip.org) to sign up because currently you can't create an account using Zulip Terminal.
 
 Now let's help you get started with using Zulip Terminal. First, if you haven't already, go ahead and complete the [installation](https://github.com/zulip/zulip-terminal#installation). If you encountered any issues, we have common issues and their solutions listed [here](https://github.com/zulip/zulip-terminal/blob/main/docs/FAQ.md) if you run into trouble. Feel free to ask questions or for help at [#zulip-terminal](https://chat.zulip.org/#narrow/stream/206-zulip-terminal) or support@zulip.com.
 
@@ -124,7 +124,7 @@ You can also type <kbd>z</kbd> to 'zoom in' or 'zoom out.' What do I mean by 'zo
 
 ### Reply to a Message
 
-To reply to a message in a narrow (stream/topic/PM), rest your cursor on the message you want to reply to and then type <kbd>r</kbd>. Type your message in the Message box that pops up at the bottom of the middle column. Type <kbd>ctrl</kbd><kbd>d</kbd> to send. If you change your mind and don't want to send the message, type <kbd>esc</kbd> to get out of the message editor. Let's try replying to a random message in the **[#test here](https://chat.zulip.org/#narrow/stream/7-test-here)** stream (don't worry about messing anything up, the [#test here](https://chat.zulip.org/#narrow/stream/7-test-here) stream was made for stuff like this).
+To reply to an existing stream- or private-message in any narrow, rest your cursor on the message you want to reply to and then type <kbd>r</kbd>. Type your message in the Message box that pops up at the bottom of the middle column. Type <kbd>ctrl</kbd><kbd>d</kbd> to send. If you change your mind and don't want to send the message, type <kbd>esc</kbd> to get out of the message editor. Let's try replying to a random message in the **[#test here](https://chat.zulip.org/#narrow/stream/7-test-here)** stream (don't worry about messing anything up, the [#test here](https://chat.zulip.org/#narrow/stream/7-test-here) stream was made for stuff like this).
 
 <img src="getting-started-imgs/reply-to-message.png" width="85%">
 
@@ -136,19 +136,19 @@ If you want to show you agree with the current message, type <kbd>+</kbd> to add
 
 ### Reply via a Private Message
 
-Let's try sending a PM to the author of a message. Select the message you sent to the [#test here](https://chat.zulip.org/#narrow/stream/7-test-here) stream earlier and press <kbd>shift</kbd><kbd>r</kbd> to send a PM to yourself. Type your message in the message editor that appears at the bottom of the middle column and then type <kbd>ctrl</kbd><kbd>d</kbd> to send. Press the <kbd>shift</kbd><kbd>p</kbd> hotkey as we did earlier in the tutorial to narrow to your PM's and make sure everything worked properly.
+Let's try sending a private message to the author of a message. Select the message you sent to the [#test here](https://chat.zulip.org/#narrow/stream/7-test-here) stream earlier and press <kbd>shift</kbd><kbd>r</kbd> to send a private message to yourself. Type your message in the message editor that appears at the bottom of the middle column and then type <kbd>ctrl</kbd><kbd>d</kbd> to send. Press the <kbd>shift</kbd><kbd>p</kbd> hotkey as we did earlier in the tutorial to narrow to your private messages and make sure everything worked properly.
 
 <img src="getting-started-imgs/send-pm.png" width="85%">
 
 ### Send a Private Message to Someone New
 
-You can send a PM by moving your cursor to the list of "Users" in the right column and selecting the name of the person you'd like to send a message to.
+You can send a private message by moving your cursor to the list of "Users" in the right column and selecting the name of the person you'd like to send a message to.
 
 From version 0.7.0 you can also use autocomplete to enter people's names from partial information, and easily send one-to-one or group private messages!
 
-To send a PM using the autocomplete feature:
+To send a private message using the autocomplete feature:
 1. Use the <kbd>x</kbd> hotkey. A message editor will pop open at the bottom of the middle column. 
-2. Type in part of the name of the person you'd like to send a PM to (IMG 1)
+2. Type in part of the name of the person you'd like to send a private message to (IMG 1)
 3. Press <kbd>ctrl</kbd><kbd>f</kbd> and a list of potential recipients will appear in the footer (highlighted in red). 
 4. Press <kbd>ctrl</kbd><kbd>f</kbd> until the name of the person you want to send a message to is highlighted (IMG 2). 
 5. Press <kbd>tab</kbd> to jump to the message section and type in your message. 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -157,7 +157,7 @@ To send a PM using the autocomplete feature:
 
 Try following the steps above to send a message to the Welcome Bot!
 
-> It's generally best to use <kbd>ctrl</kbd><kbd>f</kbd> to autocomplete the name and Zulip address of the person you want to PM; if you just type in their full name Zulip Terminal will not necessarily know who you are trying to send to.
+> It's best to use <kbd>ctrl</kbd><kbd>f</kbd> to autocomplete the name and Zulip address of the person (or bot) you want to message; if you just type in their full name, Zulip Terminal does not know for sure who you are trying to send to - and there may be multiple people with that name!
 
 <img src="getting-started-imgs/send-pm-autocomplete1.png" width="85%">
 <img src="getting-started-imgs/send-pm-autocomplete2.png" width="85%">

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -1,5 +1,5 @@
 """
-UI buttons for 'narrowing' and showing unread counts, such as Stream, PM, Topic, Home, Starred, etc
+UI buttons for 'narrowing' & showing unread counts, eg. All, Stream, Private message, Topic, Starred
 """
 
 import re


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->

Primarily:
- Expand/clarify the autocomplete section
  - Include the web-public marker
  - Improve introduction (motivation) for autocomplete
  - Style hotkeys using kbd
- Expand the PMs abbreviation into Private Messages
  - This is something of a prep for #1288, at least in documentation.

<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->

<!-- Add a link to a discussion on chat.zulip.org, if relevant -->

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [ ] New tests added (for any new behavior)
- [x] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->