### PR TITLE
Enable more ruff linting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ select = [
     "T20", # prinT present
     "W", # Warnings (pycodestyle)
     "UP", # pyUPgrade
+    "YTT", # Year TwentyTwenty (flake8-2020), sys.version checks
 ]
 [tool.ruff.per-file-ignores]
 # ANN: We don't consider this worth typing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,12 +14,16 @@ exclude = [
     "zt_venv",
 ]
 ignore = [
+    "ANN101", # Missing type annotation for `self` in method
+    "ANN102", # Missing type annotation for `cls` in classmethod
+    "ANN401", # Dynamically typed expressions (typing.Any) are disallowed
     "B006", # Do not use mutable data structures for argument defaults
     "B007", # Loop control variable not used within the loop body [informative!]
     "C408", # Unnecessary 'dict' call (rewrite as a literal)
     "UP015", # Unnecessary open mode parameters [informative?]
 ]
 select = [
+    "ANN", # Annotations
     "B", # Bugbear
     "C4", # Comprehensions
     "E", # Error (pycodestyle)
@@ -34,6 +38,14 @@ select = [
     "UP", # pyUPgrade
 ]
 [tool.ruff.per-file-ignores]
+# ANN: We don't consider this worth typing
+"setup.py" = ["ANN"]
+# ANN: These test files are not yet typed
+"tests/model/test_model.py" = ["ANN"]
+"tests/ui/test_ui_tools.py" = ["ANN"]
+"tests/ui_tools/test_messages.py" = ["ANN"]
+# ANN: This tool is an old variation from zulip/zulip and is only updated where necessary
+"tools/lister.py" = ["ANN"]
 # E501: Ignore length in tools for now (and otherwise where noqa specified)
 # T20: Expect print output from CLI from tools
 "tools/*" = ["E501", "T20"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ select = [
     "C4", # Comprehensions
     "E", # Error (pycodestyle)
     "F", # pyFlakes
+    "RUF100", # Checks noqa rules are used
     "W", # Warnings (pycodestyle)
     "UP", # pyUPgrade
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,10 +14,13 @@ exclude = [
     "zt_venv",
 ]
 ignore = [
+    "B006", # Do not use mutable data structures for argument defaults
+    "B007", # Loop control variable not used within the loop body [informative!]
 ]
 # Ignore length in tools for now (and otherwise where noqa specified)
 per-file-ignores = {"tools/*" = ["E501"]}
 select = [
+    "B", # Bugbear
     "E", # Error (pycodestyle)
     "F", # pyFlakes
     "W", # Warnings (pycodestyle)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,9 +25,13 @@ select = [
     "E", # Error (pycodestyle)
     "F", # pyFlakes
     "RUF100", # Checks noqa rules are used
+    "T20", # prinT present
     "W", # Warnings (pycodestyle)
     "UP", # pyUPgrade
 ]
 [tool.ruff.per-file-ignores]
 # E501: Ignore length in tools for now (and otherwise where noqa specified)
-"tools/*" = ["E501"]
+# T20: Expect print output from CLI from tools
+"tools/*" = ["E501", "T20"]
+# T20: Expect print output from CLI from run.py
+"zulipterminal/cli/run.py" = ["T20"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,9 @@ select = [
     "E", # Error (pycodestyle)
     "F", # pyFlakes
     "PGH", # PyGrep Hooks
+    "PLC", # pylint convention
+    "PLE", # pylint error
+    "PLW", # pylint warning
     "RUF100", # Checks noqa rules are used
     "T20", # prinT present
     "W", # Warnings (pycodestyle)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,6 @@ ignore = [
     "C408", # Unnecessary 'dict' call (rewrite as a literal)
     "UP015", # Unnecessary open mode parameters [informative?]
 ]
-# Ignore length in tools for now (and otherwise where noqa specified)
-per-file-ignores = {"tools/*" = ["E501"]}
 select = [
     "B", # Bugbear
     "C4", # Comprehensions
@@ -30,3 +28,6 @@ select = [
     "W", # Warnings (pycodestyle)
     "UP", # pyUPgrade
 ]
+[tool.ruff.per-file-ignores]
+# E501: Ignore length in tools for now (and otherwise where noqa specified)
+"tools/*" = ["E501"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,11 +16,13 @@ exclude = [
 ignore = [
     "B006", # Do not use mutable data structures for argument defaults
     "B007", # Loop control variable not used within the loop body [informative!]
+    "C408", # Unnecessary 'dict' call (rewrite as a literal)
 ]
 # Ignore length in tools for now (and otherwise where noqa specified)
 per-file-ignores = {"tools/*" = ["E501"]}
 select = [
     "B", # Bugbear
+    "C4", # Comprehensions
     "E", # Error (pycodestyle)
     "F", # pyFlakes
     "W", # Warnings (pycodestyle)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ select = [
     "C4", # Comprehensions
     "E", # Error (pycodestyle)
     "F", # pyFlakes
+    "PGH", # PyGrep Hooks
     "RUF100", # Checks noqa rules are used
     "T20", # prinT present
     "W", # Warnings (pycodestyle)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ ignore = [
     "B006", # Do not use mutable data structures for argument defaults
     "B007", # Loop control variable not used within the loop body [informative!]
     "C408", # Unnecessary 'dict' call (rewrite as a literal)
+    "UP015", # Unnecessary open mode parameters [informative?]
 ]
 # Ignore length in tools for now (and otherwise where noqa specified)
 per-file-ignores = {"tools/*" = ["E501"]}
@@ -26,4 +27,5 @@ select = [
     "E", # Error (pycodestyle)
     "F", # pyFlakes
     "W", # Warnings (pycodestyle)
+    "UP", # pyUPgrade
 ]

--- a/tests/config/test_themes.py
+++ b/tests/config/test_themes.py
@@ -89,8 +89,8 @@ def test_builtin_theme_completeness(theme_name: str) -> None:
 def test_complete_and_incomplete_themes() -> None:
     # These are sorted to ensure reproducibility
     result = (
-        sorted(list(expected_complete_themes)),
-        sorted(list(set(THEMES) - expected_complete_themes)),
+        sorted(expected_complete_themes),
+        sorted(set(THEMES) - expected_complete_themes),
     )
     assert result == complete_and_incomplete_themes()
 

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -2655,9 +2655,9 @@ class TestModel:
 
         model.index = dict(
             messages={msg_id: {"flags": flags_before} for msg_id in indexed_ids},
-            starred_msg_ids=set(
-                [msg_id for msg_id in indexed_ids if "starred" in flags_before]
-            ),
+            starred_msg_ids={
+                msg_id for msg_id in indexed_ids if "starred" in flags_before
+            },
         )
         event = {
             "type": "update_message_flags",
@@ -2673,13 +2673,11 @@ class TestModel:
 
         model._handle_update_message_flags_event(event)
 
-        assert model.index["starred_msg_ids"] == set(
-            [
-                message_id
-                for message_id, details in model.index["messages"].items()
-                if "starred" in details["flags"]
-            ]
-        )
+        assert model.index["starred_msg_ids"] == {
+            message_id
+            for message_id, details in model.index["messages"].items()
+            if "starred" in details["flags"]
+        }
         changed_ids = set(indexed_ids) & set(event_message_ids)
         for changed_id in changed_ids:
             assert model.index["messages"][changed_id]["flags"] == flags_after
@@ -2737,9 +2735,9 @@ class TestModel:
 
         model.index = dict(
             messages={msg_id: {"flags": flags_before} for msg_id in indexed_ids},
-            starred_msg_ids=set(
-                [msg_id for msg_id in indexed_ids if "starred" in flags_before]
-            ),
+            starred_msg_ids={
+                msg_id for msg_id in indexed_ids if "starred" in flags_before
+            },
         )
         event = {
             "type": "update_message_flags",
@@ -3167,7 +3165,7 @@ class TestModel:
         initial_unpinned_streams=[{"name": "all", "id": 6}],
     ):
         def set_from_list_of_dict(data):
-            return set(tuple(sorted(d.items())) for d in data)
+            return {tuple(sorted(d.items())) for d in data}
 
         event["type"] = "subscription"
 

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -511,7 +511,7 @@ class TestStreamsView:
         stream_names.sort(key=lambda stream_name: stream_name.lower())
         self.view.pinned_streams = [{"name": name} for name in to_pin]
         stream_names.sort(
-            key=lambda stream_name: stream_name in [stream for stream in to_pin],
+            key=lambda stream_name: stream_name in to_pin,
             reverse=True,
         )
         self.view.controller.is_in_editor_mode = lambda: True

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -795,7 +795,7 @@ class TestMiddleColumnView:
         self.search_box = mocker.Mock()
         self.super = mocker.patch(VIEWS + ".urwid.Frame.__init__")
         self.super_keypress = mocker.patch(VIEWS + ".urwid.Frame.keypress")
-        self.model.controller == mocker.Mock()
+        self.model.controller = mocker.Mock()
 
     @pytest.fixture
     def mid_col_view(self):

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -935,11 +935,11 @@ class TestWriteBox:
         write_box.view.pinned_streams = streams_to_pin
         write_box.stream_id = stream_categories.get("current_stream", None)
         write_box.model.stream_dict = stream_dict
-        write_box.model.muted_streams = set(
+        write_box.model.muted_streams = {
             stream["stream_id"]
             for stream in stream_dict.values()
             if stream["name"] in stream_categories.get("muted", set())
-        )
+        }
         states = state_and_required_typeahead.keys()
         required_typeaheads = list(state_and_required_typeahead.values())
         typeahead_strings = [

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -908,7 +908,7 @@ class TestMsgInfoView:
         edited_message_id: int,
     ) -> None:
         self.controller.model.index = {
-            "edited_messages": set([edited_message_id]),
+            "edited_messages": {edited_message_id},
         }
         self.controller.model.initial_data = {
             "realm_allow_edit_history": realm_allow_edit_history,

--- a/tools/fetch-unicode-emoji-data
+++ b/tools/fetch-unicode-emoji-data
@@ -13,5 +13,5 @@ r = requests.get(URL)
 
 with open(OUTPUT_FILE, "w") as f:
     f.write(r.text)
-print("Emoji dictionary saved in {}".format(OUTPUT_FILE))
+print(f"Emoji dictionary saved in {OUTPUT_FILE}")
 print("Run tools/convert-unicode-emoji-data to convert dictionary to a list")

--- a/tools/gitlint-extra-rules.py
+++ b/tools/gitlint-extra-rules.py
@@ -38,7 +38,7 @@ class AreaFormatting(CommitRule):
         exclusions = self.options["exclusions"].value
         exclusions_text = ", or ".join(exclusions)
         if exclusions_text:
-            exclusions_text = " (or {})".format(exclusions_text)
+            exclusions_text = f" (or {exclusions_text})"
         error = (
             f"Areas at start of title should be lower case{exclusions_text}, "
             "followed by ': '"

--- a/tools/lister.py
+++ b/tools/lister.py
@@ -21,7 +21,8 @@ def get_ftype(fpath: str, use_shebang: bool) -> str:
                 return "py"
             elif re.search(r"^#!", first_line):
                 print(
-                    "Error: Unknown shebang in file" ' "%s":\n%s' % (fpath, first_line),
+                    "Error: Unknown shebang in file"
+                    ' "{}":\n{}'.format(fpath, first_line),
                     file=sys.stderr,
                 )
                 return ""
@@ -105,7 +106,7 @@ def list_files(
             except (OSError, UnicodeDecodeError) as e:
                 etype = e.__class__.__name__
                 print(
-                    'Error: %s while determining type of file "%s":' % (etype, fpath),
+                    f'Error: {etype} while determining type of file "{fpath}":',
                     file=sys.stderr,
                 )
                 print(e, file=sys.stderr)

--- a/tools/run-mypy
+++ b/tools/run-mypy
@@ -160,7 +160,7 @@ if args.quick:
 # run mypy
 status = 0
 for repo, python_files in repo_python_files.items():
-    print("Running mypy for `{}`.".format(repo), flush=True)
+    print(f"Running mypy for `{repo}`.", flush=True)
     if python_files:
         result = subprocess.call([mypy_command] + extra_args + python_files)
         if result != 0:

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -435,7 +435,7 @@ def main(options: Optional[List[str]] = None) -> None:
             real_theme_name = theme_aliases[theme_to_use[0]]
             theme_to_use = (
                 real_theme_name,
-                "{} (by alias '{}')".format(theme_to_use[1], theme_to_use[0]),
+                f"{theme_to_use[1]} (by alias '{theme_to_use[0]}')",
             )
 
         if args.color_depth:

--- a/zulipterminal/config/color.py
+++ b/zulipterminal/config/color.py
@@ -66,7 +66,7 @@ def color_properties(colors: Any, *prop: str) -> Any:
     """
     prop_n = "_".join([p.upper() for p in prop])
     prop_v = " , ".join([p.lower() for p in prop])
-    updated_colors: Any = Enum(  # type: ignore # Ref: python/mypy#529, #535 and #5317
+    updated_colors: Any = Enum(  # type: ignore[misc] # python/mypy#529, #535 and #5317
         "Color",
         {
             **{c.name: c.value for c in colors},

--- a/zulipterminal/config/regexes.py
+++ b/zulipterminal/config/regexes.py
@@ -12,9 +12,9 @@ REGEX_TOPIC_NAME = r"([^*]*)"
 
 
 # (*) Example: #**zulip-terminal
-REGEX_STREAM_FENCED_HALF = r"#\*\*{stream}".format(stream=REGEX_STREAM_NAME)
+REGEX_STREAM_FENCED_HALF = rf"#\*\*{REGEX_STREAM_NAME}"
 # (*) Example: #**zulip-terminal**
-REGEX_STREAM_FENCED = r"#\*\*{stream}\*\*".format(stream=REGEX_STREAM_NAME)
+REGEX_STREAM_FENCED = rf"#\*\*{REGEX_STREAM_NAME}\*\*"
 # (*) Example text: #**stream name>Topic name
 REGEX_STREAM_AND_TOPIC_FENCED_HALF = f"{REGEX_STREAM_FENCED_HALF}>{REGEX_TOPIC_NAME}$"
 # (*) Example text: #**stream name**>Topic name
@@ -37,7 +37,7 @@ REGEX_COLOR_6_DIGIT = r"^#[0-9A-Fa-f]{6}$"
 # Example: example-user@zulip.com
 REGEX_RECIPIENT_EMAIL = r"[\w\.-]+@[\w\.-]+"
 # Example: Test User <example-user@zulip.com>
-REGEX_CLEANED_RECIPIENT = r"^(.*?)(?:\s*?<?({})>?(.*))?$".format(REGEX_RECIPIENT_EMAIL)
+REGEX_CLEANED_RECIPIENT = rf"^(.*?)(?:\s*?<?({REGEX_RECIPIENT_EMAIL})>?(.*))?$"
 # Example: # #000000-#ffffff or #000-#fff or h0-h255 or g0-g100 or g#00-g#ff
 REGEX_COLOR_VALID_FORMATS = (
     "#[\\da-f]{6}|#[\\da-f]{3}|(?:h|g)([\\d]{1,3})|g#[\\da-f]{2}|default$"

--- a/zulipterminal/config/themes.py
+++ b/zulipterminal/config/themes.py
@@ -150,8 +150,8 @@ def complete_and_incomplete_themes() -> Tuple[List[str], List[str]]:
         for meta, conf in theme.META.items()
         if set(conf) == set(REQUIRED_META.get(meta, {}))
     }
-    incomplete = list(set(THEMES) - complete)
-    return sorted(list(complete)), sorted(incomplete)
+    incomplete = set(THEMES) - complete
+    return sorted(complete), sorted(incomplete)
 
 
 def generate_theme(theme_name: str, color_depth: int) -> ThemeSpec:

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -566,7 +566,7 @@ def match_stream(
 
     # Assert that the data is sorted, in a non-decreasing order, and ordered by
     # their pinning status.
-    assert data == sorted(
+    assert data == sorted(  # noqa: C414 (nested sort)
         sorted(data, key=lambda data: data[1].lower()),
         key=lambda data: data[1] in pinned_stream_names,
         reverse=True,

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -559,7 +559,7 @@ class WriteBox(urwid.Pile):
         matching_users = [
             user for user in users_list if match_user(user, text[len(prefix_string) :])
         ]
-        matching_ids = set([user["user_id"] for user in matching_users])
+        matching_ids = {user["user_id"] for user in matching_users}
         matching_recipient_ids = set(self.recipient_user_ids) & set(matching_ids)
         # Display subscribed users/recipients first.
         sorted_matching_users = sorted(

--- a/zulipterminal/ui_tools/messages.py
+++ b/zulipterminal/ui_tools/messages.py
@@ -87,11 +87,11 @@ class MessageBox(urwid.Pile):
                 self.recipient_ids = [self.model.user_id]
             else:
                 self.recipients_names = ", ".join(
-                    list(
+                    [
                         recipient["full_name"]
                         for recipient in self.message["display_recipient"]
                         if recipient["email"] != self.model.user_email
-                    )
+                    ]
                 )
                 self.recipient_emails = [
                     recipient["email"]

--- a/zulipterminal/ui_tools/messages.py
+++ b/zulipterminal/ui_tools/messages.py
@@ -212,14 +212,17 @@ class MessageBox(urwid.Pile):
             bar_color = f"s{bar_color}"
             if len(curr_narrow) == 2 and curr_narrow[1][0] == "topic":
                 text_to_fill = (
-                    "bar",  # type: ignore
+                    "bar",  # type: ignore[assignment]
                     [
                         (bar_color, self.stream_name),
                         (bar_color, ": topic narrow"),
                     ],
                 )
             else:
-                text_to_fill = ("bar", [(bar_color, self.stream_name)])  # type: ignore
+                text_to_fill = (
+                    "bar",  # type: ignore[assignment]
+                    [(bar_color, self.stream_name)],
+                )
         elif len(curr_narrow) == 1 and len(curr_narrow[0][1].split(",")) > 1:
             text_to_fill = "Group private conversation"
         else:

--- a/zulipterminal/ui_tools/messages.py
+++ b/zulipterminal/ui_tools/messages.py
@@ -451,10 +451,10 @@ class MessageBox(urwid.Pile):
                 # uses http as the default scheme but keeps the text as-is.
                 # For instance, see how example.com/some/path becomes
                 # <a href="http://example.com">example.com/some/path</a>.
-                link_without_scheme, text_without_scheme = [
+                link_without_scheme, text_without_scheme = (
                     data.split("://")[1] if "://" in data else data
                     for data in [link, text]
-                ]  # Split on '://' is for cases where text == link.
+                )  # Split on '://' is for cases where text == link.
                 if link_without_scheme == text_without_scheme:
                     last_segment = text.split("/")[-1]
                     if "." in last_segment:

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1254,7 +1254,7 @@ class PopUpConfirmationView(urwid.Overlay):
         question: Any,
         success_callback: Callable[[], None],
         location: PopUpConfirmationViewLocation = "top-left",
-    ):
+    ) -> None:
         self.controller = controller
         self.success_callback = success_callback
         yes = urwid.Button("Yes", self.exit_popup_yes)
@@ -1682,7 +1682,7 @@ class MsgInfoView(PopUpView):
 
 
 class EditModeView(PopUpView):
-    def __init__(self, controller: Any, button: Any):
+    def __init__(self, controller: Any, button: Any) -> None:
         self.edit_mode_button = button
         self.widgets: List[urwid.RadioButton] = []
 


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->

Adds more linting via flake8-like behaviors which are integrated into ruff:
- B: flake8-bugbear
- C4: flake8-comprehensions
- UP: pyupgrade
- RUF100: unnecessary noqa
- T20: flake8-print
- PGH: pygrep-hooks
- PLC, PLE, PLW: pylint convention, error & warning checks
- ANN: flake8-annotations
- YTT: flake8-2020

As with the migration to ruff, some files are excluded, generally or just temporarily.

Linters are enabled individually; note that some require no changes right now but are likely of interest, while others require minimal changes which are included in the same commit or prior commits.

NOTE: These additions take *very little* extra time, which is great for the extra checks we enable! In addition, *some* of these can be fixed automatically by ruff (or via all the fixing in `make fix`), though those are always worth checking they are the correct kind of fix :)
<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->

<!-- Add a link to a discussion on chat.zulip.org, if relevant -->

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [ ] New tests added (for any new behavior)
- [x] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->