### PR TITLE
Improve algorithm for 'next unread topic' (n) to use current message state

### DIFF
--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -4010,6 +4010,12 @@ class TestModel:
                 (1, "topic1"),
                 id="unmuted_unread_not_present_in_next_stream_as_current_topic_not_in_unread_list",
             ),
+            case(
+                {(1, "topic1"), (1, "topic11"), (2, "topic2")},
+                (1, "topic11"),
+                (1, "topic1"),
+                id="unread_present_in_same_stream_wrap_around",
+            ),
         ],
     )
     def test_next_unread_topic_from_message(

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -3919,16 +3919,16 @@ class TestModel:
                 (1, "topic"),
                 id="unread_present_before_previous_topic",
             ),
-            case(  # TODO Should be None? (2 other cases)
+            case(
                 {(1, "topic")},
                 (1, "topic"),
-                (1, "topic"),
+                None,
                 id="unread_still_present_in_topic",
             ),
             case(
                 {},
                 (1, "topic"),
-                (1, "topic"),
+                None,
                 id="no_unreads_with_previous_topic_state",
             ),
             case({}, None, None, id="no_unreads_with_no_previous_topic_state"),
@@ -3947,7 +3947,7 @@ class TestModel:
             case(
                 {(3, "topic3")},
                 (2, "topic2"),
-                (2, "topic2"),
+                None,
                 id="unread_present_only_in_muted_stream",
             ),
             case(

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -4044,6 +4044,21 @@ class TestModel:
         assert model.last_unread_pm is None
 
     @pytest.mark.parametrize(
+        "message_id, expected_value",
+        [
+            case(537286, (205, "Test"), id="stream_message"),
+            case(537287, None, id="direct_message"),
+            case(537289, None, id="non-existent message"),
+        ],
+    )
+    def test_stream_topic_from_message_id(
+        self, mocker, model, message_id, expected_value, empty_index
+    ):
+        model.index = empty_index
+        current_topic = model.stream_topic_from_message_id(message_id)
+        assert current_topic == expected_value
+
+    @pytest.mark.parametrize(
         "stream_id, expected_response",
         [
             (1, True),

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -4012,7 +4012,7 @@ class TestModel:
             ),
         ],
     )
-    def test_get_next_unread_topic(
+    def test_next_unread_topic_from_message(
         self, mocker, model, unread_topics, current_topic, next_unread_topic
     ):
         # NOTE Not important how many unreads per topic, so just use '1'
@@ -4039,7 +4039,7 @@ class TestModel:
             ]
         }
 
-        unread_topic = model.get_next_unread_topic(current_message=current_message_id)
+        unread_topic = model.next_unread_topic_from_message_id(current_message_id)
 
         assert unread_topic == next_unread_topic
 
@@ -4054,7 +4054,7 @@ class TestModel:
             ),
         ],
     )
-    def test_get_next_unread_topic__empty_narrow(
+    def test_next_unread_topic_from_message__empty_narrow(
         self,
         mocker,
         model,
@@ -4070,7 +4070,7 @@ class TestModel:
         model.stream_id_from_name = mocker.Mock(return_value=narrow_stream_id)
         model.narrow = empty_narrow
 
-        unread_topic = model.get_next_unread_topic(current_message=None)
+        unread_topic = model.next_unread_topic_from_message_id(None)
 
         assert unread_topic == next_unread_topic
 

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -890,7 +890,7 @@ class TestMiddleColumnView:
         mocker.patch.object(self.view, "message_view")
 
         mid_col_view.model.stream_dict = {1: {"name": "stream"}}
-        mid_col_view.model.get_next_unread_topic.return_value = (1, "topic")
+        mid_col_view.model.next_unread_topic_from_message_id.return_value = (1, "topic")
 
         return_value = mid_col_view.keypress(size, key)
 
@@ -906,7 +906,7 @@ class TestMiddleColumnView:
         size = widget_size(mid_col_view)
         mocker.patch(MIDCOLVIEW + ".focus_position")
         mocker.patch.object(self.view, "message_view")
-        mid_col_view.model.get_next_unread_topic.return_value = None
+        mid_col_view.model.next_unread_topic_from_message_id.return_value = None
 
         return_value = mid_col_view.keypress(size, key)
 

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -887,6 +887,7 @@ class TestMiddleColumnView:
     ):
         size = widget_size(mid_col_view)
         mocker.patch(MIDCOLVIEW + ".focus_position")
+        mocker.patch.object(self.view, "message_view")
 
         mid_col_view.model.stream_dict = {1: {"name": "stream"}}
         mid_col_view.model.get_next_unread_topic.return_value = (1, "topic")
@@ -904,6 +905,7 @@ class TestMiddleColumnView:
     ):
         size = widget_size(mid_col_view)
         mocker.patch(MIDCOLVIEW + ".focus_position")
+        mocker.patch.object(self.view, "message_view")
         mid_col_view.model.get_next_unread_topic.return_value = None
 
         return_value = mid_col_view.keypress(size, key)

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -901,7 +901,7 @@ class Model:
             return (stream_id, topic)
         return None
 
-    def get_next_unread_topic(
+    def next_unread_topic_from_message_id(
         self, current_message: Optional[int]
     ) -> Optional[Tuple[int, str]]:
         if current_message:

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -930,6 +930,8 @@ class Model:
                 and not self.is_muted_stream(stream_id)
                 and next_topic
             ):
+                if unread_topic == current_topic:
+                    return None
                 return unread_topic
             if unread_topic == current_topic:
                 next_topic = True

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -913,6 +913,7 @@ class Model:
             )
         unread_topics = sorted(self.unread_counts["unread_topics"].keys())
         next_topic = False
+        stream_start: Optional[Tuple[int, str]] = None
         if current_topic is None:
             next_topic = True
         elif current_topic not in unread_topics:
@@ -925,14 +926,26 @@ class Model:
         # the last valid unread_topic in unread_topics list.
         for unread_topic in unread_topics * 2:
             stream_id, topic_name = unread_topic
-            if (
-                not self.is_muted_topic(stream_id, topic_name)
-                and not self.is_muted_stream(stream_id)
-                and next_topic
-            ):
-                if unread_topic == current_topic:
-                    return None
-                return unread_topic
+            if not self.is_muted_topic(
+                stream_id, topic_name
+            ) and not self.is_muted_stream(stream_id):
+                if next_topic:
+                    if unread_topic == current_topic:
+                        return None
+                    if (
+                        current_topic is not None
+                        and unread_topic[0] != current_topic[0]
+                        and stream_start != current_topic
+                    ):
+                        return stream_start
+                    return unread_topic
+
+                if (
+                    stream_start is None
+                    and current_topic is not None
+                    and unread_topic[0] == current_topic[0]
+                ):
+                    stream_start = unread_topic
             if unread_topic == current_topic:
                 next_topic = True
         return None

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -886,6 +886,21 @@ class Model:
         topic_to_search = (stream_name, topic)
         return topic_to_search in self._muted_topics
 
+    def stream_topic_from_message_id(
+        self, message_id: int
+    ) -> Optional[Tuple[int, str]]:
+        """
+        Returns the stream and topic of a message of a given message id.
+        If the message is not a stream message or if it is not present in the index,
+        None is returned.
+        """
+        message = self.index["messages"].get(message_id, None)
+        if message is not None and message["type"] == "stream":
+            stream_id = message["stream_id"]
+            topic = message["subject"]
+            return (stream_id, topic)
+        return None
+
     def get_next_unread_topic(self) -> Optional[Tuple[int, str]]:
         unread_topics = sorted(self.unread_counts["unread_topics"].keys())
         next_topic = False

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -588,13 +588,13 @@ class MiddleColumnView(urwid.Frame):
             narrow = self.model.narrow
             if focus:
                 current_msg_id = focus.original_widget.message["id"]
-                stream_topic = self.model.get_next_unread_topic(
-                    current_message=current_msg_id
+                stream_topic = self.model.next_unread_topic_from_message_id(
+                    current_msg_id
                 )
                 if stream_topic is None:
                     return key
             elif narrow[0][0] == "stream" and narrow[1][0] == "topic":
-                stream_topic = self.model.get_next_unread_topic(current_message=None)
+                stream_topic = self.model.next_unread_topic_from_message_id(None)
             else:
                 return key
 

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -584,9 +584,20 @@ class MiddleColumnView(urwid.Frame):
 
         elif is_command_key("NEXT_UNREAD_TOPIC", key):
             # narrow to next unread topic
-            stream_topic = self.model.get_next_unread_topic()
-            if stream_topic is None:
+            focus = self.view.message_view.focus
+            narrow = self.model.narrow
+            if focus:
+                current_msg_id = focus.original_widget.message["id"]
+                stream_topic = self.model.get_next_unread_topic(
+                    current_message=current_msg_id
+                )
+                if stream_topic is None:
+                    return key
+            elif narrow[0][0] == "stream" and narrow[1][0] == "topic":
+                stream_topic = self.model.get_next_unread_topic(current_message=None)
+            else:
                 return key
+
             stream_id, topic = stream_topic
             self.controller.narrow_to_topic(
                 stream_name=self.model.stream_dict[stream_id]["name"],


### PR DESCRIPTION
<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?
This PR improves the algorithm for the 'next unread topic'  method used as the 'n' keybinding. It replaces the use of the last unread topic with the topic of the currently selected message to determine the next unread topic to cycle to. 


<!--- ### Outstanding aspect(s)    <!-- DELETE SECTION IF EMPTY -->
<!-- In what ways is this not fully implemented/functioning? Compared to a discussion/issue? -->
<!-- Do you not understand something? Are you unsure about a certain approach? Want feedback? -->

### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [x] Discussed in **#zulip-terminal** in [Improve algorithm for 'next unread topic' (n)](https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/Improve.20algorithm.20for.20'next.20unread.20topic'.20.28n.29.20.23T1333.20.23T1356)
- [x] Fully fixes #1333
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [x] Manually - Behavioral changes
- [x] Manually - Visual changes
- [x] Adapting existing automated tests
- [x] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [x] It contains test additions for any new behavior
- [x] It flows clearly from a previous branch commit, and/or prepares for the next commit

### Visual changes    <!-- DELETE SECTION IF NO VISUAL CHANGE -->
<!-- Zulip tips at https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html -->
<!-- For video, try asciinema; after uploading, embed using
[![yourtitle](https://asciinema.org/a/<id>.png)](https://asciinema.org/a/<id>)
-->
[![Demo](https://asciinema.org/a/XFCM5cH7W0FHaTNbkj1dGQ71S.svg)](https://asciinema.org/a/XFCM5cH7W0FHaTNbkj1dGQ71S)