### PR TITLE
Migrate UI & Docs from Private to Direct phrasing

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The terminal client currently has a number of intentional differences to the Zul
   [Hot keys](https://github.com/zulip/zulip-terminal/blob/main/docs/hotkeys.md)
   to better support keyboard-only navigation; other than directional movement
   these also include:
-  - <kbd>z</kbd> - zoom in/out, between streams & topics, or all private messages & specific conversations
+  - <kbd>z</kbd> - zoom in/out, between streams & topics, or all direct messages & specific conversations
   - <kbd>t</kbd> - toggle view of topics for a stream in left panel
     (**later adopted for recent topics in web client**)
   - <kbd>#</kbd> - narrow to messages in which you're mentioned (<kbd>@</kbd> is already used)

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -142,7 +142,7 @@ In the longer term we may move to multiple servers per session, which is tracked
 ## What is autocomplete? Why is it useful?
 
 Autocomplete can be used to request matching options, and cycle through each option in turn, including:
-- helping to specify users for new private messages (eg. after <kbd>x</kbd>)
+- helping to specify users for new direct messages (eg. after <kbd>x</kbd>)
 - helping to specify streams and existing topics for new stream messages (eg. after <kbd>c</kbd>)
 - mentioning a user or user-group (in message content)
 - linking to a stream or existing topic (in message content)
@@ -192,7 +192,7 @@ As in the example above, a specific prefix is required to indicate which action 
 
 ### Autocomplete of message recipients
 
-Since each of the stream (1), topic (2) and private message recipients (3) areas are very specific, no prefix must be manually entered and values provided through autocomplete depend upon the context automatically.
+Since each of the stream (1), topic (2) and direct message recipients (3) areas are very specific, no prefix must be manually entered and values provided through autocomplete depend upon the context automatically.
 
 ![Stream header](https://user-images.githubusercontent.com/55916430/118403323-8e5b7580-b68b-11eb-9c8a-734c2fe6b774.png)
 
@@ -204,7 +204,7 @@ Since each of the stream (1), topic (2) and private message recipients (3) areas
 
 ![PM recipients header](https://user-images.githubusercontent.com/55916430/118403345-9d422800-b68b-11eb-9005-6d2af74adab9.png)
 
-**NOTE:** If a private message recipient's name contains comma(s) (`,`), they are currently treated as comma-separated recipients.
+**NOTE:** If a direct message recipient's name contains comma(s) (`,`), they are currently treated as comma-separated recipients.
 
 ## Unable to render symbols
 

--- a/docs/developer-feature-tutorial.md
+++ b/docs/developer-feature-tutorial.md
@@ -103,8 +103,8 @@ You can view these events in the `type` file in your `zulip-terminal` home direc
 
 Now to display if user is typing in the view, we need to check few things:
 * The `op` is `start`.
-* User is narrowed into private message conversation with a user.
-* The `user_id` of the person is present in the narrowed private message conversation recipients.
+* User is narrowed into direct message conversation with a user.
+* The `user_id` of the person is present in the narrowed direct message conversation recipients.
 
 If all the above conditions are satisfied we can successfully update the footer to display `X is typing` until we receive
 a `stop` event for typing.

--- a/docs/developer-file-overview.md
+++ b/docs/developer-file-overview.md
@@ -5,37 +5,37 @@
 
 Zulip Terminal uses [Zulip's API](https://zulip.com/api/) to store and retrieve all the information it displays. It has an [MVC structure](https://en.wikipedia.org/wiki/Model%E2%80%93view%E2%80%93controller) overall. Here is a description of some of its files:
 
-| Folder                 | File                | Description                                                                                            |
-| ---------------------- | ------------------- | ------------------------------------------------------------------------------------------------------ |
-| zulipterminal          | api_types.py        | Types from the Zulip API, translated into python, to improve type checking                             |
-|                        | core.py             | Defines the `Controller`, which sets up the `Model`, `View`, and how they interact                     |
-|                        | helper.py           | Helper functions used in multiple places                                                               |
-|                        | model.py            | Defines the `Model`, fetching and storing data retrieved from the Zulip server                         |
-|                        | platform_code.py    | Detection of supported platforms & platform-specific functions                                         |
-|                        | server_url.py       | Constructs and encodes server_url of messages.                                                         |
-|                        | ui.py               | Defines the `View`, and controls where each component is displayed                                     |
-|                        | unicode_emojis.py   | Unicode emoji data, synchronized semi-regularly with the server source                                 |
-|                        | urwid_types.py      | Types from the urwid API, to improve type checking                                                     |
-|                        | version.py          | Keeps track of the version of the current code                                                         |
-|                        |                     |                                                                                                        |
-| zulipterminal/cli      | run.py              | Marks the entry point into the application                                                             |
-|                        |                     |                                                                                                        |
-| zulipterminal/config   | color.py            | Color definitions or functions common across all themes                                                |
-|                        | keys.py             | Keybindings and their helper functions                                                                 |
-|                        | markdown_examples.py| Examples of input markdown and corresponding html output (rendered in markdown help)                   |
-|                        | regexes.py          | Regular expression constants                                                                           |
-|                        | symbols.py          | Terminal characters used to mark particular elements of the user interface                             |
-|                        | themes.py           | Styles and their colour mappings in each theme, with helper functions                                  |
-|                        | ui_mappings.py      | Relationships between state/API data and presentation in the UI                                        |
-|                        | ui_sizes.py         | Fixed sizes of UI elements                                                                             |
-|                        |                     |                                                                                                        |
-| zulipterminal/ui_tools | boxes.py            | UI boxes for entering text: WriteBox, MessageSearchBox, PanelSearchBox                                 |
-|                        | buttons.py          | UI buttons for narrowing & showing unread counts, eg. All, Stream, Private, Topic                      |
-|                        | messages.py         | UI to render a Zulip message for display, and respond contextually to actions                          |
-|                        | tables.py           | Helper functions which render tables in the UI                                                         |
-|                        | utils.py            | The `MessageBox` for every message displayed is created here                                           |
-|                        | views.py            | UI views for larger elements such as Streams, Messages, Topics, Help, etc                              |
-|                        |                     |                                                                                                        |
-| zulipterminal/scripts  |                     | Scripts bundled with the application                                                                   |
-|                        |                     |                                                                                                        |
-| zulipterminal/themes   |                     | Themes bundled with the application                                                                    |
+| Folder                 | File                | Description                                                                             |
+| ---------------------- | ------------------- | ----------------------------------------------------------------------------------------|
+| zulipterminal          | api_types.py        | Types from the Zulip API, translated into python, to improve type checking              |
+|                        | core.py             | Defines the `Controller`, which sets up the `Model`, `View`, and how they interact      |
+|                        | helper.py           | Helper functions used in multiple places                                                |
+|                        | model.py            | Defines the `Model`, fetching and storing data retrieved from the Zulip server          |
+|                        | platform_code.py    | Detection of supported platforms & platform-specific functions                          |
+|                        | server_url.py       | Constructs and encodes server_url of messages.                                          |
+|                        | ui.py               | Defines the `View`, and controls where each component is displayed                      |
+|                        | unicode_emojis.py   | Unicode emoji data, synchronized semi-regularly with the server source                  |
+|                        | urwid_types.py      | Types from the urwid API, to improve type checking                                      |
+|                        | version.py          | Keeps track of the version of the current code                                          |
+|                        |                     |                                                                                         |
+| zulipterminal/cli      | run.py              | Marks the entry point into the application                                              |
+|                        |                     |                                                                                         |
+| zulipterminal/config   | color.py            | Color definitions or functions common across all themes                                 |
+|                        | keys.py             | Keybindings and their helper functions                                                  |
+|                        | markdown_examples.py| Examples of input markdown and corresponding html output (rendered in markdown help)    |
+|                        | regexes.py          | Regular expression constants                                                            |
+|                        | symbols.py          | Terminal characters used to mark particular elements of the user interface              |
+|                        | themes.py           | Styles and their colour mappings in each theme, with helper functions                   |
+|                        | ui_mappings.py      | Relationships between state/API data and presentation in the UI                         |
+|                        | ui_sizes.py         | Fixed sizes of UI elements                                                              |
+|                        |                     |                                                                                         |
+| zulipterminal/ui_tools | boxes.py            | UI boxes for entering text: WriteBox, MessageSearchBox, PanelSearchBox                  |
+|                        | buttons.py          | UI buttons for narrowing & showing unread counts, eg. All, Stream, Private, Topic       |
+|                        | messages.py         | UI to render a Zulip message for display, and respond contextually to actions           |
+|                        | tables.py           | Helper functions which render tables in the UI                                          |
+|                        | utils.py            | The `MessageBox` for every message displayed is created here                            |
+|                        | views.py            | UI views for larger elements such as Streams, Messages, Topics, Help, etc               |
+|                        |                     |                                                                                         |
+| zulipterminal/scripts  |                     | Scripts bundled with the application                                                    |
+|                        |                     |                                                                                         |
+| zulipterminal/themes   |                     | Themes bundled with the application                                                     |

--- a/docs/developer-file-overview.md
+++ b/docs/developer-file-overview.md
@@ -30,7 +30,7 @@ Zulip Terminal uses [Zulip's API](https://zulip.com/api/) to store and retrieve 
 |                        | ui_sizes.py         | Fixed sizes of UI elements                                                              |
 |                        |                     |                                                                                         |
 | zulipterminal/ui_tools | boxes.py            | UI boxes for entering text: WriteBox, MessageSearchBox, PanelSearchBox                  |
-|                        | buttons.py          | UI buttons for narrowing & showing unread counts, eg. All, Stream, Private, Topic       |
+|                        | buttons.py          | UI buttons for narrowing & showing unread counts, eg. All, Stream, Direct, Topic        |
 |                        | messages.py         | UI to render a Zulip message for display, and respond contextually to actions           |
 |                        | tables.py           | Helper functions which render tables in the UI                                          |
 |                        | utils.py            | The `MessageBox` for every message displayed is created here                            |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -24,8 +24,8 @@ This tutorial was designed to be interactive. We highly recommend opening up Zul
     + [Narrow to the Stream or Topic of a Message](#Narrow-to-the-Stream-or-Topic-of-a-Message)
 6. [Sending Messages](#Sending-Messages)
     + [Reply to a Message](#Reply-to-a-Message)
-    + [Reply via a Private Message](#Reply-via-a-Private-Message)
-    + [Send a Private Message to Someone New](#Send-a-Private-Message-to-Someone-New)
+    + [Reply via a Direct Message](#Reply-via-a-Direct-Message)
+    + [Send a Direct Message to Someone New](#Send-a-Direct-Message-to-Someone-New)
     + [Create a New Topic](#Create-a-New-Topic)
 7. [Edit a Message](#Edit-a-Message)
 8. [Close Zulip Terminal](#Close-Zulip-Terminal)
@@ -63,7 +63,7 @@ Sometimes it can take forever to manually move our cursor where we want it - tha
 
 Let's try out a few of these shortcuts!
 
-+ First, type <kbd>shift</kbd><kbd>p</kbd> to view your **Private Messages** (PMs).
++ First, type <kbd>shift</kbd><kbd>p</kbd> to view your **Direct Messages**.
 
 + Second, type <kbd>#</kbd> to view all messages you were mentioned (@'ed) in.
 
@@ -77,7 +77,7 @@ Let's try out a few of these shortcuts!
 You'll be hearing the term 'narrow' a lot in Zulip. What does it mean?
 
 + **Noun**: A narrow is a set of filters for Zulip messages, that can be based on many different factors (like sender, stream, topic, search keywords, etc.).
-+ **Verb**: The process of navigating to a different narrow. For example, to go from viewing a stream to a topic within that stream. There are several different ways to 'narrow to a narrow' so to speak. For example, you can use the keyboard shortcuts as we did in the section above. When you used the keyboard shortcut <kbd>shift</kbd><kbd>p</kbd> to view your private messages (PMs), you 'narrowed' to the **Private Messages** narrow.
++ **Verb**: The process of navigating to a different narrow. For example, to go from viewing a stream to a topic within that stream. There are several different ways to 'narrow to a narrow' so to speak. For example, you can use the keyboard shortcuts as we did in the section above. When you used the keyboard shortcut <kbd>shift</kbd><kbd>p</kbd> to view your direct messages, you 'narrowed' to the **Direct Messages** narrow.
 
 ### Your Current Narrow
 
@@ -124,7 +124,7 @@ You can also type <kbd>z</kbd> to 'zoom in' or 'zoom out.' What do I mean by 'zo
 
 ### Reply to a Message
 
-To reply to an existing stream- or private-message in any narrow, rest your cursor on the message you want to reply to and then type <kbd>r</kbd>. Type your message in the Message box that pops up at the bottom of the middle column. Type <kbd>ctrl</kbd><kbd>d</kbd> to send. If you change your mind and don't want to send the message, type <kbd>esc</kbd> to get out of the message editor. Let's try replying to a random message in the **[#test here](https://chat.zulip.org/#narrow/stream/7-test-here)** stream (don't worry about messing anything up, the [#test here](https://chat.zulip.org/#narrow/stream/7-test-here) stream was made for stuff like this).
+To reply to an existing stream- or direct-message in any narrow, rest your cursor on the message you want to reply to and then type <kbd>r</kbd>. Type your message in the Message box that pops up at the bottom of the middle column. Type <kbd>ctrl</kbd><kbd>d</kbd> to send. If you change your mind and don't want to send the message, type <kbd>esc</kbd> to get out of the message editor. Let's try replying to a random message in the **[#test here](https://chat.zulip.org/#narrow/stream/7-test-here)** stream (don't worry about messing anything up, the [#test here](https://chat.zulip.org/#narrow/stream/7-test-here) stream was made for stuff like this).
 
 <img src="getting-started-imgs/reply-to-message.png" width="85%">
 
@@ -134,21 +134,21 @@ If you want to show you agree with the current message, type <kbd>+</kbd> to add
 
 <img src="getting-started-imgs/thumbs-up.png" width="85%">
 
-### Reply via a Private Message
+### Reply via a Direct Message
 
-Let's try sending a private message to the author of a message. Select the message you sent to the [#test here](https://chat.zulip.org/#narrow/stream/7-test-here) stream earlier and press <kbd>shift</kbd><kbd>r</kbd> to send a private message to yourself. Type your message in the message editor that appears at the bottom of the middle column and then type <kbd>ctrl</kbd><kbd>d</kbd> to send. Press the <kbd>shift</kbd><kbd>p</kbd> hotkey as we did earlier in the tutorial to narrow to your private messages and make sure everything worked properly.
+Let's try sending a direct message to the author of a message. Select the message you sent to the [#test here](https://chat.zulip.org/#narrow/stream/7-test-here) stream earlier and press <kbd>shift</kbd><kbd>r</kbd> to send a direct message to yourself. Type your message in the message editor that appears at the bottom of the middle column and then type <kbd>ctrl</kbd><kbd>d</kbd> to send. Press the <kbd>shift</kbd><kbd>p</kbd> hotkey as we did earlier in the tutorial to narrow to your direct messages and make sure everything worked properly.
 
 <img src="getting-started-imgs/send-pm.png" width="85%">
 
-### Send a Private Message to Someone New
+### Send a Direct Message to Someone New
 
-You can send a private message by moving your cursor to the list of "Users" in the right column and selecting the name of the person you'd like to send a message to.
+You can send a direct message by moving your cursor to the list of "Users" in the right column and selecting the name of the person you'd like to send a message to.
 
-From version 0.7.0 you can also use autocomplete to enter people's names from partial information, and easily send one-to-one or group private messages!
+From version 0.7.0 you can also use autocomplete to enter people's names from partial information, and easily send one-to-one or group direct messages!
 
-To send a private message using the autocomplete feature:
+To send a direct message using the autocomplete feature:
 1. Use the <kbd>x</kbd> hotkey. A message editor will pop open at the bottom of the middle column. 
-2. Type in part of the name of the person you'd like to send a private message to (IMG 1)
+2. Type in part of the name of the person you'd like to send a direct message to (IMG 1)
 3. Press <kbd>ctrl</kbd><kbd>f</kbd> and a list of potential recipients will appear in the footer (highlighted in red). 
 4. Press <kbd>ctrl</kbd><kbd>f</kbd> until the name of the person you want to send a message to is highlighted (IMG 2). 
 5. Press <kbd>tab</kbd> to jump to the message section and type in your message. 

--- a/docs/hotkeys.md
+++ b/docs/hotkeys.md
@@ -25,11 +25,11 @@
 |Scroll down|<kbd>page</kbd> + <kbd>down</kbd> / <kbd>J</kbd>|
 |Go to bottom / Last message|<kbd>end</kbd> / <kbd>G</kbd>|
 |Narrow to all messages|<kbd>a</kbd> / <kbd>esc</kbd>|
-|Narrow to all private messages|<kbd>P</kbd>|
+|Narrow to all direct messages|<kbd>P</kbd>|
 |Narrow to all starred messages|<kbd>f</kbd>|
 |Narrow to messages in which you're mentioned|<kbd>#</kbd>|
 |Next unread topic|<kbd>n</kbd>|
-|Next unread private message|<kbd>p</kbd>|
+|Next unread direct message|<kbd>p</kbd>|
 |Perform current action|<kbd>enter</kbd>|
 
 ## Searching
@@ -47,14 +47,14 @@
 |Reply to the current message|<kbd>r</kbd> / <kbd>enter</kbd>|
 |Reply mentioning the sender of the current message|<kbd>@</kbd>|
 |Reply quoting the current message text|<kbd>></kbd>|
-|Reply privately to the sender of the current message|<kbd>R</kbd>|
+|Reply directly to the sender of the current message|<kbd>R</kbd>|
 |Edit message's content or topic|<kbd>e</kbd>|
 |New message to a stream|<kbd>c</kbd>|
 |New message to a person or group of people|<kbd>x</kbd>|
 |Show/hide Emoji picker popup for current message|<kbd>:</kbd>|
 |Narrow to the stream of the current message|<kbd>s</kbd>|
 |Narrow to the topic of the current message|<kbd>S</kbd>|
-|Narrow to a topic/private-chat, or stream/all-private-messages|<kbd>z</kbd>|
+|Narrow to a topic/direct-chat, or stream/all-direct-messages|<kbd>z</kbd>|
 |Add/remove thumbs-up reaction to the current message|<kbd>+</kbd>|
 |Add/remove star status of the current message|<kbd>ctrl</kbd> + <kbd>s</kbd> / <kbd>*</kbd>|
 |Show/hide message information|<kbd>i</kbd>|

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -2081,7 +2081,7 @@ class TestModel:
 
     @pytest.mark.parametrize(
         "hide_content, expected_content",
-        [(True, "New private message from Foo Foo"), (False, "private content here.")],
+        [(True, "New direct message from Foo Foo"), (False, "private content here.")],
     )
     def test_notify_users_hides_PM_content_based_on_user_setting(
         self, mocker, model, private_message_fixture, hide_content, expected_content

--- a/tests/ui_tools/test_buttons.py
+++ b/tests/ui_tools/test_buttons.py
@@ -187,7 +187,7 @@ class TestPMButton:
     def test_button_text_title(self, mocker: MockerFixture, count: int = 10) -> None:
         pm_button = PMButton(controller=mocker.Mock(), count=count)
         title_text = pm_button.label_text[:-3].strip()
-        assert title_text == "Private messages"
+        assert title_text == "Direct messages"
 
 
 class TestStarredButton:

--- a/tests/ui_tools/test_buttons.py
+++ b/tests/ui_tools/test_buttons.py
@@ -13,6 +13,7 @@ from zulipterminal.ui_tools.buttons import (
     EmojiButton,
     MessageLinkButton,
     ParsedNarrowLink,
+    PMButton,
     StarredButton,
     StreamButton,
     TopButton,
@@ -176,6 +177,17 @@ class TestTopButton:
             expected_suffix_markup
         )
         set_attr_map.assert_called_once_with({None: top_button.label_style})
+
+
+class TestPMButton:
+    def test_button_text_length(self, mocker: MockerFixture, count: int = 10) -> None:
+        pm_button = PMButton(controller=mocker.Mock(), count=count)
+        assert len(pm_button.label_text) == 20
+
+    def test_button_text_title(self, mocker: MockerFixture, count: int = 10) -> None:
+        pm_button = PMButton(controller=mocker.Mock(), count=count)
+        title_text = pm_button.label_text[:-3].strip()
+        assert title_text == "Private messages"
 
 
 class TestStarredButton:

--- a/tests/ui_tools/test_messages.py
+++ b/tests/ui_tools/test_messages.py
@@ -908,14 +908,19 @@ class TestMessageBox:
                 f"PTEST {STREAM_TOPIC_SEPARATOR}",
                 ("bar", [("s#bd6", "PTEST"), ("s#bd6", ": topic narrow")]),
             ),
-            ([["is", "private"]], 1, "You and ", "All private messages"),
-            ([["is", "private"]], 2, "You and ", "All private messages"),
-            ([["pm_with", "boo@zulip.com"]], 1, "You and ", "Private conversation"),
+            ([["is", "private"]], 1, "You and ", "All direct messages"),
+            ([["is", "private"]], 2, "You and ", "All direct messages"),
+            (
+                [["pm_with", "boo@zulip.com"]],
+                1,
+                "You and ",
+                "Direct message conversation",
+            ),
             (
                 [["pm_with", "boo@zulip.com, bar@zulip.com"]],
                 2,
                 "You and ",
-                "Group private conversation",
+                "Group direct message conversation",
             ),
             (
                 [["is", "starred"]],
@@ -1175,7 +1180,7 @@ class TestMessageBox:
                         " You can't edit messages sent by other users"
                         " that already have a topic."
                     ),
-                    "private": " You can't edit private messages sent by other users.",
+                    "private": " You can't edit direct messages sent by other users.",
                 },
                 id="msg_sent_by_other_user_with_topic",
             ),
@@ -1250,7 +1255,7 @@ class TestMessageBox:
                         " Only topic editing is allowed."
                         " This is someone else's message but with (no topic)."
                     ),
-                    "private": " You can't edit private messages sent by other users.",
+                    "private": " You can't edit direct messages sent by other users.",
                 },
                 id="msg_sent_by_other_with_no_topic",
             ),

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -109,7 +109,7 @@ KEY_BINDINGS: 'OrderedDict[str, KeyBinding]' = OrderedDict([
     }),
     ('REPLY_AUTHOR', {
         'keys': ['R'],
-        'help_text': 'Reply privately to the sender of the current message',
+        'help_text': 'Reply directly to the sender of the current message',
         'key_category': 'msg_actions',
     }),
     ('EDIT_MESSAGE', {
@@ -176,7 +176,7 @@ KEY_BINDINGS: 'OrderedDict[str, KeyBinding]' = OrderedDict([
     ('TOGGLE_NARROW', {
         'keys': ['z'],
         'help_text':
-            'Narrow to a topic/private-chat, or stream/all-private-messages',
+            'Narrow to a topic/direct-chat, or stream/all-direct-messages',
         'key_category': 'msg_actions',
     }),
     ('TOGGLE_TOPIC', {
@@ -191,7 +191,7 @@ KEY_BINDINGS: 'OrderedDict[str, KeyBinding]' = OrderedDict([
     }),
     ('ALL_PM', {
         'keys': ['P'],
-        'help_text': 'Narrow to all private messages',
+        'help_text': 'Narrow to all direct messages',
         'key_category': 'navigation',
     }),
     ('ALL_STARRED', {
@@ -211,7 +211,7 @@ KEY_BINDINGS: 'OrderedDict[str, KeyBinding]' = OrderedDict([
     }),
     ('NEXT_UNREAD_PM', {
         'keys': ['p'],
-        'help_text': 'Next unread private message',
+        'help_text': 'Next unread direct message',
         'key_category': 'navigation',
     }),
     ('SEARCH_PEOPLE', {

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1444,7 +1444,7 @@ class Model:
                 ]
                 recipient = ", ".join(extra_targets)
             if not self.user_settings()["pm_content_in_desktop_notifications"]:
-                content = f"New private message from {message['sender_full_name']}"
+                content = f"New direct message from {message['sender_full_name']}"
                 hidden_content = True
         elif message["type"] == "stream":
             stream_id = message["stream_id"]

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -131,7 +131,7 @@ class HomeButton(TopButton):
 
 class PMButton(TopButton):
     def __init__(self, *, controller: Any, count: int) -> None:
-        button_text = f"Private messages [{primary_key_for_command('ALL_PM')}]"
+        button_text = f"Direct messages  [{primary_key_for_command('ALL_PM')}]"
 
         super().__init__(
             controller=controller,

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -1,5 +1,5 @@
 """
-UI buttons for narrowing & showing unread counts, eg. All, Stream, Private, Topic
+UI buttons for narrowing & showing unread counts, eg. All, Stream, Direct, Topic
 """
 
 import re

--- a/zulipterminal/ui_tools/messages.py
+++ b/zulipterminal/ui_tools/messages.py
@@ -204,7 +204,7 @@ class MessageBox(urwid.Pile):
         if curr_narrow == []:
             text_to_fill = "All messages"
         elif len(curr_narrow) == 1 and curr_narrow[0][1] == "private":
-            text_to_fill = "All private messages"
+            text_to_fill = "All direct messages"
         elif len(curr_narrow) == 1 and curr_narrow[0][1] == "starred":
             text_to_fill = "Starred messages"
         elif len(curr_narrow) == 1 and curr_narrow[0][1] == "mentioned":
@@ -227,9 +227,9 @@ class MessageBox(urwid.Pile):
                     [(bar_color, self.stream_name)],
                 )
         elif len(curr_narrow) == 1 and len(curr_narrow[0][1].split(",")) > 1:
-            text_to_fill = "Group private conversation"
+            text_to_fill = "Group direct message conversation"
         else:
-            text_to_fill = "Private conversation"
+            text_to_fill = "Direct message conversation"
 
         if is_search_narrow:
             title_markup = (
@@ -1017,7 +1017,7 @@ class MessageBox(urwid.Pile):
                     )
                 else:
                     self.model.controller.report_error(
-                        [" You can't edit private messages sent by other users."]
+                        [" You can't edit direct messages sent by other users."]
                     )
                 return key
             # Check if editing is allowed in the realm


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->
This PR replaces instances of 'private' with 'direct', in the context of private messages, in the UI and relevant docs.
This is in line with the design decision to rename private message (PM) to direct message (DM).   

<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->
Fixes #1288 

<!-- Add a link to a discussion on chat.zulip.org, if relevant -->
[CZO Discussion Link](https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/'private'.20to.20'direct'.20.23T1288)

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [x] New tests added (for any new behavior)
- [x] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

<!-- See https://github.com/zulip/zulip-terminal#commit-style -->
**Commit flow** <!-- if more than one commit; add/delete/fill-in as appropriate -->
<!-- For example:-->
- First, second and fourth commits change UI elements from 'private' to 'direct'.
- Third and fifth commits update the documentation.

**Notes & Questions** <!-- if any; add/delete/fill-in as appropriate -->
<!-- For example:
-
-->
- Some UI changes like the keybinding help texts in the second commit do not result in test failures. Do we need to add tests for them?