### PR TITLE
Bugfix: Update dependencies per-commit during isolation checks in CI

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -185,14 +185,12 @@ jobs:
           python-version: 3.7
           cache: 'pip'
           cache-dependency-path: 'setup.py'
-      - name: Testing install
-        if: github.event_name == 'pull_request'
-        run: pip install .[linting,testing,typing]
       - name: Run check-branch
         if: github.event_name == 'pull_request'
+        # Note that we install at each step since dependencies may change
         run:
           git fetch https://github.com/zulip/zulip-terminal main;
-          ./tools/check-branch FETCH_HEAD
+          CHECK="pip install .[linting,testing,typing] && ./tools/lint-all && pytest" ./tools/check-branch FETCH_HEAD
 
   pytest-on-other-platforms:
     needs: isolated-commits

--- a/tools/check-branch
+++ b/tools/check-branch
@@ -28,5 +28,8 @@ if git diff --quiet "$main_branch" HEAD; then
     exit 1
 fi
 
+# By default run 'make check' on each commit, if CHECK is not set
+command_per_commit=${CHECK:-"make check"}
+
 echo "Checking commits..."
-git rebase $(git merge-base "$main_branch" @) --exec 'git --no-pager log -1 && make check'
+git rebase $(git merge-base "$main_branch" @) --exec "git --no-pager log -1 && $command_per_commit"


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->

PR #1310 demonstrated an issue with the new isolation-checking part of the CI.

The `make check` command implicitly part of the `check-branch` tool was updating an installed venv, as it does locally, but this venv is not activated. Instead the packages from the previous job step were being used throughout the isolation checking process.

This PR takes one approach at resolving this, explicitly installing packages at each commit before running the checks, after enabling this feature in `check-branch` in the first commit.

<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->

<!-- Add a link to a discussion on chat.zulip.org, if relevant -->

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [ ] New tests added (for any new behavior)
- [x] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

**Notes & Questions** <!-- if any; add/delete/fill-in as appropriate -->

This approach is not as optimal as the implicit `make venv` done locally, which only updates the package install if the dependency file changes (currently `setup.py`). For now, fixing CI is the priority and this could be optimized later, depending on how significant a performance issue this is.