### PR TITLE
Enable checking of naming rules using ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,7 @@ ignore = [
     "B006", # Do not use mutable data structures for argument defaults
     "B007", # Loop control variable not used within the loop body [informative!]
     "C408", # Unnecessary 'dict' call (rewrite as a literal)
+    "N818",  # Exception name should be named with an Error suffix
     "UP015", # Unnecessary open mode parameters [informative?]
 ]
 select = [
@@ -129,6 +130,7 @@ select = [
     "E", # Error (pycodestyle)
     "F", # pyFlakes
     "G", # loGging
+    "N", # Naming
     "PGH", # PyGrep Hooks
     "PIE", # pie (miscellaneous)
     "PLC", # pylint convention
@@ -155,3 +157,5 @@ select = [
 "tools/*" = ["E501", "T20"]
 # T20: Expect print output from CLI from run.py
 "zulipterminal/cli/run.py" = ["T20"]
+# N802: Allow upper-case in test function names, eg. for commands, such as test_keypress_ENTER
+"tests/*" = ["N802"]

--- a/setup.py
+++ b/setup.py
@@ -1,27 +1,9 @@
 import codecs
 import os
-import sys
 
 from setuptools import find_packages, setup
-from setuptools.command.test import test as TestCommand
 
 from zulipterminal.version import ZT_VERSION
-
-
-class PyTest(TestCommand):
-    user_options = [("pytest-args=", "a", "Arguments to pass to pytest")]
-
-    def initialize_options(self):
-        TestCommand.initialize_options(self)
-        self.pytest_args = ""
-
-    def run_tests(self):
-        import shlex
-
-        import pytest
-
-        errno = pytest.main(shlex.split(self.pytest_args))
-        sys.exit(errno)
 
 
 def long_description():
@@ -97,8 +79,6 @@ setup(
     keywords="",
     packages=find_packages(exclude=["tests", "tests.*"]),
     zip_safe=True,
-    cmdclass={"test": PyTest},
-    test_suite="test",
     entry_points={
         "console_scripts": [
             "zulip-term = zulipterminal.cli.run:main",

--- a/tests/config/test_color.py
+++ b/tests/config/test_color.py
@@ -7,7 +7,7 @@ def test_color_properties() -> None:
     class Color(Enum):
         WHITE = "wh  #256  #24"
 
-    ExpandedColor = color_properties(Color, "BOLD", "ITALICS")
+    ExpandedColor = color_properties(Color, "BOLD", "ITALICS")  # noqa: N806
 
     assert ExpandedColor.WHITE in ExpandedColor
     assert ExpandedColor.WHITE.value == "wh  #256  #24"

--- a/tests/config/test_themes.py
+++ b/tests/config/test_themes.py
@@ -80,7 +80,7 @@ def test_builtin_theme_completeness(theme_name: str) -> None:
         fg, bg = style_conf
         assert fg in theme_colors and bg in theme_colors
     # Check completeness of META
-    expected_META = {"pygments": ["styles", "background", "overrides"]}
+    expected_META = {"pygments": ["styles", "background", "overrides"]}  # noqa: N806
     for metadata, config in expected_META.items():
         assert theme_meta[metadata]
         assert all([theme_meta[metadata][c] for c in config])

--- a/tests/config/test_themes.py
+++ b/tests/config/test_themes.py
@@ -136,14 +136,14 @@ def test_parse_themefile(
         WHITE__BOLD_ITALICS = "white  #fff   #ffffff , bold , italics"
         DARK_MAGENTA = "dark_magenta  h90    #870087"
 
-    STYLES: Dict[Optional[str], Tuple[Color, Color]] = {
+    theme_styles: Dict[Optional[str], Tuple[Color, Color]] = {
         "s1": (Color.WHITE__BOLD, Color.DARK_MAGENTA),
         "s2": (Color.WHITE__BOLD_ITALICS, Color.DARK_MAGENTA),
     }
 
     req_styles = {"s1": "", "s2": "bold"}
     mocker.patch.dict("zulipterminal.config.themes.REQUIRED_STYLES", req_styles)
-    assert parse_themefile(STYLES, color_depth) == expected_urwid_theme
+    assert parse_themefile(theme_styles, color_depth) == expected_urwid_theme
 
 
 @pytest.mark.parametrize(

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -2462,7 +2462,9 @@ class TestModel:
         Input is a list of pairs, of a message-id and a list of reaction tuples
         NOTE: reactions as None indicate not indexed, [] indicates no reaction
         """
-        MsgsType = List[Tuple[int, Optional[List[Tuple[int, str, str, str]]]]]
+        MsgsType = List[  # noqa: N806
+            Tuple[int, Optional[List[Tuple[int, str, str, str]]]]
+        ]
 
         def _factory(msgs: MsgsType):
             return {

--- a/tests/platform_code/test_platform_code.py
+++ b/tests/platform_code/test_platform_code.py
@@ -14,9 +14,9 @@ MODULE = "zulipterminal.platform_code"
 
 
 @pytest.mark.parametrize(
-    "PLATFORM, is_notification_sent",
+    "platform, is_notification_sent",
     [
-        # PLATFORM: Literal["WSL", "MacOS", "Linux", "unsupported"]
+        # platform: Literal["WSL", "MacOS", "Linux", "unsupported"]
         pytest.param(
             "WSL",
             True,
@@ -28,11 +28,11 @@ MODULE = "zulipterminal.platform_code"
     ],
 )
 def test_notify(
-    mocker: MockerFixture, PLATFORM: AllPlatforms, is_notification_sent: bool
+    mocker: MockerFixture, platform: AllPlatforms, is_notification_sent: bool
 ) -> None:
     title = "Author"
     text = "Hello!"
-    mocker.patch(MODULE + ".PLATFORM", PLATFORM)
+    mocker.patch(MODULE + ".PLATFORM", platform)
     subprocess = mocker.patch(MODULE + ".subprocess")
     notify(title, text)
     assert subprocess.run.called == is_notification_sent
@@ -49,7 +49,7 @@ def test_notify(
     ids=["X", "spaced_title", "single", "double"],
 )
 @pytest.mark.parametrize(
-    "PLATFORM, cmd_length",
+    "platform, cmd_length",
     [
         ("Linux", 4),
         ("MacOS", 10),
@@ -58,13 +58,13 @@ def test_notify(
 )
 def test_notify_quotes(
     mocker: MockerFixture,
-    PLATFORM: SupportedPlatforms,
+    platform: SupportedPlatforms,
     cmd_length: int,
     title: str,
     text: str,
 ) -> None:
     subprocess = mocker.patch(MODULE + ".subprocess")
-    mocker.patch(MODULE + ".PLATFORM", PLATFORM)
+    mocker.patch(MODULE + ".PLATFORM", platform)
 
     notify(title, text)
 
@@ -76,7 +76,7 @@ def test_notify_quotes(
 
 
 @pytest.mark.parametrize(
-    "PLATFORM, expected_return_code",
+    "platform, expected_return_code",
     [
         ("Linux", 0),
         ("MacOS", 0),
@@ -85,15 +85,15 @@ def test_notify_quotes(
 )
 def test_successful_GUI_return_code(
     mocker: MockerFixture,
-    PLATFORM: SupportedPlatforms,
+    platform: SupportedPlatforms,
     expected_return_code: int,
 ) -> None:
-    mocker.patch(MODULE + ".PLATFORM", PLATFORM)
+    mocker.patch(MODULE + ".PLATFORM", platform)
     assert successful_GUI_return_code() == expected_return_code
 
 
 @pytest.mark.parametrize(
-    "PLATFORM, expected_path",
+    "platform, expected_path",
     [
         ("Linux", "/path/to/file"),
         ("MacOS", "/path/to/file"),
@@ -102,9 +102,9 @@ def test_successful_GUI_return_code(
 )
 def test_normalized_file_path(
     mocker: MockerFixture,
-    PLATFORM: SupportedPlatforms,
+    platform: SupportedPlatforms,
     expected_path: str,
     path: str = "/path/to/file",
 ) -> None:
-    mocker.patch(MODULE + ".PLATFORM", PLATFORM)
+    mocker.patch(MODULE + ".PLATFORM", platform)
     assert normalized_file_path(path) == expected_path

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1224,7 +1224,7 @@ class TestTabView:
             ]
         ],
     )
-    @pytest.mark.parametrize("TAB_WIDTH, TAB_HEIGHT", [(3, 10)])
-    def test_tab_render(self, tab_view, TAB_WIDTH, TAB_HEIGHT, expected_output):
-        render_output = tab_view._w.render((TAB_WIDTH, TAB_HEIGHT)).text
+    @pytest.mark.parametrize("tab_width, tab_height", [(3, 10)])
+    def test_tab_render(self, tab_view, tab_width, tab_height, expected_output):
+        render_output = tab_view._w.render((tab_width, tab_height)).text
         assert render_output == expected_output

--- a/tools/generate_hotkeys.py
+++ b/tools/generate_hotkeys.py
@@ -136,8 +136,8 @@ def write_hotkeys_file(hotkeys_file_string: str) -> None:
     """
     Write hotkeys_file_string variable once to OUTPUT_FILE
     """
-    with open(OUTPUT_FILE, "w") as mdFile:
-        mdFile.write(hotkeys_file_string)
+    with open(OUTPUT_FILE, "w") as hotkeys_file:
+        hotkeys_file.write(hotkeys_file_string)
 
 
 if __name__ == "__main__":

--- a/zulipterminal/api_types.py
+++ b/zulipterminal/api_types.py
@@ -17,6 +17,11 @@ from zulip import ModifiableMessageFlag  # directly modifiable read/starred/coll
 
 RESOLVED_TOPIC_PREFIX = "✔ "
 
+# Refer to https://zulip.com/api/set-typing-status for the protocol
+# on typing notifications sent by clients.
+TYPING_STARTED_WAIT_PERIOD = 10
+TYPING_STOPPED_WAIT_PERIOD = 5
+
 
 class PrivateComposition(TypedDict):
     type: Literal["private"]

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -311,7 +311,6 @@ def parse_zuliprc(zuliprc_str: str) -> Dict[str, Any]:
         exit_with_error(f"Failed to parse zuliprc file at {zuliprc_path}")
 
     # Initialize with default settings
-    NO_CONFIG = "with no config"
     settings = {
         setting: (default, NO_CONFIG) for setting, default in DEFAULT_SETTINGS.items()
     }

--- a/zulipterminal/config/ui_sizes.py
+++ b/zulipterminal/config/ui_sizes.py
@@ -5,3 +5,10 @@ Fixed sizes of UI elements
 TAB_WIDTH = 3
 LEFT_WIDTH = 29
 RIGHT_WIDTH = 23
+
+# These affect popup width-scaling, dependent upon window width
+# At and below this width, popup is window width:
+MIN_SUPPORTED_POPUP_WIDTH = 80
+# Until this width, popup scales linearly upwards with width
+MAX_LINEAR_SCALING_WIDTH = 100
+# Above that width, popup increases as 3/4 of window width

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -21,6 +21,10 @@ from typing_extensions import Literal
 
 from zulipterminal.api_types import Composition, Message
 from zulipterminal.config.themes import ThemeSpec
+from zulipterminal.config.ui_sizes import (
+    MAX_LINEAR_SCALING_WIDTH,
+    MIN_SUPPORTED_POPUP_WIDTH,
+)
 from zulipterminal.helper import asynch, suppress_output
 from zulipterminal.model import Model
 from zulipterminal.platform_code import PLATFORM
@@ -194,14 +198,12 @@ class Controller:
     def maximum_popup_dimensions(self) -> Tuple[int, int]:
         """
         Returns 3/4th of the screen estate's columns if columns are greater
-        than 100 (MAX_LINEAR_SCALING_WIDTH) else scales accordingly until
-        popup width becomes full width at 80 (MIN_SUPPORTED_POPUP_WIDTH) below
+        than MAX_LINEAR_SCALING_WIDTH else scales accordingly until
+        popup width becomes full width at MIN_SUPPORTED_POPUP_WIDTH below
         which popup width remains full width.
         The screen estate's rows are always scaled by 3/4th to get the
         popup rows.
         """
-        MIN_SUPPORTED_POPUP_WIDTH = 80
-        MAX_LINEAR_SCALING_WIDTH = 100
 
         def clamp(n: int, minn: int, maxn: int) -> int:
             return max(min(maxn, n), minn)

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1169,11 +1169,11 @@ class Model:
             subscription["color"] = canonicalize_color(subscription["color"])
 
             self.stream_dict[subscription["stream_id"]] = subscription
-            streamData = make_reduced_stream_data(subscription)
+            stream_data = make_reduced_stream_data(subscription)
             if subscription["pin_to_top"]:
-                new_pinned_streams.append(streamData)
+                new_pinned_streams.append(stream_data)
             else:
-                new_unpinned_streams.append(streamData)
+                new_unpinned_streams.append(stream_data)
             if subscription["is_muted"]:
                 new_muted_streams.add(subscription["stream_id"])
             if subscription["desktop_notifications"]:

--- a/zulipterminal/platform_code.py
+++ b/zulipterminal/platform_code.py
@@ -62,7 +62,7 @@ def notify(title: str, text: str) -> str:
     return ""
 
 
-def successful_GUI_return_code() -> int:
+def successful_GUI_return_code() -> int:  # noqa: N802 (allow upper case)
     """
     Returns success return code for GUI commands, which are OS specific.
     """

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -13,7 +13,13 @@ import urwid
 from typing_extensions import Literal
 from urwid_readline import ReadlineEdit
 
-from zulipterminal.api_types import Composition, PrivateComposition, StreamComposition
+from zulipterminal.api_types import (
+    TYPING_STARTED_WAIT_PERIOD,
+    TYPING_STOPPED_WAIT_PERIOD,
+    Composition,
+    PrivateComposition,
+    StreamComposition,
+)
 from zulipterminal.config.keys import (
     is_command_key,
     keys_for_command,
@@ -228,13 +234,6 @@ class WriteBox(urwid.Pile):
             (self.msg_write_box, self.options()),
         ]
         self.focus_position = self.FOCUS_CONTAINER_MESSAGE
-
-        # Typing status is sent in regular intervals to limit the number of
-        # notifications sent. Idleness should also prompt a notification.
-        # Refer to https://zulip.com/api/set-typing-status for the protocol
-        # on typing notifications sent by clients.
-        TYPING_STARTED_WAIT_PERIOD = 10
-        TYPING_STOPPED_WAIT_PERIOD = 5
 
         start_period_delta = timedelta(seconds=TYPING_STARTED_WAIT_PERIOD)
         stop_period_delta = timedelta(seconds=TYPING_STOPPED_WAIT_PERIOD)

--- a/zulipterminal/ui_tools/messages.py
+++ b/zulipterminal/ui_tools/messages.py
@@ -33,6 +33,9 @@ from zulipterminal.urwid_types import urwid_MarkupTuple, urwid_Size
 if typing.TYPE_CHECKING:
     from zulipterminal.model import Model
 
+# Usernames to show before just showing reaction counts
+MAXIMUM_USERNAMES_VISIBLE = 3
+
 
 class _MessageEditState(NamedTuple):
     message_id: int
@@ -249,7 +252,6 @@ class MessageBox(urwid.Pile):
         if not reactions:
             return ""
         try:
-            MAXIMUM_USERNAMES_VISIBLE = 3
             my_user_id = self.model.user_id
             reaction_stats = defaultdict(list)
             for reaction in reactions:

--- a/zulipterminal/ui_tools/messages.py
+++ b/zulipterminal/ui_tools/messages.py
@@ -666,9 +666,8 @@ class MessageBox(urwid.Pile):
         any_differences = any(different.values())
 
         if any_differences:  # Construct content_header, if needed
-            TextType = Dict[str, urwid_MarkupTuple]
             text_keys = ("author", "star", "time", "status")
-            text: TextType = {key: (None, " ") for key in text_keys}
+            text: Dict[str, urwid_MarkupTuple] = {key: (None, " ") for key in text_keys}
 
             if any(different[key] for key in ("recipients", "author", "24h")):
                 text["author"] = ("msg_sender", message["this"]["author"])

--- a/zulipterminal/urwid_types.py
+++ b/zulipterminal/urwid_types.py
@@ -5,9 +5,11 @@ Types from the urwid API, to improve type checking
 from typing import Optional, Tuple, Union
 
 
-urwid_Fixed = Tuple[()]
-urwid_Flow = Tuple[int]
-urwid_Box = Tuple[int, int]
-urwid_Size = Union[urwid_Fixed, urwid_Flow, urwid_Box]
+# FIXME: These should likely be migrated at least partially to urwid stubs
 
-urwid_MarkupTuple = Tuple[Optional[str], str]
+urwid_Fixed = Tuple[()]  # noqa: N816
+urwid_Flow = Tuple[int]  # noqa: N816
+urwid_Box = Tuple[int, int]  # noqa: N816
+urwid_Size = Union[urwid_Fixed, urwid_Flow, urwid_Box]  # noqa: N816
+
+urwid_MarkupTuple = Tuple[Optional[str], str]  # noqa: N816


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->

This makes various smaller fixes to enable enforcing linting of names according to the `N`aming rule in ruff.

This doesn't find any specific bugs, but does lead to centralization of some constants that were localized in the code itself, and could be centralized further - as other ruff rules may suggest later.

This also drops the `test` command in `setup.py`. This is now deprecated in `setuptools`, and we've not been actively promoting it as far as I'm aware.

<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->

<!-- Add a link to a discussion on chat.zulip.org, if relevant -->

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [ ] New tests added (for any new behavior)
- [x] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

**Notes & Questions** <!-- if any; add/delete/fill-in as appropriate -->
While by no means as large an issue as in zulip/zulip, this PR takes the same approach of delaying applying the exception-naming standard of an `Error` suffix for later, to get this rule in place first. That could also be a good first issue to explore.