### PR TITLE
Improve URL error-handling prior to zuliprc generation

### DIFF
--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -8,6 +8,7 @@ import pytest
 from pytest import CaptureFixture
 from pytest_mock import MockerFixture
 
+from zulipterminal.api_types import ServerSettings
 from zulipterminal.cli.run import (
     _write_zuliprc,
     exit_with_error,
@@ -54,7 +55,11 @@ def test_in_color(color: str, code: str, text: str = "some text") -> None:
         (dict(require_email_format_usernames=True, email_auth_enabled=False), "Email"),
     ],
 )
-def test_get_login_id(mocker: MockerFixture, json: Dict[str, bool], label: str) -> None:
+def test_get_login_id(
+    mocker: MockerFixture,
+    json: ServerSettings,  # NOTE: pytest does not ensure dict above is complete
+    label: str,
+) -> None:
     mocked_styled_input = mocker.patch(
         MODULE + ".styled_input", return_value="input return value"
     )

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -12,7 +12,7 @@ from zulipterminal.api_types import ServerSettings
 from zulipterminal.cli.run import (
     _write_zuliprc,
     exit_with_error,
-    get_login_id,
+    get_login_label,
     in_color,
     main,
     parse_args,
@@ -55,19 +55,13 @@ def test_in_color(color: str, code: str, text: str = "some text") -> None:
         (dict(require_email_format_usernames=True, email_auth_enabled=False), "Email"),
     ],
 )
-def test_get_login_id(
+def test_get_login_label(
     mocker: MockerFixture,
     json: ServerSettings,  # NOTE: pytest does not ensure dict above is complete
     label: str,
 ) -> None:
-    mocked_styled_input = mocker.patch(
-        MODULE + ".styled_input", return_value="input return value"
-    )
-
-    result = get_login_id(json)
-
-    assert result == "input return value"
-    mocked_styled_input.assert_called_with(label + ": ")
+    result = get_login_label(json)
+    assert result == label + ": "
 
 
 @pytest.mark.parametrize("options", ["-h", "--help"])

--- a/zulipterminal/api_types.py
+++ b/zulipterminal/api_types.py
@@ -22,6 +22,10 @@ RESOLVED_TOPIC_PREFIX = "✔ "
 TYPING_STARTED_WAIT_PERIOD = 10
 TYPING_STOPPED_WAIT_PERIOD = 5
 
+###############################################################################
+# Parameter to pass in request to:
+#   https://zulip.com/api/send-message
+
 
 class PrivateComposition(TypedDict):
     type: Literal["private"]
@@ -36,8 +40,11 @@ class StreamComposition(TypedDict):
     subject: str  # TODO: Migrate to using topic
 
 
-# https://zulip.com/api/send-message
 Composition = Union[PrivateComposition, StreamComposition]
+
+###############################################################################
+# Parameter to pass in request to:
+#   https://zulip.com/api/update-message
 
 
 class PrivateMessageUpdateRequest(TypedDict):
@@ -64,8 +71,14 @@ class StreamMessageUpdateRequest(TypedDict):
     # stream_id: int
 
 
-# https://zulip.com/api/update-message
 MessageUpdateRequest = Union[PrivateMessageUpdateRequest, StreamMessageUpdateRequest]
+
+###############################################################################
+# In "messages" response from:
+#   https://zulip.com/api/get-messages
+# In "message" response from:
+#   https://zulip.com/api/get-events#message
+#   https://zulip.com/api/get-message  (unused)
 
 
 class Message(TypedDict, total=False):
@@ -102,7 +115,14 @@ class Message(TypedDict, total=False):
     # sender_short_name: str
 
 
-# Elements and types taken from https://zulip.com/api/get-events
+###############################################################################
+# In "subscriptions" response from:
+#   https://zulip.com/api/register-queue
+# Also directly from:
+#   https://zulip.com/api/get-events#subscription-add
+#   https://zulip.com/api/get-subscriptions (unused)
+
+
 class Subscription(TypedDict):
     stream_id: int
     name: str
@@ -134,6 +154,17 @@ class Subscription(TypedDict):
 
     # Deprecated fields
     # in_home_view: bool  # Replaced by is_muted in Zulip 2.1; still present in updates
+
+
+###############################################################################
+# In "realm_user" response from:
+#   https://zulip.com/api/register-queue
+# Also directly from:
+#   https://zulip.com/api/get-events#realm_user-add
+#   https://zulip.com/api/get-users     (unused)
+#   https://zulip.com/api/get-own-user  (unused)
+#   https://zulip.com/api/get-user      (unused)
+# NOTE: Responses between versions & endpoints vary
 
 
 class RealmUser(TypedDict):
@@ -171,6 +202,12 @@ class RealmUser(TypedDict):
     # is_moderator: bool  # NOTE: new in Zulip 4.0 (ZFL 60) - ONLY IN REGISTER RESPONSE
     # is_cross_realm_bot: bool  # NOTE: Only for cross-realm bots
     # max_message_id: int  # NOTE: DEPRECATED & only for /users/me
+
+
+###############################################################################
+# Events possible in "events" from:
+#   https://zulip.com/api/get-events
+# (also helper data structures not used elsewhere)
 
 
 class MessageEvent(TypedDict):

--- a/zulipterminal/api_types.py
+++ b/zulipterminal/api_types.py
@@ -357,3 +357,59 @@ Event = Union[
     UpdateGlobalNotificationsEvent,
     RealmUserEvent,
 ]
+
+###############################################################################
+# In response from:
+#   https://zulip.com/api/get-server-settings
+
+AuthenticationMethod = Literal[
+    "password",
+    "dev",
+    "email",
+    "ldap",
+    "remoteuser",
+    "github",
+    "azuread",
+    "gitlab",  # New in Zulip 3.0, ZFL 1
+    "apple",
+    "google",
+    "saml",
+    "openid_connect",
+]
+
+
+class ExternalAuthenticationMethod(TypedDict):
+    name: str
+    display_name: str
+    display_icon: Optional[str]
+    login_url: str
+    signup_url: str
+
+
+# As of ZFL 121
+class ServerSettings(TypedDict):
+    # authentication_methods is deprecated in favor of external_authentication_methods
+    authentication_methods: Dict[AuthenticationMethod, bool]
+    # Added in Zulip 2.1.0
+    external_authentication_methods: List[ExternalAuthenticationMethod]
+
+    # TODO Refactor ZFL to default to zero
+    zulip_feature_level: NotRequired[int]  # New in Zulip 3.0, ZFL 1
+    zulip_version: str
+    zulip_merge_base: NotRequired[str]  # New in Zulip 5.0, ZFL 88
+
+    push_notifications_enabled: bool
+    is_incompatible: bool
+    email_auth_enabled: bool
+    require_email_format_usernames: bool
+
+    # This appears to be present for all Zulip servers, even for no organization,
+    # which makes it useful to determine a 'preferred' URL for the server/organization
+    realm_uri: str
+
+    # These may only be present if it's an organization, not just a Zulip server
+    # Re realm_name discussion, See #api document > /server_settings: `realm_name`, etc.
+    realm_name: NotRequired[str]  # Absence indicates root Zulip server but no realm
+    realm_icon: str
+    realm_description: str
+    realm_web_public_access_enabled: NotRequired[bool]  # New in Zulip 5.0, ZFL 116

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -207,7 +207,7 @@ def styled_input(label: str) -> str:
     return input(in_color("blue", label))
 
 
-def get_login_id(server_properties: ServerSettings) -> str:
+def get_login_label(server_properties: ServerSettings) -> str:
     require_email_format_usernames = server_properties["require_email_format_usernames"]
     email_auth_enabled = server_properties["email_auth_enabled"]
 
@@ -219,7 +219,7 @@ def get_login_id(server_properties: ServerSettings) -> str:
         # TODO: Validate Email address
         label = "Email: "
 
-    return styled_input(label)
+    return label
 
 
 def get_api_key(realm_url: str) -> Optional[Tuple[str, str, str]]:
@@ -231,7 +231,8 @@ def get_api_key(realm_url: str) -> Optional[Tuple[str, str, str]]:
     # This avoids cases where there are redirects between http and https, for example
     preferred_realm_url = server_properties["realm_uri"]
 
-    login_id = get_login_id(server_properties)
+    login_id_label = get_login_label(server_properties)
+    login_id = styled_input(login_id_label)
     password = getpass(in_color("blue", "Password: "))
 
     response = requests.post(

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -11,11 +11,12 @@ import sys
 import traceback
 from enum import Enum
 from os import path, remove
-from typing import Any, Dict, List, NamedTuple, Optional, Tuple
+from typing import Dict, List, NamedTuple, Optional, Tuple
 
 import requests
 from urwid import display_common, set_encoding
 
+from zulipterminal.api_types import ServerSettings
 from zulipterminal.config.themes import (
     InvalidThemeColorCode,
     aliased_themes,
@@ -206,7 +207,7 @@ def styled_input(label: str) -> str:
     return input(in_color("blue", label))
 
 
-def get_login_id(server_properties: Dict[str, Any]) -> str:
+def get_login_id(server_properties: ServerSettings) -> str:
     require_email_format_usernames = server_properties["require_email_format_usernames"]
     email_auth_enabled = server_properties["email_auth_enabled"]
 

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -212,14 +212,12 @@ def get_login_label(server_properties: ServerSettings) -> str:
     email_auth_enabled = server_properties["email_auth_enabled"]
 
     if not require_email_format_usernames and email_auth_enabled:
-        label = "Email or Username: "
+        return "Email or Username: "
     elif not require_email_format_usernames:
-        label = "Username: "
+        return "Username: "
     else:
         # TODO: Validate Email address
-        label = "Email: "
-
-    return label
+        return "Email: "
 
 
 def get_api_key(realm_url: str) -> Optional[Tuple[str, str, str]]:

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -220,10 +220,15 @@ def get_login_label(server_properties: ServerSettings) -> str:
         return "Email: "
 
 
+def get_server_settings(realm_url: str) -> ServerSettings:
+    server_properties = requests.get(url=f"{realm_url}/api/v1/server_settings").json()
+    return server_properties
+
+
 def get_api_key(realm_url: str) -> Optional[Tuple[str, str, str]]:
     from getpass import getpass
 
-    server_properties = requests.get(url=f"{realm_url}/api/v1/server_settings").json()
+    server_properties = get_server_settings(realm_url)
 
     # Assuming we connect to and get data from the server, use the realm_url it suggests
     # This avoids cases where there are redirects between http and https, for example


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->

This follows up on the bugfix of #1320, now introducing and applying types for the server-settings response.

Also following from #1320, this aims to give the user more accurate feedback and exit cleanly (cf the current confusing message(s) or tracebacks) if the server URL is not recognized as corresponding to a valid Zulip Organization.

Some of this is a little WIP, since the documentation on the server-settings endpoint is a little confusing, but this is close to mergeable.

This aims to work further towards separating the text input and the logic, as well as improving the testing.

**update**
- This is now tidied, and resolved an issue experienced in [**#zulip-terminal>Crash on entering bad server URL**](https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/Crash.20on.20entering.20bad.20server.20URL)
- This now also adds some documentation for api_types.py
- The last commit as referenced by alexmv was dropped for now, in order to get this merged

<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->

<!-- Add a link to a discussion on chat.zulip.org, if relevant -->

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [x] New tests added (for any new behavior)
- [x] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->
