### PR TITLE
Reduce unnecessary CI jobs (dependencies) & check commit isolation

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -161,6 +161,15 @@ jobs:
         uses: codecov/codecov-action@v3
 
   pytest-on-other-platforms:
+    needs:
+      - mypy
+      - ruff
+      - isort
+      - black
+      - codespell
+      - hotkeys
+      - docstrings
+      - base_pytest
     strategy:
       # Not failing fast allows all matrix jobs to try & finish even if one fails early
       fail-fast: false

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -134,15 +134,40 @@ jobs:
       - name: Run lint-docstring
         run: ./tools/lint-docstring
 
-  pytest:
+  base_pytest:
+    runs-on: ubuntu-latest
+    name: Install & test - CPython 3.7 (ubuntu), codecov
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - name: Install Python version
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.7
+          cache: 'pip'
+          cache-dependency-path: 'setup.py'
+      - name: Output Python version
+        run: python --version
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
+      - name: Ensure regular package installs from checkout
+        run: pip install .
+      - name: Install test dependencies
+        run: pip install .[testing]
+      - name: Run tests with pytest
+        run: pytest --cov-report=xml
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+
+  pytest-on-other-platforms:
     strategy:
       # Not failing fast allows all matrix jobs to try & finish even if one fails early
       fail-fast: false
       matrix:
         env:
-          - {PYTHON: 3.7, OS: ubuntu-latest, NAME: "CPython 3.7 (ubuntu)", EXPECT: "Linux"}
           - {PYTHON: 3.8, OS: ubuntu-latest, NAME: "CPython 3.8 (ubuntu)", EXPECT: "Linux"}
-          - {PYTHON: 3.9, OS: ubuntu-latest, NAME: "CPython 3.9 (ubuntu)", EXPECT: "Linux", CODECOV: true}
+          - {PYTHON: 3.9, OS: ubuntu-latest, NAME: "CPython 3.9 (ubuntu)", EXPECT: "Linux"}
           - {PYTHON: "3.10", OS: ubuntu-latest, NAME: "CPython 3.10 (ubuntu)", EXPECT: "Linux"}
           - {PYTHON: "3.11", OS: ubuntu-latest, NAME: "CPython 3.11 (ubuntu)", EXPECT: "Linux"}
           - {PYTHON: 'pypy-3.7', OS: ubuntu-latest, NAME: "PyPy 3.7 (ubuntu)", EXPECT: "Linux"}
@@ -177,8 +202,4 @@ jobs:
       - name: Install test dependencies
         run: pip install .[testing]
       - name: Run tests with pytest
-        run: pytest --cov-report=xml
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        # We avoid extra work by just running codecov on one python version
-        if: matrix.env.CODECOV
+        run: pytest --cov-report=

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -160,7 +160,9 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
 
-  pytest-on-other-platforms:
+  isolated-commits:
+    runs-on: ubuntu-latest
+    name: Ensure isolated PR commits
     needs:
       - mypy
       - ruff
@@ -170,6 +172,30 @@ jobs:
       - hotkeys
       - docstrings
       - base_pytest
+    steps:
+      - uses: actions/checkout@v3
+        if: github.event_name == 'pull_request'
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+      - uses: actions/setup-python@v4
+        if: github.event_name == 'pull_request'
+        with:
+          python-version: 3.7
+          cache: 'pip'
+          cache-dependency-path: 'setup.py'
+      - name: Testing install
+        if: github.event_name == 'pull_request'
+        run: pip install .[linting,testing,typing]
+      - name: Run check-branch
+        if: github.event_name == 'pull_request'
+        run:
+          git fetch https://github.com/zulip/zulip-terminal main;
+          ./tools/check-branch FETCH_HEAD
+
+  pytest-on-other-platforms:
+    needs: isolated-commits
     strategy:
       # Not failing fast allows all matrix jobs to try & finish even if one fails early
       fail-fast: false


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->

Groups CI (GitHub Actions) jobs, so that sets of jobs must complete before others.

Currently all jobs run independently, which means that even if linting fails then we still pytest on every platform, and vice versa (assuming no other issues). That shows clearly where the problem is, but running pytest on every python+platform is something we likely should only do once the code passes simpler checks. This would minimize resources spent on spinning up various parts of CI, but also may present a simpler view to devs.

The other feature included here is an intermediate dependent stage to check for commit isolation, using the tool `check-branch` added in #1214.

<!-- Add a link to a discussion on chat.zulip.org, if relevant -->

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [ ] Existing tests (adapted, if necessary)
- [ ] New tests added (for any new behavior)
- [x] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

**Notes & Questions** <!-- if any; add/delete/fill-in as appropriate -->

**Edit** The last commit is now updated to only run the per-commit checks within a pull request, but also the other tests on a push; the format is not exactly DRY, but works fine and can be iterated upon.

Good followup would be relate each set of jobs to a part of the documentation, though even grouping in this way should help already with discussions with contributors.