### PR TITLE
Bugfix: Respect the server's choice of URL when fetching api key

### DIFF
--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -325,7 +325,9 @@ def test_main_cannot_write_zuliprc_given_good_credentials(
 
     # Give some arbitrary input and fake that it's always valid
     mocker.patch.object(builtins, "input", lambda _: "text\n")
-    mocker.patch(MODULE + ".get_api_key", return_value=("my_login", "my_api_key"))
+    mocker.patch(
+        MODULE + ".get_api_key", return_value=("my_site", "my_login", "my_api_key")
+    )
 
     with pytest.raises(SystemExit):
         main([])

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -55,16 +55,13 @@ def test_in_color(color: str, code: str, text: str = "some text") -> None:
     ],
 )
 def test_get_login_id(mocker: MockerFixture, json: Dict[str, bool], label: str) -> None:
-    response = mocker.Mock(json=lambda: json)
-    mocked_get = mocker.patch("requests.get", return_value=response)
     mocked_styled_input = mocker.patch(
         MODULE + ".styled_input", return_value="input return value"
     )
 
-    result = get_login_id("REALM_URL")
+    result = get_login_id(json)
 
     assert result == "input return value"
-    mocked_get.assert_called_with(url="REALM_URL/api/v1/server_settings")
     mocked_styled_input.assert_called_with(label + ": ")
 
 

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -11,7 +11,7 @@ import sys
 import traceback
 from enum import Enum
 from os import path, remove
-from typing import Dict, List, NamedTuple, Optional, Tuple
+from typing import Any, Dict, List, NamedTuple, Optional, Tuple
 
 import requests
 from urwid import display_common, set_encoding
@@ -206,10 +206,9 @@ def styled_input(label: str) -> str:
     return input(in_color("blue", label))
 
 
-def get_login_id(realm_url: str) -> str:
-    res_json = requests.get(url=f"{realm_url}/api/v1/server_settings").json()
-    require_email_format_usernames = res_json["require_email_format_usernames"]
-    email_auth_enabled = res_json["email_auth_enabled"]
+def get_login_id(server_properties: Dict[str, Any]) -> str:
+    require_email_format_usernames = server_properties["require_email_format_usernames"]
+    email_auth_enabled = server_properties["email_auth_enabled"]
 
     if not require_email_format_usernames and email_auth_enabled:
         label = "Email or Username: "
@@ -225,8 +224,11 @@ def get_login_id(realm_url: str) -> str:
 def get_api_key(realm_url: str) -> Optional[Tuple[str, str]]:
     from getpass import getpass
 
-    login_id = get_login_id(realm_url)
+    server_properties = requests.get(url=f"{realm_url}/api/v1/server_settings").json()
+
+    login_id = get_login_id(server_properties)
     password = getpass(in_color("blue", "Password: "))
+
     response = requests.post(
         url=f"{realm_url}/api/v1/fetch_api_key",
         data={


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->

This is a small refactor followed by a change which should fix #1318.

This uses the server settings we fetch in any case, to use the preferred URL from the server as per the `realm_uri` field.

<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->

<!-- Add a link to a discussion on chat.zulip.org, if relevant -->

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [ ] New tests added (for any new behavior)
- [x] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->