### PR TITLE
Improve event API typing & apply to model

### DIFF
--- a/zulipterminal/api_types.py
+++ b/zulipterminal/api_types.py
@@ -88,6 +88,19 @@ class StreamComposition(TypedDict):
 Composition = Union[PrivateComposition, StreamComposition]
 
 ###############################################################################
+# Parameters to pass in request to:
+#   https://zulip.com/api/update-message-flags
+
+MessageFlagStatusChange = Literal["add", "remove"]
+
+
+class MessagesFlagChange(TypedDict):
+    messages: List[int]
+    op: MessageFlagStatusChange
+    flag: ModifiableMessageFlag
+
+
+###############################################################################
 # Parameter to pass in request to:
 #   https://zulip.com/api/update-message
 
@@ -369,11 +382,13 @@ class TypingEvent(TypedDict):
 
 # -----------------------------------------------------------------------------
 # See https://zulip.com/api/get-events#update_message_flags-add and -remove
+
+
 class UpdateMessageFlagsEvent(TypedDict):
     type: Literal["update_message_flags"]
     messages: List[int]
-    operation: str  # NOTE: deprecated in Zulip 4.0 / ZFL 32 -> 'op'
-    op: str
+    operation: MessageFlagStatusChange  # NOTE: deprecated in Zulip 4.0 / ZFL 32 -> 'op'
+    op: MessageFlagStatusChange
     flag: ModifiableMessageFlag
     all: bool
 

--- a/zulipterminal/api_types.py
+++ b/zulipterminal/api_types.py
@@ -257,12 +257,16 @@ class RealmUser(TypedDict):
 # (also helper data structures not used elsewhere)
 
 
+# -----------------------------------------------------------------------------
+# See https://zulip.com/api/get-events#message
 class MessageEvent(TypedDict):
     type: Literal["message"]
     message: Message
     flags: List[MessageFlag]
 
 
+# -----------------------------------------------------------------------------
+# See https://zulip.com/api/get-events#update_message
 class UpdateMessageEvent(TypedDict):
     type: Literal["update_message"]
     message_id: int
@@ -277,6 +281,8 @@ class UpdateMessageEvent(TypedDict):
     stream_id: int
 
 
+# -----------------------------------------------------------------------------
+# See https://zulip.com/api/get-events#reaction-add and -remove
 class ReactionEvent(TypedDict):
     type: Literal["reaction"]
     op: str
@@ -287,6 +293,8 @@ class ReactionEvent(TypedDict):
     message_id: int
 
 
+# -----------------------------------------------------------------------------
+# See https://zulip.com/api/get-events#realm_user-add and -remove
 class RealmUserEventPerson(TypedDict):
     user_id: int
 
@@ -320,6 +328,9 @@ class RealmUserEvent(TypedDict):
     person: RealmUserEventPerson
 
 
+# -----------------------------------------------------------------------------
+# See https://zulip.com/api/get-events#subscription-update
+# (also -peer_add and -peer_remove; FIXME: -add & -remove are not yet supported)
 class SubscriptionEvent(TypedDict):
     type: Literal["subscription"]
     op: str
@@ -335,12 +346,16 @@ class SubscriptionEvent(TypedDict):
     message_ids: List[int]  # Present when subject of msg(s) is updated
 
 
+# -----------------------------------------------------------------------------
+# See https://zulip.com/api/get-events#typing-start and -stop
 class TypingEvent(TypedDict):
     type: Literal["typing"]
     sender: Dict[str, Any]  # 'email', ...
     op: str
 
 
+# -----------------------------------------------------------------------------
+# See https://zulip.com/api/get-events#update_message_flags-add and -remove
 class UpdateMessageFlagsEvent(TypedDict):
     type: Literal["update_message_flags"]
     messages: List[int]
@@ -350,12 +365,16 @@ class UpdateMessageFlagsEvent(TypedDict):
     all: bool
 
 
+# -----------------------------------------------------------------------------
+# See https://zulip.com/api/get-events#update_display_settings
 class UpdateDisplaySettings(TypedDict):
     type: Literal["update_display_settings"]
     setting_name: str
     setting: bool
 
 
+# -----------------------------------------------------------------------------
+# See https://zulip.com/api/get-events#realm_emoji-update
 class RealmEmojiData(TypedDict):
     id: str
     name: str
@@ -370,6 +389,8 @@ class UpdateRealmEmojiEvent(TypedDict):
     realm_emoji: Dict[str, RealmEmojiData]
 
 
+# -----------------------------------------------------------------------------
+# See https://zulip.com/api/get-events#user_settings-update
 # This is specifically only those supported by ZT
 SupportedUserSettings = Literal["send_private_typing_notifications"]
 
@@ -381,6 +402,8 @@ class UpdateUserSettingsEvent(TypedDict):
     value: Any
 
 
+# -----------------------------------------------------------------------------
+# See https://zulip.com/api/get-events#update_global_notifications
 # This is specifically only those supported by ZT
 SupportedGlobalNotificationSettings = Literal["pm_content_in_desktop_notifications"]
 
@@ -391,6 +414,7 @@ class UpdateGlobalNotificationsEvent(TypedDict):
     setting: Any
 
 
+# -----------------------------------------------------------------------------
 Event = Union[
     MessageEvent,
     UpdateMessageEvent,

--- a/zulipterminal/api_types.py
+++ b/zulipterminal/api_types.py
@@ -348,10 +348,23 @@ class SubscriptionEvent(TypedDict):
 
 # -----------------------------------------------------------------------------
 # See https://zulip.com/api/get-events#typing-start and -stop
+class _TypingEventUser(TypedDict):
+    user_id: int
+    email: str
+
+
 class TypingEvent(TypedDict):
     type: Literal["typing"]
-    sender: Dict[str, Any]  # 'email', ...
-    op: str
+    op: TypingStatusChange
+    sender: _TypingEventUser
+
+    # Unused as yet
+    # Pre Zulip 4.0, always present; now only present if message_type == "private"
+    # recipients: List[_TypingEventUser]
+    # NOTE: These fields are all new in Zulip 4.0 / ZFL 58, if client capability sent
+    # message_type: NotRequired[MessageType]
+    # stream_id: NotRequired[int]  # Only present if message_type == "stream"
+    # topic: NotRequired[str]  # Only present if message_type == "stream"
 
 
 # -----------------------------------------------------------------------------

--- a/zulipterminal/api_types.py
+++ b/zulipterminal/api_types.py
@@ -394,14 +394,6 @@ class UpdateMessageFlagsEvent(TypedDict):
 
 
 # -----------------------------------------------------------------------------
-# See https://zulip.com/api/get-events#update_display_settings
-class UpdateDisplaySettings(TypedDict):
-    type: Literal["update_display_settings"]
-    setting_name: str
-    setting: bool
-
-
-# -----------------------------------------------------------------------------
 # See https://zulip.com/api/get-events#realm_emoji-update
 class RealmEmojiData(TypedDict):
     id: str
@@ -443,6 +435,18 @@ class UpdateGlobalNotificationsEvent(TypedDict):
 
 
 # -----------------------------------------------------------------------------
+# See https://zulip.com/api/get-events#update_display_settings
+# This is specifically only those supported by ZT
+SupportedDisplaySettings = Literal["twenty_four_hour_time"]
+
+
+class UpdateDisplaySettingsEvent(TypedDict):
+    type: Literal["update_display_settings"]
+    setting_name: SupportedDisplaySettings
+    setting: bool
+
+
+# -----------------------------------------------------------------------------
 Event = Union[
     MessageEvent,
     UpdateMessageEvent,
@@ -450,7 +454,7 @@ Event = Union[
     SubscriptionEvent,
     TypingEvent,
     UpdateMessageFlagsEvent,
-    UpdateDisplaySettings,
+    UpdateDisplaySettingsEvent,
     UpdateRealmEmojiEvent,
     UpdateUserSettingsEvent,
     UpdateGlobalNotificationsEvent,

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -38,6 +38,7 @@ from zulipterminal.api_types import (
     DirectTypingNotification,
     EditPropagateMode,
     Event,
+    MessagesFlagChange,
     PrivateComposition,
     PrivateMessageUpdateRequest,
     RealmEmojiData,
@@ -493,11 +494,11 @@ class Model:
 
     @asynch
     def toggle_message_star_status(self, message: Message) -> None:
-        base_request = dict(flag="starred", messages=[message["id"]])
+        messages = [message["id"]]
         if "starred" in message["flags"]:
-            request = dict(base_request, op="remove")
+            request = MessagesFlagChange(messages=messages, flag="starred", op="remove")
         else:
-            request = dict(base_request, op="add")
+            request = MessagesFlagChange(messages=messages, flag="starred", op="add")
         response = self.client.update_message_flags(request)
         display_error_if_present(response, self.controller)
 
@@ -506,11 +507,7 @@ class Model:
         if not id_list:
             return
         response = self.client.update_message_flags(
-            {
-                "messages": id_list,
-                "flag": "read",
-                "op": "add",
-            }
+            MessagesFlagChange(messages=id_list, flag="read", op="add")
         )
         display_error_if_present(response, self.controller)
 

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -46,6 +46,7 @@ from zulipterminal.api_types import (
     StreamComposition,
     StreamMessageUpdateRequest,
     Subscription,
+    SubscriptionSettingChange,
     TypingStatusChange,
 )
 from zulipterminal.config.keys import primary_key_for_command
@@ -1220,12 +1221,12 @@ class Model:
 
     def toggle_stream_muted_status(self, stream_id: int) -> None:
         request = [
-            {
-                "stream_id": stream_id,
-                "property": "is_muted",
-                "value": not self.is_muted_stream(stream_id)
+            SubscriptionSettingChange(
+                stream_id=stream_id,
+                property="is_muted",
+                value=not self.is_muted_stream(stream_id)
                 # True for muting and False for unmuting.
-            }
+            )
         ]
         response = self.client.update_subscription_settings(request)
         display_error_if_present(response, self.controller)
@@ -1251,11 +1252,11 @@ class Model:
 
     def toggle_stream_pinned_status(self, stream_id: int) -> bool:
         request = [
-            {
-                "stream_id": stream_id,
-                "property": "pin_to_top",
-                "value": not self.is_pinned_stream(stream_id),
-            }
+            SubscriptionSettingChange(
+                stream_id=stream_id,
+                property="pin_to_top",
+                value=not self.is_pinned_stream(stream_id),
+            )
         ]
         response = self.client.update_subscription_settings(request)
         return response["result"] == "success"
@@ -1268,11 +1269,11 @@ class Model:
 
     def toggle_stream_visual_notifications(self, stream_id: int) -> None:
         request = [
-            {
-                "stream_id": stream_id,
-                "property": "desktop_notifications",
-                "value": not self.is_visual_notifications_enabled(stream_id),
-            }
+            SubscriptionSettingChange(
+                stream_id=stream_id,
+                property="desktop_notifications",
+                value=not self.is_visual_notifications_enabled(stream_id),
+            )
         ]
         response = self.client.update_subscription_settings(request)
         display_error_if_present(response, self.controller)


### PR DESCRIPTION
<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?

This is a follow-up to #1384, reusing a typing notification literal in an event, and then applying similar principles to other events. This includes extracting some dicts to use to improve the calls to the API, which are often very similar, and otherwise currently untyped dicts.

This also adds some much-needed commented sub-structure for events, which now have various associated dicts or literals, and links to the appropriate place in the API docs.

### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [ ] Discussed in **#zulip-terminal** in `topic`
- [ ] Fully fixes #
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [ ] Manually - Behavioral changes
- [ ] Manually - Visual changes
- [ ] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [x] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [ ] It contains test additions for any new behavior
- [x] It flows clearly from a previous branch commit, and/or prepares for the next commit