### PR TITLE
Improve handling of pressing ``Esc`` during message compose

### DIFF
--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -529,6 +529,11 @@ class Controller:
         mute_this_stream = partial(self.model.toggle_stream_muted_status, stream_id)
         self.loop.widget = PopUpConfirmationView(self, question, mute_this_stream)
 
+    def exit_compose_confirmation_popup(self, draft: Composition) -> None:
+        question = urwid.Text(("bold", f"Save composed message as a draft?"))
+        save_draft = partial(self.model.save_draft, draft)
+        self.loop.widget = PopUpConfirmationView(self, question, save_draft)
+
     def copy_to_clipboard(self, text: str, text_category: str) -> None:
         try:
             pyperclip.copy(text)

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -805,6 +805,29 @@ class WriteBox(urwid.Pile):
                     )
         elif is_command_key("GO_BACK", key):
             self.send_stop_typing_status()
+            if len(self.msg_write_box.edit_text) > 10:
+                if self.compose_box_status == "open_with_private":
+                    all_valid = self._tidy_valid_recipients_and_notify_invalid_ones(
+                        self.to_write_box
+                    )
+                    if not all_valid:
+                        return key
+                    self.update_recipients(self.to_write_box)
+                    draft: Composition = PrivateComposition(
+                        type="private",
+                        to=self.recipient_user_ids,
+                        content=self.msg_write_box.edit_text,
+                    )
+                elif self.compose_box_status == "open_with_stream":
+                    draft = StreamComposition(
+                        type="stream",
+                        to=self.stream_write_box.edit_text,
+                        content=self.msg_write_box.edit_text,
+                        subject=self.title_write_box.edit_text,
+                    )
+                self.view.controller.exit_compose_confirmation_popup(
+                    draft,
+                )
             self._set_compose_attributes_to_defaults()
             self.view.controller.exit_editor_mode()
             self.main_view(False)


### PR DESCRIPTION
<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?
Adds a confirmation popup to save composed message as a draft before exiting the message compose to avoid accidental exit while typing a message and loosing it.

### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [x] Discussed in **#zulip-terminal** in `Improve handling Esc during msg compose #T1342 #T1362 #T1442`
- [x] Fully fixes #1342 
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [x] Manually - Behavioral changes
- [x] Manually - Visual changes
- [ ] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [ ] It contains test additions for any new behavior
- [x] It flows clearly from a previous branch commit, and/or prepares for the next commit

### Visual changes    <!-- DELETE SECTION IF NO VISUAL CHANGE -->
<!-- Zulip tips at https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html -->
<!-- For video, try asciinema; after uploading, embed using
[![yourtitle](https://asciinema.org/a/<id>.png)](https://asciinema.org/a/<id>)
-->
![image](https://user-images.githubusercontent.com/53873549/228343011-5f37aa50-4abf-4f32-aabf-6e0e415e7010.png)
