### PR TITLE
Upgrade to mypy 1.0.0 after incompatible typeshed change

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ linting_deps = [
 
 typing_deps = [
     "lxml-stubs",
-    "mypy==0.961",
+    "mypy~=1.0.0",
     "types-pygments",
     "types-python-dateutil",
     "types-tzlocal",

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -550,7 +550,7 @@ def main(options: Optional[List[str]] = None) -> None:
                 pudb.post_mortem()
 
         if hasattr(e, "extra_info"):
-            print(in_color("red", f"\n{e.extra_info}"), file=sys.stderr)  # type: ignore
+            print(in_color("red", f"\n{e.extra_info}"), file=sys.stderr)
 
         print(
             in_color(

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -1096,6 +1096,7 @@ class MessageBox(urwid.Pile):
             ]
         else:
             self.model.controller.view.search_box.text_box.set_edit_text("")
+        text_to_fill: Union[str, Tuple[str, List[Tuple[str, str]]]]
         if curr_narrow == []:
             text_to_fill = "All messages"
         elif len(curr_narrow) == 1 and curr_narrow[0][1] == "private":
@@ -1110,14 +1111,14 @@ class MessageBox(urwid.Pile):
             bar_color = f"s{bar_color}"
             if len(curr_narrow) == 2 and curr_narrow[1][0] == "topic":
                 text_to_fill = (
-                    "bar",  # type: ignore
+                    "bar",
                     [
                         (bar_color, self.stream_name),
                         (bar_color, ": topic narrow"),
                     ],
                 )
             else:
-                text_to_fill = ("bar", [(bar_color, self.stream_name)])  # type: ignore
+                text_to_fill = ("bar", [(bar_color, self.stream_name)])
         elif len(curr_narrow) == 1 and len(curr_narrow[0][1].split(",")) > 1:
             text_to_fill = "Group private conversation"
         else:


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->

Bumps mypy version to 1.0.0 and makes minor changes to remove some type ignores, one of which caused a linting error.

The commits are structured to bump mypy first, since it seems that lots of type stubs became incompatible with mypy < 1.0 in python/typeshed#9702, which I assume translated into an incompatible `types-requests`. This translates into 2 `Self?`-related errors in ZT, maybe more elsewhere.

The second commit then makes some minor adjustments to take into account the mypy bump. These are only typing changes (or ignore-comments) so should not substantively affect the code running, though arguably they do fix the previous commit. I'm keeping them separate for clarity.

<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->

<!-- Add a link to a discussion on chat.zulip.org, if relevant -->

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [ ] New tests added (for any new behavior)
- [ ] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

<!-- See https://github.com/zulip/zulip-terminal#commit-style -->
