### PR TITLE
[WIP] Notify when a message with alert word is received

### DIFF
--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -1978,6 +1978,8 @@ class TestModel:
             "vary_each_msg",
             "visual_notification_status",
             "types_when_notify_called",
+            "is_muted_stream",
+            "is_muted_topic",
         ],
         [
             (
@@ -1985,11 +1987,52 @@ class TestModel:
                 {"flags": ["mentioned", "wildcard_mentioned"]},
                 True,
                 [],
+                None,
+                None,
             ),  # message_fixture sender_id is 5140
-            (5179, {"flags": ["mentioned"]}, False, ["stream", "private"]),
-            (5179, {"flags": ["wildcard_mentioned"]}, False, ["stream", "private"]),
-            (5179, {"flags": []}, True, ["stream", "private"]),
-            (5179, {"flags": []}, False, ["private"]),
+            (5179, {"flags": ["mentioned"]}, False, ["stream", "private"], None, None),
+            (
+                5179,
+                {"flags": ["wildcard_mentioned"]},
+                False,
+                ["stream", "private"],
+                None,
+                None,
+            ),
+            (5179, {"flags": []}, True, ["stream", "private"], None, None),
+            (5179, {"flags": []}, False, ["private"], None, None),
+            (
+                5179,
+                {"flags": ["has_alert_word"]},
+                False,
+                ["stream", "private"],
+                True,
+                True,
+            ),
+            (
+                5179,
+                {"flags": ["has_alert_word"]},
+                False,
+                ["stream", "private"],
+                True,
+                False,
+            ),
+            (
+                5179,
+                {"flags": ["has_alert_word"]},
+                False,
+                ["stream", "private"],
+                False,
+                True,
+            ),
+            (
+                5179,
+                {"flags": ["has_alert_word"]},
+                False,
+                ["stream", "private"],
+                False,
+                False,
+            ),
         ],
         ids=[
             "not_notified_since_self_message",
@@ -1997,6 +2040,10 @@ class TestModel:
             "notified_stream_and_private_since_wildcard_mentioned",
             "notified_stream_since_stream_has_desktop_notifications",
             "notified_private_since_private_message",
+            "not_notified_for_stream_since_topic/stream_both_muted",
+            "not_notified_for_stream_since_stream_muted",
+            "not_notified_for_stream_since_topic_muted",
+            "notified_for_stream_since_topic/stream_both_not_muted",
         ],
     )
     def test_notify_users_calling_msg_type(
@@ -2008,6 +2055,8 @@ class TestModel:
         vary_each_msg,
         visual_notification_status,
         types_when_notify_called,
+        is_muted_stream: Optional[bool],
+        is_muted_topic: Optional[bool],
     ):
         message_fixture.update(vary_each_msg)
         model.user_id = user_id
@@ -2015,6 +2064,8 @@ class TestModel:
             MODEL + ".is_visual_notifications_enabled",
             return_value=visual_notification_status,
         )
+        mocker.patch.object(model, "is_muted_stream", return_value=is_muted_stream)
+        mocker.patch.object(model, "is_muted_topic", return_value=is_muted_topic)
         notify = mocker.patch(MODULE + ".notify")
 
         model.notify_user(message_fixture)
@@ -2031,7 +2082,17 @@ class TestModel:
         if target is not None:
             title = f"Test Organization Name:\nFoo Foo (to {target})"
             # TODO: Test message content too?
-            notify.assert_called_once_with(title, mocker.ANY)
+            if message_fixture["type"] == "private":
+                notify.assert_called_once_with(title, mocker.ANY)
+            elif len(
+                vary_each_msg["flags"]
+            ) == 1 and "has_alert_word" in vary_each_msg.get("flags"):
+                if not is_muted_topic and not is_muted_stream:
+                    notify.assert_called_once_with(title, mocker.ANY)
+                else:
+                    notify.assert_not_called()
+            else:
+                notify.assert_called_once_with(title, mocker.ANY)
         else:
             notify.assert_not_called()
 

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1517,6 +1517,13 @@ class Model:
             ) or self.is_visual_notifications_enabled(stream_id):
                 recipient = "{display_recipient} -> {subject}".format(**message)
 
+            if "has_alert_word" in message["flags"]:
+                # Check if stream or topic is muted
+                topic = message.get("subject", "")
+                if not self.is_muted_stream(stream_id) and not self.is_muted_topic(
+                    stream_id, topic
+                ):
+                    recipient = "{display_recipient} -> {subject}".format(**message)
         if recipient:
             if hidden_content:
                 text = content


### PR DESCRIPTION
model/test_model/conftest : Notify when a message with alert word is received

<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->

<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->
Partial fix for #588
<!-- Add a link to a discussion on chat.zulip.org, if relevant -->

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [X] Manually
- [X] Existing tests (adapted, if necessary)
- [X] New tests added (for any new behavior)
- [X] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

<!-- See https://github.com/zulip/zulip-terminal#commit-style -->
**Commit flow** <!-- if more than one commit; add/delete/fill-in as appropriate -->
<!-- For example:
- first commit doing some thing
- maybe multiple commits doing similar things
-->

**Notes & Questions** <!-- if any; add/delete/fill-in as appropriate -->
<!-- For example:
- this doesn't include feature X (yet?)
- unsure about Y
- should this do Z?
-->
->No changes have been made to for private messages(not required as alert_words would be a subset case for this) 
and in stream added the condition `not is_muted_topic` and `not is_muted_stream` when a message has `flag:'has_alert_word`'
-> Added tests specifically for stream with 3 parameters  `visual_notification_status`,`is_stream_muted`,`is_topic_muted`
-> Added a new `stream_msg_fixture` in `conftest.py` as msg_fixture was present for private messages but not for stream. And the same fixture has been used in added tests.

