### PR TITLE
Style inline code like code blocks (via #1012)

### DIFF
--- a/tests/ui_tools/test_messages.py
+++ b/tests/ui_tools/test_messages.py
@@ -108,7 +108,7 @@ class TestMessageBox:
                 [("msg_mention", "@A Group")],
                 id="group-mention",
             ),
-            case("<code>some code", [("msg_code", "some code")], id="code"),
+            case("<code>some code", [("pygments:w", "some code")], id="inline-code"),
             case(
                 '<div class="codehilite" data-code-language="python">'
                 "<pre><span></span>"

--- a/zulipterminal/config/themes.py
+++ b/zulipterminal/config/themes.py
@@ -48,7 +48,6 @@ REQUIRED_STYLES = {
     'msg_link'        : '',
     'msg_link_index'  : 'bold',
     'msg_quote'       : 'underline',
-    'msg_code'        : 'bold',
     'msg_bold'        : 'bold',
     'msg_time'        : 'bold',
     'footer'          : 'standout',
@@ -78,6 +77,7 @@ REQUIRED_STYLES = {
     'task:success'    : 'standout',
     'task:error'      : 'standout',
     'task:warning'    : 'standout',
+    'ui_code'         : 'bold',
 }
 
 REQUIRED_META = {

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -547,8 +547,8 @@ class Controller:
                 " installing any ONE of the copy/paste mechanisms below:\n",
                 ("msg_bold", "- xclip\n- xsel"),
                 "\n\nvia something like:\n",
-                ("msg_code", "apt-get install xclip [Recommended]\n"),
-                ("msg_code", "apt-get install xsel"),
+                ("ui_code", "apt-get install xclip [Recommended]\n"),
+                ("ui_code", "apt-get install xsel"),
             ]
             self.show_pop_up(
                 NoticeView(self, body, 60, "UTILITY PACKAGE MISSING"), "area:error"

--- a/zulipterminal/themes/gruvbox_dark.py
+++ b/zulipterminal/themes/gruvbox_dark.py
@@ -43,7 +43,6 @@ STYLES = {
     'msg_link'         : (Color.BRIGHT_BLUE,           Color.DARK0_HARD),
     'msg_link_index'   : (Color.BRIGHT_BLUE__BOLD,     Color.DARK0_HARD),
     'msg_quote'        : (Color.NEUTRAL_YELLOW,        Color.DARK0_HARD),
-    'msg_code'         : (Color.DARK0_HARD,            Color.LIGHT2),
     'msg_bold'         : (Color.LIGHT2__BOLD,          Color.DARK0_HARD),
     'msg_time'         : (Color.DARK0_HARD,            Color.LIGHT2),
     'footer'           : (Color.DARK0_HARD,            Color.LIGHT4),
@@ -73,6 +72,7 @@ STYLES = {
     'task:success'     : (Color.DARK0_HARD,            Color.BRIGHT_GREEN),
     'task:error'       : (Color.DARK0_HARD,            Color.BRIGHT_RED),
     'task:warning'     : (Color.DARK0_HARD,            Color.NEUTRAL_PURPLE),
+    'ui_code'          : (Color.DARK0_HARD,            Color.LIGHT2),
 }
 
 META = {

--- a/zulipterminal/themes/gruvbox_light.py
+++ b/zulipterminal/themes/gruvbox_light.py
@@ -42,7 +42,6 @@ STYLES = {
     'msg_link'         : (Color.FADED_BLUE,             Color.LIGHT0_HARD),
     'msg_link_index'   : (Color.FADED_BLUE__BOLD,       Color.LIGHT0_HARD),
     'msg_quote'        : (Color.NEUTRAL_YELLOW,         Color.LIGHT0_HARD),
-    'msg_code'         : (Color.LIGHT0_HARD,            Color.DARK2),
     'msg_bold'         : (Color.DARK2__BOLD,            Color.LIGHT0_HARD),
     'msg_time'         : (Color.LIGHT0_HARD,            Color.DARK2),
     'footer'           : (Color.LIGHT0_HARD,            Color.DARK4),
@@ -72,6 +71,7 @@ STYLES = {
     'task:success'     : (Color.LIGHT0_HARD,            Color.FADED_GREEN),
     'task:error'       : (Color.LIGHT0_HARD,            Color.FADED_RED),
     'task:warning'     : (Color.LIGHT0_HARD,            Color.NEUTRAL_PURPLE),
+    'ui_code'          : (Color.LIGHT0_HARD,            Color.DARK2),
 }
 
 META = {

--- a/zulipterminal/themes/zt_blue.py
+++ b/zulipterminal/themes/zt_blue.py
@@ -37,7 +37,6 @@ STYLES = {
     'msg_link'        : (Color.DARK_BLUE,           Color.LIGHT_GRAY),
     'msg_link_index'  : (Color.DARK_BLUE__BOLD,     Color.LIGHT_GRAY),
     'msg_quote'       : (Color.BROWN,               Color.DARK_BLUE),
-    'msg_code'        : (Color.DARK_BLUE,           Color.WHITE),
     'msg_bold'        : (Color.WHITE__BOLD,         Color.DARK_BLUE),
     'msg_time'        : (Color.DARK_BLUE,           Color.WHITE),
     'footer'          : (Color.WHITE,               Color.DARK_GRAY),
@@ -67,6 +66,7 @@ STYLES = {
     'task:success'    : (Color.WHITE,               Color.DARK_GREEN),
     'task:error'      : (Color.WHITE,               Color.DARK_RED),
     'task:warning'    : (Color.WHITE,               Color.BROWN),
+    'ui_code'         : (Color.DARK_BLUE,           Color.WHITE),
 }
 
 META = {

--- a/zulipterminal/themes/zt_dark.py
+++ b/zulipterminal/themes/zt_dark.py
@@ -37,7 +37,6 @@ STYLES = {
     'msg_link'        : (Color.LIGHT_BLUE,          Color.BLACK),
     'msg_link_index'  : (Color.LIGHT_BLUE__BOLD,    Color.BLACK),
     'msg_quote'       : (Color.BROWN,               Color.BLACK),
-    'msg_code'        : (Color.BLACK,               Color.WHITE),
     'msg_bold'        : (Color.WHITE__BOLD,         Color.BLACK),
     'msg_time'        : (Color.BLACK,               Color.WHITE),
     'footer'          : (Color.BLACK,               Color.LIGHT_GRAY),
@@ -67,6 +66,7 @@ STYLES = {
     'task:success'    : (Color.WHITE,               Color.DARK_GREEN),
     'task:error'      : (Color.WHITE,               Color.DARK_RED),
     'task:warning'    : (Color.WHITE,               Color.BROWN),
+    'ui_code'         : (Color.BLACK,               Color.WHITE),
 }
 
 META = {

--- a/zulipterminal/themes/zt_light.py
+++ b/zulipterminal/themes/zt_light.py
@@ -37,7 +37,6 @@ STYLES = {
     'msg_link'        : (Color.DARK_BLUE,           Color.WHITE),
     'msg_link_index'  : (Color.DARK_BLUE__BOLD,     Color.WHITE),
     'msg_quote'       : (Color.BLACK,               Color.BROWN),
-    'msg_code'        : (Color.BLACK,               Color.LIGHT_GRAY),
     'msg_bold'        : (Color.WHITE__BOLD,         Color.DARK_GRAY),
     'msg_time'        : (Color.WHITE,               Color.DARK_GRAY),
     'footer'          : (Color.WHITE,               Color.DARK_GRAY),
@@ -67,6 +66,7 @@ STYLES = {
     'task:success'    : (Color.BLACK,               Color.DARK_GREEN),
     'task:error'      : (Color.WHITE,               Color.DARK_RED),
     'task:warning'    : (Color.BLACK,               Color.YELLOW),
+    'ui_code'         : (Color.BLACK,               Color.LIGHT_GRAY),
 }
 
 META = {

--- a/zulipterminal/ui_tools/messages.py
+++ b/zulipterminal/ui_tools/messages.py
@@ -511,8 +511,13 @@ class MessageBox(urwid.Pile):
                 # BLOCKQUOTE TEXT
                 markup.append(("msg_quote", cls.soup2markup(element, metadata)[0]))
             elif tag == "code":
-                # CODE (INLINE?)
-                markup.append(("msg_code", tag_text))
+                """
+                CODE INLINE
+                -----------
+                Use the same style as plain text codeblocks
+                which is the `whitespace` token of pygments.
+                """
+                markup.append(("pygments:w", tag_text))
             elif tag == "div" and "codehilite" in tag_classes:
                 """
                 CODE BLOCK


### PR DESCRIPTION
<!-- Please see https://github.com/zulip/zulip-terminal#contributor-guidelines ! -->

**What does this PR do?**  <!-- Overall description goes here -->

This adapts the last commit of #1012, which was neglected while discussing how to handle the padding/blocking of codeblock rendering.

The change is now in messages.py, but works well after a manual movement.

The associated removal of `msg_code` is split into a second commit which instead renames the style to `ui_code`, since it is still used in a notification popup. This could have been migrated to use the pygments style too, but for now it feels cleaner to keep pygments within the message rendering functionality, and not hard-code the style elsewhere.

<!-- If fixing a filed bug or new feature, add 'Fixes #<issue>' or 'Partial fix for #<issue>' -->

<!-- Add a link to a discussion on chat.zulip.org, if relevant -->

**Tested?** <!-- Fine to leave some of these unchecked if this is a draft/work-in-progress -->
- [x] Manually
- [x] Existing tests (adapted, if necessary)
- [ ] New tests added (for any new behavior)
- [x] Passed linting & tests (each commit)
<!-- Code must pass CI (GitHub Actions) before merging - look for the green tick! -->
