### PR TITLE
test_boxes.py/helper.py: support and test multi-word matching without any ordering algorithm

### DIFF
--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -96,10 +96,18 @@ class TestWriteBox:
         [
             ("#**Stream 1>T", 0, True, "#**Stream 1>Topic 1**"),
             ("#**Stream 1>T", 1, True, "#**Stream 1>This is a topic**"),
-            ("#**Stream 1>T", 2, True, None),
-            ("#**Stream 1>T", -1, True, "#**Stream 1>This is a topic**"),
-            ("#**Stream 1>T", -2, True, "#**Stream 1>Topic 1**"),
-            ("#**Stream 1>T", -3, True, None),
+            # ("#**Stream 1>T", 2, True, None),
+            # changed test
+            ("#**Stream 1>T", 2, True, "#**Stream 1>Hello there!**"),
+            # ("#**Stream 1>T", -1, True, "#**Stream 1>This is a topic**"),
+            # changed test
+            ("#**Stream 1>T", -1, True, "#**Stream 1>Hello there!**"),
+            # ("#**Stream 1>T", -2, True, "#**Stream 1>Topic 1**"),
+            # changed test
+            ("#**Stream 1>T", -2, True, "#**Stream 1>This is a topic**"),
+            # ("#**Stream 1>T", -3, True, None),
+            # changed test
+            ("#**Stream 1>T", -3, True, "#**Stream 1>Topic 1**"),
             ("#**Stream 1>To", 0, True, "#**Stream 1>Topic 1**"),
             ("#**Stream 1>H", 0, True, "#**Stream 1>Hello there!**"),
             ("#**Stream 1>Hello ", 0, True, "#**Stream 1>Hello there!**"),
@@ -112,6 +120,8 @@ class TestWriteBox:
             # Unfenced prefix
             ("#Stream 1>T", 0, True, "#**Stream 1>Topic 1**"),
             ("#Stream 1>T", 1, True, "#**Stream 1>This is a topic**"),
+            ("#Stream 1>T", 2, True, "#**Stream 1>Hello there!**"),
+            # added test
             # Invalid stream
             ("#**invalid stream>", 0, False, None),
             ("#**invalid stream**>", 0, False, None),
@@ -1307,7 +1317,9 @@ class TestWriteBox:
         "text, matching_topics",
         [
             ("", ["Topic 1", "This is a topic", "Hello there!"]),
-            ("Th", ["This is a topic"]),
+            # ("Th", ["This is a topic"]),
+            # changed test
+            ("Th", ["This is a topic", "Hello there!"]),
         ],
         ids=[
             "no_search_text",
@@ -1325,7 +1337,6 @@ class TestWriteBox:
     ) -> None:
         write_box.model.topics_in_stream.return_value = topics
         _process_typeaheads = mocker.patch(WRITEBOX + "._process_typeaheads")
-
         write_box._topic_box_autocomplete(text, state)
 
         _process_typeaheads.assert_called_once_with(

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -535,9 +535,18 @@ def match_emoji(emoji: str, text: str) -> bool:
 
 
 def match_topics(topic_names: List[str], search_text: str) -> List[str]:
-    return [
-        name for name in topic_names if name.lower().startswith(search_text.lower())
-    ]
+    res = []
+    for topic_name_raw in topic_names:
+        delimiters = "-_/"
+        trans = str.maketrans(delimiters, len(delimiters) * " ")
+        # "abc def-gh" --> ["abc def gh", "def", "gh"]
+        topic_name_lst = [topic_name_raw] + topic_name_raw.translate(trans).split()[1:]
+
+        for word in topic_name_lst:
+            if word.lower().startswith(search_text.lower()):
+                res.append(topic_name_raw)
+                break
+    return res
 
 
 DataT = TypeVar("DataT")

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -445,9 +445,7 @@ class WriteBox(urwid.Pile):
 
     def _topic_box_autocomplete(self, text: str, state: Optional[int]) -> Optional[str]:
         topic_names = self.model.topics_in_stream(self.stream_id)
-
         topic_typeaheads = match_topics(topic_names, text)
-
         # Typeaheads and suggestions are the same.
         return self._process_typeaheads(topic_typeaheads, state, topic_typeaheads)
 
@@ -486,7 +484,6 @@ class WriteBox(urwid.Pile):
         #        anything; this implementation simply chooses the right-most
         #        match of the longest length
         prefix_indices = {prefix: text.rfind(prefix) for prefix in autocomplete_map}
-
         text = self.validate_and_patch_autocomplete_stream_and_topic(
             text, autocomplete_map, prefix_indices
         )


### PR DESCRIPTION
<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?
This PR supports multiword match in topic search and created and changes a few test cases to support it.


### Outstanding aspect(s)    <!-- DELETE SECTION IF EMPTY -->
<!-- In what ways is this not fully implemented/functioning? Compared to a discussion/issue? --> 

<!-- Do you not understand something? Are you unsure about a certain approach? Want feedback? --> 

- [ ] not sure if we should prioritize words if they appear earlier
- [ ] it does not have a decent ordering algorithm yet.


### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [x] Discussed in **#zulip-terminal** in `Multi-word matching for topic autocomplete #T1358 #T1371`
- [ ] Fully fixes #
- [x] Partially fixes issue #1358
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [ ] Manually - Behavioral changes
- [ ] Manually - Visual changes
- [x] Adapting existing automated tests
- [x] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [x] It contains test additions for any new behavior
- [x] It flows clearly from a previous branch commit, and/or prepares for the next commit

### Visual changes    <!-- DELETE SECTION IF NO VISUAL CHANGE -->
<!-- Zulip tips at https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html -->
<!-- For video, try asciinema; after uploading, embed using
[![yourtitle](https://asciinema.org/a/<id>.png)](https://asciinema.org/a/<id>)
-->
