### PR TITLE
Displays user information for sender of message on u hotkey

### DIFF
--- a/docs/hotkeys.md
+++ b/docs/hotkeys.md
@@ -58,6 +58,7 @@
 |Add/remove thumbs-up reaction to the current message|<kbd>+</kbd>|
 |Add/remove star status of the current message|<kbd>ctrl</kbd> + <kbd>s</kbd> / <kbd>*</kbd>|
 |Show/hide message information|<kbd>i</kbd>|
+|Show/hide message sender information|<kbd>u</kbd>|
 |Show/hide edit history (from message information)|<kbd>e</kbd>|
 |View current message in browser (from message information)|<kbd>v</kbd>|
 |Show/hide full rendered message (from message information)|<kbd>f</kbd>|

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -272,7 +272,7 @@ class TestUserInfoView:
         )
 
         self.user_info_view = UserInfoView(
-            self.controller, 10000, "User Info (up/down scrolls)"
+            self.controller, 10000, "User Info (up/down scrolls)", "USER_INFO"
         )
 
     @pytest.mark.parametrize(

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -264,6 +264,11 @@ KEY_BINDINGS: Dict[str, KeyBinding] = {
         'help_text': 'Show/hide message information',
         'key_category': 'msg_actions',
     },
+    'MSG_SENDER_INFO': {
+        'keys': ['u'],
+        'help_text': 'Show/hide message sender information',
+        'key_category': 'msg_actions',
+    },
     'EDIT_HISTORY': {
         'keys': ['e'],
         'help_text': 'Show/hide edit history (from message information)',

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -314,7 +314,9 @@ class Controller:
 
     def show_user_info(self, user_id: int) -> None:
         self.show_pop_up(
-            UserInfoView(self, user_id, "User Information (up/down scrolls)"),
+            UserInfoView(
+                self, user_id, "User Information (up/down scrolls)", "USER_INFO"
+            ),
             "area:user",
         )
 

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -320,6 +320,17 @@ class Controller:
             "area:user",
         )
 
+    def show_msg_sender_info(self, user_id: int) -> None:
+        self.show_pop_up(
+            UserInfoView(
+                self,
+                user_id,
+                "Message Sender Information (up/down scrolls)",
+                "MSG_SENDER_INFO",
+            ),
+            "area:user",
+        )
+
     def show_full_rendered_message(
         self,
         message: Message,

--- a/zulipterminal/ui_tools/messages.py
+++ b/zulipterminal/ui_tools/messages.py
@@ -1110,4 +1110,6 @@ class MessageBox(urwid.Pile):
             )
         elif is_command_key("ADD_REACTION", key):
             self.model.controller.show_emoji_picker(self.message)
+        elif is_command_key("MSG_SENDER_INFO", key):
+            self.model.controller.show_msg_sender_info(self.message["sender_id"])
         return key

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1083,7 +1083,7 @@ class AboutView(PopUpView):
 
 
 class UserInfoView(PopUpView):
-    def __init__(self, controller: Any, user_id: int, title: str) -> None:
+    def __init__(self, controller: Any, user_id: int, title: str, command: str) -> None:
         display_data = self._fetch_user_data(controller, user_id)
 
         user_details = [
@@ -1096,7 +1096,7 @@ class UserInfoView(PopUpView):
         )
         widgets = self.make_table_with_categories(user_view_content, column_widths)
 
-        super().__init__(controller, widgets, "USER_INFO", popup_width, title)
+        super().__init__(controller, widgets, command, popup_width, title)
 
     @staticmethod
     def _fetch_user_data(controller: Any, user_id: int) -> Dict[str, Any]:


### PR DESCRIPTION
<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?
This PR adds functionality which displays user information for the sender of a message when the 'u' hotkey is pressed on an active message box. This would match the behavior in the web app.

### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [ ] Discussed in **#zulip-terminal** in `topic`
- [x] Fully fixes #1397
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [x] Manually - Behavioral changes
- [x] Manually - Visual changes
- [x] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the motivation and reasoning for the change
- [x] It individually passes linting and tests
- [ ] It contains test additions for any new behavior
- [ ] It flows clearly from a previous branch commit, and/or prepares for the next commit

### Visual changes    <!-- DELETE SECTION IF NO VISUAL CHANGE -->
![Updated UI](https://github.com/zulip/zulip-terminal/assets/59661679/79df3003-397a-4c43-bd1e-fbe44926219f)

<!-- NOTE: Attached videos/images will be clearer from smaller terminal windows -->
