### PR TITLE
Migrate from flake8 to ruff

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -31,9 +31,9 @@ jobs:
       - name: Run mypy
         run: ./tools/run-mypy
 
-  flake8:
+  ruff:
     runs-on: ubuntu-latest
-    name: Lint - PEP8 & more (flake8)
+    name: Lint - PEP8 & more (ruff)
     steps:
       - uses: actions/checkout@v3
         with:
@@ -45,8 +45,8 @@ jobs:
           cache-dependency-path: 'setup.py'
       - name: Install with linting tools
         run: pip install .[linting]
-      - name: Run flake8
-        run: flake8 zulipterminal/ tests/ setup.py `tools/python_tools.py`
+      - name: Run ruff
+        run: ruff zulipterminal/ tests/ setup.py `tools/python_tools.py`
 
   isort:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -5,10 +5,12 @@
 [![Zulip chat](https://img.shields.io/badge/zulip-join_chat-brightgreen.svg)](https://chat.zulip.org/#narrow/stream/206-zulip-terminal)
 [![PyPI](https://img.shields.io/pypi/v/zulip-term.svg)](https://pypi.python.org/pypi/zulip-term)
 [![Python Versions](https://img.shields.io/pypi/pyversions/zulip-term.svg)](https://pypi.python.org/pypi/zulip-term)
+
 [![GitHub Actions - Linting & tests](https://github.com/zulip/zulip-terminal/workflows/Linting%20%26%20tests/badge.svg?branch=main)](https://github.com/zulip/zulip-terminal/actions?query=workflow%3A%22Linting+%26+tests%22+branch%3Amain)
 [![Coverage status](https://img.shields.io/codecov/c/github/zulip/zulip-terminal/main.svg)](https://app.codecov.io/gh/zulip/zulip-terminal/branch/main)
 [![Checked with mypy](http://www.mypy-lang.org/static/mypy_badge.svg)](http://mypy-lang.org/)
 [![code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/charliermarsh/ruff/main/assets/badge/v1.json)](https://github.com/charliermarsh/ruff)
 
 ![Screenshot](https://user-images.githubusercontent.com/9568999/169362381-3c2b19e2-2176-4ad0-bd41-604946432512.png)
 

--- a/docs/developer-file-overview.md
+++ b/docs/developer-file-overview.md
@@ -8,7 +8,7 @@ Zulip Terminal uses [Zulip's API](https://zulip.com/api/) to store and retrieve 
 | Folder                 | File                | Description                                                                                            |
 | ---------------------- | ------------------- | ------------------------------------------------------------------------------------------------------ |
 | zulipterminal          | api_types.py        | Types from the Zulip API, translated into python, to improve type checking                             |
-|                        | core.py             | Defines the `Controller`, which sets up the `model`, `view`, and coordinates the application           |
+|                        | core.py             | Defines the `Controller`, which sets up the `Model`, `View`, and how they interact                     |
 |                        | helper.py           | Helper functions used in multiple places                                                               |
 |                        | model.py            | Defines the `Model`, fetching and storing data retrieved from the Zulip server                         |
 |                        | platform_code.py    | Detection of supported platforms & platform-specific functions                                         |
@@ -30,7 +30,7 @@ Zulip Terminal uses [Zulip's API](https://zulip.com/api/) to store and retrieve 
 |                        | ui_sizes.py         | Fixed sizes of UI elements                                                                             |
 |                        |                     |                                                                                                        |
 | zulipterminal/ui_tools | boxes.py            | UI boxes for entering text: WriteBox, MessageSearchBox, PanelSearchBox                                 |
-|                        | buttons.py          | UI buttons for 'narrowing' & showing unread counts, eg. All, Stream, Private message, Topic, Starred   |
+|                        | buttons.py          | UI buttons for narrowing & showing unread counts, eg. All, Stream, Private, Topic                      |
 |                        | messages.py         | UI to render a Zulip message for display, and respond contextually to actions                          |
 |                        | tables.py           | Helper functions which render tables in the UI                                                         |
 |                        | utils.py            | The `MessageBox` for every message displayed is created here                                           |

--- a/makefile
+++ b/makefile
@@ -36,8 +36,7 @@ force-fix: venv
 	@echo "=== Auto-fixing files ==="
 	isort $(SOURCES) tools
 	black zulipterminal/ tests/
-	autopep8 --recursive --in-place $(SOURCES)
-	autoflake --recursive --in-place $(SOURCES)
+	ruff --fix $(SOURCES)
 
 ### VENV SETUP ###
 # Short name for file dependency

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,11 +14,11 @@ exclude = [
     "zt_venv",
 ]
 ignore = [
-    # E501 - Ignore max-line-length property - this is already defined by black
-    "E501",
     # F841 - assigned to but never used - FIXME: indicates potential issues
     "F841",
 ]
+# Ignore length in tools for now (and otherwise where noqa specified)
+per-file-ignores = {"tools/*" = ["E501"]}
 select = [
     "E", # Error (pycodestyle)
     "F", # pyFlakes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,26 @@
 [tool.black]
-# Default line-length, but use explicit value here since used for isort & flake8
+# Default line-length, but use explicit value here since used for isort & ruff
 line-length = 88
 target-version = ['py36']
+
+[tool.ruff]
+line-length = 88
+target-version = "py37"
+exclude = [
+    ".git",
+    "__pycache__",
+    "build",
+    "dist",
+    "zt_venv",
+]
+ignore = [
+    # E501 - Ignore max-line-length property - this is already defined by black
+    "E501",
+    # F841 - assigned to but never used - FIXME: indicates potential issues
+    "F841",
+]
+select = [
+    "E", # Error (pycodestyle)
+    "F", # pyFlakes
+    "W", # Warnings (pycodestyle)
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,6 @@ exclude = [
     "zt_venv",
 ]
 ignore = [
-    # F841 - assigned to but never used - FIXME: indicates potential issues
-    "F841",
 ]
 # Ignore length in tools for now (and otherwise where noqa specified)
 per-file-ignores = {"tools/*" = ["E501"]}

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,37 +21,6 @@ atomic=True
 # This is compatible with black, but we could remove it
 lines_after_imports=2
 
-# flake8 takes a little more time than pycodestyle, but finds more things
-# (we could also look at pylint, zulint, etc.)
-[flake8]
-max-line-length=88
-ignore=
-  # E121 - continuation line under-indented for hanging indent
-  E121,
-  # E123 - closing bracket does not match indentation of opening bracket's line
-  E123,
-  # E126 - continuation line over-indented for hanging indent
-  E126,
-  # W503 - line break before binary operator - new PEP8 best practice, cf W504
-  W503,
-  # E203 - Colons should not have any space before them (conflicts with black)
-  E203,
-  # E241 - Multiple spaces after ',' - breaks layouts like themes files
-  E241,
-  # E221 - Multiple spaces before operator - breaks layouts like theme files
-  E221,
-  # E252 - Spaces in parameters, a style deliberately avoided
-  E252,
-  # E501 - Ignore max-line-length property - this is already defined by black
-  E501,
-  # F841 - assigned to but never used - FIXME: indicates potential issues
-  F841,
-  # Q000 - inline quotes - FIXME: standardize on " or ' in future?
-  Q000,
-inline-quotes = "
-multiline-quotes = """
-exclude=.git,__pycache__,build,dist,zt_venv
-
 [mypy]
 python_version = 3.6
 

--- a/setup.py
+++ b/setup.py
@@ -43,10 +43,8 @@ testing_deps = [
 
 linting_deps = [
     "isort~=5.10.1",
-    "flake8~=4.0.1",
-    "flake8-quotes~=3.2.0",
-    "flake8-continuation~=1.0.5",
     "black~=23.0",
+    "ruff",
 ]
 
 typing_deps = [
@@ -63,8 +61,6 @@ dev_helper_deps = [
     "pudb==2022.1.1",
     "snakeviz>=2.1.1",
     "gitlint>=0.17",
-    "autopep8~=1.6.0",
-    "autoflake~=1.4.0",
 ]
 
 setup(

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -420,11 +420,13 @@ def test_successful_main_function_with_config(
     [
         (
             {"footlinks": "enabled", "maximum-footlinks": "3"},
-            "Configuration Error: footlinks and maximum-footlinks options cannot be used together",
+            "Configuration Error: footlinks and maximum-footlinks options"
+            " cannot be used together",
         ),
         (
             {"maximum-footlinks": "-3"},
-            "Configuration Error: Minimum value allowed for maximum-footlinks is 0; you used '-3'",
+            "Configuration Error: Minimum value allowed for maximum-footlinks"
+            " is 0; you used '-3'",
         ),
     ],
 )

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -434,7 +434,7 @@ class TestController:
 
     def test_main(self, mocker: MockerFixture, controller: Controller) -> None:
         controller.view.palette = {"default": "theme_properties"}
-        mock_tsk = mocker.patch(MODULE + ".Screen.tty_signal_keys")
+        mocker.patch(MODULE + ".Screen.tty_signal_keys")
         controller.loop.screen.tty_signal_keys = mocker.Mock(return_value={})
 
         controller.main()
@@ -564,7 +564,7 @@ class TestController:
         active_conversation_info: Dict[str, str],
     ) -> None:
         set_footer_text = mocker.patch(VIEW + ".set_footer_text")
-        sleep = mocker.patch(MODULE + ".time.sleep")
+        mocker.patch(MODULE + ".time.sleep")
         controller.active_conversation_info = active_conversation_info
 
         def mock_typing() -> None:

--- a/tests/helper/test_helper.py
+++ b/tests/helper/test_helper.py
@@ -436,7 +436,8 @@ def test_notify_if_message_sent_outside_narrow(
         key = primary_key_for_command("NARROW_MESSAGE_RECIPIENT")
         report_success.assert_called_once_with(
             [
-                f"Message is sent outside of current narrow. Press [{key}] to narrow to conversation."
+                "Message is sent outside of current narrow."
+                f" Press [{key}] to narrow to conversation."
             ],
             duration=6,
         )

--- a/tests/helper/test_helper.py
+++ b/tests/helper/test_helper.py
@@ -312,7 +312,7 @@ def test_color_formats(mocker: MockerFixture, color: str) -> None:
 )
 def test_invalid_color_format(mocker: MockerFixture, color: str) -> None:
     with pytest.raises(ValueError) as e:
-        canon = canonicalize_color(color)
+        canonicalize_color(color)
     assert str(e.value) == f'Unknown format for color "{color}"'
 
 

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -1101,7 +1101,8 @@ class TestModel:
                     "_moderator": ["", True],
                     "_member": ["", True],
                     "_guest": [
-                        "Only organization administrators, moderators, full members and members can edit topic",
+                        "Only organization administrators, moderators, full members and"
+                        " members can edit topic",
                         False,
                     ],
                 },
@@ -1137,7 +1138,8 @@ class TestModel:
                     "_moderator": ["", True],
                     "_member": ["", True],
                     "_guest": [
-                        "Only organization administrators, moderators and full members can edit topic",
+                        "Only organization administrators, moderators and full members"
+                        " can edit topic",
                         False,
                     ],
                 },
@@ -1151,11 +1153,13 @@ class TestModel:
                     "_admin": ["", True],
                     "_moderator": ["", True],
                     "_member": [
-                        "Only organization administrators and moderators can edit topic",
+                        "Only organization administrators and moderators"
+                        " can edit topic",
                         False,
                     ],
                     "_guest": [
-                        "Only organization administrators and moderators can edit topic",
+                        "Only organization administrators and moderators"
+                        " can edit topic",
                         False,
                     ],
                 },
@@ -3591,11 +3595,11 @@ class TestModel:
                 (1, "topic"),
                 id="unread_present_before_previous_topic",
             ),
-            case(
+            case(  # TODO Should be None? (2 other cases)
                 {(1, "topic")},
                 (1, "topic"),
                 (1, "topic"),
-                id="unread_still_present_in_topic",  # TODO Should be None? (2 other cases)
+                id="unread_still_present_in_topic",
             ),
             case(
                 {},

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -197,7 +197,7 @@ class TestModel:
         )
 
         with pytest.raises(ServerConnectionFailure) as e:
-            model = Model(self.controller)
+            Model(self.controller)
 
         assert str(e.value) == "Invalid API key (get_messages, register)"
 
@@ -215,7 +215,7 @@ class TestModel:
         )
 
         with pytest.raises(ServerConnectionFailure) as e:
-            model = Model(self.controller)
+            Model(self.controller)
 
         assert str(e.value) == exception_text + " (get_messages, register)"
 
@@ -1364,8 +1364,6 @@ class TestModel:
         model = Model(self.controller)
         model.get_messages(num_before=num_before, num_after=num_after, anchor=0)
         self.client.get_messages.return_value = messages_successful_response
-        # anchor should have remained the same
-        anchor = messages_successful_response["anchor"]
         assert model.index["pointer"][repr(model.narrow)] == 0
 
         # TEST `query_range` < no of messages received
@@ -1391,7 +1389,7 @@ class TestModel:
         # self.client.do_api_query.return_value = error_response
 
         with pytest.raises(ServerConnectionFailure):
-            model = Model(self.controller)
+            Model(self.controller)
 
     @pytest.mark.parametrize(
         "response, expected_raw_content, display_error_called",
@@ -1660,7 +1658,7 @@ class TestModel:
     ):
         model._have_last_message[repr([])] = True
         mocker.patch(MODEL + "._update_topic_index")
-        index_msg = mocker.patch(MODULE + ".index_messages", return_value={})
+        mocker.patch(MODULE + ".index_messages", return_value={})
         self.controller.view.message_view = mocker.Mock(log=[])
         create_msg_box_list = mocker.patch(
             MODULE + ".create_msg_box_list", return_value=["msg_w"]
@@ -1679,7 +1677,7 @@ class TestModel:
     def test__handle_message_event_with_valid_log(self, mocker, model, message_fixture):
         model._have_last_message[repr([])] = True
         mocker.patch(MODEL + "._update_topic_index")
-        index_msg = mocker.patch(MODULE + ".index_messages", return_value={})
+        mocker.patch(MODULE + ".index_messages", return_value={})
         self.controller.view.message_view = mocker.Mock(log=[mocker.Mock()])
         create_msg_box_list = mocker.patch(
             MODULE + ".create_msg_box_list", return_value=["msg_w"]
@@ -1701,11 +1699,9 @@ class TestModel:
     def test__handle_message_event_with_flags(self, mocker, model, message_fixture):
         model._have_last_message[repr([])] = True
         mocker.patch(MODEL + "._update_topic_index")
-        index_msg = mocker.patch(MODULE + ".index_messages", return_value={})
+        mocker.patch(MODULE + ".index_messages", return_value={})
         self.controller.view.message_view = mocker.Mock(log=[mocker.Mock()])
-        create_msg_box_list = mocker.patch(
-            MODULE + ".create_msg_box_list", return_value=["msg_w"]
-        )
+        mocker.patch(MODULE + ".create_msg_box_list", return_value=["msg_w"])
         model.notify_user = mocker.Mock()
         set_count = mocker.patch(MODULE + ".set_count")
 
@@ -1841,10 +1837,8 @@ class TestModel:
     ):
         model._have_last_message[repr(narrow)] = True
         mocker.patch(MODEL + "._update_topic_index")
-        index_msg = mocker.patch(MODULE + ".index_messages", return_value={})
-        create_msg_box_list = mocker.patch(
-            MODULE + ".create_msg_box_list", return_value=["msg_w"]
-        )
+        mocker.patch(MODULE + ".index_messages", return_value={})
+        mocker.patch(MODULE + ".create_msg_box_list", return_value=["msg_w"])
         set_count = mocker.patch(MODULE + ".set_count")
         self.controller.view.message_view = mocker.Mock(log=[])
         (
@@ -2397,7 +2391,7 @@ class TestModel:
         self.controller.view.message_view = mocker.Mock(log=[msg_w, other_msg_w])
         # New msg widget generated after updating index.
         new_msg_w = mocker.Mock()
-        cmbl = mocker.patch(MODULE + ".create_msg_box_list", return_value=[new_msg_w])
+        mocker.patch(MODULE + ".create_msg_box_list", return_value=[new_msg_w])
 
         model._update_rendered_view(msg_id)
 
@@ -2427,14 +2421,13 @@ class TestModel:
         self, mocker, model, subject, narrow, narrow_changed, msg_id=1
     ):
         msg_w = mocker.Mock()
-        other_msg_w = mocker.Mock()
         msg_w.original_widget.message = {"id": msg_id, "subject": subject}
         model.narrow = narrow
         self.controller.view.message_view = mocker.Mock(log=[msg_w])
         # New msg widget generated after updating index.
         original_widget = mocker.Mock(message=dict(id=2))  # FIXME: id matters?
         new_msg_w = mocker.Mock(original_widget=original_widget)
-        cmbl = mocker.patch(MODULE + ".create_msg_box_list", return_value=[new_msg_w])
+        mocker.patch(MODULE + ".create_msg_box_list", return_value=[new_msg_w])
 
         model._update_rendered_view(msg_id)
 

--- a/tests/platform_code/test_platform_code.py
+++ b/tests/platform_code/test_platform_code.py
@@ -64,7 +64,7 @@ def test_notify_quotes(
     text: str,
 ) -> None:
     subprocess = mocker.patch(MODULE + ".subprocess")
-    platform = mocker.patch(MODULE + ".PLATFORM", PLATFORM)
+    mocker.patch(MODULE + ".PLATFORM", PLATFORM)
 
     notify(title, text)
 

--- a/tests/ui/test_ui.py
+++ b/tests/ui/test_ui.py
@@ -474,7 +474,7 @@ class TestView:
         view.body = mocker.Mock()
         view.user_search = mocker.Mock()
 
-        super_view = mocker.patch(MODULE + ".urwid.WidgetWrap.keypress")
+        mocker.patch(MODULE + ".urwid.WidgetWrap.keypress")
 
         view.controller.is_in_editor_mode = lambda: True
         size = widget_size(view)

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1018,7 +1018,7 @@ class TestRightColumnView:
         self.view.users = ["USER1", "USER2"]
         mocker.patch(VIEWS + ".match_user", return_value=match_return_value)
         mocker.patch(VIEWS + ".UsersView")
-        list_w = mocker.patch(VIEWS + ".urwid.SimpleFocusListWalker")
+        mocker.patch(VIEWS + ".urwid.SimpleFocusListWalker")
         set_body = mocker.patch(VIEWS + ".urwid.Frame.set_body")
 
         right_col_view.update_user_list("SEARCH_BOX", search_string)
@@ -1059,7 +1059,6 @@ class TestRightColumnView:
         users_view = mocker.patch(VIEWS + ".UsersView")
         right_col_view = RightColumnView(self.view)
         if status != "inactive":
-            unread_counts = right_col_view.view.model.unread_counts
             user_btn.assert_called_once_with(
                 user=self.view.users[0],
                 controller=self.view.controller,
@@ -1152,11 +1151,11 @@ class TestLeftColumnView:
         self.view.unpinned_streams = [s for s in streams if s["id"] not in pinned]
         self.view.pinned_streams = [s for s in streams if s["id"] in pinned]
         stream_button = mocker.patch(VIEWS + ".StreamButton")
-        stream_view = mocker.patch(VIEWS + ".StreamsView")
-        line_box = mocker.patch(VIEWS + ".urwid.LineBox")
+        mocker.patch(VIEWS + ".StreamsView")
+        mocker.patch(VIEWS + ".urwid.LineBox")
         divider = mocker.patch(VIEWS + ".StreamsViewDivider")
 
-        left_col_view = LeftColumnView(self.view)
+        LeftColumnView(self.view)
 
         if pinned:
             assert divider.called
@@ -1179,8 +1178,8 @@ class TestLeftColumnView:
         mocker.patch(VIEWS + ".LeftColumnView.streams_view")
         mocker.patch(VIEWS + ".LeftColumnView.menu_view")
         topic_button = mocker.patch(VIEWS + ".TopicButton")
-        topics_view = mocker.patch(VIEWS + ".TopicsView")
-        line_box = mocker.patch(VIEWS + ".urwid.LineBox")
+        mocker.patch(VIEWS + ".TopicsView")
+        mocker.patch(VIEWS + ".urwid.LineBox")
         topic_list = ["TOPIC1", "TOPIC2", "TOPIC3"]
         unread_count_list = [34, 100, 0]
         self.view.model.topics_in_stream = mocker.Mock(return_value=topic_list)

--- a/tests/ui/test_utils.py
+++ b/tests/ui/test_utils.py
@@ -164,7 +164,7 @@ def test_create_msg_box_list(
         },
         "pointer": {},
     }
-    msg_box = mocker.patch(MODULE + ".MessageBox")
+    mocker.patch(MODULE + ".MessageBox")
     mocker.patch(MODULE + ".urwid.AttrMap", return_value="MSG")
     mock_muted = mocker.patch(MODULE + ".is_muted", return_value=muted)
     mocker.patch(

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -854,7 +854,8 @@ class TestWriteBox:
                 },
                 {"pinned": ["Secret stream", "Stream 1"], "muted": ["Secret stream"]},
             ),
-            # With 'Stream 1' and 'Secret stream' pinned, 'Some general stream' and 'Stream 2' muted.
+            # With 'Stream 1' and 'Secret stream' pinned,
+            # 'Some general stream' and 'Stream 2' muted.
             (
                 "#Stream",
                 {
@@ -869,7 +870,8 @@ class TestWriteBox:
                     "muted": ["Some general stream", "Stream 2"],
                 },
             ),
-            # With 'Stream 1' and 'Secret stream' pinned, 'Secret stream' and 'Stream 2' muted.
+            # With 'Stream 1' and 'Secret stream' pinned,
+            # 'Secret stream' and 'Stream 2' muted.
             (
                 "#Stream",
                 {
@@ -896,7 +898,8 @@ class TestWriteBox:
                 },
                 {"current_stream": 1},
             ),
-            # With 'Stream 1' and 'Secret stream' pinned, 'Secret stream' and 'Stream 2' muted, 'Stream 2' as current stream.
+            # With 'Stream 1' and 'Secret stream' pinned,
+            # 'Secret stream' and 'Stream 2' muted, 'Stream 2' as current stream.
             (
                 "#Stream",
                 {
@@ -1224,7 +1227,8 @@ class TestWriteBox:
         )
 
     @pytest.mark.parametrize(
-        "stream_name, stream_id, is_valid_stream, stream_access_type, expected_marker, expected_color",
+        "stream_name, stream_id, is_valid_stream, stream_access_type,"
+        " expected_marker, expected_color",
         [
             (
                 "Web public stream",

--- a/tests/ui_tools/test_buttons.py
+++ b/tests/ui_tools/test_buttons.py
@@ -324,7 +324,7 @@ class TestEmojiButton:
     ) -> None:
         controller = mocker.Mock()
         controller.model.has_user_reacted_to_message = mocker.Mock(return_value=False)
-        update_widget = mocker.patch(MODULE + ".EmojiButton.update_check_mark")
+        mocker.patch(MODULE + ".EmojiButton.update_check_mark")
         top_button = mocker.patch(MODULE + ".TopButton.__init__")
         label = ", ".join([emoji_unit[0], *emoji_unit[2]])
         message_fixture["reactions"] = to_vary_in_message["reactions"]
@@ -476,7 +476,7 @@ class TestTopicButton:
         )
         controller.model.stream_dict = {205: {"name": stream_name}}
         view = mocker.Mock()
-        topic_button = TopicButton(
+        TopicButton(
             stream_id=205,
             topic=title,
             controller=controller,

--- a/tests/ui_tools/test_messages.py
+++ b/tests/ui_tools/test_messages.py
@@ -63,7 +63,7 @@ class TestMessageBox:
         message = dict(type="BLAH")
 
         with pytest.raises(RuntimeError):
-            msg_box = MessageBox(message, self.model, None)
+            MessageBox(message, self.model, None)
 
     def test_private_message_to_self(self, mocker):
         message = dict(
@@ -748,7 +748,7 @@ class TestMessageBox:
                 "color": "#bd6",
             },
         }
-        msg_box = MessageBox(message, self.model, last_message)
+        MessageBox(message, self.model, last_message)
 
     @pytest.mark.parametrize(
         "message",

--- a/tests/ui_tools/test_messages.py
+++ b/tests/ui_tools/test_messages.py
@@ -1171,7 +1171,10 @@ class TestMessageBox:
                 {"stream": False, "private": False},
                 {"stream": False, "private": False},
                 {
-                    "stream": " You can't edit messages sent by other users that already have a topic.",
+                    "stream": (
+                        " You can't edit messages sent by other users"
+                        " that already have a topic."
+                    ),
                     "private": " You can't edit private messages sent by other users.",
                 },
                 id="msg_sent_by_other_user_with_topic",
@@ -1183,8 +1186,10 @@ class TestMessageBox:
                 {"stream": False, "private": False},
                 {"stream": True, "private": False},
                 {
-                    "stream": " Only topic editing allowed."
-                    " Time Limit for editing the message body has been exceeded.",
+                    "stream": (
+                        " Only topic editing allowed."
+                        " Time Limit for editing the message body has been exceeded."
+                    ),
                     "private": " Time Limit for editing the message has been exceeded.",
                 },
                 id="topic_edit_only_after_time_limit",
@@ -1226,8 +1231,10 @@ class TestMessageBox:
                 {"stream": False, "private": False},
                 {"stream": True, "private": False},
                 {
-                    "stream": " Only topic editing allowed."
-                    " Time Limit for editing the message body has been exceeded.",
+                    "stream": (
+                        " Only topic editing allowed."
+                        " Time Limit for editing the message body has been exceeded."
+                    ),
                     "private": " Time Limit for editing the message has been exceeded.",
                 },
                 id="msg_sent_by_me_with_no_topic",
@@ -1239,8 +1246,10 @@ class TestMessageBox:
                 {"stream": False, "private": False},
                 {"stream": True, "private": False},
                 {
-                    "stream": " Only topic editing is allowed."
-                    " This is someone else's message but with (no topic).",
+                    "stream": (
+                        " Only topic editing is allowed."
+                        " This is someone else's message but with (no topic)."
+                    ),
                     "private": " You can't edit private messages sent by other users.",
                 },
                 id="msg_sent_by_other_with_no_topic",

--- a/tools/convert-unicode-emoji-data
+++ b/tools/convert-unicode-emoji-data
@@ -41,6 +41,8 @@ with OUTPUT_FILE.open("w") as f:
                 '"""',
                 DOCSTRING,
                 '"""',
+                "# Ignore long lines",
+                "# ruff: noqa: E501",
                 "",
                 "from collections import OrderedDict\n\n",
                 "# fmt: off",

--- a/tools/convert-unicode-emoji-data
+++ b/tools/convert-unicode-emoji-data
@@ -73,4 +73,4 @@ try:
     INPUT_FILE.unlink()
     print(f"{INPUT_FILE} deleted.")
 except Exception as exc:
-    print("Warning: Could not delete file:\n{exc}")
+    print(f"Warning: Could not delete file:\n{exc}")

--- a/tools/lint-all
+++ b/tools/lint-all
@@ -17,7 +17,7 @@ python_sources += lintable_tools_files
 tools = {
     "Import order (isort)": "./tools/run-isort-check",
     "Type consistency (mypy)": "./tools/run-mypy",
-    "PEP8 & more (flake8)": ["flake8"] + python_sources,
+    "PEP8 & more (ruff)": ["ruff"] + python_sources,
     "Formatting (black)": ["black", "--check"] + python_sources,
     "Hotkey linting & docs sync check": [
         "./tools/generate_hotkeys.py",

--- a/tools/lint-docstring
+++ b/tools/lint-docstring
@@ -9,7 +9,7 @@ from typing import Dict, List
 
 
 TABLE_OFFSET = 10
-COLUMN_WIDTHS = (23, 20, 103)
+COLUMN_WIDTHS = (23, 20, 88)  # Use 88 as line-length for docstring for simplicity
 SPACEBAR = " "
 
 # leaving blank rows after exhausting files from each folder

--- a/tools/lister.py
+++ b/tools/lister.py
@@ -84,8 +84,8 @@ def list_files(
     # throw away empty lines and non-files (like symlinks)
     files = list(filter(os.path.isfile, files_gen))
 
-    result_dict = defaultdict(list)  # type: Dict[str, List[str]]
-    result_list = []  # type: List[str]
+    result_dict: Dict[str, List[str]] = defaultdict(list)
+    result_list: List[str] = []
 
     for fpath in files:
         # this will take a long time if exclude is very large

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -262,7 +262,7 @@ def _write_zuliprc(
         ) as f:
             f.write(f"[api]\nemail={login_id}\nkey={api_key}\nsite={server_url}")
         return ""
-    except FileExistsError as ex:
+    except FileExistsError:
         return f"zuliprc already exists at {to_path}"
     except OSError as ex:
         return f"{ex.__class__.__name__}: zuliprc could not be created at {to_path}"

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -433,7 +433,7 @@ def is_command_key(command: str, key: str) -> bool:
     try:
         return key in KEY_BINDINGS[command]["keys"]
     except KeyError as exception:
-        raise InvalidCommand(command)
+        raise InvalidCommand(command) from exception
 
 
 def keys_for_command(command: str) -> List[str]:
@@ -443,7 +443,7 @@ def keys_for_command(command: str) -> List[str]:
     try:
         return list(KEY_BINDINGS[command]["keys"])
     except KeyError as exception:
-        raise InvalidCommand(command)
+        raise InvalidCommand(command) from exception
 
 
 def primary_key_for_command(command: str) -> str:

--- a/zulipterminal/config/ui_mappings.py
+++ b/zulipterminal/config/ui_mappings.py
@@ -62,12 +62,12 @@ ROLE_BY_ID: Dict[int, Dict[str, str]] = {
 STREAM_POST_POLICY = {
     1: "Any user can post",
     2: "Only organization administrators can send to this stream",
-    3: "Only organization administrators, moderators and full members can send to this stream",
+    3: "Only organization administrators, moderators and full members can send to this stream",  # noqa: E501
     4: "Only organization administrators and moderators can send to this stream",
 }
 
 EDIT_TOPIC_POLICY = {
-    1: "Only organization administrators, moderators, full members and members can edit topic",
+    1: "Only organization administrators, moderators, full members and members can edit topic",  # noqa: E501
     2: "Only organization administrators can edit topic",
     3: "Only organization administrators, moderators and full members can edit topic",
     4: "Only organization administrators and moderators can edit topic",

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -419,7 +419,8 @@ class Controller:
                 browser_controller.open(url)
                 self.report_success(
                     [
-                        f"The link was successfully opened using {browser_controller.name}"
+                        "The link was successfully opened using "
+                        f"{browser_controller.name}"
                     ]
                 )
         except webbrowser.Error as e:

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -1,5 +1,5 @@
 """
-Defines the `Controller`, which sets up the `model`, `view`, and coordinates the application
+Defines the `Controller`, which sets up the `Model`, `View`, and how they interact
 """
 
 import itertools

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -670,7 +670,8 @@ def check_narrow_and_notify(
 
         controller.report_success(
             [
-                f"Message is sent outside of current narrow. Press [{key}] to narrow to conversation."
+                "Message is sent outside of current narrow."
+                f" Press [{key}] to narrow to conversation."
             ],
             duration=6,
         )

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -680,8 +680,6 @@ def check_narrow_and_notify(
 def notify_if_message_sent_outside_narrow(
     message: Composition, controller: Any
 ) -> None:
-    current_narrow = controller.model.narrow
-
     if message["type"] == "stream":
         stream_narrow = [["stream", message["to"]]]
         topic_narrow = stream_narrow + [["topic", message["subject"]]]

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1293,7 +1293,7 @@ class Model:
                     event.get("property", None) == "in_home_view"
                     or event.get("property", None) == "is_muted"
                 ):
-                    # Account for in_home_view and is_muted having opposite boolean values
+                    # in_home_view and is_muted have opposite boolean values
                     event_stream_muted_value: bool
                     if event.get("property", None) == "in_home_view":
                         event_stream_muted_value = not event["value"]

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -1,5 +1,5 @@
 """
-UI buttons for 'narrowing' & showing unread counts, eg. All, Stream, Private message, Topic, Starred
+UI buttons for narrowing & showing unread counts, eg. All, Stream, Private, Topic
 """
 
 import re

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -318,7 +318,7 @@ class TopicButton(TopButton):
             topic_name=self.topic_name,
         )
 
-        # The space acts as a TopButton prefix and gives an effective 3 spaces for unresolved topics.
+        # The space gives an effective 3 spaces for unresolved topics
         topic_prefix = " "
         topic_name = self.topic_name
         if self.topic_name.startswith(RESOLVED_TOPIC_PREFIX):

--- a/zulipterminal/ui_tools/messages.py
+++ b/zulipterminal/ui_tools/messages.py
@@ -1038,7 +1038,8 @@ class MessageBox(urwid.Pile):
                         if self.message["type"] == "private":
                             self.model.controller.report_error(
                                 [
-                                    " Time Limit for editing the message has been exceeded."
+                                    " Time Limit for editing the message"
+                                    " has been exceeded."
                                 ]
                             )
                             return key

--- a/zulipterminal/unicode_emojis.py
+++ b/zulipterminal/unicode_emojis.py
@@ -1,6 +1,8 @@
 """
 Unicode emoji data, synchronized semi-regularly with the server source
 """
+# Ignore long lines
+# ruff: noqa: E501
 
 from collections import OrderedDict
 


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->

This is primarily a straight conversion of the current flake8 linter to use ruff instead.

While this project is significantly smaller in size than the main Zulip repo, so the absolute time savings are smaller, the time saved over many runs will still be significant - and also allow for more checks to be added with very low overhead.

Right now flake8 takes just over 2s on my local machine, and a fraction of a second with ruff, though some of the latter may be with caching. The proportional time saving is similar to that on the ruff site, ie. ruff takes ~1-2% of the time of flake8.

<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->

<!-- Add a link to a discussion on chat.zulip.org, if relevant -->

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [ ] New tests added (for any new behavior)
- [x] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

<!-- See https://github.com/zulip/zulip-terminal#commit-style -->
**Commit flow** <!-- if more than one commit; add/delete/fill-in as appropriate -->

The commits follow a basic structure of migrating, then simplifying existing rules:
* minor adjustment, then migrate packages in use and linting tools
* shorten lines (strings, comments), except few marked with noqa, then drop ignoring E501 (line length)
  * including adjusting docstring linter length
* remove/use set by unused variables, then drop ignoring F841
* add Ruff badge :)

**Notes & Questions** <!-- if any; add/delete/fill-in as appropriate -->

This is a basic migration only. Other commits are forthcoming for other flake8 components that are integrated into ruff, but having this merged keeps things simpler, given the number of changes here already.