### PR TITLE
Add typing for MessageType & typing notifications

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ import pytest
 from pytest_mock import MockerFixture
 from urwid import Widget
 
-from zulipterminal.api_types import Message
+from zulipterminal.api_types import Message, MessageType
 from zulipterminal.config.keys import (
     ZT_TO_URWID_CMD_MAPPING,
     keys_for_command,
@@ -416,7 +416,7 @@ def display_recipient_factory(
 
 def msg_template_factory(
     msg_id: int,
-    msg_type: str,
+    msg_type: MessageType,
     timestamp: int,
     *,
     subject: str = "",

--- a/zulipterminal/api_types.py
+++ b/zulipterminal/api_types.py
@@ -23,18 +23,27 @@ TYPING_STARTED_WAIT_PERIOD = 10
 TYPING_STOPPED_WAIT_PERIOD = 5
 
 ###############################################################################
+# Core message types (used in Composition and Message below)
+
+DirectMessageString = Literal["private"]
+StreamMessageString = Literal["stream"]
+
+MessageType = Union[DirectMessageString, StreamMessageString]
+
+
+###############################################################################
 # Parameter to pass in request to:
 #   https://zulip.com/api/send-message
 
 
 class PrivateComposition(TypedDict):
-    type: Literal["private"]
+    type: DirectMessageString
     content: str
     to: List[int]  # User ids
 
 
 class StreamComposition(TypedDict):
-    type: Literal["stream"]
+    type: StreamMessageString
     content: str
     to: str  # stream name  # TODO: Migrate to using int (stream id)
     subject: str  # TODO: Migrate to using topic
@@ -80,6 +89,8 @@ MessageUpdateRequest = Union[PrivateMessageUpdateRequest, StreamMessageUpdateReq
 #   https://zulip.com/api/get-events#message
 #   https://zulip.com/api/get-message  (unused)
 
+## TODO: Improve this typing to split private and stream message data
+
 
 class Message(TypedDict, total=False):
     id: int
@@ -101,7 +112,7 @@ class Message(TypedDict, total=False):
     sender_email: str
     sender_realm_str: str
     display_recipient: Any
-    type: str
+    type: MessageType
     stream_id: int  # Only for stream msgs.
     avatar_url: str
     content_type: str

--- a/zulipterminal/api_types.py
+++ b/zulipterminal/api_types.py
@@ -17,12 +17,6 @@ from zulip import ModifiableMessageFlag  # directly modifiable read/starred/coll
 
 RESOLVED_TOPIC_PREFIX = "✔ "
 
-# Refer to https://zulip.com/api/set-typing-status for the protocol
-# on typing notifications sent by clients.
-TYPING_STARTED_WAIT_PERIOD = 10
-TYPING_STOPPED_WAIT_PERIOD = 5
-
-
 ###############################################################################
 # These values are in the register response from ZFL 53
 # Before this feature level, they had the listed default (fixed) values
@@ -40,6 +34,37 @@ DirectMessageString = Literal["private"]
 StreamMessageString = Literal["stream"]
 
 MessageType = Union[DirectMessageString, StreamMessageString]
+
+
+###############################################################################
+# Parameters to pass in request to:
+#   https://zulip.com/api/set-typing-status
+# Refer to the top of that page for the expected protocol clients should observe
+#
+# NOTE: `to` field could be email until ZFL 11/3.0; ids were possible from 2.0+
+
+# Timing parameters for when notifications should occur
+TYPING_STARTED_WAIT_PERIOD: Final = 10
+TYPING_STOPPED_WAIT_PERIOD: Final = 5
+TYPING_STARTED_EXPIRY_PERIOD: Final = 15  # TODO: Needs implementation in ZT
+
+TypingStatusChange = Literal["start", "stop"]
+
+
+class DirectTypingNotification(TypedDict):
+    # The type field was added in ZFL 58, Zulip 4.0, so don't require it yet
+    ## type: DirectMessageString
+    op: TypingStatusChange
+    to: List[int]
+
+
+# NOTE: Not yet implemented in ZT
+# New in ZFL 58, Zulip 4.0
+class StreamTypingNotification(TypedDict):
+    type: StreamMessageString
+    op: TypingStatusChange
+    to: List[int]  # NOTE: Length 1, stream id
+    topic: str
 
 
 ###############################################################################

--- a/zulipterminal/api_types.py
+++ b/zulipterminal/api_types.py
@@ -6,7 +6,7 @@ Types from the Zulip API, translated into python, to improve type checking
 
 from typing import Any, Dict, List, Optional, Union
 
-from typing_extensions import Literal, NotRequired, TypedDict
+from typing_extensions import Final, Literal, NotRequired, TypedDict
 
 # These are documented in the zulip package (python-zulip-api repo)
 from zulip import EditPropagateMode  # one/all/later
@@ -21,6 +21,17 @@ RESOLVED_TOPIC_PREFIX = "✔ "
 # on typing notifications sent by clients.
 TYPING_STARTED_WAIT_PERIOD = 10
 TYPING_STOPPED_WAIT_PERIOD = 5
+
+
+###############################################################################
+# These values are in the register response from ZFL 53
+# Before this feature level, they had the listed default (fixed) values
+# (strictly, the stream value was available, under a different name)
+
+MAX_STREAM_NAME_LENGTH: Final = 60
+MAX_TOPIC_NAME_LENGTH: Final = 60
+MAX_MESSAGE_LENGTH: Final = 10000
+
 
 ###############################################################################
 # Core message types (used in Composition and Message below)

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -27,7 +27,7 @@ from urllib.parse import urlparse
 
 import zulip
 from bs4 import BeautifulSoup
-from typing_extensions import Literal, TypedDict
+from typing_extensions import TypedDict
 
 from zulipterminal import unicode_emojis
 from zulipterminal.api_types import (
@@ -35,6 +35,7 @@ from zulipterminal.api_types import (
     MAX_STREAM_NAME_LENGTH,
     MAX_TOPIC_NAME_LENGTH,
     Composition,
+    DirectTypingNotification,
     EditPropagateMode,
     Event,
     PrivateComposition,
@@ -44,6 +45,7 @@ from zulipterminal.api_types import (
     StreamComposition,
     StreamMessageUpdateRequest,
     Subscription,
+    TypingStatusChange,
 )
 from zulipterminal.config.keys import primary_key_for_command
 from zulipterminal.config.symbols import STREAM_TOPIC_SEPARATOR
@@ -513,12 +515,12 @@ class Model:
 
     @asynch
     def send_typing_status_by_user_ids(
-        self, recipient_user_ids: List[int], *, status: Literal["start", "stop"]
+        self, recipient_user_ids: List[int], *, status: TypingStatusChange
     ) -> None:
         if not self.user_settings()["send_private_typing_notifications"]:
             return
         if recipient_user_ids:
-            request = {"to": recipient_user_ids, "op": status}
+            request: DirectTypingNotification = {"to": recipient_user_ids, "op": status}
             response = self.client.set_typing_status(request)
             display_error_if_present(response, self.controller)
         else:

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -31,6 +31,9 @@ from typing_extensions import Literal, TypedDict
 
 from zulipterminal import unicode_emojis
 from zulipterminal.api_types import (
+    MAX_MESSAGE_LENGTH,
+    MAX_STREAM_NAME_LENGTH,
+    MAX_TOPIC_NAME_LENGTH,
     Composition,
     EditPropagateMode,
     Event,
@@ -69,14 +72,6 @@ from zulipterminal.ui_tools.utils import create_msg_box_list
 
 
 OFFLINE_THRESHOLD_SECS = 140
-
-# Adapted from zerver/models.py
-# These fields have migrated to the API inside the Realm object
-# in ZFL 53. To allow backporting to earlier server versions, we
-# define these hard-coded parameters.
-MAX_STREAM_NAME_LENGTH = 60
-MAX_TOPIC_NAME_LENGTH = 60
-MAX_MESSAGE_LENGTH = 10000
 
 
 class ServerConnectionFailure(Exception):


### PR DESCRIPTION
<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?

Message type was previously only typed as `str`, whereas Zulip specifically only has the two types `private` and `stream` (for now). This will be changing soon to migrate `private` to `direct`, though will remain backwards compatible for a long time.

This upcoming change partially motivated the above, but related conversation discussed the typing notifications also migrating, which was also not previously typed in the ZT code.

Other constants relevant to the API were also migrated in a third commit.

### Outstanding aspect(s)    <!-- DELETE SECTION IF EMPTY -->
<!-- In what ways is this not fully implemented/functioning? Compared to a discussion/issue? -->
<!-- Do you not understand something? Are you unsure about a certain approach? Want feedback? -->
- [ ] While `MessageType` is reasonable for `private|stream`, `Direct|StreamMessageString` don't appear great - though these are internal to the typing right now

### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [ ] Discussed in **#zulip-terminal** in `topic`
- [ ] Fully fixes #
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [ ] Manually - Behavioral changes
- [ ] Manually - Visual changes
- [ ] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [x] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [ ] It contains test additions for any new behavior
- [x] It flows clearly from a previous branch commit, and/or prepares for the next commit
