### PR TITLE
WIP: Themes: Minimal working solarized dark theme (via #1175)

### DIFF
--- a/tests/config/test_themes.py
+++ b/tests/config/test_themes.py
@@ -26,6 +26,7 @@ expected_complete_themes = {
     "zt_dark",
     "gruvbox_dark",
     "gruvbox_light",
+    "solarized_dark",
     "zt_light",
     "zt_blue",
 }

--- a/zulipterminal/config/themes.py
+++ b/zulipterminal/config/themes.py
@@ -104,7 +104,6 @@ THEMES: Dict[str, Any] = {
 THEME_ALIASES = {
     "default": "zt_dark",
     "gruvbox": "gruvbox_dark",
-    "solarized": "solarized_dark",
     "light": "zt_light",
     "blue": "zt_blue",
 }

--- a/zulipterminal/config/themes.py
+++ b/zulipterminal/config/themes.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 from pygments.token import STANDARD_TYPES
 
 from zulipterminal.config.color import term16
-from zulipterminal.themes import gruvbox_dark, gruvbox_light, zt_blue, zt_dark, zt_light
+from zulipterminal.themes import gruvbox_dark, gruvbox_light, solarized_dark, zt_blue, zt_dark, zt_light
 
 
 StyleSpec = Union[
@@ -93,6 +93,7 @@ REQUIRED_META = {
 THEMES: Dict[str, Any] = {
     "gruvbox_dark": gruvbox_dark,
     "gruvbox_light": gruvbox_light,
+    "solarized_dark": solarized_dark,
     "zt_dark": zt_dark,
     "zt_light": zt_light,
     "zt_blue": zt_blue,
@@ -103,6 +104,7 @@ THEMES: Dict[str, Any] = {
 THEME_ALIASES = {
     "default": "zt_dark",
     "gruvbox": "gruvbox_dark",
+    "solarized": "solarized_dark",
     "light": "zt_light",
     "blue": "zt_blue",
 }

--- a/zulipterminal/themes/colors_solarized.py
+++ b/zulipterminal/themes/colors_solarized.py
@@ -1,6 +1,6 @@
 """
 COLORS FOR SOLARIZED THEMES
--------------------------
+---------------------------
 Contains color definitions or functions common accross solarized themes.
 For further details on themefiles look at the theme contribution guide.
 
@@ -11,30 +11,41 @@ For color reference see:
 
 from enum import Enum
 
-from zulipterminal.config.color import DefaultBoldColor, color_properties
+from zulipterminal.config.color import color_properties
 
 class SolarizedColor(Enum):
     # color          =  16code          256code   24code
-    base03           = 'dark_gray       h234      #002b36'
-    base02           = 'black           h235      #073642'
-    base01           = 'light_green     h239      #586e75'
-    base00           = 'dark_gray       h240      #657b83'
-    base0            = 'light_blue      h244      #839496'
-    base1            = 'light_cyan      h245      #93a1a1'
-    base2            = 'light_gray      h187      #eee8d5'
-    base3            = 'white           h230      #fdf6e3'
-    yellow           = 'yellow          h136      #b58900'
-    orange           = 'light_red       h166      #cb4b16'
-    red              = 'dark_red        h124      #dc322f'
-    magenta          = 'dark_magenta    h125      #d33682'
-    violet           = 'light_magenta   h61       #6c71c4'
-    blue             = 'dark_blue       h33       #268bd2'
-    cyan             = 'dark_cyan       h37       #2aa198'
-    green            = 'dark_green      h64       #859900'
+    BASE03           = 'dark_gray       h234      #002b36'
+    BASE02           = 'black           h234      #073642' # check 16+256, not used in dark right now
+    BASE01           = 'light_green     h239      #586e75'
+    BASE00           = 'yellow          h240      #657b83' # neiljp update 16
 
+    BASE0            = 'light_blue      h244      #839496'
+    BASE1            = 'light_cyan      h245      #93a1a1'
+    BASE2            = 'white           h187      #eee8d5' # neiljp update 16 swap down
+    BASE3            = 'light_gray      h230      #fdf6e3' # neiljp update 16 swap ^
 
+    # These aliases are chosen to make it easier to select unique names in themes
+    # Default text should be FG_PRIMARY on BG_REGULAR
+    # Highlight can be FG_EMPHASIZE on BG_HIGHLIGHT (same brightness difference)
+    #  - note that this is a very light highlight
+    DARK_FG_EMPHASIZE = BASE1
+    DARK_FG_PRIMARY   = BASE0
+    DARK_FG_SECONDARY = BASE01
+    DARK_BG_HIGHLIGHT = BASE02
+    DARK_BG_REGULAR   = BASE03
 
+    LIGHT_FG_EMPHASIZE = BASE01
+    LIGHT_FG_PRIMARY   = BASE00
+    LIGHT_FG_SECONDARY = BASE1
+    LIGHT_BG_HIGHLIGHT = BASE2
+    LIGHT_BG_REGULAR   = BASE3
 
-DefaultBoldColor = color_properties(SolarizedColor, "BOLD")
-
-    
+    YELLOW           = 'yellow          h136      #b58900'
+    ORANGE           = 'light_red       h136      #cb4b16' # check 16+256, not used in dark right now
+    RED              = 'dark_red        h124      #dc322f'
+    MAGENTA          = 'dark_magenta    h125      #d33682'
+    VIOLET           = 'light_magenta   h61       #6c71c4'
+    BLUE             = 'dark_blue       h33       #268bd2'
+    CYAN             = 'dark_cyan       h37       #2aa198'
+    GREEN            = 'dark_green      h64       #859900'

--- a/zulipterminal/themes/colors_solarized.py
+++ b/zulipterminal/themes/colors_solarized.py
@@ -1,0 +1,40 @@
+"""
+COLORS FOR SOLARIZED THEMES
+-------------------------
+Contains color definitions or functions common accross solarized themes.
+For further details on themefiles look at the theme contribution guide.
+
+This file uses the official solarized colors.
+For color reference see:
+    https://github.com/altercation/solarized/blob/master/vim-colors-solarized/colors/solarized.vim
+"""
+
+from enum import Enum
+
+from zulipterminal.config.color import DefaultBoldColor, color_properties
+
+class SolarizedColor(Enum):
+    # color          =  16code          256code   24code
+    base03           = 'dark_gray       h234      #002b36'
+    base02           = 'black           h235      #073642'
+    base01           = 'light_green     h239      #586e75'
+    base00           = 'dark_gray       h240      #657b83'
+    base0            = 'light_blue      h244      #839496'
+    base1            = 'light_cyan      h245      #93a1a1'
+    base2            = 'light_gray      h187      #eee8d5'
+    base3            = 'white           h230      #fdf6e3'
+    yellow           = 'yellow          h136      #b58900'
+    orange           = 'light_red       h166      #cb4b16'
+    red              = 'dark_red        h124      #dc322f'
+    magenta          = 'dark_magenta    h125      #d33682'
+    violet           = 'light_magenta   h61       #6c71c4'
+    blue             = 'dark_blue       h33       #268bd2'
+    cyan             = 'dark_cyan       h37       #2aa198'
+    green            = 'dark_green      h64       #859900'
+
+
+
+
+DefaultBoldColor = color_properties(SolarizedColor, "BOLD")
+
+    

--- a/zulipterminal/themes/solarized_dark.py
+++ b/zulipterminal/themes/solarized_dark.py
@@ -7,65 +7,65 @@ SOLARIZED DARK
 
 from pygments.styles.solarized import SolarizedDarkStyle
 
-from zulipterminal.themes.colors_solarized import DefaultBoldColor as Color
+from zulipterminal.themes.colors_solarized import SolarizedColor as Color
 
 STYLES = {
     # style_name       :  foreground                   background
-    None               : (Color.base0,                 Color.base03),
-    'selected'         : (Color.base0,                 Color.base02),
-    'msg_selected'     : (Color.base0,                 Color.base02),
-    'header'           : (Color.cyan,                  Color.blue),
-    'general_narrow'   : (Color.base0,                 Color.blue),
-    'general_bar'      : (Color.base0,                 Color.base03),
-    'name'             : (Color.red__BOLD,             Color.base03),
-    'unread'           : (Color.violet,                Color.base03),
-    'user_active'      : (Color.green,                 Color.base03),
-    'user_idle'        : (Color.yellow,                Color.base03),
-    'user_offline'     : (Color.base01,                Color.base03),
-    'user_inactive'    : (Color.base01,                Color.base03),
-    'title'            : (Color.base0__BOLD,           Color.base03),
-    'column_title'     : (Color.base0__BOLD,           Color.base03),
-    'time'             : (Color.base01,                Color.base03),
-    'bar'              : (Color.base0,                 Color.base00),
-    'msg_emoji'        : (Color.violet,                Color.base03),
-    'reaction'         : (Color.violet__BOLD,          Color.base03),
-    'reaction_mine'    : (Color.base03,                Color.violet),
-    'msg_heading'      : (Color.base03__BOLD,          Color.base01),
-    'msg_math'         : (Color.base02,                Color.base00),
-    'msg_mention'      : (Color.orange__BOLD,          Color.base03),
-    'msg_link'         : (Color.blue,                  Color.base03),
-    'msg_link_index'   : (Color.blue__BOLD,            Color.base03),
-    'msg_quote'        : (Color.base1,                 Color.base03),
-    'msg_code'         : (Color.base03,                Color.base0),
-    'msg_bold'         : (Color.base0__BOLD,           Color.base03),
-    'msg_time'         : (Color.base03,                Color.base1),
-    'footer'           : (Color.base03,                Color.base2),
-    'footer_contrast'  : (Color.base2,                 Color.base03),
-    'starred'          : (Color.orange__BOLD,          Color.base03),
-    'unread_count'     : (Color.base1,                 Color.base03),
-    'starred_count'    : (Color.base2,                 Color.base03),
-    'table_head'       : (Color.base0__BOLD,           Color.base03),
-    'filter_results'   : (Color.base03,                Color.base01),
-    'edit_topic'       : (Color.base03,                Color.base00),
-    'edit_tag'         : (Color.base03,                Color.base00),
-    'edit_author'      : (Color.base1,                 Color.base03),
-    'edit_time'        : (Color.base01,                Color.base03),
-    'current_user'     : (Color.base0,                 Color.base03),
-    'muted'            : (Color.base00,                Color.base03),
-    'popup_border'     : (Color.base0,                 Color.base03),
-    'popup_category'   : (Color.base0__BOLD,           Color.base03),
-    'popup_contrast'   : (Color.base03,                Color.base00),
-    'popup_important'  : (Color.orange__BOLD,          Color.base03),
-    'widget_disabled'  : (Color.base00,                Color.base03),
-    'area:help'        : (Color.base03,                Color.base01),
-    'area:msg'         : (Color.base03,                Color.orange),
-    'area:stream'      : (Color.base03,                Color.base0),
-    'area:error'       : (Color.base0,                 Color.red),
-    'area:user'        : (Color.base0,                 Color.blue),
-    'search_error'     : (Color.orange,                Color.base03),
-    'task:success'     : (Color.base03,                Color.base01),
-    'task:error'       : (Color.base0,                 Color.red),
-    'task:warning'     : (Color.base03,                Color.orange),   
+    None               : (Color.DARK_FG_PRIMARY,   Color.DARK_BG_REGULAR),
+    'selected'         : (Color.DARK_BG_REGULAR,   Color.CYAN), # neiljp # inverted + COLOR
+    'msg_selected'     : (Color.DARK_BG_REGULAR,   Color.CYAN), # neiljp # inverted + COLOR
+    'header'           : (Color.CYAN,              Color.BLUE),
+    'general_narrow'   : (Color.DARK_BG_REGULAR,   Color.BLUE), # neiljp # update fg for contrast
+    'general_bar'      : (Color.DARK_FG_PRIMARY,   Color.DARK_BG_REGULAR),
+    'msg_sender'       : (Color.RED,               Color.DARK_BG_REGULAR), # neiljp # update name
+    'unread'           : (Color.VIOLET,            Color.DARK_BG_REGULAR),
+    'user_active'      : (Color.GREEN,             Color.DARK_BG_REGULAR),
+    'user_idle'        : (Color.YELLOW,            Color.DARK_BG_REGULAR),
+    'user_offline'     : (Color.DARK_FG_SECONDARY, Color.DARK_BG_REGULAR),
+    'user_inactive'    : (Color.DARK_FG_SECONDARY, Color.DARK_BG_REGULAR),
+    'title'            : (Color.BASE0,             Color.DARK_BG_REGULAR),
+    'column_title'     : (Color.BASE0,             Color.DARK_BG_REGULAR),
+    'time'             : (Color.DARK_FG_SECONDARY, Color.DARK_BG_REGULAR),
+    'bar'              : (Color.DARK_FG_PRIMARY,   Color.DARK_FG_PRIMARY), # neiljp # BASE00 -> FG_PRIM?
+    'msg_emoji'        : (Color.VIOLET,            Color.DARK_BG_REGULAR),
+    'reaction'         : (Color.VIOLET,            Color.DARK_BG_REGULAR),
+    'reaction_mine'    : (Color.DARK_BG_REGULAR,   Color.VIOLET),
+    'msg_heading'      : (Color.DARK_BG_REGULAR,   Color.DARK_FG_SECONDARY),
+    'msg_math'         : (Color.DARK_BG_HIGHLIGHT, Color.DARK_FG_PRIMARY), # neiljp # BASE00 -> FG_PRIM?
+    'msg_mention'      : (Color.ORANGE,            Color.DARK_BG_REGULAR),
+    'msg_link'         : (Color.BLUE,              Color.DARK_BG_REGULAR),
+    'msg_link_index'   : (Color.BLUE,              Color.DARK_BG_REGULAR),
+    'msg_quote'        : (Color.DARK_FG_EMPHASIZE, Color.DARK_BG_REGULAR),
+    'msg_code'         : (Color.DARK_BG_REGULAR,   Color.DARK_FG_PRIMARY),
+    'msg_bold'         : (Color.BASE0,             Color.DARK_BG_REGULAR),
+    'msg_time'         : (Color.DARK_BG_REGULAR,   Color.DARK_FG_EMPHASIZE),
+    'footer'           : (Color.DARK_BG_REGULAR,   Color.BASE2),
+    'footer_contrast'  : (Color.BASE2,             Color.DARK_BG_REGULAR),
+    'starred'          : (Color.ORANGE,            Color.DARK_BG_REGULAR),
+    'unread_count'     : (Color.DARK_FG_EMPHASIZE, Color.DARK_BG_REGULAR),
+    'starred_count'    : (Color.BASE2,             Color.DARK_BG_REGULAR),
+    'table_head'       : (Color.BASE0,             Color.DARK_BG_REGULAR),
+    'filter_results'   : (Color.DARK_BG_REGULAR,   Color.DARK_FG_SECONDARY),
+    'edit_topic'       : (Color.DARK_BG_REGULAR,   Color.DARK_FG_PRIMARY), # neiljp # BASE00 -> FG_PRIM?
+    'edit_tag'         : (Color.DARK_BG_REGULAR,   Color.DARK_FG_PRIMARY), # neiljp # BASE00 -> FG_PRIM?
+    'edit_author'      : (Color.DARK_FG_EMPHASIZE, Color.DARK_BG_REGULAR),
+    'edit_time'        : (Color.DARK_FG_SECONDARY, Color.DARK_BG_REGULAR),
+    'current_user'     : (Color.DARK_FG_PRIMARY,   Color.DARK_BG_REGULAR),
+    'muted'            : (Color.DARK_FG_PRIMARY,   Color.DARK_BG_REGULAR), # neiljp # BASE00 -> FG_PRIM?
+    'popup_border'     : (Color.DARK_FG_PRIMARY,   Color.DARK_BG_REGULAR),
+    'popup_category'   : (Color.DARK_FG_PRIMARY,   Color.DARK_BG_REGULAR),
+    'popup_contrast'   : (Color.DARK_BG_REGULAR,   Color.DARK_FG_PRIMARY), # neiljp # BASE00 -> FG_PRIM?
+    'popup_important'  : (Color.ORANGE,            Color.DARK_BG_REGULAR),
+    'widget_disabled'  : (Color.DARK_FG_PRIMARY,   Color.DARK_BG_REGULAR), # neiljp # BASE00 -> FG_PRIM?
+    'area:help'        : (Color.DARK_BG_REGULAR,   Color.DARK_FG_SECONDARY),
+    'area:msg'         : (Color.DARK_BG_REGULAR,   Color.ORANGE),
+    'area:stream'      : (Color.DARK_BG_REGULAR,   Color.BASE0),
+    'area:error'       : (Color.DARK_FG_PRIMARY,   Color.RED),
+    'area:user'        : (Color.DARK_FG_PRIMARY,   Color.BLUE),
+    'search_error'     : (Color.ORANGE,            Color.DARK_BG_REGULAR),
+    'task:success'     : (Color.DARK_BG_REGULAR,   Color.DARK_FG_SECONDARY),
+    'task:error'       : (Color.DARK_FG_PRIMARY,   Color.RED),
+    'task:warning'     : (Color.DARK_BG_REGULAR,   Color.ORANGE),
 }
 
 META = {
@@ -73,15 +73,15 @@ META = {
         'styles'    : SolarizedDarkStyle().styles,
         'background': 'h234',
         'overrides' : {
-            'c'   : '#586e75, italics',    # base01
-            'cp'  : '#d33682',             # magenta
-            'cpf' : '#586e75',             # base01
-            'ge'  : '#839496, italics',    # base0
-            'gh'  : '#839496, bold',       # base0
-            'gu'  : '#839496, underline',  # base0
-            'gp'  : '#268bd2, bold',       # blue
-            'gs'  : '#839496, bold',       # base0
-            'err' : '#dc322f',             # red
+            'c'   : '#586e75, italics',    # DARK_FG_SECONDARY
+            'cp'  : '#d33682',             # MAGENTA
+            'cpf' : '#586e75',             # DARK_FG_SECONDARY
+            'ge'  : '#839496, italics',    # BASE0
+            'gh'  : '#839496, bold',       # BASE0
+            'gu'  : '#839496, underline',  # BASE0
+            'gp'  : '#268bd2, bold',       # BLUE
+            'gs'  : '#839496, bold',       # BASE0
+            'err' : '#dc322f',             # RED
             'n'   : '#bdae93',             # gruvbox: light4
             'p'   : '#bdae93',             # gruvbox: light4
             'w'   : '#bdae93',             # gruvbox: light4

--- a/zulipterminal/themes/solarized_dark.py
+++ b/zulipterminal/themes/solarized_dark.py
@@ -1,0 +1,90 @@
+"""
+SOLARIZED DARK
+--------------
+
+
+"""
+
+from pygments.styles.solarized import SolarizedDarkStyle
+
+from zulipterminal.themes.colors_solarized import DefaultBoldColor as Color
+
+STYLES = {
+    # style_name       :  foreground                   background
+    None               : (Color.base0,                 Color.base03),
+    'selected'         : (Color.base0,                 Color.base02),
+    'msg_selected'     : (Color.base0,                 Color.base02),
+    'header'           : (Color.cyan,                  Color.blue),
+    'general_narrow'   : (Color.base0,                 Color.blue),
+    'general_bar'      : (Color.base0,                 Color.base03),
+    'name'             : (Color.red__BOLD,             Color.base03),
+    'unread'           : (Color.violet,                Color.base03),
+    'user_active'      : (Color.green,                 Color.base03),
+    'user_idle'        : (Color.yellow,                Color.base03),
+    'user_offline'     : (Color.base01,                Color.base03),
+    'user_inactive'    : (Color.base01,                Color.base03),
+    'title'            : (Color.base0__BOLD,           Color.base03),
+    'column_title'     : (Color.base0__BOLD,           Color.base03),
+    'time'             : (Color.base01,                Color.base03),
+    'bar'              : (Color.base0,                 Color.base00),
+    'msg_emoji'        : (Color.violet,                Color.base03),
+    'reaction'         : (Color.violet__BOLD,          Color.base03),
+    'reaction_mine'    : (Color.base03,                Color.violet),
+    'msg_heading'      : (Color.base03__BOLD,          Color.base01),
+    'msg_math'         : (Color.base02,                Color.base00),
+    'msg_mention'      : (Color.orange__BOLD,          Color.base03),
+    'msg_link'         : (Color.blue,                  Color.base03),
+    'msg_link_index'   : (Color.blue__BOLD,            Color.base03),
+    'msg_quote'        : (Color.base1,                 Color.base03),
+    'msg_code'         : (Color.base03,                Color.base0),
+    'msg_bold'         : (Color.base0__BOLD,           Color.base03),
+    'msg_time'         : (Color.base03,                Color.base1),
+    'footer'           : (Color.base03,                Color.base2),
+    'footer_contrast'  : (Color.base2,                 Color.base03),
+    'starred'          : (Color.orange__BOLD,          Color.base03),
+    'unread_count'     : (Color.base1,                 Color.base03),
+    'starred_count'    : (Color.base2,                 Color.base03),
+    'table_head'       : (Color.base0__BOLD,           Color.base03),
+    'filter_results'   : (Color.base03,                Color.base01),
+    'edit_topic'       : (Color.base03,                Color.base00),
+    'edit_tag'         : (Color.base03,                Color.base00),
+    'edit_author'      : (Color.base1,                 Color.base03),
+    'edit_time'        : (Color.base01,                Color.base03),
+    'current_user'     : (Color.base0,                 Color.base03),
+    'muted'            : (Color.base00,                Color.base03),
+    'popup_border'     : (Color.base0,                 Color.base03),
+    'popup_category'   : (Color.base0__BOLD,           Color.base03),
+    'popup_contrast'   : (Color.base03,                Color.base00),
+    'popup_important'  : (Color.orange__BOLD,          Color.base03),
+    'widget_disabled'  : (Color.base00,                Color.base03),
+    'area:help'        : (Color.base03,                Color.base01),
+    'area:msg'         : (Color.base03,                Color.orange),
+    'area:stream'      : (Color.base03,                Color.base0),
+    'area:error'       : (Color.base0,                 Color.red),
+    'area:user'        : (Color.base0,                 Color.blue),
+    'search_error'     : (Color.orange,                Color.base03),
+    'task:success'     : (Color.base03,                Color.base01),
+    'task:error'       : (Color.base0,                 Color.red),
+    'task:warning'     : (Color.base03,                Color.orange),   
+}
+
+META = {
+    'pygments': {
+        'styles'    : SolarizedDarkStyle().styles,
+        'background': 'h234',
+        'overrides' : {
+            'c'   : '#586e75, italics',    # base01
+            'cp'  : '#d33682',             # magenta
+            'cpf' : '#586e75',             # base01
+            'ge'  : '#839496, italics',    # base0
+            'gh'  : '#839496, bold',       # base0
+            'gu'  : '#839496, underline',  # base0
+            'gp'  : '#268bd2, bold',       # blue
+            'gs'  : '#839496, bold',       # base0
+            'err' : '#dc322f',             # red
+            'n'   : '#bdae93',             # gruvbox: light4
+            'p'   : '#bdae93',             # gruvbox: light4
+            'w'   : '#bdae93',             # gruvbox: light4
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->

There are currently 3 open PRs (#1300, #1175, #324) for solarized dark, so I've taken the most complete (#1175) and added extra commits such that this runs and is usable with current ZT.

In doing so, the extra commits address my outstanding concerns regarding #1175.

I'm going to close the other PRs, though they can still be referenced.

While this is broadly usable as it is, there are various factors that it'd be good to address before merging:
- validate colors at lower bit depths (ie. 16 or 256 colors) approximate those at 24bit depth; there is various discussion (#324) regarding this, though the code layout is different in that PR
- avoid using palette entries inappropriate to the dark theme (specifically from the light theme)
- manual validation that styled elements are all reasonably legible

Compared to #1175, my update to use dark-theme aliases in the enum breaks the addition of BOLD to the colors, so we could explore an alternative to that, as discussed in my commit.

When building upon this PR (see tools/fetch-pull-request), please keep commits separate on top for comparison, at least initially, since there will be multiple authors.

<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->

<!-- Add a link to a discussion on chat.zulip.org, if relevant -->

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [ ] New tests added (for any new behavior)
- [ ] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->