### PR TITLE
Enable checking of Simplication rules using ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,7 @@ ignore = [
     "B007", # Loop control variable not used within the loop body [informative!]
     "C408", # Unnecessary 'dict' call (rewrite as a literal)
     "N818",  # Exception name should be named with an Error suffix
+    "SIM108", # Prefer ternary operator over if-else (as per zulip/zulip)
     "UP015", # Unnecessary open mode parameters [informative?]
 ]
 select = [
@@ -138,6 +139,7 @@ select = [
     "RSE", # RaiSE
     "PLW", # pylint warning
     "RUF100", # Checks noqa rules are used
+    "SIM", # SIMplify
     "T20", # prinT present
     "W", # Warnings (pycodestyle)
     "UP", # pyUPgrade

--- a/tests/emoji_data/test_emoji_data.py
+++ b/tests/emoji_data/test_emoji_data.py
@@ -5,7 +5,7 @@ from zulipterminal.unicode_emojis import EMOJI_DATA
 
 
 def test_generated_emoji_list_sorted() -> None:
-    assert EMOJI_DATA == OrderedDict(sorted(EMOJI_DATA.items()))
+    assert OrderedDict(sorted(EMOJI_DATA.items())) == EMOJI_DATA
 
 
 def test_unicode_emojis_fixture_sorted(

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -1664,7 +1664,7 @@ class TestWriteBox:
                 expected_focus_col_name
             )
         else:
-            assert write_box.FOCUS_MESSAGE_BOX_BODY == focus_val(
+            assert write_box.FOCUS_MESSAGE_BOX_BODY == focus_val(  # noqa: SIM300
                 expected_focus_col_name
             )
 

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -1781,7 +1781,7 @@ class TestPanelSearchBox:
         size = widget_size(panel_search_box)
         panel_search_box.panel_view.view.controller.is_in_editor_mode = lambda: True
         panel_search_box.panel_view.log = log
-        empty_search = False if log else True
+        empty_search = not log
         panel_search_box.panel_view.empty_search = empty_search
         panel_search_box.set_caption("")
         panel_search_box.edit_text = "key words"

--- a/tools/generate_hotkeys.py
+++ b/tools/generate_hotkeys.py
@@ -38,7 +38,7 @@ def lint_hotkeys_file() -> None:
     # To lint keys description
     error_flag = 0
     categories = read_help_categories()
-    for action in HELP_CATEGORIES.keys():
+    for action in HELP_CATEGORIES:
         check_duplicate_keys_list: List[str] = []
         for help_text, key_combinations_list in categories[action]:
             check_duplicate_keys_list.extend(key_combinations_list)
@@ -95,7 +95,7 @@ def get_hotkeys_file_string() -> str:
         f"<!--- Generated automatically by tools/{SCRIPT_NAME} -->\n"
         "<!--- Do not modify -->\n\n# Hot Keys\n"
     )
-    for action in HELP_CATEGORIES.keys():
+    for action in HELP_CATEGORIES:
         hotkeys_file_string += (
             f"## {HELP_CATEGORIES[action]}\n"
             "|Command|Key Combination|\n"

--- a/tools/generate_hotkeys.py
+++ b/tools/generate_hotkeys.py
@@ -114,7 +114,9 @@ def get_hotkeys_file_string() -> str:
 
 
 def output_file_matches_string(hotkeys_file_string: str) -> bool:
-    if hotkeys_file_string == open(OUTPUT_FILE).read():
+    with open(OUTPUT_FILE) as output_file:
+        content_is_identical = hotkeys_file_string == output_file.read()
+    if content_is_identical:
         print(f"{OUTPUT_FILE_NAME} file already in sync with config/{KEYS_FILE_NAME}")
         return True
     else:

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -170,10 +170,10 @@ class Controller:
 
         if self.debug_path is not None:
             # buffering=1 avoids need for flush=True with print() debugging
-            sys.stdout = open(self.debug_path, "a", buffering=1)
+            sys.stdout = open(self.debug_path, "a", buffering=1)  # noqa: SIM115
         else:
             # Redirect stdout (print does nothing)
-            sys.stdout = open(os.devnull, "a")
+            sys.stdout = open(os.devnull, "a")  # noqa: SIM115
 
     def restore_stdout(self) -> None:
         if not hasattr(self, "_stdout"):

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -510,10 +510,7 @@ def match_user(user: Any, text: str) -> bool:
     # adding full_name helps in further narrowing down the right user.
     keywords.append(full_name)
     keywords.append(user["email"].lower())
-    for keyword in keywords:
-        if keyword.startswith(text.lower()):
-            return True
-    return False
+    return any(keyword.startswith(text.lower()) for keyword in keywords)
 
 
 def match_user_name_and_email(user: Any, text: str) -> bool:
@@ -527,10 +524,7 @@ def match_user_name_and_email(user: Any, text: str) -> bool:
     keywords.append(full_name)
     keywords.append(email)
     keywords.append(f"{full_name} <{email}>")
-    for keyword in keywords:
-        if keyword.startswith(text.lower()):
-            return True
-    return False
+    return any(keyword.startswith(text.lower()) for keyword in keywords)
 
 
 def match_emoji(emoji: str, text: str) -> bool:

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -410,13 +410,12 @@ def index_messages(messages: List[Message], model: Any, index: Index) -> Index:
             continue
 
         if len(narrow) == 1:
-            if narrow[0][1] == "starred":
-                if "starred" in msg["flags"]:
-                    index["starred_msg_ids"].add(msg["id"])
+            if narrow[0][1] == "starred" and "starred" in msg["flags"]:
+                index["starred_msg_ids"].add(msg["id"])
 
-            if narrow[0][1] == "mentioned":
-                if {"mentioned", "wildcard_mentioned"} & set(msg["flags"]):
-                    index["mentioned_msg_ids"].add(msg["id"])
+            msg_has_mention = {"mentioned", "wildcard_mentioned"} & set(msg["flags"])
+            if narrow[0][1] == "mentioned" and msg_has_mention:
+                index["mentioned_msg_ids"].add(msg["id"])
 
             if msg["type"] == "private":
                 index["private_msg_ids"].add(msg["id"])

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -398,7 +398,7 @@ def index_messages(messages: List[Message], model: Any, index: Index) -> Index:
     """
     narrow = model.narrow
     for msg in messages:
-        if "edit_history" in msg.keys():
+        if "edit_history" in msg:
             index["edited_messages"].add(msg["id"])
 
         index["messages"][msg["id"]] = msg

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1062,15 +1062,12 @@ class Model:
                     elif (time.time() - timestamp) < OFFLINE_THRESHOLD_SECS:
                         if status == "active":
                             aggregate_status = "active"
-                        if status == "idle":
-                            if aggregate_status != "active":
-                                aggregate_status = status
-                        if status == "offline":
-                            if (
-                                aggregate_status != "active"
-                                and aggregate_status != "idle"
-                            ):
-                                aggregate_status = status
+                        if status == "idle" and aggregate_status != "active":
+                            aggregate_status = status
+                        if status == "offline" and (
+                            aggregate_status != "active" and aggregate_status != "idle"
+                        ):
+                            aggregate_status = status
 
                 status = aggregate_status
             else:
@@ -1813,11 +1810,11 @@ class Model:
         (previously "update_display_settings" and "update_global_notifications")
         """
         assert event["type"] == "user_settings"
-        if event["op"] == "update":  # Should always be the case
-            # Only update settings after initialization
-            if event["property"] in self._user_settings:
-                setting = event["property"]
-                self._user_settings[setting] = event["value"]
+        # We only expect these to be "update" event operations
+        # Update the setting (property) to the value, but only if already initialized
+        if event["op"] == "update" and event["property"] in self._user_settings:
+            setting = event["property"]
+            self._user_settings[setting] = event["value"]
 
     def _handle_update_global_notifications_event(self, event: Event) -> None:
         assert event["type"] == "update_global_notifications"

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1624,7 +1624,7 @@ class Model:
                     self._update_rendered_view(msg_id)
 
             # If topic view is open, reload list else reset cache.
-            if stream_id in self.index["topics"]:
+            if stream_id in self.index["topics"]:  # noqa: SIM102
                 if hasattr(self.controller, "view"):
                     view = self.controller.view
                     if view.left_panel.is_in_topic_view_with_stream_id(stream_id):

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -878,7 +878,7 @@ class Model:
         """
         stream_name = self.stream_dict[stream_id]["name"]
         topic_to_search = (stream_name, topic)
-        return topic_to_search in self._muted_topics.keys()
+        return topic_to_search in self._muted_topics
 
     def get_next_unread_topic(self) -> Optional[Tuple[int, str]]:
         unread_topics = sorted(self.unread_counts["unread_topics"].keys())
@@ -1815,7 +1815,7 @@ class Model:
         assert event["type"] == "user_settings"
         if event["op"] == "update":  # Should always be the case
             # Only update settings after initialization
-            if event["property"] in self._user_settings.keys():
+            if event["property"] in self._user_settings:
                 setting = event["property"]
                 self._user_settings[setting] = event["value"]
 

--- a/zulipterminal/scripts/render_symbols.py
+++ b/zulipterminal/scripts/render_symbols.py
@@ -18,9 +18,9 @@ symbol_dict = {
     for name, symbol in vars(symbols).items()
     if not name.startswith("__") and not name.endswith("__")
 }
-max_symbol_name_length = max([len(name) for name in symbol_dict.keys()])
+max_symbol_name_length = max([len(name) for name in symbol_dict])
 
-symbol_names_list = [urwid.Text(name, align="center") for name in symbol_dict.keys()]
+symbol_names_list = [urwid.Text(name, align="center") for name in symbol_dict]
 symbols_list = [urwid.Text(symbol) for symbol in symbol_dict.values()]
 
 symbols_display_box = urwid.Columns(

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -715,14 +715,13 @@ class WriteBox(urwid.Pile):
         return emoji_typeahead, emojis
 
     def keypress(self, size: urwid_Size, key: str) -> Optional[str]:
-        if self.is_in_typeahead_mode:
-            if not (
-                is_command_key("AUTOCOMPLETE", key)
-                or is_command_key("AUTOCOMPLETE_REVERSE", key)
-            ):
-                # set default footer when done with autocomplete
-                self.is_in_typeahead_mode = False
-                self.view.set_footer_text()
+        if self.is_in_typeahead_mode and not (
+            is_command_key("AUTOCOMPLETE", key)
+            or is_command_key("AUTOCOMPLETE_REVERSE", key)
+        ):
+            # set default footer when done with autocomplete
+            self.is_in_typeahead_mode = False
+            self.view.set_footer_text()
 
         if is_command_key("SEND_MESSAGE", key):
             self.send_stop_typing_status()

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -608,21 +608,21 @@ class MessageLinkButton(urwid.Button):
         Switches narrow via narrow_to_* methods.
         """
         narrow = parsed_link["narrow"]
-        if "stream" == narrow:
+        if narrow == "stream":
             self.controller.narrow_to_stream(
                 stream_name=parsed_link["stream"]["stream_name"],
             )
-        elif "stream:near" == narrow:
+        elif narrow == "stream:near":
             self.controller.narrow_to_stream(
                 stream_name=parsed_link["stream"]["stream_name"],
                 contextual_message_id=parsed_link["message_id"],
             )
-        elif "stream:topic" == narrow:
+        elif narrow == "stream:topic":
             self.controller.narrow_to_topic(
                 stream_name=parsed_link["stream"]["stream_name"],
                 topic_name=parsed_link["topic_name"],
             )
-        elif "stream:topic:near" == narrow:
+        elif narrow == "stream:topic:near":
             self.controller.narrow_to_topic(
                 stream_name=parsed_link["stream"]["stream_name"],
                 topic_name=parsed_link["topic_name"],

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -394,10 +394,9 @@ class EmojiButton(TopButton):
     def mouse_event(
         self, size: urwid_Size, event: str, button: int, col: int, row: int, focus: int
     ) -> bool:
-        if event == "mouse press":
-            if button == 1:
-                self.keypress(size, primary_key_for_command("ENTER"))
-                return True
+        if event == "mouse press" and button == 1:
+            self.keypress(size, primary_key_for_command("ENTER"))
+            return True
         return super().mouse_event(size, event, button, col, row, focus)
 
     def update_emoji_button(self) -> None:

--- a/zulipterminal/ui_tools/messages.py
+++ b/zulipterminal/ui_tools/messages.py
@@ -880,12 +880,11 @@ class MessageBox(urwid.Pile):
     def mouse_event(
         self, size: urwid_Size, event: str, button: int, col: int, row: int, focus: bool
     ) -> bool:
-        if event == "mouse press":
-            if button == 1:
-                if self.model.controller.is_in_editor_mode():
-                    return True
-                self.keypress(size, primary_key_for_command("ENTER"))
+        if event == "mouse press" and button == 1:
+            if self.model.controller.is_in_editor_mode():
                 return True
+            self.keypress(size, primary_key_for_command("ENTER"))
+            return True
 
         return super().mouse_event(size, event, button, col, row, focus)
 

--- a/zulipterminal/ui_tools/utils.py
+++ b/zulipterminal/ui_tools/utils.py
@@ -56,14 +56,15 @@ def create_msg_box_list(
     return w_list
 
 
+# The SIM114 warnings are ignored here since combining the branches would be less clear
 def is_muted(msg: Message, model: Any) -> bool:
     # PMs cannot be muted
-    if msg["type"] == "private":
+    if msg["type"] == "private":  # noqa: SIM114
         return False
     # In a topic narrow
     elif len(model.narrow) == 2:
         return False
-    elif model.is_muted_stream(msg["stream_id"]):
+    elif model.is_muted_stream(msg["stream_id"]):  # noqa: SIM114
         return True
     elif model.is_muted_topic(msg["stream_id"], msg["subject"]):
         return True

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -226,16 +226,13 @@ class MessageView(urwid.ListBox):
             else:
                 return super().keypress(size, primary_key_for_command("SCROLL_DOWN"))
 
-        elif is_command_key("THUMBS_UP", key):
-            if self.focus is not None:
-                self.model.toggle_message_reaction(
-                    self.focus.original_widget.message, reaction_to_toggle="thumbs_up"
-                )
+        elif is_command_key("THUMBS_UP", key) and self.focus is not None:
+            message = self.focus.original_widget.message
+            self.model.toggle_message_reaction(message, reaction_to_toggle="thumbs_up")
 
-        elif is_command_key("TOGGLE_STAR_STATUS", key):
-            if self.focus is not None:
-                message = self.focus.original_widget.message
-                self.model.toggle_message_star_status(message)
+        elif is_command_key("TOGGLE_STAR_STATUS", key) and self.focus is not None:
+            message = self.focus.original_widget.message
+            self.model.toggle_message_star_status(message)
 
         key = super().keypress(size, key)
         return key
@@ -361,13 +358,12 @@ class StreamsView(urwid.Frame):
                 if stream.stream_name not in pinned_stream_names:
                     first_unpinned_index = index
                     break
-            if first_unpinned_index not in [0, streams_display_num]:
-                # Do not add a divider when it is already present. This can
-                # happen when new_text=''.
-                if not isinstance(
-                    streams_display[first_unpinned_index], StreamsViewDivider
-                ):
-                    streams_display.insert(first_unpinned_index, StreamsViewDivider())
+            # Do not add a divider when it is already present. This can
+            # happen when new_text=''.
+            if first_unpinned_index not in [0, streams_display_num] and not isinstance(
+                streams_display[first_unpinned_index], StreamsViewDivider
+            ):
+                streams_display.insert(first_unpinned_index, StreamsViewDivider())
 
             self.log.clear()
             if not self.empty_search:
@@ -533,9 +529,8 @@ class UsersView(urwid.ListBox):
         self, size: urwid_Size, event: str, button: int, col: int, row: int, focus: bool
     ) -> bool:
         if event == "mouse press":
-            if button == 1:
-                if self.controller.is_in_editor_mode():
-                    return True
+            if button == 1 and self.controller.is_in_editor_mode():
+                return True
             if button == 4:
                 for _ in range(SIDE_PANELS_MOUSE_SCROLL_LINES):
                     self.keypress(size, primary_key_for_command("GO_UP"))

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1686,7 +1686,7 @@ class EditModeView(PopUpView):
         self.edit_mode_button = button
         self.widgets: List[urwid.RadioButton] = []
 
-        for mode in EDIT_MODE_CAPTIONS.keys():
+        for mode in EDIT_MODE_CAPTIONS:
             self.add_radio_button(mode)
         super().__init__(
             controller, self.widgets, "ENTER", 62, "Topic edit propagation mode"


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->

This makes changes associated with the SIM rules in ruff, which are recommended simplifications.

This excludes SIM108 (prefer ternary if-else), as in zulip/zulip, though other changes may be necessary in time.

As per other PRs adding rules to be checked, this is a set of refactors, followed by enabling of the rule with some noqa changes. This ensures commit isolation, including that noqa lines are not flagged as unnecessary before the associated rule is enabled.

<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->

<!-- Add a link to a discussion on chat.zulip.org, if relevant -->

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [ ] New tests added (for any new behavior)
- [x] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->