### PR TITLE
Adding prefix icons to current message headers

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -119,9 +119,11 @@ def msg_box(
     """
     Mocked MessageBox with stream message
     """
+    model_mock = mocker.patch("zulipterminal.model.Model")
+    model_mock.stream_access_type.return_value = "public"
     return MessageBox(
         messages_successful_response["messages"][0],
-        mocker.patch("zulipterminal.model.Model"),
+        model_mock,
         None,
     )
 

--- a/tests/ui_tools/test_messages.py
+++ b/tests/ui_tools/test_messages.py
@@ -11,6 +11,7 @@ from zulipterminal.config.keys import keys_for_command
 from zulipterminal.config.symbols import (
     QUOTED_TEXT_MARKER,
     STATUS_INACTIVE,
+    STREAM_MARKER_PUBLIC,
     STREAM_TOPIC_SEPARATOR,
     TIME_MENTION_MARKER,
 )
@@ -28,6 +29,7 @@ class TestMessageBox:
     def mock_external_classes(self, mocker, initial_index):
         self.model = mocker.MagicMock()
         self.model.index = initial_index
+        self.model.stream_access_type.return_value = "public"
 
     @pytest.mark.parametrize(
         "message_type, set_fields",
@@ -893,19 +895,24 @@ class TestMessageBox:
     @pytest.mark.parametrize(
         "msg_narrow, msg_type, assert_header_bar, assert_search_bar",
         [
-            ([], 0, f"PTEST {STREAM_TOPIC_SEPARATOR} ", "All messages"),
+            (
+                [],
+                0,
+                f" {STREAM_MARKER_PUBLIC} PTEST {STREAM_TOPIC_SEPARATOR} ",
+                "All messages",
+            ),
             ([], 1, "You and ", "All messages"),
             ([], 2, "You and ", "All messages"),
             (
                 [["stream", "PTEST"]],
                 0,
-                f"PTEST {STREAM_TOPIC_SEPARATOR} ",
+                f" {STREAM_MARKER_PUBLIC} PTEST {STREAM_TOPIC_SEPARATOR} ",
                 ("bar", [("s#bd6", "PTEST")]),
             ),
             (
                 [["stream", "PTEST"], ["topic", "b"]],
                 0,
-                f"PTEST {STREAM_TOPIC_SEPARATOR}",
+                f" {STREAM_MARKER_PUBLIC} PTEST {STREAM_TOPIC_SEPARATOR}",
                 ("bar", [("s#bd6", "PTEST"), ("s#bd6", ": topic narrow")]),
             ),
             ([["is", "private"]], 1, "You and ", "All direct messages"),
@@ -925,7 +932,7 @@ class TestMessageBox:
             (
                 [["is", "starred"]],
                 0,
-                f"PTEST {STREAM_TOPIC_SEPARATOR} ",
+                f" {STREAM_MARKER_PUBLIC} PTEST {STREAM_TOPIC_SEPARATOR} ",
                 "Starred messages",
             ),
             ([["is", "starred"]], 1, "You and ", "Starred messages"),
@@ -934,10 +941,15 @@ class TestMessageBox:
             (
                 [["search", "FOO"]],
                 0,
-                f"PTEST {STREAM_TOPIC_SEPARATOR} ",
+                f" {STREAM_MARKER_PUBLIC} PTEST {STREAM_TOPIC_SEPARATOR} ",
                 "All messages",
             ),
-            ([["is", "mentioned"]], 0, f"PTEST {STREAM_TOPIC_SEPARATOR} ", "Mentions"),
+            (
+                [["is", "mentioned"]],
+                0,
+                f" {STREAM_MARKER_PUBLIC} PTEST {STREAM_TOPIC_SEPARATOR} ",
+                "Mentions",
+            ),
             ([["is", "mentioned"]], 1, "You and ", "Mentions"),
             ([["is", "mentioned"]], 2, "You and ", "Mentions"),
             ([["is", "mentioned"], ["search", "FOO"]], 1, "You and ", "Mentions"),

--- a/tests/ui_tools/test_messages.py
+++ b/tests/ui_tools/test_messages.py
@@ -9,6 +9,7 @@ from urwid import Columns, Divider, Padding, Text
 
 from zulipterminal.config.keys import keys_for_command
 from zulipterminal.config.symbols import (
+    DIRECT_MESSAGE_MARKER,
     QUOTED_TEXT_MARKER,
     STATUS_INACTIVE,
     STREAM_MARKER_PUBLIC,
@@ -901,8 +902,8 @@ class TestMessageBox:
                 f" {STREAM_MARKER_PUBLIC} PTEST {STREAM_TOPIC_SEPARATOR} ",
                 "All messages",
             ),
-            ([], 1, "You and ", "All messages"),
-            ([], 2, "You and ", "All messages"),
+            ([], 1, f" {DIRECT_MESSAGE_MARKER} You and ", "All messages"),
+            ([], 2, f" {DIRECT_MESSAGE_MARKER} You and ", "All messages"),
             (
                 [["stream", "PTEST"]],
                 0,
@@ -915,18 +916,28 @@ class TestMessageBox:
                 f" {STREAM_MARKER_PUBLIC} PTEST {STREAM_TOPIC_SEPARATOR}",
                 ("bar", [("s#bd6", "PTEST"), ("s#bd6", ": topic narrow")]),
             ),
-            ([["is", "private"]], 1, "You and ", "All direct messages"),
-            ([["is", "private"]], 2, "You and ", "All direct messages"),
+            (
+                [["is", "private"]],
+                1,
+                f" {DIRECT_MESSAGE_MARKER} You and ",
+                "All direct messages",
+            ),
+            (
+                [["is", "private"]],
+                2,
+                f" {DIRECT_MESSAGE_MARKER} You and ",
+                "All direct messages",
+            ),
             (
                 [["pm-with", "boo@zulip.com"]],
                 1,
-                "You and ",
+                f" {DIRECT_MESSAGE_MARKER} You and ",
                 "Direct message conversation",
             ),
             (
                 [["pm-with", "boo@zulip.com, bar@zulip.com"]],
                 2,
-                "You and ",
+                f" {DIRECT_MESSAGE_MARKER} You and ",
                 "Group direct message conversation",
             ),
             (
@@ -935,9 +946,24 @@ class TestMessageBox:
                 f" {STREAM_MARKER_PUBLIC} PTEST {STREAM_TOPIC_SEPARATOR} ",
                 "Starred messages",
             ),
-            ([["is", "starred"]], 1, "You and ", "Starred messages"),
-            ([["is", "starred"]], 2, "You and ", "Starred messages"),
-            ([["is", "starred"], ["search", "FOO"]], 1, "You and ", "Starred messages"),
+            (
+                [["is", "starred"]],
+                1,
+                f" {DIRECT_MESSAGE_MARKER} You and ",
+                "Starred messages",
+            ),
+            (
+                [["is", "starred"]],
+                2,
+                f" {DIRECT_MESSAGE_MARKER} You and ",
+                "Starred messages",
+            ),
+            (
+                [["is", "starred"], ["search", "FOO"]],
+                1,
+                f" {DIRECT_MESSAGE_MARKER} You and ",
+                "Starred messages",
+            ),
             (
                 [["search", "FOO"]],
                 0,
@@ -950,9 +976,24 @@ class TestMessageBox:
                 f" {STREAM_MARKER_PUBLIC} PTEST {STREAM_TOPIC_SEPARATOR} ",
                 "Mentions",
             ),
-            ([["is", "mentioned"]], 1, "You and ", "Mentions"),
-            ([["is", "mentioned"]], 2, "You and ", "Mentions"),
-            ([["is", "mentioned"], ["search", "FOO"]], 1, "You and ", "Mentions"),
+            (
+                [["is", "mentioned"]],
+                1,
+                f" {DIRECT_MESSAGE_MARKER} You and ",
+                "Mentions",
+            ),
+            (
+                [["is", "mentioned"]],
+                2,
+                f" {DIRECT_MESSAGE_MARKER} You and ",
+                "Mentions",
+            ),
+            (
+                [["is", "mentioned"], ["search", "FOO"]],
+                1,
+                f" {DIRECT_MESSAGE_MARKER} You and ",
+                "Mentions",
+            ),
         ],
     )
     def test_msg_generates_search_and_header_bar(

--- a/zulipterminal/config/symbols.py
+++ b/zulipterminal/config/symbols.py
@@ -8,6 +8,7 @@ Terminal characters used to mark particular elements of the user interface
 # Suffix comments indicate: unicode name, codepoint (unicode block, version if not v1.1)
 
 INVALID_MARKER = "✗"  # BALLOT X, U+2717 (Dingbats)
+DIRECT_MESSAGE_MARKER = "§"  # SECTION SIGN, U+00A7 (Latin-1 supplement)
 STREAM_MARKER_PRIVATE = "P"
 STREAM_MARKER_PUBLIC = "#"
 STREAM_MARKER_WEB_PUBLIC = "⊚"  # CIRCLED RING OPERATOR, U+229A (Mathematical operators)

--- a/zulipterminal/ui_tools/messages.py
+++ b/zulipterminal/ui_tools/messages.py
@@ -18,6 +18,7 @@ from tzlocal import get_localzone
 from zulipterminal.api_types import Message
 from zulipterminal.config.keys import is_command_key, primary_key_for_command
 from zulipterminal.config.symbols import (
+    DIRECT_MESSAGE_MARKER,
     MESSAGE_CONTENT_MARKER,
     MESSAGE_HEADER_DIVIDER,
     QUOTED_TEXT_MARKER,
@@ -177,7 +178,11 @@ class MessageBox(urwid.Pile):
     def private_header(self) -> Any:
         title_markup = (
             "header",
-            [("general_narrow", "You and "), ("general_narrow", self.recipients_names)],
+            [
+                ("general_narrow", f" {DIRECT_MESSAGE_MARKER} "),
+                ("general_narrow", "You and "),
+                ("general_narrow", self.recipients_names),
+            ],
         )
         title = urwid.Text(title_markup)
         header = urwid.Columns(

--- a/zulipterminal/ui_tools/messages.py
+++ b/zulipterminal/ui_tools/messages.py
@@ -24,7 +24,7 @@ from zulipterminal.config.symbols import (
     STREAM_TOPIC_SEPARATOR,
     TIME_MENTION_MARKER,
 )
-from zulipterminal.config.ui_mappings import STATE_ICON
+from zulipterminal.config.ui_mappings import STATE_ICON, STREAM_ACCESS_TYPE
 from zulipterminal.helper import get_unused_fence
 from zulipterminal.server_url import near_message_url
 from zulipterminal.ui_tools.tables import render_table
@@ -153,9 +153,12 @@ class MessageBox(urwid.Pile):
         assert self.stream_id is not None
         color = self.model.stream_dict[self.stream_id]["color"]
         bar_color = f"s{color}"
+        stream_access_type = self.model.stream_access_type(self.stream_id)
+        stream_icon = STREAM_ACCESS_TYPE[stream_access_type]["icon"]
         stream_title_markup = (
             "bar",
             [
+                (bar_color, f" {stream_icon} "),
                 (bar_color, f"{self.stream_name} {STREAM_TOPIC_SEPARATOR} "),
                 ("title", f" {self.topic_name}"),
             ],


### PR DESCRIPTION
<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?
Adds prefix icons to currents message headers


### Outstanding aspect(s)    <!-- DELETE SECTION IF EMPTY -->
<!-- In what ways is this not fully implemented/functioning? Compared to a discussion/issue? -->
There are other parts of the ui that also needs the prefix icons but the person who opened the issue said that each section could be done with multiple pull request so that is how I chose to do it.
<!-- Do you not understand something? Are you unsure about a certain approach? Want feedback? -->
- [ ] 

### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [ ] Discussed in **#zulip-terminal** in `topic`
- [ ] Fully fixes #
- [x] Partially fixes issue #1348 
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [ ] Manually - Behavioral changes
- [x] Manually - Visual changes
- [ ] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [ ] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits-
--speeding-up-reviews-merging--development) (title & body)
- [ ] It has a commit summary describing the  motivation and reasoning for the change
- [ ] It individually passes linting and tests
- [ ] It contains test additions for any new behavior
- [ ] It flows clearly from a previous branch commit, and/or prepares for the next commit

### Visual changes    <!-- DELETE SECTION IF NO VISUAL CHANGE -->
<!-- Zulip tips at https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html -->
<!-- For video, try asciinema; after uploading, embed using
[![yourtitle](https://asciinema.org/a/<id>.png)](https://asciinema.org/a/<id>)
-->
<img width="321" alt="Screenshot 2023-04-24 at 16 18 38" src="https://user-images.githubusercontent.com/77788985/234008283-aafe4a28-6751-48ac-88cd-1e0b0253f742.png">

<img width="321" alt="Screenshot 2023-04-24 at 16 18 38" src="https://user-images.githubusercontent.com/77788985/234008463-02b53520-c849-4ccb-9aad-5c88e4198c84.png">

<img width="1020" alt="Screenshot 2023-04-24 at 16 20 30" src="https://user-images.githubusercontent.com/77788985/234008657-bf0d4c51-54a9-437c-bba7-27b2ed0fbd22.png">
