### PR TITLE
Edit message in a terminal editor subprocess

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,10 @@ color-depth=256
 ## This is highly dependent on a suitable terminal emulator, and support in the selected theme
 ## Terminal emulators without this feature may show an arbitrary solid background color
 transparency=disabled
+
+## Editor: set external editor command, to edit message content
+## If not set, this falls back to the $ZULIP_EDITOR_COMMAND then $EDITOR environment variables
+# editor: nano
 ```
 
 > **NOTE:** Most of these configuration settings may be specified on the

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -13,6 +13,7 @@
   - [When are messages marked as having been read?](#when-are-messages-marked-as-having-been-read)
   - [How do I access multiple servers?](#how-do-i-access-multiple-servers)
   - [What is autocomplete? Why is it useful?](#what-is-autocomplete-why-is-it-useful)
+  - [Can I compose messages in another editor?](#can-i-compose-messages-in-another-editor)
 - Something is not working!
   - [Colors appear mismatched, don't change with theme, or look strange](#colors-appear-mismatched-dont-change-with-theme-or-look-strange)
   - [Symbols look different to in the provided screenshots, or just look incorrect](#symbols-look-different-to-in-the-provided-screenshots-or-just-look-incorrect)
@@ -372,6 +373,55 @@ through autocomplete depend upon the context automatically.
 
 **NOTE:** If a direct message recipient's name contains comma(s) (`,`), they
 are currently treated as comma-separated recipients.
+
+## Can I compose messages in another editor?
+
+In the `main` branch of zulip-terminal, you can now use an external editor of
+your choice to compose your messages using the `Ctrl o` hotkey.
+
+The editor command is looked for in the `ZULIP_EDITOR_COMMAND` and `EDITOR`
+environment variables (in that order), or the `editor` entry of the zuliprc
+file (which overrides both of those).
+
+It should work directly for most terminal editors with only the program name,
+eg. `vim`, `nano`, `helix`, `kakoune`, `nvim`, etc.
+
+It can also be used with a desktop editor with some constraints: the program
+must not fork or detach from the running terminal and should open in a new
+window. For this reason it may be useful to use `ZULIP_EDITOR_COMMAND` (or the
+zuliprc setting) to avoid conflict with the more widely used `EDITOR`
+environment variable. Some examples include:
+
+- [lapce](https://github.com/lapce/lapce) with `lapce -n -w`
+- [sublime-text](https://www.sublimetext.com/) with `subl -n -w`
+- [marker](https://github.com/fabiocolacio/Marker) with `marker`
+- [vim](https://github.com/vim/vim) with `vim -g -f` or `gvim -f`
+- [vscode](https://github.com/microsoft/vscode) with `code -n -w`
+
+**NOTE:** Backslashing white space (`\ `) is needed when using an executable
+containing them, for example Sublime Text on macOS can be configured with
+`/Applications/Sublime\ Text.app/Contents/SharedSupport/bin/subl`.
+
+This feature works by sending the message content back and forth using
+temporary files:
+- A temporary file is created, filled with any existing message content;
+- The editor command is run, with the filename appended (standard practice for editors);
+- You edit your text in the editor of your choice;
+- When the external editor process ends (closing the window, or quitting the terminal
+editor), the compose box will be updated with the new message content from
+the temporary file.
+
+> NOTE 1: If using a terminal-based editor, it will temporarily take over the
+> entire terminal and replace the application. However, upon exiting that
+> editor, the application should return to the terminal.
+
+> NOTE 2: Whichever type of editor you use (terminal or desktop/graphical), the
+> application will temporarily pause while you are editing. The application
+> should resume as normal once you exit the external editor and the text you
+> entered appears in the compose area.
+
+**If you have success with other editors, these examples do not work, or have
+other problems, please let us know!**
 
 ## Colors appear mismatched, don't change with theme, or look strange
 

--- a/docs/hotkeys.md
+++ b/docs/hotkeys.md
@@ -97,6 +97,7 @@
 |Cycle through autocomplete suggestions in reverse|<kbd>Ctrl</kbd> + <kbd>r</kbd>|
 |Exit message compose box|<kbd>Esc</kbd>|
 |Insert new line|<kbd>Enter</kbd>|
+|Open an external editor to edit the message content|<kbd>Ctrl</kbd> + <kbd>o</kbd>|
 
 ## Editor: Navigation
 |Command|Key Combination|

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -27,6 +27,8 @@ from zulipterminal.version import ZT_VERSION
 MODULE = "zulipterminal.cli.run"
 CONTROLLER = MODULE + ".Controller"
 
+os.environ["ZULIP_EDITOR_COMMAND"] = ""
+
 
 @pytest.mark.parametrize(
     "color, code",
@@ -206,6 +208,7 @@ def test_valid_zuliprc_but_no_connection(
         "   color depth setting '256' specified from default config.",
         "   notify setting 'disabled' specified from default config.",
         "   transparency setting 'disabled' specified from default config.",
+        "   external editor command '' specified from environment.",
         "\x1b[91m",
         f"Error connecting to Zulip server: {server_connection_error}.\x1b[0m",
     ]
@@ -266,6 +269,7 @@ def test_warning_regarding_incomplete_theme(
         "   color depth setting '256' specified from default config.",
         "   notify setting 'disabled' specified from default config.",
         "   transparency setting 'disabled' specified from default config.",
+        "   external editor command '' specified from environment.",
         "\x1b[91m",
         f"Error connecting to Zulip server: {server_connection_error}.\x1b[0m",
     ]
@@ -486,6 +490,7 @@ def test_successful_main_function_with_config(
         "   color depth setting '256' specified in zuliprc file.",
         "   notify setting 'enabled' specified in zuliprc file.",
         "   transparency setting 'disabled' specified from default config.",
+        "   external editor command '' specified from environment.",
     ]
     assert lines == expected_lines
 

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -61,6 +61,7 @@ class TestController:
             color_depth=256,
             in_explore_mode=self.in_explore_mode,
             debug_path=None,
+            editor_command="",
             **dict(
                 autohide=self.autohide,
                 notify=self.notify_enabled,

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -428,6 +428,11 @@ KEY_BINDINGS: Dict[str, KeyBinding] = {
         'help_text': 'Insert new line',
         'key_category': 'compose_box',
     },
+    'OPEN_EXTERNAL_EDITOR': {
+        'keys': ['ctrl o'],
+        'help_text': 'Open an external editor to edit the message content',
+        'key_category': 'compose_box',
+    },
     'FULL_RENDERED_MESSAGE': {
         'keys': ['f'],
         'help_text': 'Show/hide full rendered message (from message information)',

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -69,6 +69,7 @@ class Controller:
         theme: ThemeSpec,
         color_depth: int,
         debug_path: Optional[str],
+        editor_command: str,
         in_explore_mode: bool,
         transparency: bool,
         autohide: bool,
@@ -84,6 +85,7 @@ class Controller:
         self.exit_confirmation = exit_confirmation
         self.notify_enabled = notify
         self.maximum_footlinks = maximum_footlinks
+        self.editor_command = editor_command
 
         self.debug_path = debug_path
 


### PR DESCRIPTION
Create a new command OPEN_IN_TERMINAL_EDITOR (default `ctrl o`) for editing the current message in terminal editor with python tempfile.

<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?

I am using helix as my terminal editor and when I write in terminal I found myself using it's shortcut. 

### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [x] Discussed in **#zulip-terminal** in `Composing in terminal editor #T1394`
- [ ] Fully fixes #
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [ ] Manually - Behavioral changes
- [x] Manually - Visual changes
- [ ] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [ ] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [ ] It contains test additions for any new behavior
- [ ] It flows clearly from a previous branch commit, and/or prepares for the next commit

### Visual changes    <!-- DELETE SECTION IF NO VISUAL CHANGE -->
<!-- Zulip tips at https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html -->
<!-- For video, try asciinema; after uploading, embed using
[![yourtitle](https://asciinema.org/a/<id>.png)](https://asciinema.org/a/<id>)
-->

[![Composing in terminal editor](https://asciinema.org/a/3CsC3bfnwZl2gZFHYoxSP22tM.png)](https://asciinema.org/a/3CsC3bfnwZl2gZFHYoxSP22tM)