### PR TITLE
Migrated get_next_unread_pm & tests to model. Fixes #1335

### DIFF
--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -3767,9 +3767,7 @@ class TestModel:
     def test_get_next_unread_pm(
         self, model, unread_pms, last_unread_pm, next_unread_pm
     ):
-        model.unread_counts = {
-            "unread_pms": {stream_pm: 1 for stream_pm in unread_pms}
-        }
+        model.unread_counts = {"unread_pms": {stream_pm: 1 for stream_pm in unread_pms}}
         model.last_unread_pm = last_unread_pm
 
         unread_pm = model.get_next_unread_pm()

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -810,7 +810,6 @@ class TestMiddleColumnView:
             "MSG_LIST", header=self.search_box, footer=self.write_box
         )
 
-
     @pytest.mark.parametrize("key", keys_for_command("SEARCH_MESSAGES"))
     def test_keypress_focus_header(self, mid_col_view, mocker, key, widget_size):
         size = widget_size(mid_col_view)

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -911,7 +911,7 @@ class TestMiddleColumnView:
     ):
         size = widget_size(mid_col_view)
         mocker.patch(MIDCOLVIEW + ".focus_position")
-        
+
         mid_col_view.model.user_id_email_dict = {1: "EMAIL"}
         mid_col_view.model.get_next_unread_pm.return_value = 1
 

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -108,6 +108,7 @@ class Model:
         self.recipients: FrozenSet[Any] = frozenset()
         self.index = initial_index
         self._last_unread_topic = None
+        self.last_unread_pm = None
 
         self.user_id = -1
         self.user_email = ""
@@ -900,6 +901,21 @@ class Model:
                 return unread_topic
             if unread_topic == self._last_unread_topic:
                 next_topic = True
+        return None
+
+    def get_next_unread_pm(self) -> Optional[int]:
+        pms = sorted(self.unread_counts["unread_pms"].keys())
+        next_pm = False
+        for pm in pms:
+            if next_pm is True:
+                self.last_unread_pm = pm
+                return pm
+            if pm == self.last_unread_pm:
+                next_pm = True
+        if len(pms) > 0:
+            pm = pms[0]
+            self.last_unread_pm = pm
+            return pm
         return None
 
     def _fetch_initial_data(self) -> None:

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -550,7 +550,6 @@ class MiddleColumnView(urwid.Frame):
         view.message_view = message_view
         super().__init__(message_view, header=search_box, footer=write_box)
 
-
     def update_message_list_status_markers(self) -> None:
         for message_w in self.body.log:
             message_box = message_w.original_widget

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -546,25 +546,10 @@ class MiddleColumnView(urwid.Frame):
         self.model = model
         self.controller = model.controller
         self.view = view
-        self.last_unread_pm = None
         self.search_box = search_box
         view.message_view = message_view
         super().__init__(message_view, header=search_box, footer=write_box)
 
-    def get_next_unread_pm(self) -> Optional[int]:
-        pms = list(self.model.unread_counts["unread_pms"].keys())
-        next_pm = False
-        for pm in pms:
-            if next_pm is True:
-                self.last_unread_pm = pm
-                return pm
-            if pm == self.last_unread_pm:
-                next_pm = True
-        if len(pms) > 0:
-            pm = pms[0]
-            self.last_unread_pm = pm
-            return pm
-        return None
 
     def update_message_list_status_markers(self) -> None:
         for message_w in self.body.log:
@@ -621,7 +606,7 @@ class MiddleColumnView(urwid.Frame):
             return key
         elif is_command_key("NEXT_UNREAD_PM", key):
             # narrow to next unread pm
-            pm = self.get_next_unread_pm()
+            pm = self.model.get_next_unread_pm()
             if pm is None:
                 return key
             email = self.model.user_id_email_dict[pm]
@@ -629,6 +614,7 @@ class MiddleColumnView(urwid.Frame):
                 recipient_emails=[email],
                 contextual_message_id=pm,
             )
+            return key
         elif is_command_key("PRIVATE_MESSAGE", key):
             # Create new PM message
             self.footer.private_box_view()


### PR DESCRIPTION
### What does this PR do, and why?
This pull request Migrates get_next_unread_pm & tests to model. This is a precursor for improving the get_next_unread_pm method.
Fixes #1335

### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [ ] Discussed in **#zulip-terminal** in `topic`
- [x] Fully fixes #1335
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [x] Merge will enable work on #1336

### How did you test this?
<!-- [x] all that apply -->
- [ ] Manually - Behavioral changes
- [ ] Manually - Visual changes
- [ ] Adapting existing automated tests
- [x] Adding automated tests for new behavior (or missing tests)
- [x] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [ ] It contains test additions for any new behavior
- [ ] It flows clearly from a previous branch commit, and/or prepares for the next commit


