### PR TITLE
'=' keyboard shortcut for reaction agreement

### DIFF
--- a/docs/hotkeys.md
+++ b/docs/hotkeys.md
@@ -55,6 +55,7 @@
 |Narrow to the stream of the current message|<kbd>s</kbd>|
 |Narrow to the topic of the current message|<kbd>S</kbd>|
 |Narrow to a topic/direct-chat, or stream/all-direct-messages|<kbd>z</kbd>|
+|Toggle first emoji reaction on selected message|<kbd>=</kbd>|
 |Add/remove thumbs-up reaction to the current message|<kbd>+</kbd>|
 |Add/remove star status of the current message|<kbd>ctrl</kbd> + <kbd>s</kbd> / <kbd>*</kbd>|
 |Show/hide message information|<kbd>i</kbd>|

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -178,6 +178,11 @@ KEY_BINDINGS: Dict[str, KeyBinding] = {
             'Narrow to a topic/direct-chat, or stream/all-direct-messages',
         'key_category': 'msg_actions',
     },
+    'REACTION_AGREEMENT': {
+        'keys': ['='],
+        'help_text': 'Toggle first emoji reaction on selected message',
+        'key_category': 'msg_actions',
+    },
     'TOGGLE_TOPIC': {
         'keys': ['t'],
         'help_text': 'Toggle topics in a stream',

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -236,6 +236,15 @@ class MessageView(urwid.ListBox):
             message = self.focus.original_widget.message
             self.model.toggle_message_star_status(message)
 
+        elif is_command_key("REACTION_AGREEMENT", key) and self.focus is not None:
+            message = self.focus.original_widget.message
+            message_reactions = message["reactions"]
+            if len(message_reactions) > 0:
+                for reaction in message_reactions:
+                    emoji = reaction["emoji_name"]
+                    self.model.toggle_message_reaction(message, emoji)
+                    break
+
         key = super().keypress(size, key)
         return key
 


### PR DESCRIPTION
<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?

It enables a key press shortcut using '=' to toggle the first emoji reaction on a message if there is one.

### Outstanding aspect(s)    <!-- DELETE SECTION IF EMPTY -->
<!-- In what ways is this not fully implemented/functioning? Compared to a discussion/issue? -->
<!-- Do you not understand something? Are you unsure about a certain approach? Want feedback? -->
- I would appreciate feedback on if the coding style is acceptable.

### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [ ] Discussed in **#zulip-terminal** in `topic`
- [X] Fully fixes #1369 
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [X] Manually - Behavioral changes
- [X] Manually - Visual changes
- [ ] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [X] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [X] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [X] It has a commit summary describing the  motivation and reasoning for the change
- [X] It individually passes linting and tests
- [ ] It contains test additions for any new behavior
- [X] It flows clearly from a previous branch commit, and/or prepares for the next commit

### Visual changes    <!-- DELETE SECTION IF NO VISUAL CHANGE -->
<!-- Zulip tips at https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html -->
<!-- For video, try asciinema; after uploading, embed using
[![yourtitle](https://asciinema.org/a/<id>.png)](https://asciinema.org/a/<id>)
-->

Visual Test:

https://user-images.githubusercontent.com/55665883/232629469-830cf284-15f4-471c-805a-a93a0e087066.MOV


