### PR TITLE
views/keys/hotkeys: Add key to copy message content

### DIFF
--- a/docs/hotkeys.md
+++ b/docs/hotkeys.md
@@ -62,6 +62,7 @@
 |View current message in browser (from message information)|<kbd>v</kbd>|
 |Show/hide full rendered message (from message information)|<kbd>f</kbd>|
 |Show/hide full raw message (from message information)|<kbd>r</kbd>|
+|Copy message content to clipboard|<kbd>C</kbd>|
 
 ## Stream list actions
 |Command|Key Combination|

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -1001,6 +1001,18 @@ class TestMsgInfoView:
             time_mentions=list(),
         )
 
+    @pytest.mark.parametrize("key", keys_for_command("COPY_MESSAGE"))
+    def test_keypress_copy_message(
+        self, key: str, widget_size: Callable[[Widget], urwid_Size]
+    ) -> None:
+        size = widget_size(self.msg_info_view)
+
+        self.msg_info_view.keypress(size, key)
+
+        self.controller.copy_to_clipboard.assert_called_once_with(
+            self.msg_info_view.msg["content"], "Message Content"
+        )
+
     @pytest.mark.parametrize(
         "key", {*keys_for_command("GO_BACK"), *keys_for_command("MSG_INFO")}
     )
@@ -1027,13 +1039,14 @@ class TestMsgInfoView:
         assert self.controller.open_in_browser.called
 
     def test_height_noreactions(self) -> None:
-        expected_height = 8
-        # 6 = 1 (date & time) +1 (sender's name) +1 (sender's email)
-        # +1 (display group header)
+        expected_height = 9
+        # 9 = 1 (date & time) +1 (sender's name) +1 (sender's email)
         # +1 (whitespace column)
+        # +1 (display group header)
         # +1 (view message in browser)
         # +1 (full rendered message)
         # +1 (full raw message)
+        # +1 (copy message content)
         assert self.msg_info_view.height == expected_height
 
     # FIXME This is the same parametrize as MessageBox:test_reactions_view
@@ -1101,9 +1114,9 @@ class TestMsgInfoView:
             OrderedDict(),
             list(),
         )
-        # 12 = 7 labels + 2 blank lines + 1 'Reactions' (category)
+        # 15 = 8 labels + 2 blank lines + 1 'Reactions' (category)
         # + 4 reactions (excluding 'Message Links').
-        expected_height = 14
+        expected_height = 15
         assert self.msg_info_view.height == expected_height
 
     @pytest.mark.parametrize(

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -396,6 +396,12 @@ KEY_BINDINGS: 'OrderedDict[str, KeyBinding]' = OrderedDict([
         'help_text': 'Show/hide full raw message (from message information)',
         'key_category': 'msg_actions',
     }),
+    ('COPY_MESSAGE', {
+        'keys': ['C'],
+        'help_text':
+            'Copy message content to clipboard',
+        'key_category': 'msg_actions',
+    }),
 ])
 # fmt: on
 

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1530,6 +1530,9 @@ class MsgInfoView(PopUpView):
         full_raw_message_keys = "[{}]".format(
             ", ".join(map(str, keys_for_command("FULL_RAW_MESSAGE")))
         )
+        copy_message_keys = "[{}]".format(
+            ", ".join(map(str, keys_for_command("COPY_MESSAGE")))
+        )
         msg_info = [
             (
                 "",
@@ -1548,6 +1551,7 @@ class MsgInfoView(PopUpView):
                 ("Open in web browser", view_in_browser_keys),
                 ("Full rendered message", full_rendered_message_keys),
                 ("Full raw message", full_raw_message_keys),
+                ("Copy message", copy_message_keys),
             ],
         )
         msg_info.append(viewing_actions)
@@ -1678,6 +1682,17 @@ class MsgInfoView(PopUpView):
                 time_mentions=self.time_mentions,
             )
             return key
+        elif is_command_key("COPY_MESSAGE", key):
+            rendered_content, *_ = MessageBox.transform_content(
+                self.msg["content"], self.controller.model.server_url
+            )
+            content = []
+            for word in rendered_content[1]:
+                if isinstance(word, tuple):  # if msg content has markup
+                    content.append(word[1])
+                else:
+                    content.append(word)
+            self.controller.copy_to_clipboard("".join(content), "Message Content")
         return super().keypress(size, key)
 
 


### PR DESCRIPTION
<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?
Copying a message using terminal selection does not work across multiple lines, as it also selects text in one or both of the side bars.

It would be useful to be able to copy selected message(s) independently of how the UI is set up.
This could be for quoting in another stream, or external to ZT.

Adding a key to copy message content which can be then pasted. Implemented using preexisting `copy_to_clipboard` function.


### Outstanding aspect(s)    <!-- DELETE SECTION IF EMPTY -->
<!-- In what ways is this not fully implemented/functioning? Compared to a discussion/issue? -->
This seems to not work for quotes messages because of the nested list
<!-- Do you not understand something? Are you unsure about a certain approach? Want feedback? -->
Unsure as to how to navigate about specific cases like 

### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [ ] Discussed in **#zulip-terminal** in `topic`
- [ ] Fully fixes #
- [x] Partially fixes issue #546 
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [x] Manually - Behavioral changes
- [x] Manually - Visual changes
- [x] Adapting existing automated tests
- [x] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [ ] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [x] It contains test additions for any new behavior
- [ ] It flows clearly from a previous branch commit, and/or prepares for the next commit

### Visual changes    <!-- DELETE SECTION IF NO VISUAL CHANGE -->
<!-- Zulip tips at https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html -->
<!-- For video, try asciinema; after uploading, embed using
[![yourtitle](https://asciinema.org/a/<id>.png)](https://asciinema.org/a/<id>)
-->
[![asciicast](https://asciinema.org/a/HkVCgXI6U6FCbWDf5OY27H4XM.svg)](https://asciinema.org/a/HkVCgXI6U6FCbWDf5OY27H4XM?t=10)
