### PR TITLE
Add codespell linting

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -83,6 +83,23 @@ jobs:
       - name: Check code & tests meet black standards
         run: black --check zulipterminal/ tests/ setup.py `tools/python_tools.py`
 
+  codespell:
+    runs-on: ubuntu-latest
+    name: Lint - Spelling (codespell)
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.7
+          cache: 'pip'
+          cache-dependency-path: 'setup.py'
+      - name: Install with linting tools
+        run: pip install .[linting]
+      - name: Check spelling
+        run: ./tools/run-codespell
+
   hotkeys:
     runs-on: ubuntu-latest
     name: Lint - Hotkeys linting & docs sync check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,14 @@
 line-length = 88
 target-version = ['py36']
 
+[tool.codespell]
+# codespell doesn't appear to support skip as a list?
+# unicode_emojis: words are defined externally
+# test_themes: uses wrong words as part of a theme syntax test
+# test_boxes: uses word prefixes as part of an autocomplete test
+# test_messages: uses IST as Indian time zone, which is confused for IS/IT/ITS/IT'S/etc
+skip = "zulipterminal/unicode_emojis.py,tests/config/test_themes.py,tests/ui_tools/test_boxes.py,tests/ui_tools/test_messages.py"
+
 [tool.ruff]
 line-length = 88
 target-version = "py37"

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ linting_deps = [
     "isort~=5.10.1",
     "black~=23.0",
     "ruff",
+    "codespell[toml]~=2.2.2",
 ]
 
 typing_deps = [

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -589,7 +589,7 @@ class TestModel:
             ),
             case(
                 ("grinning", "1f600", "unicode_emoji"),
-                [dict(user="mot me", emoji_code="1f600")],
+                [dict(user="not me", emoji_code="1f600")],
                 "POST",
                 id="add_unicode_alias_others_existing_same_emoji",
             ),

--- a/tools/lint-all
+++ b/tools/lint-all
@@ -19,6 +19,7 @@ tools = {
     "Type consistency (mypy)": "./tools/run-mypy",
     "PEP8 & more (ruff)": ["ruff"] + python_sources,
     "Formatting (black)": ["black", "--check"] + python_sources,
+    "Common spelling mistakes (codespell)": "./tools/run-codespell",
     "Hotkey linting & docs sync check": [
         "./tools/generate_hotkeys.py",
         "--check-only",

--- a/tools/lint-docstring
+++ b/tools/lint-docstring
@@ -193,7 +193,7 @@ def extract_docstrings_from_file_overview() -> Dict[str, Dict[str, str]]:
     """
     Reads the developer-file-overview.md document and creates
     a dictionary containing folder name which in turn is a dictionary
-    containing files and their respective descriptons
+    containing files and their respective descriptions
     """
     with open(DEVELOPER_DOC_PATH, "r") as file:
         doc_data = file.readlines()

--- a/tools/run-codespell
+++ b/tools/run-codespell
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+import subprocess
+import sys
+
+
+cmds = ["codespell"]
+files = [
+    "zulipterminal",
+    "tests",
+    "tools",
+    "setup.py",
+    "docs",
+    "docker",
+    "README.md",
+    "CHANGELOG.md",
+]
+
+result = subprocess.call(cmds + ["--toml pyproject.toml"] + files)
+
+if result == 0:
+    print("All files appear to have correct spelling.")
+else:
+    print("Some files have incorrect spelling according to codespell.")
+    print("Try 'codespell -i3 -w <path>' to fix a path recursively.")
+
+sys.exit(result)

--- a/zulipterminal/config/color.py
+++ b/zulipterminal/config/color.py
@@ -54,7 +54,7 @@ class DefaultColor(Enum):
 def color_properties(colors: Any, *prop: str) -> Any:
     """
     Adds properties(Bold, Italics, etc...) to Enum Colors in theme files.
-    Useage: color_properties(Color, 'BOLD', 'ITALICS', 'STRIKETHROUGH')
+    Usage: color_properties(Color, 'BOLD', 'ITALICS', 'STRIKETHROUGH')
 
         NOTE: color_properties(Color, BOLD, ITALICS) would result in only
         Color.WHITE and Color.WHITE__BOLD_ITALICS

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -194,7 +194,7 @@ class Controller:
     def maximum_popup_dimensions(self) -> Tuple[int, int]:
         """
         Returns 3/4th of the screen estate's columns if columns are greater
-        than 100 (MAX_LINEAR_SCALING_WIDTH) else scales accordingly untill
+        than 100 (MAX_LINEAR_SCALING_WIDTH) else scales accordingly until
         popup width becomes full width at 80 (MIN_SUPPORTED_POPUP_WIDTH) below
         which popup width remains full width.
         The screen estate's rows are always scaled by 3/4th to get the

--- a/zulipterminal/platform_code.py
+++ b/zulipterminal/platform_code.py
@@ -64,7 +64,7 @@ def notify(title: str, text: str) -> str:
 
 def successful_GUI_return_code() -> int:
     """
-    Returns success retrn code for GUI commands, which are OS specific.
+    Returns success return code for GUI commands, which are OS specific.
     """
     # WSL uses GUI return code as 1. Refer below link to know more:
     # https://stackoverflow.com/questions/52423031/

--- a/zulipterminal/server_url.py
+++ b/zulipterminal/server_url.py
@@ -19,7 +19,7 @@ def hash_util_encode(string: str) -> str:
 
 def encode_stream(stream_id: int, stream_name: str) -> str:
     """
-    Encodes stream_name with stream_id and replacing any occurence
+    Encodes stream_name with stream_id and replacing any occurrence
     of whitespace to '-'. This is the format of message representation
     in webapp. Referred from zerver/lib/url_encoding.py.
     """

--- a/zulipterminal/ui_tools/messages.py
+++ b/zulipterminal/ui_tools/messages.py
@@ -848,8 +848,8 @@ class MessageBox(urwid.Pile):
                 if len(child_block) == 0:
                     child_iterator = child_list
                 else:
-                    # If there is some text at the begining of a
-                    # quote, we pad it seperately.
+                    # If there is some text at the beginning of a
+                    # quote, we pad it separately.
                     if child_list[0].name == "p":
                         new_tag = soup.new_tag("p")
                         new_tag.string = f"\n{actual_padding}"

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -751,7 +751,7 @@ class RightColumnView(urwid.Frame):
                 )
             )
         user_w = UsersView(self.view.controller, users_btn_list)
-        # Donot reset them while searching.
+        # Do not reset them while searching.
         if reset_default_view_users:
             self.users_btn_list = users_btn_list
             self.view.user_w = user_w


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->

To follow up on a remaining element of #508, this adds `codespell` as a local configured tool via a wrapper, which also runs in CI.

Commit-wise, a few small language changes are made, before the tool is then installed, wrapped and configured in pyproject.toml, then integrated into local and CI tools.

<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->

<!-- Add a link to a discussion on chat.zulip.org, if relevant -->

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [ ] New tests added (for any new behavior)
- [x] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->