### PR TITLE
README/editorconfig: Add .editorconfig to improve editing consistency.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,26 @@
+# See https://editorconfig.org
+
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+indent_size = 4
+indent_style = space
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{py,pyi}]
+max_line_length = 88
+
+[*.{md,yaml,yml}]
+indent_size = 2
+
+[Makefile]
+indent_style = tab
+
+[*.diff]
+trim_trailing_whitespace = false
+
+[.git/*]
+trim_trailing_whitespace = false

--- a/README.md
+++ b/README.md
@@ -494,6 +494,15 @@ If using make with pip, running `make` will ensure the development environment
 is up to date with the specified dependencies, useful after fetching from git
 and rebasing.
 
+#### Editing the source
+
+Pick your favorite text editor or development environment!
+
+The source includes an `.editorconfig` file which enables many editors to
+automatically configure themselves to produce files which meet the minimum
+requirements for the project. See https://editorconfig.org for editor support;
+note that some may require plugins if you wish to use this feature.
+
 #### Passing linters and automated tests
 
 The linters and automated tests (pytest) are run in CI (GitHub Actions) when


### PR DESCRIPTION
<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?

EditorConfig is rather useful - standardized basic formatting and a few other goodies.

See editorconfig.org, or the note added to the README here.

### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [x] Discussed in **#zulip-terminal** in `EditorConfig #T1389`
- [ ] Fully fixes #
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [ ] Manually - Behavioral changes
- [ ] Manually - Visual changes
- [ ] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [x] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [ ] It contains test additions for any new behavior
- [ ] It flows clearly from a previous branch commit, and/or prepares for the next commit

### Visual changes    <!-- DELETE SECTION IF NO VISUAL CHANGE -->
This may depend on your editor - in vim I get a nice red column for the maximum line length :)