### PR TITLE
lint-all: Reorder linting for faster development cycle.

### DIFF
--- a/tools/lint-all
+++ b/tools/lint-all
@@ -15,10 +15,10 @@ python_sources = [
 python_sources += lintable_tools_files
 
 tools = {
-    "Import order (isort)": "./tools/run-isort-check",
-    "Type consistency (mypy)": "./tools/run-mypy",
     "PEP8 & more (ruff)": ["ruff"] + python_sources,
     "Formatting (black)": ["black", "--check"] + python_sources,
+    "Import order (isort)": "./tools/run-isort-check",
+    "Type consistency (mypy)": "./tools/run-mypy",
     "Common spelling mistakes": "./tools/run-spellcheck",
     "Hotkey linting & docs sync check": ["./tools/lint-hotkeys"],
     "Docstring linting & docs sync check (lint-docstring)": "./tools/lint-docstring",


### PR DESCRIPTION
<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?

This is a small change, but with a potentially large impact if running lint-all frequently.

By running more important, faster checks first, feedback is given to the developer sooner when failures occur.

In addition, this addresses two specific issues:
- ruff and black appear to disagree in some cases; running them first makes that faster to resolve
- isort gives less specific feedback on error locations than black (or ruff) when there are syntax errors, so if isort is first and fails, causing linting as a whole to fail, then that information is not available

The tools most likely to trigger failures are now run in order of the fastest tool first, ie. starting with:
- ruff (check) [was 3rd]
- black (check) [was 4th]
- isort (check) [was 1st]
- mypy [was 2nd]

Spelling and code-document synchronization typically run fast, but are less important checks that can be worked on later, so remain after the above tools.

### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [ ] Discussed in **#zulip-terminal** in `topic`
- [x] Motivated by https://github.com/zulip/zulip-terminal/pull/1355#discussion_r1148454004
- [ ] Fully fixes #
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [x] Manually - Behavioral changes
- [ ] Manually - Visual changes
- [ ] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [x] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [ ] It contains test additions for any new behavior
- [ ] It flows clearly from a previous branch commit, and/or prepares for the next commit