### PR TITLE
Normalize update_stream_message behavior regarding notification messages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,4 +152,6 @@ select = [
 # T20: Expect print output from CLI from run.py
 "zulipterminal/cli/run.py" = ["T20"]
 # N802: Allow upper-case in test function names, eg. for commands, such as test_keypress_ENTER
-"tests/*" = ["N802"]
+# N803: Allow upper-case in test function argument names, eg. ZFL, API
+# N806: Allow upper-case in test function variables
+"tests/*" = ["N802", "N803", "N806"]

--- a/tests/config/test_color.py
+++ b/tests/config/test_color.py
@@ -7,7 +7,7 @@ def test_color_properties() -> None:
     class Color(Enum):
         WHITE = "wh  #256  #24"
 
-    ExpandedColor = color_properties(Color, "BOLD", "ITALICS")  # noqa: N806
+    ExpandedColor = color_properties(Color, "BOLD", "ITALICS")
 
     assert ExpandedColor.WHITE in ExpandedColor
     assert ExpandedColor.WHITE.value == "wh  #256  #24"

--- a/tests/config/test_themes.py
+++ b/tests/config/test_themes.py
@@ -80,7 +80,7 @@ def test_builtin_theme_completeness(theme_name: str) -> None:
         fg, bg = style_conf
         assert fg in theme_colors and bg in theme_colors
     # Check completeness of META
-    expected_META = {"pygments": ["styles", "background", "overrides"]}  # noqa: N806
+    expected_META = {"pygments": ["styles", "background", "overrides"]}
     for metadata, config in expected_META.items():
         assert theme_meta[metadata]
         assert all(theme_meta[metadata][c] for c in config)

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -935,6 +935,7 @@ class TestModel:
         return_value,
         kwargs,
         expected_report_success,
+        old_content="old content",
         old_stream_name="stream",
         old_topic_name="old topic",
         message_id=1,
@@ -942,6 +943,7 @@ class TestModel:
         self.client.update_message = mocker.Mock(return_value=response)
         model.index["messages"][message_id]["subject"] = old_topic_name
         model.index["messages"][message_id]["display_recipient"] = old_stream_name
+        model.index["messages"][message_id]["content"] = old_content
 
         result = model.update_stream_message(message_id=message_id, **kwargs)
 

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -841,7 +841,6 @@ class TestModel:
         [
             case(
                 {
-                    "message_id": 1,
                     "propagate_mode": "change_one",
                     "content": "hi!",
                     "topic": "Some topic",
@@ -851,7 +850,6 @@ class TestModel:
             ),
             case(
                 {
-                    "message_id": 1,
                     "propagate_mode": "change_one",
                     "topic": "Topic change",
                 },
@@ -868,7 +866,6 @@ class TestModel:
             ),
             case(
                 {
-                    "message_id": 1,
                     "propagate_mode": "change_all",
                     "topic": "Old topic",
                 },
@@ -877,7 +874,6 @@ class TestModel:
             ),
             case(
                 {
-                    "message_id": 1,
                     "propagate_mode": "change_later",
                     "content": ":smile:",
                     "topic": "terminal",
@@ -887,7 +883,6 @@ class TestModel:
             ),
             case(
                 {
-                    "message_id": 1,
                     "propagate_mode": "change_later",
                     "content": ":smile:",
                     "topic": "new_terminal",
@@ -905,7 +900,6 @@ class TestModel:
             ),
             case(
                 {
-                    "message_id": 1,
                     "propagate_mode": "change_one",
                     "content": "Hey!",
                     "topic": "grett",
@@ -923,7 +917,6 @@ class TestModel:
             ),
             case(
                 {
-                    "message_id": 1,
                     "propagate_mode": "change_all",
                     "content": "Lets party!",
                     "topic": "party",
@@ -951,14 +944,13 @@ class TestModel:
         old_topic,
         expected_report_success,
         old_stream_name="stream",
+        message_id=1,
     ):
         self.client.update_message = mocker.Mock(return_value=response)
-        model.index["messages"][kwargs["message_id"]]["subject"] = old_topic
-        model.index["messages"][kwargs["message_id"]][
-            "display_recipient"
-        ] = old_stream_name
+        model.index["messages"][message_id]["subject"] = old_topic
+        model.index["messages"][message_id]["display_recipient"] = old_stream_name
 
-        result = model.update_stream_message(**kwargs)
+        result = model.update_stream_message(message_id=message_id, **kwargs)
 
         assert result == return_value
 
@@ -971,7 +963,9 @@ class TestModel:
             report_success.assert_not_called()
 
         # Implementation detail
-        self.client.update_message.assert_called_once_with(kwargs)
+        self.client.update_message.assert_called_once_with(
+            dict(message_id=message_id, **kwargs)
+        )
 
     @pytest.mark.parametrize(
         "response, return_value",

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -832,8 +832,8 @@ class TestModel:
     @pytest.mark.parametrize(
         "response, return_value",
         [
-            ({"result": "success"}, True),
-            ({"result": "some_failure"}, False),
+            case({"result": "success"}, True, id="API_success"),
+            case({"result": "some_failure"}, False, id="API_error"),
         ],
     )
     @pytest.mark.parametrize(
@@ -846,6 +846,7 @@ class TestModel:
                     "topic": "old topic",
                 },
                 None,  # None as footer is not updated.
+                id="topic_passed_but_same_so_not_changed:content_changed",
             ),
             case(
                 {
@@ -861,6 +862,7 @@ class TestModel:
                     ("footer_contrast", " Topic change "),
                     " .",
                 ],
+                id="topic_changed[one]",
             ),
             case(
                 {
@@ -868,6 +870,7 @@ class TestModel:
                     "topic": "old topic",
                 },
                 None,  # None as footer is not updated.
+                id="topic_passed_but_same_so_not_changed[all]",
             ),
             case(
                 {
@@ -876,6 +879,7 @@ class TestModel:
                     "topic": "old topic",
                 },
                 None,  # None as footer is not updated.
+                id="topic_passed_but_same_so_not_changed[later]:content_changed",
             ),
             case(
                 {
@@ -892,6 +896,7 @@ class TestModel:
                     ("footer_contrast", " new_terminal "),
                     " .",
                 ],
+                id="topic_changed[later]:content_changed",
             ),
             case(
                 {
@@ -908,6 +913,7 @@ class TestModel:
                     ("footer_contrast", " grett "),
                     " .",
                 ],
+                id="topic_changed[one]:content_changed",
             ),
             case(
                 {
@@ -924,6 +930,7 @@ class TestModel:
                     ("footer_contrast", " party "),
                     " .",
                 ],
+                id="topic_changed[all]:content_changed",
             ),
         ],
     )

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -837,15 +837,14 @@ class TestModel:
         ],
     )
     @pytest.mark.parametrize(
-        "kwargs, old_topic, expected_report_success",
+        "kwargs, expected_report_success",
         [
             case(
                 {
                     "propagate_mode": "change_one",
                     "content": "hi!",
-                    "topic": "Some topic",
+                    "topic": "old topic",
                 },
-                "Some topic",
                 None,  # None as footer is not updated.
             ),
             case(
@@ -853,11 +852,10 @@ class TestModel:
                     "propagate_mode": "change_one",
                     "topic": "Topic change",
                 },
-                "Old topic",
                 [
                     "You changed one message's topic from ",
                     ("footer_contrast", f" stream {STREAM_TOPIC_SEPARATOR} "),
-                    ("footer_contrast", " Old topic "),
+                    ("footer_contrast", " old topic "),
                     " to ",
                     ("footer_contrast", f" stream {STREAM_TOPIC_SEPARATOR} "),
                     ("footer_contrast", " Topic change "),
@@ -867,18 +865,16 @@ class TestModel:
             case(
                 {
                     "propagate_mode": "change_all",
-                    "topic": "Old topic",
+                    "topic": "old topic",
                 },
-                "Old topic",
                 None,  # None as footer is not updated.
             ),
             case(
                 {
                     "propagate_mode": "change_later",
                     "content": ":smile:",
-                    "topic": "terminal",
+                    "topic": "old topic",
                 },
-                "terminal",
                 None,  # None as footer is not updated.
             ),
             case(
@@ -887,11 +883,10 @@ class TestModel:
                     "content": ":smile:",
                     "topic": "new_terminal",
                 },
-                "old_terminal",
                 [
                     "You changed some messages' topic from ",
                     ("footer_contrast", f" stream {STREAM_TOPIC_SEPARATOR} "),
-                    ("footer_contrast", " old_terminal "),
+                    ("footer_contrast", " old topic "),
                     " to ",
                     ("footer_contrast", f" stream {STREAM_TOPIC_SEPARATOR} "),
                     ("footer_contrast", " new_terminal "),
@@ -904,11 +899,10 @@ class TestModel:
                     "content": "Hey!",
                     "topic": "grett",
                 },
-                "greet",
                 [
                     "You changed one message's topic from ",
                     ("footer_contrast", f" stream {STREAM_TOPIC_SEPARATOR} "),
-                    ("footer_contrast", " greet "),
+                    ("footer_contrast", " old topic "),
                     " to ",
                     ("footer_contrast", f" stream {STREAM_TOPIC_SEPARATOR} "),
                     ("footer_contrast", " grett "),
@@ -921,11 +915,10 @@ class TestModel:
                     "content": "Lets party!",
                     "topic": "party",
                 },
-                "lets_party",
                 [
                     "You changed all messages' topic from ",
                     ("footer_contrast", f" stream {STREAM_TOPIC_SEPARATOR} "),
-                    ("footer_contrast", " lets_party "),
+                    ("footer_contrast", " old topic "),
                     " to ",
                     ("footer_contrast", f" stream {STREAM_TOPIC_SEPARATOR} "),
                     ("footer_contrast", " party "),
@@ -941,13 +934,13 @@ class TestModel:
         response,
         return_value,
         kwargs,
-        old_topic,
         expected_report_success,
         old_stream_name="stream",
+        old_topic_name="old topic",
         message_id=1,
     ):
         self.client.update_message = mocker.Mock(return_value=response)
-        model.index["messages"][message_id]["subject"] = old_topic
+        model.index["messages"][message_id]["subject"] = old_topic_name
         model.index["messages"][message_id]["display_recipient"] = old_stream_name
 
         result = model.update_stream_message(message_id=message_id, **kwargs)

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -2464,9 +2464,7 @@ class TestModel:
         Input is a list of pairs, of a message-id and a list of reaction tuples
         NOTE: reactions as None indicate not indexed, [] indicates no reaction
         """
-        MsgsType = List[  # noqa: N806
-            Tuple[int, Optional[List[Tuple[int, str, str, str]]]]
-        ]
+        MsgsType = List[Tuple[int, Optional[List[Tuple[int, str, str, str]]]]]
 
         def _factory(msgs: MsgsType):
             return {

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -837,7 +837,7 @@ class TestModel:
         ],
     )
     @pytest.mark.parametrize(
-        "req, old_topic, expected_report_success",
+        "kwargs, old_topic, expected_report_success",
         [
             case(
                 {
@@ -947,25 +947,31 @@ class TestModel:
         model,
         response,
         return_value,
-        req,
+        kwargs,
         old_topic,
         expected_report_success,
         old_stream_name="stream",
     ):
         self.client.update_message = mocker.Mock(return_value=response)
-        model.index["messages"][req["message_id"]]["subject"] = old_topic
-        model.index["messages"][req["message_id"]][
+        model.index["messages"][kwargs["message_id"]]["subject"] = old_topic
+        model.index["messages"][kwargs["message_id"]][
             "display_recipient"
         ] = old_stream_name
-        result = model.update_stream_message(**req)
-        self.client.update_message.assert_called_once_with(req)
+
+        result = model.update_stream_message(**kwargs)
+
         assert result == return_value
+
         self.display_error_if_present.assert_called_once_with(response, self.controller)
+
         report_success = model.controller.report_success
         if result and expected_report_success is not None:
             report_success.assert_called_once_with(expected_report_success, duration=6)
         else:
             report_success.assert_not_called()
+
+        # Implementation detail
+        self.client.update_message.assert_called_once_with(kwargs)
 
     @pytest.mark.parametrize(
         "response, return_value",

--- a/zulipterminal/api_types.py
+++ b/zulipterminal/api_types.py
@@ -6,7 +6,7 @@ Types from the Zulip API, translated into python, to improve type checking
 
 from typing import Any, Dict, List, Optional, Union
 
-from typing_extensions import Literal, TypedDict
+from typing_extensions import Literal, NotRequired, TypedDict
 
 # These are documented in the zulip package (python-zulip-api repo)
 from zulip import EditPropagateMode  # one/all/later
@@ -36,7 +36,36 @@ class StreamComposition(TypedDict):
     subject: str  # TODO: Migrate to using topic
 
 
+# https://zulip.com/api/send-message
 Composition = Union[PrivateComposition, StreamComposition]
+
+
+class PrivateMessageUpdateRequest(TypedDict):
+    message_id: int
+    content: str
+
+
+class StreamMessageUpdateRequest(TypedDict):
+    message_id: int
+
+    # May update combination of content for specified message
+    # ...and/or topic of that message and potentially others (via mode)
+    # ...but content and stream may not be changed together
+    content: NotRequired[str]
+    topic: NotRequired[str]
+    propagate_mode: NotRequired[EditPropagateMode]
+
+    # Supported for stream moves in ZFL 9 (Zulip 3)
+    # Default values if not passed in ZFL 152 (Zulip 6)
+    send_notification_to_old_thread: NotRequired[bool]
+    send_notification_to_new_thread: NotRequired[bool]
+
+    # TODO: Implement message moves between streams
+    # stream_id: int
+
+
+# https://zulip.com/api/update-message
+MessageUpdateRequest = Union[PrivateMessageUpdateRequest, StreamMessageUpdateRequest]
 
 
 class Message(TypedDict, total=False):

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -34,9 +34,11 @@ from zulipterminal.api_types import (
     EditPropagateMode,
     Event,
     PrivateComposition,
+    PrivateMessageUpdateRequest,
     RealmEmojiData,
     RealmUser,
     StreamComposition,
+    StreamMessageUpdateRequest,
     Subscription,
 )
 from zulipterminal.config.keys import primary_key_for_command
@@ -561,7 +563,7 @@ class Model:
         return message_was_sent
 
     def update_private_message(self, msg_id: int, content: str) -> bool:
-        request = {
+        request: PrivateMessageUpdateRequest = {
             "message_id": msg_id,
             "content": content,
         }
@@ -578,7 +580,7 @@ class Model:
         notify_old: bool = False,
         notify_new: bool = False,
     ) -> bool:
-        request = {
+        request: StreamMessageUpdateRequest = {
             "message_id": message_id,
             "propagate_mode": propagate_mode,
             "topic": topic,

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -575,6 +575,8 @@ class Model:
         message_id: int,
         propagate_mode: EditPropagateMode,
         content: Optional[str] = None,
+        notify_old: bool = False,
+        notify_new: bool = False,
     ) -> bool:
         request = {
             "message_id": message_id,
@@ -583,6 +585,10 @@ class Model:
         }
         if content is not None:
             request["content"] = content
+
+        if self.server_feature_level is not None and self.server_feature_level >= 9:
+            request["send_notification_to_old_thread"] = notify_old
+            request["send_notification_to_new_thread"] = notify_new
 
         response = self.client.update_message(request)
         display_error_if_present(response, self.controller)


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->

This addresses the change in API behavior in update_stream introduced at ZFL 152, essentially requiring additional parameters to retain the previous behavior.
(ref https://zulip.com/api/update-message#parameter-send_notification_to_old_thread)

Prior to this change, another test for the same function is simplified and test-case ids added.

Further, to allow various names in the new function, the ruff exclusion list for naming linting is first updated to allow mixed case in general in tests/*.

After these changes, a commit applies typing to these parameters as defined at the above URL.

<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->

<!-- Add a link to a discussion on chat.zulip.org, if relevant -->

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [x] New tests added (for any new behavior)
- [x] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

**Notes & Questions** <!-- if any; add/delete/fill-in as appropriate -->
- Passing these parameters to the API will be necessary to use the new functionality in future, which this change enables
- This PR leaves topic editing as *not* giving a bot notification by default. This is both expected ZT behavior in previous server versions, as well as how the 'rename topic' behavior works with the web app.
- We could do a pop-up when only moving *one/some* messages from a topic, much like the web app does.