### PR TITLE
Bugfix for previous refactor

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -80,8 +80,10 @@ class TestMessageView:
         assert msg_view.old_loading is False
         assert msg_view.new_loading is False
 
-    @pytest.mark.parametrize("narrow_focus_pos, focus_msg", [(set(), 1), (0, 0)])
-    def test_main_view(self, mocker, narrow_focus_pos, focus_msg):
+    @pytest.mark.parametrize(
+        "narrow_focus_pos, expected_focus_msg", [(None, 1), (0, 0)]
+    )
+    def test_main_view(self, mocker, narrow_focus_pos, expected_focus_msg):
         mocker.patch(MESSAGEVIEW + ".read_message")
         self.urwid.SimpleFocusListWalker.return_value = mocker.Mock()
         mocker.patch(MESSAGEVIEW + ".set_focus")
@@ -91,7 +93,7 @@ class TestMessageView:
 
         msg_view = MessageView(self.model, self.view)
 
-        assert msg_view.focus_msg == focus_msg
+        assert msg_view.focus_msg == expected_focus_msg
 
     @pytest.mark.parametrize(
         "messages_fetched",

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -121,7 +121,7 @@ class MessageView(urwid.ListBox):
     def main_view(self) -> List[Any]:
         msg_btn_list = create_msg_box_list(self.model)
         focus_msg = self.model.get_focus_in_current_narrow()
-        if focus_msg == set():
+        if focus_msg is None:
             focus_msg = len(msg_btn_list) - 1
         self.focus_msg = focus_msg
         return msg_btn_list


### PR DESCRIPTION
<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?

This is expected to be a bugfix for a missing part of the refactor in #1393, which causes a crash with no unread messages, as pointed out by @theViz343 :+1:

This fix was delayed due to observing other issues, which took longer to fix so are now deferred to another PR.

### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [x] Discussed in **#zulip-terminal** in `ZT crashes when there is no unread messages`
- [ ] Fully fixes #
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [x] Is a follow-up to work in PR #1393 
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [x] Manually - Behavioral changes
- [ ] Manually - Visual changes
- [x] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [ ] It contains test additions for any new behavior
- [ ] It flows clearly from a previous branch commit, and/or prepares for the next commit
