### PR TITLE
[WIP]model/messages/api_types: alert_words mark up

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -660,6 +660,7 @@ def initial_data(
             }
         ],
         "result": "success",
+        "alert_words": [],
         "queue_id": "1522420755:786",
         "realm_users": users_fixture,
         "cross_realm_bots": [

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -255,6 +255,7 @@ class TestModel:
             "user_settings",
             "realm_emoji",
             "zulip_version",
+            "alert_words",
         ]
         model.client.register.assert_called_once_with(
             event_types=event_types,

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -228,6 +228,7 @@ class TestModel:
         model = Model(self.controller)
 
         event_types = [
+            "alert_words",
             "message",
             "update_message",
             "reaction",
@@ -2705,6 +2706,49 @@ class TestModel:
     )
     def update_message_flags_operation(self, request):
         return request.param
+
+    @pytest.mark.parametrize(
+        "event,initial_alerted_words, expected_alert_words",
+        [
+            case(
+                {"type": "alert_words", "alert_words": ["word1", "word2", "word3"]},
+                ["word1"],
+                ["word1", "word2", "word3"],
+                id="Add_multiple_alert_words",
+            ),
+            case(
+                {"type": "alert_words", "alert_words": []},
+                ["word1"],
+                [],
+                id="Empty_alert_words",
+            ),
+            case(
+                {"type": "alert_words", "alert_words": ["word1", "word4"]},
+                ["word1"],
+                ["word1", "word4"],
+                id="Add_single_new_alert_words",
+            ),
+            case(
+                {"type": "alert_words", "alert_words": ["word1", "word2"]},
+                ["word1", "word2", "word3"],
+                ["word1", "word2"],
+                id="Delete_an_alert_word",
+            ),
+            case(
+                {"type": "alert_words", "alert_words": ["word1", "word3"]},
+                ["word1", "word2"],
+                ["word1", "word3"],
+                id="Add_and_delete_alert_words",
+            ),
+        ],
+    )
+    def test__handle_alert_words_event__single_user(
+        self, mocker, model, event, initial_alerted_words, expected_alert_words
+    ):
+        model._handle_alert_words_event(event)
+
+        assert model._alert_words != initial_alerted_words
+        assert model._alert_words == expected_alert_words
 
     def test_update_star_status_no_index(
         self, mocker, model, update_message_flags_operation

--- a/zulipterminal/api_types.py
+++ b/zulipterminal/api_types.py
@@ -517,6 +517,11 @@ class UpdateDisplaySettingsEvent(TypedDict):
 
 
 # -----------------------------------------------------------------------------
+class AlertWordEvent(TypedDict):
+    type: Literal["alert_words"]
+    alert_words: List[str]
+
+
 Event = Union[
     MessageEvent,
     UpdateMessageContentEvent,
@@ -531,6 +536,7 @@ Event = Union[
     UpdateUserSettingsEvent,
     UpdateGlobalNotificationsEvent,
     RealmUserEvent,
+    AlertWordEvent,
 ]
 
 ###############################################################################

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -147,6 +147,7 @@ class Model:
 
         # Events desired with their corresponding callback
         self.event_actions: Dict[str, Callable[[Event], None]] = {
+            "alert_words": self._handle_alert_words_event,
             "message": self._handle_message_event,
             "update_message": self._handle_update_message_event,
             "reaction": self._handle_reaction_event,
@@ -1379,6 +1380,13 @@ class Model:
                     else:
                         for user_id in user_ids:
                             subscribers.remove(user_id)
+
+    def _handle_alert_words_event(self, event: Event) -> None:
+        """
+        Handle alert_words events
+        """
+        assert event["type"] == "alert_words"
+        self._alert_words = event["alert_words"]
 
     def _handle_typing_event(self, event: Event) -> None:
         """

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -142,6 +142,7 @@ class Model:
             # zulip_version and zulip_feature_level are always returned in
             # POST /register from Feature level 3.
             "zulip_version",
+            "alert_words",
         ]
 
         # Events desired with their corresponding callback
@@ -180,6 +181,8 @@ class Model:
         self.visual_notified_streams: Set[int] = set()
 
         self._subscribe_to_streams(self.initial_data["subscriptions"])
+
+        self._alert_words: List[str] = self.initial_data["alert_words"]
 
         # NOTE: The date_created field of stream has been added in feature
         # level 30, server version 4. For consistency we add this field
@@ -236,6 +239,9 @@ class Model:
 
     def user_settings(self) -> UserSettings:
         return deepcopy(self._user_settings)
+
+    def get_alert_words(self) -> List[str]:
+        return self._alert_words.copy()
 
     def message_retention_days_response(self, days: int, org_default: bool) -> str:
         suffix = " [Organization default]" if org_default else ""

--- a/zulipterminal/ui_tools/messages.py
+++ b/zulipterminal/ui_tools/messages.py
@@ -824,10 +824,8 @@ class MessageBox(urwid.Pile):
 
         clean: str
 
-        def replace_callback(match: Match[Union[str, str, str]]) -> str:
-            before = match.group(1)
-            word = match.group(2)
-            after = match.group(3)
+        def replace_callback(match: Union[Match[str]]) -> str:
+            before,word,after = match.group(1,2,3)
             offset = match.start()
             matched_content = match.string
             pre_match = matched_content[:offset]
@@ -840,8 +838,7 @@ class MessageBox(urwid.Pile):
         for word in alerted_list:
             clean = "".join(alert_regex_replacements.get(c, c) for c in word)
             regex = f"({before_punctuation})({clean})({after_punctuation})"
-            regex1 = re.compile(regex, re.IGNORECASE)
-            content = re.sub(regex1, replace_callback, content)
+            content = re.sub(regex, replace_callback, content, flags=re.IGNORECASE)
 
         return content
 
@@ -857,6 +854,8 @@ class MessageBox(urwid.Pile):
         Dict[str, Tuple[str, int, bool]],
         List[Tuple[str, str]],
     ]:
+        #This method is translated from web/src/aler_tword.js of zulip/zulip
+
         if alert_word_present:
             content = cls.transform_content_alert_words(content, alerted_list)
 

--- a/zulipterminal/ui_tools/messages.py
+++ b/zulipterminal/ui_tools/messages.py
@@ -2,11 +2,12 @@
 UI to render a Zulip message for display, and respond contextually to actions
 """
 
+import re
 import typing
 from collections import defaultdict
 from datetime import date, datetime
 from time import time
-from typing import Any, Dict, List, NamedTuple, Optional, Tuple, Union
+from typing import Any, Dict, List, Match, NamedTuple, Optional, Tuple, Union
 from urllib.parse import urljoin, urlparse
 
 import dateutil.parser
@@ -392,6 +393,9 @@ class MessageBox(urwid.Pile):
                     metadata["bq_len"] -= 1
                     continue
                 markup.append(element)
+            elif tag == "span" and "alert-word" in element.get("class", []):
+                if tag_text:
+                    markup.append(("msg_code", tag_text))
             elif tag == "div" and (set(tag_classes) & set(unrendered_div_classes)):
                 # UNRENDERED DIV CLASSES
                 # NOTE: Though `matches` is generalized for multiple
@@ -628,6 +632,8 @@ class MessageBox(urwid.Pile):
         else:
             recipient_header = None
 
+        self.alerted_words: Optional[Any] = self.model.get_alert_words()
+
         # Content Header
         message = {
             key: {
@@ -716,7 +722,11 @@ class MessageBox(urwid.Pile):
 
         # Transform raw message content into markup (As needed by urwid.Text)
         content, self.message_links, self.time_mentions = self.transform_content(
-            self.message["content"], self.model.server_url
+            self.message["content"],
+            self.model.server_url,
+            self.alerted_words,
+            "has_alert_word" in self.message["flags"]
+            # self.message["flags"],
         )
         self.content.set_text(content)
 
@@ -797,14 +807,59 @@ class MessageBox(urwid.Pile):
 
         return author_is_present
 
+    @staticmethod
+    def transform_content_alert_words(content: str, alerted_list: List[str]) -> Any:
+        alert_regex_replacements = {
+            "&": "&amp;",
+            "<": "&lt;",
+            ">": "&gt;",
+            # Accept quotes with or without HTML escaping
+            '"': r"(?:\"|&quot;)",
+            "'": r"(?:\'|&#39;)",
+        }
+
+        before_punctuation = r"\s|^|>|[\\(\".,';\\[]"
+
+        after_punctuation = r"(?=\s|$|<|[\\)\"?!:.,';\]!])"
+
+        clean: str
+
+        def replace_callback(match: Match[Union[str, str, str]]) -> str:
+            before = match.group(1)
+            word = match.group(2)
+            after = match.group(3)
+            offset = match.start()
+            matched_content = match.string
+            pre_match = matched_content[:offset]
+            check_string = pre_match + match.group()
+            in_tag = check_string.rfind("<") > check_string.rfind(">")
+            if in_tag:
+                return f"{before}{word}{after}"
+            return f"{before}<span class='alert-word'>{word}</span>{after}"
+
+        for word in alerted_list:
+            clean = "".join(alert_regex_replacements.get(c, c) for c in word)
+            regex = f"({before_punctuation})({clean})({after_punctuation})"
+            regex1 = re.compile(regex, re.IGNORECASE)
+            content = re.sub(regex1, replace_callback, content)
+
+        return content
+
     @classmethod
     def transform_content(
-        cls, content: Any, server_url: str
+        cls,
+        content: Any,
+        server_url: str,
+        alerted_list: List[str] = list(),
+        alert_word_present: bool = False,
     ) -> Tuple[
         Tuple[None, Any],
         Dict[str, Tuple[str, int, bool]],
         List[Tuple[str, str]],
     ]:
+        if alert_word_present:
+            content = cls.transform_content_alert_words(content, alerted_list)
+
         soup = BeautifulSoup(content, "lxml")
         body = soup.find(name="body")
 


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->

<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->
Partial fix for #588
<!-- Add a link to a discussion on chat.zulip.org, if relevant -->

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [X] Manually
- [X] Existing tests (adapted, if necessary)
- [X] New tests added (for any new behavior)
- [X] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

<!-- See https://github.com/zulip/zulip-terminal#commit-style -->
**Commit flow** <!-- if more than one commit; add/delete/fill-in as appropriate -->
<!-- For example:
- first commit doing some thing
- maybe multiple commits doing similar things
-->
first commit:Fetches alert words and registers for any `alert_word` event and updates the alerts words.
second commit: adds transform_content_alert_words which adds `<span class=alert-word>` around alert-words

**Notes** <!-- if any; add/delete/fill-in as appropriate -->
<!-- For example:
- this doesn't include feature X (yet?)
- unsure about Y
- should this do Z?
-->
-> This PR(specifically the second commit) is based on the alert word implementation of the Zulip web client which was later adapted by other clients. 
link for the web implementation code: [link](https://github.com/zulip/zulip/blob/main/web/src/alert_words.js)
-> Other helpful documentations for contributors:
     1. [regex wrt python](https://docs.python.org/3/howto/regex.html#regex-howto)
     2. [re module](https://docs.python.org/3/library/re.html#functions)
-> Whats Done?
1. fetching and registering of alert_words
2. finding the alert_word patterns and applying the <span> 

-> What needs to be done?

1. Even though applying span logic is ready but the logic for applying markup for alert words inside of multiple elements is not ready. So basically the markup works for the alert-words without any other `tag`s indie `soup2markup`. Before that we have to decide whether we want to apply different markup when multiple tags are present for a alert_word or we have to choose the markup from any one of them.

2. Currently the markup applied for alert-words is same as `code`  tag i.e `msg_code` as the markup for different `zt_themes` are yet to be discussed.

3. Tests are not added as the non-test code is yet to reach a stable state.

