### PR TITLE
Add moved label for topic/stream changes

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1073,6 +1073,7 @@ def empty_index(
             stream_msg_ids_by_stream_id=defaultdict(set, {}),
             topic_msg_ids=defaultdict(dict, {}),
             edited_messages=set(),
+            moved_messages=set(),
             topics=defaultdict(list),
             search=set(),
             messages=defaultdict(

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -2150,7 +2150,8 @@ class TestModel:
                     "topic_msg_ids": {
                         10: {"new subject": {1}, "old subject": {2}},
                     },
-                    "edited_messages": {1},
+                    "edited_messages": set(),
+                    "moved_messages": {1},
                     "topics": {10: []},
                 },
                 False,
@@ -2186,7 +2187,8 @@ class TestModel:
                     "topic_msg_ids": {
                         10: {"new subject": {1, 2}, "old subject": set()},
                     },
-                    "edited_messages": {1},
+                    "edited_messages": set(),
+                    "moved_messages": {1},
                     "topics": {10: []},
                 },
                 False,
@@ -2292,6 +2294,7 @@ class TestModel:
                         10: {"new subject": set(), "old subject": {1, 2}},
                     },
                     "edited_messages": {1},
+                    "moved_messages": set(),
                     "topics": {10: ["new subject", "old subject"]},
                 },
                 False,
@@ -2329,7 +2332,8 @@ class TestModel:
                     "topic_msg_ids": {
                         10: {"new subject": {1}, "old subject": {2}},
                     },
-                    "edited_messages": {1},
+                    "edited_messages": set(),
+                    "moved_messages": {1},
                     "topics": {10: []},
                 },
                 False,
@@ -2363,6 +2367,7 @@ class TestModel:
                         10: {"new subject": set(), "old subject": {1, 2}},
                     },
                     "edited_messages": {1},
+                    "moved_messages": set(),
                     "topics": {10: ["new subject", "old subject"]},
                 },
                 False,
@@ -2401,6 +2406,7 @@ class TestModel:
                         10: {"new subject": {3}, "old subject": {1, 2}},
                     },
                     "edited_messages": set(),
+                    "moved_messages": set(),
                     "topics": {10: []},  # This resets the cache
                 },
                 False,
@@ -2439,6 +2445,7 @@ class TestModel:
                         10: {"new subject": {3}, "old subject": {1, 2}},
                     },
                     "edited_messages": set(),
+                    "moved_messages": set(),
                     "topics": {10: ["new subject", "old subject"]},
                 },
                 True,
@@ -2476,7 +2483,8 @@ class TestModel:
                     "topic_msg_ids": {
                         10: {"new subject": {1}, "old subject": {2}},
                     },
-                    "edited_messages": {1},
+                    "edited_messages": set(),
+                    "moved_messages": {1},
                     "topics": {10: ["new subject", "old subject"]},
                 },
                 True,
@@ -2512,6 +2520,7 @@ class TestModel:
                 10: {"new subject": set(), "old subject": {1, 2}},
             },
             "edited_messages": set(),
+            "moved_messages": set(),
             "topics": {10: ["new subject", "old subject"]},
         }
         mocker.patch(MODEL + "._update_rendered_view")

--- a/tests/ui_tools/test_messages.py
+++ b/tests/ui_tools/test_messages.py
@@ -1135,18 +1135,52 @@ class TestMessageBox:
         assert len(view_components) == 1
         assert isinstance(view_components[0], Padding)
 
-    def test_main_view_generates_EDITED_label(
-        self, mocker, messages_successful_response
+    @pytest.mark.parametrize(
+        [
+            "message_edited",
+            "message_moved",
+            "expected_left_padding",
+            "expected_label_text",
+        ],
+        [
+            case(True, False, 7, "EDITED", id="message_indexed_to_edited_messages"),
+            case(False, True, 6, "MOVED", id="message_indexed_to_moved_messages"),
+            case(
+                False,
+                False,
+                0,
+                "EDITED",
+                id="message_neither_index_to_edited_messages_or_moved_messages",
+            ),
+        ],
+    )
+    def test_main_view_generates_EDITED_or_MOVED_label(
+        self,
+        mocker,
+        messages_successful_response,
+        message_edited,
+        message_moved,
+        expected_left_padding,
+        expected_label_text,
     ):
         messages = messages_successful_response["messages"]
         for message in messages:
-            self.model.index["edited_messages"].add(message["id"])
+            msg_id = message["id"]
+            message_index = {
+                "edited_messages": {msg_id} if message_edited else set(),
+                "moved_messages": {msg_id} if message_moved else set(),
+            }
+            self.model.index = dict(
+                self.model.index,
+                edited_messages=message_index["edited_messages"],
+                moved_messages=message_index["moved_messages"],
+            )
             msg_box = MessageBox(message, self.model, message)
             view_components = msg_box.main_view()
 
             label = view_components[0].original_widget.contents[0]
-            assert label[0].text == "EDITED"
-            assert label[1][1] == 7
+            assert label[0].text == expected_label_text
+            assert label[1][1] == expected_left_padding
 
     @pytest.mark.parametrize(
         "to_vary_in_last_message, update_required",

--- a/zulipterminal/api_types.py
+++ b/zulipterminal/api_types.py
@@ -182,6 +182,7 @@ class Message(TypedDict, total=False):
     # NOTE: `subject_links` in Zulip 2.1; deprecated from Zulip 3.0 / ZFL 1
     subject_links: List[str]
     is_me_message: bool
+    edit_history: List[Dict[str, Any]]
     reactions: List[Dict[str, Any]]
     submessages: List[Dict[str, Any]]
     flags: List[MessageFlag]

--- a/zulipterminal/ui_tools/messages.py
+++ b/zulipterminal/ui_tools/messages.py
@@ -732,14 +732,20 @@ class MessageBox(urwid.Pile):
         if self.message["id"] in self.model.index["edited_messages"]:
             edited_label_size = 7
             left_padding = 1
+            label_text = "EDITED"
+        elif self.message["id"] in self.model.index["moved_messages"]:
+            edited_label_size = 6
+            left_padding = 2
+            label_text = "MOVED"
         else:
             edited_label_size = 0
             left_padding = 8
+            label_text = "EDITED"
 
         wrapped_content = urwid.Padding(
             urwid.Columns(
                 [
-                    (edited_label_size, urwid.Text("EDITED")),
+                    (edited_label_size, urwid.Text(label_text)),
                     urwid.LineBox(
                         urwid.Columns(
                             [


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->

<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->
Fixes #1253
<!-- Add a link to a discussion on chat.zulip.org, if relevant -->

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [X] Manually
- [X] Existing tests (adapted, if necessary)
- [x] New tests added (for any new behavior)
- [X] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

<!-- See https://github.com/zulip/zulip-terminal#commit-style -->
**Commit flow** <!-- if more than one commit; add/delete/fill-in as appropriate -->
<!-- For example:
- first commit doing some thing
- maybe multiple commits doing similar things
-->
commit 1: 
1. add the moved_message field in class Index 
2. Add the logic of when to add message to index["moved_messages"] and index["edited_messages"].

Tried to achieve parity with the logic of Zulip webapp's handling of edits 
mainly from the `analyse_edit_history` function of `zulip/static/js/message_list_view.js` 
(web app's code doesn't use indexing like ZT though)

commit 2:

the second commit focusses on implementing the same logic in case of update_message_event. But in first commit the logic was related to the response values of `Message` but in this case its with `update_message` event.
does similar job.

In both of the commits , the code identifies a real topic change vs unresolve/resolve 
**Notes & Questions** <!-- if any; add/delete/fill-in as appropriate -->
<!-- For example:
- this doesn't include feature X (yet?)
- unsure about Y
- should this do Z?
-->

**Interactions** <!-- if any; add/delete/fill-in as appropriate -->
<!-- eg.
- Waiting on #<PR>
- Blocks #<PR>
-->


