### PR TITLE
Upgrade black from >=22.1.0 to ~=23.0 & reformat.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ linting_deps = [
     "flake8~=4.0.1",
     "flake8-quotes~=3.2.0",
     "flake8-continuation~=1.0.5",
-    "black>=22.1.0",
+    "black~=23.0",
 ]
 
 typing_deps = [

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -1284,7 +1284,6 @@ class TestModel:
     def test_modernize_message_response(
         self, model, messages, expected_messages_response
     ):
-
         assert model.modernize_message_response(messages) == expected_messages_response
 
     @pytest.mark.parametrize(

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -343,7 +343,6 @@ class TestWriteBox:
         raw_recipients: str,
         invalid_recipients: str,
     ) -> None:
-
         write_box.model.is_valid_private_recipient = mocker.Mock(return_value=False)
         write_box.private_box_view()
         assert write_box.to_write_box is not None

--- a/tests/ui_tools/test_buttons.py
+++ b/tests/ui_tools/test_buttons.py
@@ -48,7 +48,6 @@ class TestTopButton:
         return top_button
 
     def test_init(self, mocker: MockerFixture, top_button: TopButton) -> None:
-
         assert top_button.controller == self.controller
         assert top_button._prefix_markup == ("style", "-")
         assert top_button._label_markup == (None, "label")

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -398,7 +398,6 @@ def index_messages(messages: List[Message], model: Any, index: Index) -> Index:
     """
     narrow = model.narrow
     for msg in messages:
-
         if "edit_history" in msg.keys():
             index["edited_messages"].add(msg["id"])
 
@@ -411,7 +410,6 @@ def index_messages(messages: List[Message], model: Any, index: Index) -> Index:
             continue
 
         if len(narrow) == 1:
-
             if narrow[0][1] == "starred":
                 if "starred" in msg["flags"]:
                     index["starred_msg_ids"].add(msg["id"])

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1645,7 +1645,6 @@ class Model:
         message_id = event["message_id"]
         # If the message is indexed
         if message_id in self.index["messages"]:
-
             message = self.index["messages"][message_id]
             if event["op"] == "add":
                 message["reactions"].append(

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -192,7 +192,6 @@ class WriteBox(urwid.Pile):
         *,
         recipient_user_ids: Optional[List[int]] = None,
     ) -> None:
-
         self.set_editor_mode()
 
         self.compose_box_status = "open_with_private"
@@ -1513,7 +1512,6 @@ class MessageBox(urwid.Pile):
         return markup, metadata["message_links"], metadata["time_mentions"]
 
     def main_view(self) -> List[Any]:
-
         # Recipient Header
         if self.need_recipient_header():
             if self.message["type"] == "stream":

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1123,7 +1123,6 @@ class AboutView(PopUpView):
 
 class UserInfoView(PopUpView):
     def __init__(self, controller: Any, user_id: int, title: str) -> None:
-
         display_data = self._fetch_user_data(controller, user_id)
 
         user_details = [


### PR DESCRIPTION
**What does this PR do?**  <!-- Overall description goes here -->

This results in minor removal of blank lines at start of blocks.

The previous >=22.1.0 versioning worked fine until version 23+ was released,
which required these changes. This was not noticeable on already-installed
systems, but can trigger in updated/new dev environments, including when
testing in GitHub Actions (CI).

The requirement change to ~=23.0 should maintain stability for 2023 releases of black.
(https://black.readthedocs.io/en/stable/the_black_code_style/index.html#stability-policy)

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [ ] New tests added (for any new behavior)
- [x] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->