### PR TITLE
Highlight current narrow (rebased/simplified/extended) #1244

### DIFF
--- a/zulipterminal/config/themes.py
+++ b/zulipterminal/config/themes.py
@@ -75,6 +75,7 @@ REQUIRED_STYLES = {
     'area:error'      : 'standout',
     'area:user'       : 'standout',
     'search_error'    : 'standout',
+    'active_narrow'   : 'standout',
     'task:success'    : 'standout',
     'task:error'      : 'standout',
     'task:warning'    : 'standout',

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -343,6 +343,18 @@ class Model:
                 ]
                 self.active_button = new_stream_button  # Save to deactivate
                 self.active_button.is_active = True
+            if new_narrow == []:
+                self.active_button = self.controller.view.home_button
+                self.active_button.is_active = True
+            if pms is True:
+                self.active_button = self.controller.view.pm_button
+                self.active_button.is_active = True
+            if starred is True:
+                self.active_button = self.controller.view.starred_button
+                self.active_button.is_active = True
+            if mentioned is True:
+                self.active_button = self.controller.view.mentioned_button
+                self.active_button.is_active = True
 
             return False
         else:

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -114,6 +114,8 @@ class Model:
         self._last_unread_topic = None
         self.last_unread_pm = None
 
+        self.active_button: Any = None
+
         self.user_id = -1
         self.user_email = ""
         self.user_full_name = ""
@@ -314,6 +316,10 @@ class Model:
             raise RuntimeError("Model.set_narrow parameters used incorrectly.")
 
         if new_narrow != self.narrow:
+            # Deactivate any previous button
+            if self.active_button is not None:
+                self.active_button.is_active = False
+
             self.narrow = new_narrow
 
             if pm_with is not None and new_narrow[0][0] == "pm-with":
@@ -329,6 +335,14 @@ class Model:
                 self.stream_id = self.stream_id_from_name(stream)
             else:
                 self.stream_id = None
+
+            # Activate new button (if stream)
+            if self.stream_id:
+                new_stream_button = self.controller.view.stream_id_to_button[
+                    self.stream_id
+                ]
+                self.active_button = new_stream_button  # Save to deactivate
+                self.active_button.is_active = True
 
             return False
         else:

--- a/zulipterminal/themes/gruvbox_dark.py
+++ b/zulipterminal/themes/gruvbox_dark.py
@@ -70,6 +70,7 @@ STYLES = {
     'area:error'       : (Color.DARK0_HARD,            Color.BRIGHT_RED),
     'area:user'        : (Color.DARK0_HARD,            Color.BRIGHT_YELLOW),
     'search_error'     : (Color.BRIGHT_RED,            Color.DARK0_HARD),
+    'active_narrow'    : (Color.DARK0_HARD,            Color.BRIGHT_GREEN),
     'task:success'     : (Color.DARK0_HARD,            Color.BRIGHT_GREEN),
     'task:error'       : (Color.DARK0_HARD,            Color.BRIGHT_RED),
     'task:warning'     : (Color.DARK0_HARD,            Color.NEUTRAL_PURPLE),

--- a/zulipterminal/themes/gruvbox_light.py
+++ b/zulipterminal/themes/gruvbox_light.py
@@ -69,6 +69,7 @@ STYLES = {
     'area:error'       : (Color.LIGHT0_HARD,            Color.FADED_RED),
     'area:user'        : (Color.LIGHT0_HARD,            Color.FADED_YELLOW),
     'search_error'     : (Color.FADED_RED,              Color.LIGHT0_HARD),
+    'active_narrow'    : (Color.LIGHT0_HARD,            Color.FADED_GREEN),
     'task:success'     : (Color.LIGHT0_HARD,            Color.FADED_GREEN),
     'task:error'       : (Color.LIGHT0_HARD,            Color.FADED_RED),
     'task:warning'     : (Color.LIGHT0_HARD,            Color.NEUTRAL_PURPLE),

--- a/zulipterminal/themes/zt_blue.py
+++ b/zulipterminal/themes/zt_blue.py
@@ -64,6 +64,7 @@ STYLES = {
     'area:error'      : (Color.WHITE,               Color.DARK_RED),
     'area:user'       : (Color.WHITE,               Color.DARK_BLUE),
     'search_error'    : (Color.LIGHT_RED,           Color.LIGHT_BLUE),
+    'active_narrow'   : (Color.WHITE,               Color.DARK_GREEN),
     'task:success'    : (Color.WHITE,               Color.DARK_GREEN),
     'task:error'      : (Color.WHITE,               Color.DARK_RED),
     'task:warning'    : (Color.WHITE,               Color.BROWN),

--- a/zulipterminal/themes/zt_dark.py
+++ b/zulipterminal/themes/zt_dark.py
@@ -64,6 +64,7 @@ STYLES = {
     'area:error'      : (Color.WHITE,               Color.DARK_RED),
     'area:user'       : (Color.WHITE,               Color.DARK_BLUE),
     'search_error'    : (Color.LIGHT_RED,           Color.BLACK),
+    'active_narrow'   : (Color.WHITE,               Color.DARK_GREEN),
     'task:success'    : (Color.WHITE,               Color.DARK_GREEN),
     'task:error'      : (Color.WHITE,               Color.DARK_RED),
     'task:warning'    : (Color.WHITE,               Color.BROWN),

--- a/zulipterminal/themes/zt_light.py
+++ b/zulipterminal/themes/zt_light.py
@@ -64,6 +64,7 @@ STYLES = {
     'area:error'      : (Color.BLACK,               Color.LIGHT_RED),
     'area:user'       : (Color.WHITE,               Color.DARK_BLUE),
     'search_error'    : (Color.LIGHT_RED,           Color.WHITE),
+    'active_narrow'   : (Color.BLACK,               Color.DARK_GREEN),
     'task:success'    : (Color.BLACK,               Color.DARK_GREEN),
     'task:error'      : (Color.WHITE,               Color.DARK_RED),
     'task:warning'    : (Color.BLACK,               Color.YELLOW),

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -37,6 +37,8 @@ class TopButton(urwid.Button):
         self.show_function = show_function
         self.count = count
 
+        self._is_active = False
+
         super().__init__("")
 
         self.button_prefix = urwid.Text("")
@@ -56,6 +58,18 @@ class TopButton(urwid.Button):
         self.update_count(count)
 
         urwid.connect_signal(self, "click", self.activate)
+
+    @property
+    def is_active(self) -> bool:
+        return self._is_active
+
+    @is_active.setter
+    def is_active(self, new_value: bool) -> None:
+        self._is_active = new_value
+        if self._is_active:
+            self._w.set_attr_map({None: "active_narrow"})
+        else:
+            self._w.set_attr_map({None: self.label_style})
 
     def _set_prefix_style(self, style: str) -> None:
         self._prefix_markup = (style, self._prefix_markup[1])
@@ -100,7 +114,6 @@ class TopButton(urwid.Button):
         self.button_prefix.set_text(prefix)
         self.set_label(self.label_text)
         self.button_suffix.set_text(suffix)
-        self._w.set_attr_map({None: self.label_style})
 
     def activate(self, key: Any) -> None:
         self.controller.view.show_left_panel(visible=False)


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->

This is a rebase and minor adjustment to get #1244 working against current `main`.

This seems to work well, highlighting the stream in the left panel when in the associated narrow, and with some simple extensions also shows the top-left buttons highlighted when changing to the appropriate narrow.

This still has no tests and may benefit from refactoring - digging into the view to toggle button highlighting is not great.

A final version of something like this would fix #516, like the original.

<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->

<!-- Add a link to a discussion on chat.zulip.org, if relevant -->

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [ ] Existing tests (adapted, if necessary)
- [ ] New tests added (for any new behavior)
- [ ] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->

**Notes & Questions** <!-- if any; add/delete/fill-in as appropriate -->

I'm particularly interested in the style per theme - this can be changed later, but we can get some reasonable values to begin with.

**Visual changes** <!-- if any; add/delete/fill-in with screenshot/diagram as appropriate -->
