### PR TITLE
WIP: bugfix: Use server_timestamp for presences

### DIFF
--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1231,10 +1231,9 @@ class Model:
                 * UserStatus, an arbitrary one is chosen.
                 """
                 aggregate_status: UserStatus = "offline"
-                for client in presences[email].items():
-                    client_name = client[0]
-                    status = client[1]["status"]
-                    timestamp = client[1]["timestamp"]
+                for client_name, client_presence in presences[email].items():
+                    status = client_presence["status"]
+                    timestamp = client_presence["timestamp"]
                     if client_name == "aggregated":
                         continue
                     if (

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1231,24 +1231,27 @@ class Model:
                 * UserStatus, an arbitrary one is chosen.
                 """
                 aggregate_status: UserStatus = "offline"
+                server_aggregate_status = "offline"
                 for client_name, client_presence in presences[email].items():
                     status = client_presence["status"]
                     timestamp = client_presence["timestamp"]
-                    if client_name == "aggregated":
-                        continue
                     if (
                         server_timestamp - timestamp
                     ) < self.server_presence_offline_threshold_secs:
-                        if status == "active":
-                            aggregate_status = "active"
-                        if status == "idle" and aggregate_status != "active":
-                            aggregate_status = status
-                        if status == "offline" and (
-                            aggregate_status != "active" and aggregate_status != "idle"
-                        ):
-                            aggregate_status = status
+                        if client_name == "aggregated":
+                            server_aggregate_status = status
+                        else:
+                            if status == "active":
+                                aggregate_status = "active"
+                            if status == "idle" and aggregate_status != "active":
+                                aggregate_status = status
+                            if status == "offline" and (
+                                aggregate_status != "active"
+                                and aggregate_status != "idle"
+                            ):
+                                aggregate_status = status
 
-                status = aggregate_status
+                status = server_aggregate_status
             else:
                 # Set status of users not in the  `presence` list
                 # as 'inactive'. They will not be displayed in the

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -444,7 +444,7 @@ class Model:
             if response["result"] == "success":
                 self.initial_data["presences"] = response["presences"]
 
-                self._presence_timestamp = time.time()
+                self._presence_timestamp = response.get("server_timestamp", time.time())
                 self._update_users_data_from_initial_data()
 
                 if hasattr(self.controller, "view"):


### PR DESCRIPTION
<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?

We previously relied on local time for determining presence, rather than the returned timestamp.

### Outstanding aspect(s)    <!-- DELETE SECTION IF EMPTY -->
<!-- In what ways is this not fully implemented/functioning? Compared to a discussion/issue? -->
<!-- Do you not understand something? Are you unsure about a certain approach? Want feedback? -->
- [ ] Tests
- [ ] Validate assumptions
- [ ] Potentially split out refactoring
- [ ] Determine aggregate or not, and future of presence
- [ ] Improve presence waiting

### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [x] Discussed in **#zulip-terminal** in `Users list not showing all the online users #T527`
- [ ] Fully fixes #
- [x] Partially fixes issue #527 
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [x] Manually - Behavioral changes
- [x] Manually - Visual changes
- [ ] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [ ] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [ ] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [ ] It has a commit summary describing the  motivation and reasoning for the change
- [ ] It individually passes linting and tests
- [ ] It contains test additions for any new behavior
- [ ] It flows clearly from a previous branch commit, and/or prepares for the next commit
