### PR TITLE
Migrated get_next_unread_pm and tests to model.

### DIFF
--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -3744,24 +3744,33 @@ class TestModel:
 
         assert unread_topic == next_unread_topic
 
-    def test_get_next_unread_pm(self, model):
-        model.unread_counts = {"unread_pms": {1: 1, 2: 1}}
-        return_value = model.get_next_unread_pm()
-        assert return_value == 1
-        assert model.last_unread_pm == 1
+    @pytest.mark.parametrize(
+        "unread_pms, last_unread_pm, next_unread_pm",
+        [
+            case(
+                {(1, "pm"), (2, "pm2")},
+                None,
+                (1, "pm"),
+                id="unread_present_after_no_state",
+            ),
+            case(
+                {(1, "pm"), (2, "pm2")},
+                (1, "pm"),
+                (2, "pm2"),
+                id="unread_present_after_previous_pm",
+            ),
+            case({}, None, None, id="no_unreads"),
+        ],
+    )
+    def test_get_next_unread_pm(
+        self, model, unread_pms, last_unread_pm, next_unread_pm
+    ):
+        model.unread_counts = {"unread_pms": {stream_pm: 1 for stream_pm in unread_pms}}
+        model.last_unread_pm = last_unread_pm
 
-    def test_get_next_unread_pm_again(self, model):
-        model.unread_counts = {"unread_pms": {1: 1, 2: 1}}
-        model.last_unread_pm = 1
-        return_value = model.get_next_unread_pm()
-        assert return_value == 2
-        assert model.last_unread_pm == 2
+        unread_pm = model.get_next_unread_pm()
 
-    def test_get_next_unread_pm_no_unread(self, model):
-        model.unread_counts = {"unread_pms": {}}
-        return_value = model.get_next_unread_pm()
-        assert return_value is None
-        assert model.last_unread_pm is None
+        assert unread_pm == next_unread_pm
 
     @pytest.mark.parametrize(
         "stream_id, expected_response",

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -916,12 +916,13 @@ class TestMiddleColumnView:
         mid_col_view.model.user_id_email_dict = {1: "EMAIL"}
         mid_col_view.model.get_next_unread_pm.return_value = 1
 
-        mid_col_view.keypress(size, key)
+        return_value = mid_col_view.keypress(size, key)
 
         mid_col_view.controller.narrow_to_user.assert_called_once_with(
             recipient_emails=["EMAIL"],
             contextual_message_id=1,
         )
+        assert return_value == key
 
     @pytest.mark.parametrize("key", keys_for_command("NEXT_UNREAD_PM"))
     def test_keypress_NEXT_UNREAD_PM_no_pm(
@@ -933,6 +934,7 @@ class TestMiddleColumnView:
 
         return_value = mid_col_view.keypress(size, key)
 
+        assert not mid_col_view.controller.narrow_to_user.called
         assert return_value == key
 
     @pytest.mark.parametrize("key", keys_for_command("PRIVATE_MESSAGE"))

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -616,6 +616,7 @@ class MiddleColumnView(urwid.Frame):
                 recipient_emails=[email],
                 contextual_message_id=pm,
             )
+            return key
         elif is_command_key("PRIVATE_MESSAGE", key):
             # Create new PM message
             self.footer.private_box_view()


### PR DESCRIPTION
<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?
This pull request Migrates get_next_unread_pm & tests to model.
Created this new version to the pull request to make it cleaner by splitting the changes into two commits.
This is a precursor for improving the get_next_unread_pm method.
Fixes #1335 


### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [ ] Discussed in **#zulip-terminal** in `topic`
- [x] Fully fixes #1335 
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [x] Merge will enable work on #1336 

### How did you test this?
<!-- [x] all that apply -->
- [ ] Manually - Behavioral changes
- [ ] Manually - Visual changes
- [ ] Adapting existing automated tests
- [x] Adding automated tests for new behavior (or missing tests)
- [x] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [ ] It contains test additions for any new behavior
- [ ] It flows clearly from a previous branch commit, and/or prepares for the next commit

