### PR TITLE
Add support for all streams

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -216,6 +216,7 @@ def general_stream() -> Dict[str, Any]:
         "pin_to_top": False,
         "stream_id": 1000,
         "is_muted": False,
+        "is_web_public": False,
         "audible_notifications": False,
         "description": "General Stream",
         "rendered_description": "General Stream",
@@ -245,6 +246,7 @@ def secret_stream() -> Dict[str, Any]:
         "rendered_description": "Some private stream",
         "color": "#ccc",  # Color in '#xxx' format
         "is_muted": False,
+        "is_web_public": False,
         "audible_notifications": False,
         "is_old_stream": True,
         "desktop_notifications": False,
@@ -325,6 +327,7 @@ def streams_fixture(
                 "email_address": f"stream{i}@example.com",
                 "subscribers": [1001, 11, 12],
                 "history_public_to_subscribers": True,
+                "is_web_public": False,
             }
         )
     return deepcopy(streams)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -299,12 +299,12 @@ def web_public_stream() -> Subscription:
 @pytest.fixture
 def get_stream_from_id_fixture(
     stream_id: int,
-    stream_dict: Dict[int, Subscription],
+    _subscribed_streams: Dict[int, Subscription],
     unsubscribed_streams_fixture: Dict[int, Subscription],
     never_subscribed_streams_fixture: Dict[int, Stream],
 ) -> Union[Subscription, Stream]:
-    if stream_id in stream_dict:
-        return stream_dict[stream_id]
+    if stream_id in _subscribed_streams:
+        return _subscribed_streams[stream_id]
     elif stream_id in unsubscribed_streams_fixture:
         return unsubscribed_streams_fixture[stream_id]
     else:
@@ -1278,7 +1278,7 @@ def never_subscribed_streams_fixture() -> Dict[int, Stream]:
 
 
 @pytest.fixture
-def stream_dict(streams_fixture: List[Subscription]) -> Dict[int, Subscription]:
+def _subscribed_streams(streams_fixture: List[Subscription]) -> Dict[int, Subscription]:
     return {stream["stream_id"]: stream for stream in streams_fixture}
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -207,7 +207,7 @@ def logged_on_user() -> Dict[str, Any]:
 
 
 @pytest.fixture
-def general_stream() -> Dict[str, Any]:
+def general_stream() -> Subscription:
     return {
         "name": "Some general stream",
         "date_created": 1472091253,
@@ -220,7 +220,6 @@ def general_stream() -> Dict[str, Any]:
         "audible_notifications": False,
         "description": "General Stream",
         "rendered_description": "General Stream",
-        "is_old_stream": True,
         "desktop_notifications": False,
         "stream_weekly_traffic": 0,
         "push_notifications": False,
@@ -228,13 +227,18 @@ def general_stream() -> Dict[str, Any]:
         "message_retention_days": 10,
         "subscribers": [1001, 11, 12],
         "history_public_to_subscribers": True,
+        "is_announcement_only": False,
+        "stream_post_policy": 0,
+        "first_message_id": 1,
+        "email_notifications": False,
+        "wildcard_mentions_notify": False,
     }
 
 
 # This is a private stream;
 # only description/stream_id/invite_only/name/color vary from above
 @pytest.fixture
-def secret_stream() -> Dict[str, Any]:
+def secret_stream() -> Subscription:
     return {
         "description": "Some private stream",
         "stream_id": 99,
@@ -248,19 +252,23 @@ def secret_stream() -> Dict[str, Any]:
         "is_muted": False,
         "is_web_public": False,
         "audible_notifications": False,
-        "is_old_stream": True,
         "desktop_notifications": False,
         "stream_weekly_traffic": 0,
         "message_retention_days": -1,
         "push_notifications": False,
         "subscribers": [1001, 11],
         "history_public_to_subscribers": False,
+        "is_announcement_only": False,
+        "stream_post_policy": 0,
+        "first_message_id": 1,
+        "email_notifications": False,
+        "wildcard_mentions_notify": False,
     }
 
 
 # Like public stream but with is_web_public=True
 @pytest.fixture
-def web_public_stream() -> Dict[str, Any]:
+def web_public_stream() -> Subscription:
     return {
         "description": "Some web public stream",
         "stream_id": 999,
@@ -273,7 +281,6 @@ def web_public_stream() -> Dict[str, Any]:
         "color": "#ddd",  # Color in '#xxx' format
         "is_muted": False,
         "audible_notifications": False,
-        "is_old_stream": True,
         "desktop_notifications": False,
         "stream_weekly_traffic": 0,
         "message_retention_days": -1,
@@ -281,16 +288,21 @@ def web_public_stream() -> Dict[str, Any]:
         "subscribers": [1001, 11],
         "history_public_to_subscribers": False,
         "is_web_public": True,
+        "is_announcement_only": False,
+        "stream_post_policy": 0,
+        "first_message_id": 1,
+        "email_notifications": False,
+        "wildcard_mentions_notify": False,
     }
 
 
 @pytest.fixture
 def get_stream_from_id_fixture(
     stream_id: int,
-    stream_dict: Dict[int, Any],
+    stream_dict: Dict[int, Subscription],
     unsubscribed_streams_fixture: Dict[int, Subscription],
     never_subscribed_streams_fixture: Dict[int, Stream],
-) -> Union[Subscription, Stream, Any]:
+) -> Union[Subscription, Stream]:
     if stream_id in stream_dict:
         return stream_dict[stream_id]
     elif stream_id in unsubscribed_streams_fixture:
@@ -301,10 +313,10 @@ def get_stream_from_id_fixture(
 
 @pytest.fixture
 def streams_fixture(
-    general_stream: Dict[str, Any],
-    secret_stream: Dict[str, Any],
-    web_public_stream: Dict[str, Any],
-) -> List[Dict[str, Any]]:
+    general_stream: Subscription,
+    secret_stream: Subscription,
+    web_public_stream: Subscription,
+) -> List[Subscription]:
     streams = [general_stream, secret_stream, web_public_stream]
     for i in range(1, 3):
         streams.append(
@@ -319,7 +331,6 @@ def streams_fixture(
                 "audible_notifications": False,
                 "description": f"A description of stream {i}",
                 "rendered_description": f"A description of stream {i}",
-                "is_old_stream": True,
                 "desktop_notifications": False,
                 "stream_weekly_traffic": 0,
                 "push_notifications": False,
@@ -328,6 +339,11 @@ def streams_fixture(
                 "subscribers": [1001, 11, 12],
                 "history_public_to_subscribers": True,
                 "is_web_public": False,
+                "is_announcement_only": False,
+                "stream_post_policy": 0,
+                "first_message_id": 1,
+                "email_notifications": False,
+                "wildcard_mentions_notify": False,
             }
         )
     return deepcopy(streams)
@@ -648,7 +664,7 @@ def mentioned_messages_combination(request: Any) -> Tuple[Set[int], Set[int]]:
 def initial_data(
     logged_on_user: Dict[str, Any],
     users_fixture: List[Dict[str, Any]],
-    streams_fixture: List[Dict[str, Any]],
+    streams_fixture: List[Dict[str, Subscription]],
     realm_emojis: Dict[str, Dict[str, Any]],
 ) -> Dict[str, Any]:
     """
@@ -1262,7 +1278,7 @@ def never_subscribed_streams_fixture() -> Dict[int, Stream]:
 
 
 @pytest.fixture
-def stream_dict(streams_fixture: List[Dict[str, Any]]) -> Dict[int, Any]:
+def stream_dict(streams_fixture: List[Subscription]) -> Dict[int, Subscription]:
     return {stream["stream_id"]: stream for stream in streams_fixture}
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ import pytest
 from pytest_mock import MockerFixture
 from urwid import Widget
 
-from zulipterminal.api_types import Message, MessageType
+from zulipterminal.api_types import Message, MessageType, Stream, Subscription
 from zulipterminal.config.keys import (
     ZT_TO_URWID_CMD_MAPPING,
     keys_for_command,
@@ -280,6 +280,21 @@ def web_public_stream() -> Dict[str, Any]:
         "history_public_to_subscribers": False,
         "is_web_public": True,
     }
+
+
+@pytest.fixture
+def get_stream_from_id_fixture(
+    stream_id: int,
+    stream_dict: Dict[int, Any],
+    unsubscribed_streams_fixture: Dict[int, Subscription],
+    never_subscribed_streams_fixture: Dict[int, Stream],
+) -> Union[Subscription, Stream, Any]:
+    if stream_id in stream_dict:
+        return stream_dict[stream_id]
+    elif stream_id in unsubscribed_streams_fixture:
+        return unsubscribed_streams_fixture[stream_id]
+    else:
+        return never_subscribed_streams_fixture[stream_id]
 
 
 @pytest.fixture
@@ -1186,6 +1201,61 @@ def user_id(logged_on_user: Dict[str, Any]) -> int:
     according to current Fixtures.
     """
     return logged_on_user["user_id"]
+
+
+@pytest.fixture
+def unsubscribed_streams_fixture() -> Dict[int, Subscription]:
+    unsubscribed_streams: Dict[int, Subscription] = {}
+    for i in range(3, 5):
+        unsubscribed_streams[i] = {
+            "name": f"Stream {i}",
+            "date_created": 1472047124 + i,
+            "invite_only": False,
+            "color": "#b0a5fd",
+            "pin_to_top": False,
+            "stream_id": i,
+            "is_muted": False,
+            "audible_notifications": False,
+            "description": f"A description of stream {i}",
+            "rendered_description": f"A description of stream {i}",
+            "desktop_notifications": False,
+            "stream_weekly_traffic": 0,
+            "push_notifications": False,
+            "message_retention_days": i + 30,
+            "email_address": f"stream{i}@example.com",
+            "email_notifications": False,
+            "wildcard_mentions_notify": False,
+            "subscribers": [1001, 11, 12],
+            "history_public_to_subscribers": True,
+            "is_announcement_only": True,
+            "stream_post_policy": 0,
+            "is_web_public": True,
+            "first_message_id": None,
+        }
+    return deepcopy(unsubscribed_streams)
+
+
+@pytest.fixture
+def never_subscribed_streams_fixture() -> Dict[int, Stream]:
+    never_subscribed_streams: Dict[int, Stream] = {}
+    for i in range(5, 7):
+        never_subscribed_streams[i] = {
+            "name": f"Stream {i}",
+            "date_created": 1472047124 + i,
+            "invite_only": False,
+            "stream_id": i,
+            "description": f"A description of stream {i}",
+            "rendered_description": f"A description of stream {i}",
+            "stream_weekly_traffic": 0,
+            "message_retention_days": i + 30,
+            "subscribers": [1001, 11, 12],
+            "history_public_to_subscribers": True,
+            "is_announcement_only": True,
+            "stream_post_policy": 0,
+            "is_web_public": True,
+            "first_message_id": None,
+        }
+    return deepcopy(never_subscribed_streams)
 
 
 @pytest.fixture

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -9,6 +9,7 @@ import pytest
 from pytest import param as case
 from pytest_mock import MockerFixture
 
+from zulipterminal.api_types import Subscription
 from zulipterminal.config.themes import generate_theme
 from zulipterminal.core import Controller
 from zulipterminal.helper import Index
@@ -124,6 +125,7 @@ class TestController:
         mocker: MockerFixture,
         controller: Controller,
         index_stream: Index,
+        general_stream: Subscription,
         stream_id: int = 205,
         stream_name: str = "PTEST",
     ) -> None:
@@ -131,11 +133,14 @@ class TestController:
         controller.model.index = index_stream
         controller.view.message_view = mocker.patch("urwid.ListBox")
         controller.model.stream_dict = {
-            stream_id: {
+            stream_id: general_stream,
+        }
+        controller.model.stream_dict[stream_id].update(
+            {
                 "color": "#ffffff",
                 "name": stream_name,
             }
-        }
+        )
         controller.model._unsubscribed_streams = {}
         controller.model._never_subscribed_streams = {}
         controller.model.muted_streams = set()
@@ -173,6 +178,7 @@ class TestController:
         initial_stream_id: Optional[int],
         anchor: Optional[int],
         expected_final_focus: int,
+        general_stream: Subscription,
         stream_name: str = "PTEST",
         topic_name: str = "Test",
         stream_id: int = 205,
@@ -186,11 +192,14 @@ class TestController:
         controller.model.stream_id = initial_stream_id
         controller.view.message_view = mocker.patch("urwid.ListBox")
         controller.model.stream_dict = {
-            stream_id: {
+            stream_id: general_stream,
+        }
+        controller.model.stream_dict[stream_id].update(
+            {
                 "color": "#ffffff",
                 "name": stream_name,
             }
-        }
+        )
         controller.model._unsubscribed_streams = {}
         controller.model._never_subscribed_streams = {}
         controller.model.muted_streams = set()
@@ -250,6 +259,7 @@ class TestController:
         controller: Controller,
         index_all_messages: Index,
         anchor: Optional[int],
+        general_stream: Subscription,
         expected_final_focus_msg_id: int,
     ) -> None:
         controller.model.narrow = [["stream", "PTEST"]]
@@ -258,10 +268,13 @@ class TestController:
         controller.model.user_email = "some@email"
         controller.model.user_id = 1
         controller.model.stream_dict = {
-            205: {
+            205: general_stream,
+        }
+        controller.model.stream_dict[205].update(
+            {
                 "color": "#ffffff",
             }
-        }
+        )
         controller.model.muted_streams = set()
         mocker.patch(MODEL + ".is_muted_topic", return_value=False)
 
@@ -297,7 +310,11 @@ class TestController:
         assert msg_ids == id_list
 
     def test_narrow_to_all_starred(
-        self, mocker: MockerFixture, controller: Controller, index_all_starred: Index
+        self,
+        mocker: MockerFixture,
+        controller: Controller,
+        index_all_starred: Index,
+        general_stream: Subscription,
     ) -> None:
         controller.model.narrow = []
         controller.model.index = index_all_starred
@@ -307,10 +324,13 @@ class TestController:
         mocker.patch(MODEL + ".is_muted_topic", return_value=False)
         controller.model.user_email = "some@email"
         controller.model.stream_dict = {
-            205: {
+            205: general_stream,
+        }
+        controller.model.stream_dict[205].update(
+            {
                 "color": "#ffffff",
             }
-        }
+        )
         controller.view.message_view = mocker.patch("urwid.ListBox")
 
         controller.narrow_to_all_starred()  # FIXME: Add id narrowing test
@@ -324,7 +344,11 @@ class TestController:
         assert msg_ids == id_list
 
     def test_narrow_to_all_mentions(
-        self, mocker: MockerFixture, controller: Controller, index_all_mentions: Index
+        self,
+        mocker: MockerFixture,
+        controller: Controller,
+        index_all_mentions: Index,
+        general_stream: Subscription,
     ) -> None:
         controller.model.narrow = []
         controller.model.index = index_all_mentions
@@ -334,10 +358,13 @@ class TestController:
         controller.model.user_email = "some@email"
         controller.model.user_id = 1
         controller.model.stream_dict = {
-            205: {
+            205: general_stream,
+        }
+        controller.model.stream_dict[205].update(
+            {
                 "color": "#ffffff",
             }
-        }
+        )
         controller.view.message_view = mocker.patch("urwid.ListBox")
 
         controller.narrow_to_all_mentions()  # FIXME: Add id narrowing test

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -132,10 +132,10 @@ class TestController:
         controller.model.narrow = []
         controller.model.index = index_stream
         controller.view.message_view = mocker.patch("urwid.ListBox")
-        controller.model.stream_dict = {
+        controller.model._subscribed_streams = {
             stream_id: general_stream,
         }
-        controller.model.stream_dict[stream_id].update(
+        controller.model._subscribed_streams[stream_id].update(
             {
                 "color": "#ffffff",
                 "name": stream_name,
@@ -191,10 +191,10 @@ class TestController:
         controller.model.index = index_multiple_topic_msg
         controller.model.stream_id = initial_stream_id
         controller.view.message_view = mocker.patch("urwid.ListBox")
-        controller.model.stream_dict = {
+        controller.model._subscribed_streams = {
             stream_id: general_stream,
         }
-        controller.model.stream_dict[stream_id].update(
+        controller.model._subscribed_streams[stream_id].update(
             {
                 "color": "#ffffff",
                 "name": stream_name,
@@ -267,10 +267,10 @@ class TestController:
         controller.view.message_view = mocker.patch("urwid.ListBox")
         controller.model.user_email = "some@email"
         controller.model.user_id = 1
-        controller.model.stream_dict = {
+        controller.model._subscribed_streams = {
             205: general_stream,
         }
-        controller.model.stream_dict[205].update(
+        controller.model._subscribed_streams[205].update(
             {
                 "color": "#ffffff",
             }
@@ -323,10 +323,10 @@ class TestController:
         # FIXME: Expand upon is_muted_topic().
         mocker.patch(MODEL + ".is_muted_topic", return_value=False)
         controller.model.user_email = "some@email"
-        controller.model.stream_dict = {
+        controller.model._subscribed_streams = {
             205: general_stream,
         }
-        controller.model.stream_dict[205].update(
+        controller.model._subscribed_streams[205].update(
             {
                 "color": "#ffffff",
             }
@@ -357,10 +357,10 @@ class TestController:
         mocker.patch(MODEL + ".is_muted_topic", return_value=False)
         controller.model.user_email = "some@email"
         controller.model.user_id = 1
-        controller.model.stream_dict = {
+        controller.model._subscribed_streams = {
             205: general_stream,
         }
-        controller.model.stream_dict[205].update(
+        controller.model._subscribed_streams[205].update(
             {
                 "color": "#ffffff",
             }

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -136,6 +136,8 @@ class TestController:
                 "name": stream_name,
             }
         }
+        controller.model._unsubscribed_streams = {}
+        controller.model._never_subscribed_streams = {}
         controller.model.muted_streams = set()
         mocker.patch(MODEL + ".is_muted_topic", return_value=False)
 
@@ -189,6 +191,8 @@ class TestController:
                 "name": stream_name,
             }
         }
+        controller.model._unsubscribed_streams = {}
+        controller.model._never_subscribed_streams = {}
         controller.model.muted_streams = set()
         mocker.patch(MODEL + ".is_muted_topic", return_value=False)
 

--- a/tests/helper/test_helper.py
+++ b/tests/helper/test_helper.py
@@ -278,18 +278,21 @@ def test_powerset(
 def test_classify_unread_counts(
     mocker: MockerFixture,
     initial_data: Dict[str, Any],
-    stream_dict: Dict[int, Subscription],
+    _subscribed_streams: Dict[int, Subscription],
     classified_unread_counts: Dict[str, Any],
     muted_topics: List[List[str]],
     muted_streams: Set[int],
     vary_in_unreads: Dict[str, Any],
 ) -> None:
     model = mocker.Mock()
-    model.stream_dict = stream_dict
+    model._subscribed_streams = _subscribed_streams
     model.initial_data = initial_data
     model.is_muted_topic = mocker.Mock(
         side_effect=(
-            lambda stream_id, topic: [model.stream_dict[stream_id]["name"], topic]
+            lambda stream_id, topic: [
+                model._subscribed_streams[stream_id]["name"],
+                topic,
+            ]
             in muted_topics
         )
     )

--- a/tests/helper/test_helper.py
+++ b/tests/helper/test_helper.py
@@ -4,7 +4,7 @@ import pytest
 from pytest import param as case
 from pytest_mock import MockerFixture
 
-from zulipterminal.api_types import Composition
+from zulipterminal.api_types import Composition, Subscription
 from zulipterminal.config.keys import primary_key_for_command
 from zulipterminal.helper import (
     Index,
@@ -278,7 +278,7 @@ def test_powerset(
 def test_classify_unread_counts(
     mocker: MockerFixture,
     initial_data: Dict[str, Any],
-    stream_dict: Dict[int, Dict[str, Any]],
+    stream_dict: Dict[int, Subscription],
     classified_unread_counts: Dict[str, Any],
     muted_topics: List[List[str]],
     muted_streams: Set[int],

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -1973,6 +1973,89 @@ class TestModel:
         assert model.is_stream_web_public(stream_id) == expected_value
         model._get_stream_from_id.assert_called_once()
 
+    @pytest.mark.parametrize(
+        "stream_id, to_vary, expected_value",
+        [
+            case(
+                1000,
+                {
+                    "message_retention_days": None,
+                },
+                None,
+            ),
+            case(
+                3,
+                {
+                    "message_retention_days": 33,
+                },
+                33,
+            ),
+            case(
+                5,
+                {
+                    "message_retention_days": 35,
+                },
+                35,
+            ),
+        ],
+    )
+    def test_get_stream_message_retention_days(
+        self,
+        model,
+        mocker,
+        get_stream_from_id_fixture,
+        stream_id,
+        to_vary,
+        expected_value,
+    ):
+        get_stream_from_id_fixture.update(to_vary)
+        mocker.patch(
+            MODEL + "._get_stream_from_id", return_value=get_stream_from_id_fixture
+        )
+        assert model.get_stream_message_retention_days(stream_id) == expected_value
+        model._get_stream_from_id.assert_called_once()
+
+    @pytest.mark.parametrize(
+        "stream_id, to_vary",
+        [
+            case(
+                1000,
+                {
+                    "message_retention_days": None,
+                },
+            ),
+            case(
+                3,
+                {
+                    "message_retention_days": 33,
+                },
+            ),
+            case(
+                5,
+                {
+                    "message_retention_days": 35,
+                },
+            ),
+        ],
+    )
+    def test_set_stream_message_retention_days(
+        self,
+        model,
+        mocker,
+        get_stream_from_id_fixture,
+        stream_id,
+        to_vary,
+        value_to_be_changed=30,
+    ):
+        get_stream_from_id_fixture.update(to_vary)
+        mocker.patch(
+            MODEL + "._get_stream_from_id", return_value=get_stream_from_id_fixture
+        )
+
+        model.set_stream_message_retention_days(stream_id, value_to_be_changed)
+        model._get_stream_from_id.assert_called_once()
+        assert model.get_stream_message_retention_days(stream_id) == 30
+
     @pytest.mark.parametrize("muted", powerset([99, 1000]))
     @pytest.mark.parametrize("visual_notification_enabled", powerset([99, 1000]))
     def test__subscribe_to_streams(

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -2248,6 +2248,37 @@ class TestModel:
         assert model.get_stream_weekly_traffic(stream_id) == expected_value
         model._get_stream_from_id.assert_called_once()
 
+    @pytest.mark.parametrize(
+        "stream_id, expected_value",
+        [
+            case(
+                1000,
+                "General Stream",
+            ),
+            case(
+                3,
+                "A description of stream 3",
+            ),
+            case(
+                5,
+                "A description of stream 5",
+            ),
+        ],
+    )
+    def test_get_stream_rendered_description(
+        self,
+        model,
+        mocker,
+        get_stream_from_id_fixture,
+        stream_id,
+        expected_value,
+    ):
+        mocker.patch(
+            MODEL + "._get_stream_from_id", return_value=get_stream_from_id_fixture
+        )
+        assert model.get_stream_rendered_description(stream_id) == expected_value
+        model._get_stream_from_id.assert_called_once()
+
     @pytest.mark.parametrize("muted", powerset([99, 1000]))
     @pytest.mark.parametrize("visual_notification_enabled", powerset([99, 1000]))
     def test__subscribe_to_streams(

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -2279,6 +2279,15 @@ class TestModel:
         assert model.get_stream_rendered_description(stream_id) == expected_value
         model._get_stream_from_id.assert_called_once()
 
+    def test_get_all_subscription_ids(
+        self,
+        model,
+        stream_dict,
+        expected_value=[1000, 99, 999, 1, 2],
+    ):
+        model.stream_dict = stream_dict
+        assert model.get_all_subscription_ids() == expected_value
+
     @pytest.mark.parametrize("muted", powerset([99, 1000]))
     @pytest.mark.parametrize("visual_notification_enabled", powerset([99, 1000]))
     def test__subscribe_to_streams(

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -2091,6 +2091,46 @@ class TestModel:
         assert model.is_stream_invite_only(stream_id) == expected_value
         model._get_stream_from_id.assert_called_once()
 
+    @pytest.mark.parametrize(
+        "stream_id, to_vary, expected_value",
+        [
+            case(
+                1000,
+                {},
+                None,
+            ),
+            case(
+                3,
+                {
+                    "stream_post_policy": 1,
+                },
+                1,
+            ),
+            case(
+                5,
+                {
+                    "stream_post_policy": 3,
+                },
+                3,
+            ),
+        ],
+    )
+    def test_get_stream_post_policy(
+        self,
+        model,
+        mocker,
+        get_stream_from_id_fixture,
+        stream_id,
+        to_vary,
+        expected_value,
+    ):
+        get_stream_from_id_fixture.update(to_vary)
+        mocker.patch(
+            MODEL + "._get_stream_from_id", return_value=get_stream_from_id_fixture
+        )
+        assert model.get_stream_post_policy(stream_id) == expected_value
+        model._get_stream_from_id.assert_called_once()
+
     @pytest.mark.parametrize("muted", powerset([99, 1000]))
     @pytest.mark.parametrize("visual_notification_enabled", powerset([99, 1000]))
     def test__subscribe_to_streams(

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -2279,6 +2279,21 @@ class TestModel:
         assert model.get_stream_rendered_description(stream_id) == expected_value
         model._get_stream_from_id.assert_called_once()
 
+    @pytest.mark.parametrize(
+        "stream_id, expected_value",
+        [
+            case(
+                1,
+                "#baf",
+            ),
+        ],
+    )
+    def test_get_subscription_color(
+        self, model, stream_dict, stream_id, expected_value
+    ):
+        model.stream_dict = stream_dict
+        assert model.get_subscription_color(stream_id) == expected_value
+
     def test_get_all_subscription_ids(
         self,
         model,

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -1847,6 +1847,89 @@ class TestModel:
         assert model.get_stream_subscribers(stream_id) == expected_value
         model._get_stream_from_id.assert_called_once()
 
+    @pytest.mark.parametrize(
+        "stream_id, to_vary, expected_value",
+        [
+            case(
+                1000,
+                {
+                    "date_created": None,
+                },
+                None,
+            ),
+            case(
+                3,
+                {
+                    "date_created": 1472047124,
+                },
+                1472047124,
+            ),
+            case(
+                5,
+                {
+                    "date_created": 1472423124,
+                },
+                1472423124,
+            ),
+        ],
+    )
+    def test_get_stream_date_created(
+        self,
+        model,
+        mocker,
+        get_stream_from_id_fixture,
+        stream_id,
+        to_vary,
+        expected_value,
+    ):
+        get_stream_from_id_fixture.update(to_vary)
+        mocker.patch(
+            MODEL + "._get_stream_from_id", return_value=get_stream_from_id_fixture
+        )
+        assert model.get_stream_date_created(stream_id) == expected_value
+        model._get_stream_from_id.assert_called_once()
+
+    @pytest.mark.parametrize(
+        "stream_id, to_vary",
+        [
+            case(
+                1000,
+                {
+                    "date_created": None,
+                },
+            ),
+            case(
+                3,
+                {
+                    "date_created": 1472047124,
+                },
+            ),
+            case(
+                5,
+                {
+                    "date_created": 1472423124,
+                },
+            ),
+        ],
+    )
+    def test_set_stream_date_created(
+        self,
+        model,
+        mocker,
+        get_stream_from_id_fixture,
+        stream_id,
+        to_vary,
+        value_to_be_changed=1400000000,
+    ):
+        get_stream_from_id_fixture.update(to_vary)
+        mocker.patch(
+            MODEL + "._get_stream_from_id", return_value=get_stream_from_id_fixture
+        )
+
+        model.set_stream_date_created(stream_id, value_to_be_changed)
+        model._get_stream_from_id.assert_called_once()
+        assert model.get_stream_date_created(stream_id) == 1400000000
+
     @pytest.mark.parametrize("muted", powerset([99, 1000]))
     @pytest.mark.parametrize("visual_notification_enabled", powerset([99, 1000]))
     def test__subscribe_to_streams(

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -2208,6 +2208,46 @@ class TestModel:
         )
         model._get_stream_from_id.assert_called_once()
 
+    @pytest.mark.parametrize(
+        "stream_id, to_vary, expected_value",
+        [
+            case(
+                1000,
+                {"stream_weekly_traffic": 100},
+                100,
+            ),
+            case(
+                3,
+                {
+                    "stream_weekly_traffic": 5,
+                },
+                5,
+            ),
+            case(
+                5,
+                {
+                    "stream_weekly_traffic": None,
+                },
+                None,
+            ),
+        ],
+    )
+    def test_get_stream_weekly_traffic(
+        self,
+        model,
+        mocker,
+        get_stream_from_id_fixture,
+        stream_id,
+        to_vary,
+        expected_value,
+    ):
+        get_stream_from_id_fixture.update(to_vary)
+        mocker.patch(
+            MODEL + "._get_stream_from_id", return_value=get_stream_from_id_fixture
+        )
+        assert model.get_stream_weekly_traffic(stream_id) == expected_value
+        model._get_stream_from_id.assert_called_once()
+
     @pytest.mark.parametrize("muted", powerset([99, 1000]))
     @pytest.mark.parametrize("visual_notification_enabled", powerset([99, 1000]))
     def test__subscribe_to_streams(

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -2171,6 +2171,43 @@ class TestModel:
         assert model.is_stream_announcement_only(stream_id) == expected_value
         model._get_stream_from_id.assert_called_once()
 
+    @pytest.mark.parametrize(
+        "stream_id, to_vary, expected_value",
+        [
+            case(
+                3,
+                {
+                    "history_public_to_subscribers": False,
+                },
+                False,
+            ),
+            case(
+                5,
+                {
+                    "history_public_to_subscribers": True,
+                },
+                True,
+            ),
+        ],
+    )
+    def test_is_stream_history_public_to_subscribers(
+        self,
+        model,
+        mocker,
+        get_stream_from_id_fixture,
+        stream_id,
+        to_vary,
+        expected_value,
+    ):
+        get_stream_from_id_fixture.update(to_vary)
+        mocker.patch(
+            MODEL + "._get_stream_from_id", return_value=get_stream_from_id_fixture
+        )
+        assert (
+            model.is_stream_history_public_to_subscribers(stream_id) == expected_value
+        )
+        model._get_stream_from_id.assert_called_once()
+
     @pytest.mark.parametrize("muted", powerset([99, 1000]))
     @pytest.mark.parametrize("visual_notification_enabled", powerset([99, 1000]))
     def test__subscribe_to_streams(

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -2131,6 +2131,46 @@ class TestModel:
         assert model.get_stream_post_policy(stream_id) == expected_value
         model._get_stream_from_id.assert_called_once()
 
+    @pytest.mark.parametrize(
+        "stream_id, to_vary, expected_value",
+        [
+            case(
+                1000,
+                {},
+                None,
+            ),
+            case(
+                3,
+                {
+                    "is_announcement_only": False,
+                },
+                False,
+            ),
+            case(
+                5,
+                {
+                    "is_announcement_only": True,
+                },
+                True,
+            ),
+        ],
+    )
+    def test_is_stream_announcement_only(
+        self,
+        model,
+        mocker,
+        get_stream_from_id_fixture,
+        stream_id,
+        to_vary,
+        expected_value,
+    ):
+        get_stream_from_id_fixture.update(to_vary)
+        mocker.patch(
+            MODEL + "._get_stream_from_id", return_value=get_stream_from_id_fixture
+        )
+        assert model.is_stream_announcement_only(stream_id) == expected_value
+        model._get_stream_from_id.assert_called_once()
+
     @pytest.mark.parametrize("muted", powerset([99, 1000]))
     @pytest.mark.parametrize("visual_notification_enabled", powerset([99, 1000]))
     def test__subscribe_to_streams(

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -2294,6 +2294,45 @@ class TestModel:
         model.stream_dict = stream_dict
         assert model.get_subscription_color(stream_id) == expected_value
 
+    @pytest.mark.parametrize(
+        "stream_id, expected_value",
+        [
+            case(
+                1000,
+                "general@example.comm",
+            ),
+            case(
+                3,
+                "stream3@example.com",
+            ),
+        ],
+    )
+    def test_get_subscription_email(
+        self,
+        model,
+        stream_dict,
+        unsubscribed_streams_fixture,
+        stream_id,
+        expected_value,
+    ):
+        model.stream_dict = stream_dict
+        model._unsubscribed_streams = unsubscribed_streams_fixture
+        assert model.get_subscription_email(stream_id) == expected_value
+
+    def test_get_subscription_email_not_subscribed(
+        self,
+        model,
+        stream_dict,
+        unsubscribed_streams_fixture,
+        stream_id=5,
+    ):
+        model.stream_dict = stream_dict
+        model._unsubscribed_streams = unsubscribed_streams_fixture
+        with pytest.raises(
+            RuntimeError, match=f"Stream with id {stream_id} is not subscribed to!"
+        ):
+            model.get_subscription_email(stream_id)
+
     def test_get_all_subscription_ids(
         self,
         model,

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -1779,6 +1779,32 @@ class TestModel:
         model._never_subscribed_streams = never_subscribed_streams_fixture
         assert model.get_all_stream_ids() == expected_value
 
+    @pytest.mark.parametrize(
+        "stream_id, expected_value",
+        [
+            case(
+                1000,
+                "Some general stream",
+            ),
+            case(
+                3,
+                "Stream 3",
+            ),
+            case(
+                5,
+                "Stream 5",
+            ),
+        ],
+    )
+    def test_get_stream_name(
+        self, model, mocker, get_stream_from_id_fixture, stream_id, expected_value
+    ):
+        mocker.patch(
+            MODEL + "._get_stream_from_id", return_value=get_stream_from_id_fixture
+        )
+        assert model.get_stream_name(stream_id) == expected_value
+        model._get_stream_from_id.assert_called_once()
+
     @pytest.mark.parametrize("muted", powerset([99, 1000]))
     @pytest.mark.parametrize("visual_notification_enabled", powerset([99, 1000]))
     def test__subscribe_to_streams(

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -2056,6 +2056,41 @@ class TestModel:
         model._get_stream_from_id.assert_called_once()
         assert model.get_stream_message_retention_days(stream_id) == 30
 
+    @pytest.mark.parametrize(
+        "stream_id, to_vary, expected_value",
+        [
+            case(
+                1000,
+                {
+                    "invite_only": False,
+                },
+                False,
+            ),
+            case(
+                3,
+                {
+                    "invite_only": True,
+                },
+                True,
+            ),
+        ],
+    )
+    def test_is_stream_invite_only(
+        self,
+        model,
+        mocker,
+        get_stream_from_id_fixture,
+        stream_id,
+        to_vary,
+        expected_value,
+    ):
+        get_stream_from_id_fixture.update(to_vary)
+        mocker.patch(
+            MODEL + "._get_stream_from_id", return_value=get_stream_from_id_fixture
+        )
+        assert model.is_stream_invite_only(stream_id) == expected_value
+        model._get_stream_from_id.assert_called_once()
+
     @pytest.mark.parametrize("muted", powerset([99, 1000]))
     @pytest.mark.parametrize("visual_notification_enabled", powerset([99, 1000]))
     def test__subscribe_to_streams(

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -1676,6 +1676,7 @@ class TestModel:
                     "pin_to_top": False,
                     "stream_id": 1000,
                     "is_muted": False,
+                    "is_web_public": False,
                     "audible_notifications": False,
                     "description": "General Stream",
                     "rendered_description": "General Stream",
@@ -1929,6 +1930,48 @@ class TestModel:
         model.set_stream_date_created(stream_id, value_to_be_changed)
         model._get_stream_from_id.assert_called_once()
         assert model.get_stream_date_created(stream_id) == 1400000000
+
+    @pytest.mark.parametrize(
+        "stream_id, to_vary, expected_value",
+        [
+            case(
+                1000,
+                {
+                    "is_web_public": False,
+                },
+                False,
+            ),
+            case(
+                3,
+                {
+                    "is_web_public": True,
+                },
+                True,
+            ),
+            case(
+                5,
+                {
+                    "is_web_public": False,
+                },
+                False,
+            ),
+        ],
+    )
+    def test_is_stream_web_public(
+        self,
+        model,
+        mocker,
+        get_stream_from_id_fixture,
+        stream_id,
+        to_vary,
+        expected_value,
+    ):
+        get_stream_from_id_fixture.update(to_vary)
+        mocker.patch(
+            MODEL + "._get_stream_from_id", return_value=get_stream_from_id_fixture
+        )
+        assert model.is_stream_web_public(stream_id) == expected_value
+        model._get_stream_from_id.assert_called_once()
 
     @pytest.mark.parametrize("muted", powerset([99, 1000]))
     @pytest.mark.parametrize("visual_notification_enabled", powerset([99, 1000]))

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -1663,6 +1663,122 @@ class TestModel:
         assert model.user_dict == user_dict
         assert model.users == user_list
 
+    @pytest.mark.parametrize(
+        "stream_id, expected_value",
+        [
+            case(
+                1000,
+                {
+                    "name": "Some general stream",
+                    "date_created": None,
+                    "invite_only": False,
+                    "color": "#baf",  # Color in '#xxxxxx' format
+                    "pin_to_top": False,
+                    "stream_id": 1000,
+                    "is_muted": False,
+                    "audible_notifications": False,
+                    "description": "General Stream",
+                    "rendered_description": "General Stream",
+                    "is_old_stream": True,
+                    "desktop_notifications": False,
+                    "stream_weekly_traffic": 0,
+                    "push_notifications": False,
+                    "email_address": "general@example.comm",
+                    "message_retention_days": None,
+                    "subscribers": [1001, 11, 12],
+                    "history_public_to_subscribers": True,
+                },
+            ),
+            case(
+                3,
+                {
+                    "name": "Stream 3",
+                    "date_created": 1472047127,
+                    "invite_only": False,
+                    "color": "#b0a5fd",
+                    "pin_to_top": False,
+                    "stream_id": 3,
+                    "is_muted": False,
+                    "audible_notifications": False,
+                    "description": "A description of stream 3",
+                    "rendered_description": "A description of stream 3",
+                    "desktop_notifications": False,
+                    "stream_weekly_traffic": 0,
+                    "push_notifications": False,
+                    "message_retention_days": 33,
+                    "email_address": "stream3@example.com",
+                    "email_notifications": False,
+                    "wildcard_mentions_notify": False,
+                    "subscribers": [1001, 11, 12],
+                    "history_public_to_subscribers": True,
+                    "is_announcement_only": True,
+                    "stream_post_policy": 0,
+                    "is_web_public": True,
+                    "first_message_id": None,
+                },
+            ),
+            case(
+                5,
+                {
+                    "name": "Stream 5",
+                    "date_created": 1472047129,
+                    "invite_only": False,
+                    "stream_id": 5,
+                    "description": "A description of stream 5",
+                    "rendered_description": "A description of stream 5",
+                    "stream_weekly_traffic": 0,
+                    "message_retention_days": 35,
+                    "subscribers": [1001, 11, 12],
+                    "history_public_to_subscribers": True,
+                    "is_announcement_only": True,
+                    "stream_post_policy": 0,
+                    "is_web_public": True,
+                    "first_message_id": None,
+                },
+            ),
+        ],
+    )
+    def test_get_stream_from_id(
+        self,
+        model,
+        stream_id,
+        expected_value,
+        stream_dict,
+        unsubscribed_streams_fixture,
+        never_subscribed_streams_fixture,
+    ):
+        model.stream_dict = stream_dict
+        model._unsubscribed_streams = unsubscribed_streams_fixture
+        model._never_subscribed_streams = never_subscribed_streams_fixture
+        assert model._get_stream_from_id(stream_id) == expected_value
+
+    def test_get_stream_from_id_nonexistent_stream(
+        self,
+        model,
+        stream_dict,
+        unsubscribed_streams_fixture,
+        never_subscribed_streams_fixture,
+        stream_id=231,  # id 231 does not belong to any stream
+    ):
+        model.stream_dict = stream_dict
+        model._unsubscribed_streams = unsubscribed_streams_fixture
+        model._never_subscribed_streams = never_subscribed_streams_fixture
+        with pytest.raises(RuntimeError):
+            model._get_stream_from_id(stream_id)
+
+    def test_get_all_stream_ids(
+        self,
+        model,
+        stream_dict,
+        unsubscribed_streams_fixture,
+        never_subscribed_streams_fixture,
+        expected_value=[1000, 99, 999, 1, 2, 3, 4, 5, 6],
+    ):
+        model.stream_dict = stream_dict
+        model._unsubscribed_streams = unsubscribed_streams_fixture
+        model._never_subscribed_streams = never_subscribed_streams_fixture
+        assert model.get_all_stream_ids() == expected_value
+
     @pytest.mark.parametrize("muted", powerset([99, 1000]))
     @pytest.mark.parametrize("visual_notification_enabled", powerset([99, 1000]))
     def test__subscribe_to_streams(

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -1680,7 +1680,6 @@ class TestModel:
                     "audible_notifications": False,
                     "description": "General Stream",
                     "rendered_description": "General Stream",
-                    "is_old_stream": True,
                     "desktop_notifications": False,
                     "stream_weekly_traffic": 0,
                     "push_notifications": False,
@@ -1688,6 +1687,11 @@ class TestModel:
                     "message_retention_days": None,
                     "subscribers": [1001, 11, 12],
                     "history_public_to_subscribers": True,
+                    "is_announcement_only": False,
+                    "stream_post_policy": 0,
+                    "first_message_id": 1,
+                    "email_notifications": False,
+                    "wildcard_mentions_notify": False,
                 },
             ),
             case(
@@ -2096,8 +2100,10 @@ class TestModel:
         [
             case(
                 1000,
-                {},
-                None,
+                {
+                    "stream_post_policy": 0,
+                },
+                0,
             ),
             case(
                 3,
@@ -2136,8 +2142,10 @@ class TestModel:
         [
             case(
                 1000,
-                {},
-                None,
+                {
+                    "is_announcement_only": True,
+                },
+                True,
             ),
             case(
                 3,

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -1805,6 +1805,48 @@ class TestModel:
         assert model.get_stream_name(stream_id) == expected_value
         model._get_stream_from_id.assert_called_once()
 
+    @pytest.mark.parametrize(
+        "stream_id, to_vary, expected_value",
+        [
+            case(
+                1000,
+                {
+                    "subscribers": [1001, 11, 12],
+                },
+                [1001, 11, 12],
+            ),
+            case(
+                3,
+                {
+                    "subscribers": [1001, 11, 12, 13],
+                },
+                [1001, 11, 12, 13],
+            ),
+            case(
+                5,
+                {
+                    "subscribers": [1001, 14],
+                },
+                [1001, 14],
+            ),
+        ],
+    )
+    def test_get_stream_subscribers(
+        self,
+        model,
+        mocker,
+        get_stream_from_id_fixture,
+        stream_id,
+        to_vary,
+        expected_value,
+    ):
+        get_stream_from_id_fixture.update(to_vary)
+        mocker.patch(
+            MODEL + "._get_stream_from_id", return_value=get_stream_from_id_fixture
+        )
+        assert model.get_stream_subscribers(stream_id) == expected_value
+        model._get_stream_from_id.assert_called_once()
+
     @pytest.mark.parametrize("muted", powerset([99, 1000]))
     @pytest.mark.parametrize("visual_notification_enabled", powerset([99, 1000]))
     def test__subscribe_to_streams(

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -666,7 +666,7 @@ class TestTopicsView:
     ):
         mocker.patch(SUBDIR + ".buttons.TopButton.__init__", return_value=None)
         set_focus_valign = mocker.patch(VIEWS + ".urwid.ListBox.set_focus_valign")
-        topic_view.view.controller.model.stream_dict = {86: {"name": "PTEST"}}
+        topic_view.view.controller.model._subscribed_streams = {86: {"name": "PTEST"}}
         topic_view.view.controller.model.is_muted_topic = mocker.Mock(
             return_value=False
         )
@@ -888,7 +888,7 @@ class TestMiddleColumnView:
         size = widget_size(mid_col_view)
         mocker.patch(MIDCOLVIEW + ".focus_position")
 
-        mid_col_view.model.stream_dict = {1: {"name": "stream"}}
+        mid_col_view.model._subscribed_streams = {1: {"name": "stream"}}
         mid_col_view.model.get_stream_name.return_value = "stream"
         mid_col_view.model.get_next_unread_topic.return_value = (1, "topic")
 

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -889,6 +889,7 @@ class TestMiddleColumnView:
         mocker.patch(MIDCOLVIEW + ".focus_position")
 
         mid_col_view.model.stream_dict = {1: {"name": "stream"}}
+        mid_col_view.model.get_stream_name.return_value = "stream"
         mid_col_view.model.get_next_unread_topic.return_value = (1, "topic")
 
         return_value = mid_col_view.keypress(size, key)

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -1284,6 +1284,7 @@ class TestWriteBox:
     ) -> None:
         # FIXME: Refactor when we have ~ Model.is_private_stream
         write_box.model.stream_dict = stream_dict
+        write_box.model.get_subscription_color.return_value = expected_color
         write_box.model.is_valid_stream.return_value = is_valid_stream
         write_box.model.stream_id_from_name.return_value = stream_id
         write_box.model.stream_access_type.return_value = stream_access_type

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -952,6 +952,11 @@ class TestWriteBox:
         write_box.view.pinned_streams = streams_to_pin
         write_box.stream_id = stream_categories.get("current_stream", None)
         write_box.model.stream_dict = stream_dict
+        write_box.model.get_stream_name = (
+            lambda stream_id: stream_dict[stream_id].get("name")
+            if stream_dict.get(stream_id)
+            else None
+        )
         write_box.model.muted_streams = {
             stream["stream_id"]
             for stream in stream_dict.values()

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -7,6 +7,7 @@ from pytest import param as case
 from pytest_mock import MockerFixture
 from urwid import Widget
 
+from zulipterminal.api_types import Subscription
 from zulipterminal.config.keys import keys_for_command, primary_key_for_command
 from zulipterminal.config.symbols import (
     INVALID_MARKER,
@@ -153,7 +154,7 @@ class TestWriteBox:
         is_valid_stream: bool,
         required_typeahead: Optional[str],
         topics: List[str],
-        stream_dict: Dict[int, Dict[str, Any]],
+        stream_dict: Dict[int, Subscription],
     ) -> None:
         write_box.model.topics_in_stream.return_value = topics
         write_box.model.is_valid_stream.return_value = is_valid_stream
@@ -573,7 +574,7 @@ class TestWriteBox:
         state: Optional[int],
         footer_text: List[Any],
         text: str,
-        stream_dict: Dict[int, Dict[str, Any]],
+        stream_dict: Dict[int, Subscription],
     ) -> None:
         write_box.view.set_typeahead_footer = mocker.patch(
             "zulipterminal.ui.View.set_typeahead_footer"
@@ -940,7 +941,7 @@ class TestWriteBox:
         text: str,
         state_and_required_typeahead: Dict[int, Optional[str]],
         stream_categories: Dict[str, Any],
-        stream_dict: Dict[int, Dict[str, Any]],
+        stream_dict: Dict[int, Subscription],
     ) -> None:
         streams_to_pin = (
             [{"name": stream_name} for stream_name in stream_categories["pinned"]]
@@ -1279,7 +1280,7 @@ class TestWriteBox:
         is_valid_stream: bool,
         stream_access_type: StreamAccessType,
         expected_marker: str,
-        stream_dict: Dict[int, Any],
+        stream_dict: Dict[int, Subscription],
         expected_color: str,
     ) -> None:
         # FIXME: Refactor when we have ~ Model.is_private_stream

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -154,11 +154,11 @@ class TestWriteBox:
         is_valid_stream: bool,
         required_typeahead: Optional[str],
         topics: List[str],
-        stream_dict: Dict[int, Subscription],
+        _subscribed_streams: Dict[int, Subscription],
     ) -> None:
         write_box.model.topics_in_stream.return_value = topics
         write_box.model.is_valid_stream.return_value = is_valid_stream
-        write_box.model.stream_dict = stream_dict
+        write_box.model._subscribed_streams = _subscribed_streams
         write_box.model.muted_streams = set()
         typeahead_string = write_box.generic_autocomplete(text, state)
 
@@ -574,12 +574,12 @@ class TestWriteBox:
         state: Optional[int],
         footer_text: List[Any],
         text: str,
-        stream_dict: Dict[int, Subscription],
+        _subscribed_streams: Dict[int, Subscription],
     ) -> None:
         write_box.view.set_typeahead_footer = mocker.patch(
             "zulipterminal.ui.View.set_typeahead_footer"
         )
-        write_box.model.stream_dict = stream_dict
+        write_box.model._subscribed_streams = _subscribed_streams
         write_box.model.muted_streams = set()
         write_box.generic_autocomplete(text, state)
 
@@ -941,7 +941,7 @@ class TestWriteBox:
         text: str,
         state_and_required_typeahead: Dict[int, Optional[str]],
         stream_categories: Dict[str, Any],
-        stream_dict: Dict[int, Subscription],
+        _subscribed_streams: Dict[int, Subscription],
     ) -> None:
         streams_to_pin = (
             [{"name": stream_name} for stream_name in stream_categories["pinned"]]
@@ -952,15 +952,15 @@ class TestWriteBox:
             write_box.view.unpinned_streams.remove(stream)
         write_box.view.pinned_streams = streams_to_pin
         write_box.stream_id = stream_categories.get("current_stream", None)
-        write_box.model.stream_dict = stream_dict
+        write_box.model._subscribed_streams = _subscribed_streams
         write_box.model.get_stream_name = (
-            lambda stream_id: stream_dict[stream_id].get("name")
-            if stream_dict.get(stream_id)
+            lambda stream_id: _subscribed_streams[stream_id].get("name")
+            if _subscribed_streams.get(stream_id)
             else None
         )
         write_box.model.muted_streams = {
             stream["stream_id"]
-            for stream in stream_dict.values()
+            for stream in _subscribed_streams.values()
             if stream["name"] in stream_categories.get("muted", set())
         }
         states = state_and_required_typeahead.keys()
@@ -1280,11 +1280,11 @@ class TestWriteBox:
         is_valid_stream: bool,
         stream_access_type: StreamAccessType,
         expected_marker: str,
-        stream_dict: Dict[int, Subscription],
+        _subscribed_streams: Dict[int, Subscription],
         expected_color: str,
     ) -> None:
         # FIXME: Refactor when we have ~ Model.is_private_stream
-        write_box.model.stream_dict = stream_dict
+        write_box.model._subscribed_streams = _subscribed_streams
         write_box.model.get_subscription_color.return_value = expected_color
         write_box.model.is_valid_stream.return_value = is_valid_stream
         write_box.model.stream_id_from_name.return_value = stream_id

--- a/tests/ui_tools/test_buttons.py
+++ b/tests/ui_tools/test_buttons.py
@@ -443,6 +443,7 @@ class TestTopicButton:
         view = mocker.Mock()
         top_button = mocker.patch(MODULE + ".TopButton.__init__")
         params = dict(controller=controller, count=count)
+        controller.model.get_stream_name.return_value = stream_name
 
         topic_button = TopicButton(
             stream_id=stream_id, topic=title, view=view, **params
@@ -883,6 +884,7 @@ class TestMessageLinkButton:
             "is_user_subscribed_to_stream",
             "is_valid_stream",
             "stream_id_from_name_return_value",
+            "get_stream_name",
             "expected_parsed_link",
             "expected_error",
         ],
@@ -894,6 +896,7 @@ class TestMessageLinkButton:
                 True,
                 None,
                 None,
+                "Stream 1",
                 ParsedNarrowLink(
                     stream=DecodedStream(stream_id=1, stream_name="Stream 1")
                 ),
@@ -906,6 +909,7 @@ class TestMessageLinkButton:
                 False,
                 None,
                 None,
+                None,
                 ParsedNarrowLink(stream=DecodedStream(stream_id=462, stream_name=None)),
                 "The stream seems to be either unknown or unsubscribed",
             ),
@@ -916,6 +920,7 @@ class TestMessageLinkButton:
                 None,
                 True,
                 1,
+                "Stream 1",
                 ParsedNarrowLink(
                     stream=DecodedStream(stream_id=1, stream_name="Stream 1")
                 ),
@@ -928,6 +933,7 @@ class TestMessageLinkButton:
                 None,
                 False,
                 None,
+                "foo",
                 ParsedNarrowLink(
                     stream=DecodedStream(stream_id=None, stream_name="foo")
                 ),
@@ -948,10 +954,12 @@ class TestMessageLinkButton:
         is_user_subscribed_to_stream: Optional[bool],
         is_valid_stream: Optional[bool],
         stream_id_from_name_return_value: Optional[int],
+        get_stream_name: Optional[str],
         expected_parsed_link: ParsedNarrowLink,
         expected_error: str,
     ) -> None:
         self.controller.model.stream_dict = stream_dict
+        self.controller.model.get_stream_name.return_value = get_stream_name
         self.controller.model.stream_id_from_name.return_value = (
             stream_id_from_name_return_value
         )

--- a/tests/ui_tools/test_buttons.py
+++ b/tests/ui_tools/test_buttons.py
@@ -434,7 +434,7 @@ class TestTopicButton:
         is_resolved: bool,
     ) -> None:
         controller = mocker.Mock()
-        controller.model.stream_dict = {
+        controller.model._subscribed_streams = {
             205: {"name": "PTEST"},
             86: {"name": "Django"},
             14: {"name": "GSoC"},
@@ -487,7 +487,7 @@ class TestTopicButton:
         controller.model.is_muted_topic = mocker.Mock(
             return_value=is_muted_topic_return_value
         )
-        controller.model.stream_dict = {205: {"name": stream_name}}
+        controller.model._subscribed_streams = {205: {"name": stream_name}}
         view = mocker.Mock()
         TopicButton(
             stream_id=205,
@@ -859,14 +859,14 @@ class TestMessageLinkButton:
     )
     def test__validate_narrow_link(
         self,
-        stream_dict: Dict[int, Subscription],
+        _subscribed_streams: Dict[int, Subscription],
         parsed_link: ParsedNarrowLink,
         is_user_subscribed_to_stream: Optional[bool],
         is_valid_stream: Optional[bool],
         topics_in_stream: Optional[List[str]],
         expected_error: str,
     ) -> None:
-        self.controller.model.stream_dict = stream_dict
+        self.controller.model._subscribed_streams = _subscribed_streams
         self.controller.model.is_user_subscribed_to_stream.return_value = (
             is_user_subscribed_to_stream
         )
@@ -949,7 +949,7 @@ class TestMessageLinkButton:
     )
     def test__validate_and_patch_stream_data(
         self,
-        stream_dict: Dict[int, Subscription],
+        _subscribed_streams: Dict[int, Subscription],
         parsed_link: ParsedNarrowLink,
         is_user_subscribed_to_stream: Optional[bool],
         is_valid_stream: Optional[bool],
@@ -958,7 +958,7 @@ class TestMessageLinkButton:
         expected_parsed_link: ParsedNarrowLink,
         expected_error: str,
     ) -> None:
-        self.controller.model.stream_dict = stream_dict
+        self.controller.model._subscribed_streams = _subscribed_streams
         self.controller.model.get_stream_name.return_value = get_stream_name
         self.controller.model.stream_id_from_name.return_value = (
             stream_id_from_name_return_value

--- a/tests/ui_tools/test_buttons.py
+++ b/tests/ui_tools/test_buttons.py
@@ -5,7 +5,7 @@ from pytest import param as case
 from pytest_mock import MockerFixture
 from urwid import AttrMap, Overlay, Widget
 
-from zulipterminal.api_types import Message
+from zulipterminal.api_types import Message, Subscription
 from zulipterminal.config.keys import keys_for_command
 from zulipterminal.config.symbols import CHECK_MARK, MUTE_MARKER
 from zulipterminal.ui_tools.buttons import (
@@ -859,7 +859,7 @@ class TestMessageLinkButton:
     )
     def test__validate_narrow_link(
         self,
-        stream_dict: Dict[int, Any],
+        stream_dict: Dict[int, Subscription],
         parsed_link: ParsedNarrowLink,
         is_user_subscribed_to_stream: Optional[bool],
         is_valid_stream: Optional[bool],
@@ -949,7 +949,7 @@ class TestMessageLinkButton:
     )
     def test__validate_and_patch_stream_data(
         self,
-        stream_dict: Dict[int, Any],
+        stream_dict: Dict[int, Subscription],
         parsed_link: ParsedNarrowLink,
         is_user_subscribed_to_stream: Optional[bool],
         is_valid_stream: Optional[bool],

--- a/tests/ui_tools/test_messages.py
+++ b/tests/ui_tools/test_messages.py
@@ -743,7 +743,7 @@ class TestMessageBox:
         ],
     )
     def test_main_view(self, mocker, message, last_message):
-        self.model.stream_dict = {
+        self.model._subscribed_streams = {
             5: {
                 "color": "#bd6",
             },
@@ -822,7 +822,7 @@ class TestMessageBox:
     def test_main_view_generates_stream_header(
         self, mocker, message, to_vary_in_last_message
     ):
-        self.model.stream_dict = {
+        self.model._subscribed_streams = {
             5: {
                 "color": "#bd6",
             },
@@ -953,7 +953,7 @@ class TestMessageBox:
         assert_search_bar,
         stream_color="#bd6",
     ):
-        self.model.stream_dict = {
+        self.model._subscribed_streams = {
             205: {
                 "color": stream_color,
             },

--- a/tests/ui_tools/test_messages.py
+++ b/tests/ui_tools/test_messages.py
@@ -951,13 +951,15 @@ class TestMessageBox:
         msg_narrow,
         assert_header_bar,
         assert_search_bar,
+        stream_color="#bd6",
     ):
         self.model.stream_dict = {
             205: {
-                "color": "#bd6",
+                "color": stream_color,
             },
         }
         self.model.narrow = msg_narrow
+        self.model.get_subscription_color.return_value = stream_color
         messages = messages_successful_response["messages"]
         current_message = messages[msg_type]
         msg_box = MessageBox(current_message, self.model, messages[0])

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -1172,7 +1172,7 @@ class TestStreamInfoView:
         self.controller.model.server_feature_level = 40
         self.controller.model.cached_retention_text = {self.stream_id: "10"}
 
-        self.controller.model.stream_dict = {self.stream_id: general_stream}
+        self.controller.model._subscribed_streams = {self.stream_id: general_stream}
         self.controller.model.get_stream_post_policy.return_value = general_stream.get(
             "stream_post_policy"
         )
@@ -1301,8 +1301,8 @@ class TestStreamInfoView:
     ) -> None:
         model = self.controller.model
         stream_id = general_stream["stream_id"]
-        model.stream_dict = {stream_id: general_stream}
-        model.stream_dict[stream_id].update(to_vary_in_stream_data)
+        model._subscribed_streams = {stream_id: general_stream}
+        model._subscribed_streams[stream_id].update(to_vary_in_stream_data)
         model.get_stream_date_created.return_value = to_vary_in_stream_data[
             "date_created"
         ]

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -1173,6 +1173,9 @@ class TestStreamInfoView:
         self.controller.model.cached_retention_text = {self.stream_id: "10"}
 
         self.controller.model.stream_dict = {self.stream_id: general_stream}
+        self.controller.model.get_stream_post_policy.return_value = general_stream.get(
+            "stream_post_policy"
+        )
         self.controller.model.stream_access_type.return_value = "public"
         self.controller.model.get_stream_subscribers.return_value = general_stream[
             "subscribers"
@@ -1300,6 +1303,9 @@ class TestStreamInfoView:
         model.get_stream_date_created.return_value = to_vary_in_stream_data[
             "date_created"
         ]
+        model.get_stream_post_policy.return_value = to_vary_in_stream_data.get(
+            "stream_post_policy"
+        )
         model.cached_retention_text = {stream_id: cached_message_retention_text}
         model.server_feature_level = server_feature_level
 

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -1176,6 +1176,9 @@ class TestStreamInfoView:
         self.controller.model.get_stream_post_policy.return_value = general_stream.get(
             "stream_post_policy"
         )
+        self.controller.model.get_stream_rendered_description.return_value = (
+            general_stream.get("rendered_description")
+        )
         self.controller.model.stream_access_type.return_value = "public"
         self.controller.model.get_stream_subscribers.return_value = general_stream[
             "subscribers"
@@ -1362,7 +1365,7 @@ class TestStreamInfoView:
         self, rendered_description: str, expected_markup: Tuple[None, Any]
     ) -> None:
         model = self.controller.model
-        model.stream_dict[self.stream_id]["rendered_description"] = rendered_description
+        model.get_stream_rendered_description.return_value = rendered_description
 
         stream_info_view = StreamInfoView(self.controller, self.stream_id)
 

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -1174,6 +1174,9 @@ class TestStreamInfoView:
 
         self.controller.model.stream_dict = {self.stream_id: general_stream}
         self.controller.model.stream_access_type.return_value = "public"
+        self.controller.model.get_stream_subscribers.return_value = general_stream[
+            "subscribers"
+        ]
 
         self.stream_info_view = StreamInfoView(self.controller, self.stream_id)
 

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -1306,6 +1306,9 @@ class TestStreamInfoView:
         model.get_stream_post_policy.return_value = to_vary_in_stream_data.get(
             "stream_post_policy"
         )
+        model.is_stream_announcement_only.return_value = to_vary_in_stream_data.get(
+            "is_announcement_only"
+        )
         model.cached_retention_text = {stream_id: cached_message_retention_text}
         model.server_feature_level = server_feature_level
 

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -1309,6 +1309,9 @@ class TestStreamInfoView:
         model.is_stream_announcement_only.return_value = to_vary_in_stream_data.get(
             "is_announcement_only"
         )
+        model.get_stream_weekly_traffic.return_value = general_stream.get(
+            "stream_weekly_traffic"
+        )
         model.cached_retention_text = {stream_id: cached_message_retention_text}
         model.server_feature_level = server_feature_level
 

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -1297,6 +1297,9 @@ class TestStreamInfoView:
         stream_id = general_stream["stream_id"]
         model.stream_dict = {stream_id: general_stream}
         model.stream_dict[stream_id].update(to_vary_in_stream_data)
+        model.get_stream_date_created.return_value = to_vary_in_stream_data[
+            "date_created"
+        ]
         model.cached_retention_text = {stream_id: cached_message_retention_text}
         model.server_feature_level = server_feature_level
 

--- a/zulipterminal/api_types.py
+++ b/zulipterminal/api_types.py
@@ -197,21 +197,36 @@ class Message(TypedDict, total=False):
 
 
 ###############################################################################
-# In "subscriptions" response from:
+# In "subscriptions", "unsubscribed", and "never_subscribed" responses from:
 #   https://zulip.com/api/register-queue
 # Also directly from:
 #   https://zulip.com/api/get-events#subscription-add
 #   https://zulip.com/api/get-subscriptions (unused)
 
 
-class Subscription(TypedDict):
+class Stream(TypedDict):
     stream_id: int
     name: str
     description: str
     rendered_description: str
-    date_created: int  # NOTE: new in Zulip 4.0 / ZFL 30
+    date_created: Optional[int]  # NOTE: new in Zulip 4.0 / ZFL 30
     invite_only: bool
     subscribers: List[int]
+
+    is_announcement_only: bool  # Deprecated in Zulip 3.0 -> stream_post_policy
+    stream_post_policy: int  # NOTE: new in Zulip 3.0 / ZFL 1
+
+    is_web_public: bool
+    message_retention_days: Optional[int]  # NOTE: new in Zulip 3.0 / ZFL 17
+    history_public_to_subscribers: bool
+    first_message_id: Optional[int]
+    stream_weekly_traffic: Optional[int]
+
+    # Deprecated fields
+    # in_home_view: bool  # Replaced by is_muted in Zulip 2.1; still present in updates
+
+
+class Subscription(Stream):
     desktop_notifications: Optional[bool]
     email_notifications: Optional[bool]
     wildcard_mentions_notify: Optional[bool]
@@ -222,19 +237,8 @@ class Subscription(TypedDict):
 
     is_muted: bool
 
-    is_announcement_only: bool  # Deprecated in Zulip 3.0 -> stream_post_policy
-    stream_post_policy: int  # NOTE: new in Zulip 3.0 / ZFL 1
-
-    is_web_public: bool
-    role: int  # NOTE: new in Zulip 4.0 / ZFL 31
+    role: NotRequired[int]  # NOTE: new in Zulip 4.0 / ZFL 31
     color: str
-    message_retention_days: Optional[int]  # NOTE: new in Zulip 3.0 / ZFL 17
-    history_public_to_subscribers: bool
-    first_message_id: Optional[int]
-    stream_weekly_traffic: Optional[int]
-
-    # Deprecated fields
-    # in_home_view: bool  # Replaced by is_muted in Zulip 2.1; still present in updates
 
 
 ###############################################################################

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1218,6 +1218,9 @@ class Model:
     def is_stream_invite_only(self, stream_id: int) -> bool:
         return self._get_stream_from_id(stream_id)["invite_only"]
 
+    def get_stream_post_policy(self, stream_id: int) -> Optional[int]:
+        return self._get_stream_from_id(stream_id).get("stream_post_policy")
+
     def _subscribe_to_streams(self, subscriptions: List[Subscription]) -> None:
         def make_reduced_stream_data(stream: Subscription) -> StreamData:
             # stream_id has been changed to id.

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -193,8 +193,8 @@ class Model:
         # level 30, server version 4. For consistency we add this field
         # on server iterations even before this with value of None.
         if self.server_feature_level is None or self.server_feature_level < 30:
-            for stream in self.stream_dict.values():
-                stream["date_created"] = None
+            for stream_id in self.get_all_stream_ids():
+                self.set_stream_date_created(stream_id, None)
 
         self.normalize_and_cache_message_retention_text()
 
@@ -1197,6 +1197,12 @@ class Model:
 
     def get_stream_subscribers(self, stream_id: int) -> List[int]:
         return self._get_stream_from_id(stream_id)["subscribers"]
+
+    def get_stream_date_created(self, stream_id: int) -> Optional[int]:
+        return self._get_stream_from_id(stream_id).get("date_created")
+
+    def set_stream_date_created(self, stream_id: int, value: Optional[int]) -> None:
+        self._get_stream_from_id(stream_id)["date_created"] = value
 
     def _subscribe_to_streams(self, subscriptions: List[Subscription]) -> None:
         def make_reduced_stream_data(stream: Subscription) -> StreamData:

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -971,15 +971,15 @@ class Model:
 
             return [
                 sub
-                for sub in self.stream_dict[stream_id]["subscribers"]
+                for sub in self.get_stream_subscribers(stream_id)
                 if sub != self.user_id
             ]
         else:
             return [
                 sub
-                for _, stream in self.stream_dict.items()
-                for sub in stream["subscribers"]
-                if self.get_stream_name(stream["stream_id"]) == stream_name
+                for stream_id in self.get_all_stream_ids()
+                for sub in self.get_stream_subscribers(stream_id)
+                if self.get_stream_name(stream_id) == stream_name
                 if sub != self.user_id
             ]
 
@@ -1195,6 +1195,9 @@ class Model:
     def get_stream_name(self, stream_id: int) -> Optional[str]:
         return self._get_stream_from_id(stream_id).get("name")
 
+    def get_stream_subscribers(self, stream_id: int) -> List[int]:
+        return self._get_stream_from_id(stream_id)["subscribers"]
+
     def _subscribe_to_streams(self, subscriptions: List[Subscription]) -> None:
         def make_reduced_stream_data(stream: Subscription) -> StreamData:
             # stream_id has been changed to id.
@@ -1406,7 +1409,7 @@ class Model:
 
             for stream_id in stream_ids:
                 if self.is_user_subscribed_to_stream(stream_id):
-                    subscribers = self.stream_dict[stream_id]["subscribers"]
+                    subscribers = self.get_stream_subscribers(stream_id)
                     if event["op"] == "peer_add":
                         subscribers.extend(user_ids)
                     else:

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -43,6 +43,7 @@ from zulipterminal.api_types import (
     PrivateMessageUpdateRequest,
     RealmEmojiData,
     RealmUser,
+    Stream,
     StreamComposition,
     StreamMessageUpdateRequest,
     Subscription,
@@ -174,10 +175,17 @@ class Model:
         self.users = self.get_all_users()
 
         self.stream_dict: Dict[int, Any] = {}
+        self._unsubscribed_streams: Dict[int, Subscription] = {}
+        self._never_subscribed_streams: Dict[int, Stream] = {}
         self.muted_streams: Set[int] = set()
         self.pinned_streams: List[StreamData] = []
         self.unpinned_streams: List[StreamData] = []
         self.visual_notified_streams: Set[int] = set()
+
+        self._register_non_subscribed_streams(
+            unsubscribed_streams=self.initial_data["unsubscribed"],
+            never_subscribed_streams=self.initial_data["never_subscribed"],
+        )
 
         self._subscribe_to_streams(self.initial_data["subscriptions"])
 
@@ -1155,6 +1163,18 @@ class Model:
             raise RuntimeError("Invalid user ID.")
 
         return self.user_dict[user_email]["full_name"]
+
+    def _register_non_subscribed_streams(
+        self,
+        unsubscribed_streams: List[Subscription],
+        never_subscribed_streams: List[Stream],
+    ) -> None:
+        self._unsubscribed_streams = {
+            stream["stream_id"]: stream for stream in unsubscribed_streams
+        }
+        self._never_subscribed_streams = {
+            stream["stream_id"]: stream for stream in never_subscribed_streams
+        }
 
     def _subscribe_to_streams(self, subscriptions: List[Subscription]) -> None:
         def make_reduced_stream_data(stream: Subscription) -> StreamData:

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1236,6 +1236,13 @@ class Model:
     def get_stream_rendered_description(self, stream_id: int) -> str:
         return self._get_stream_from_id(stream_id)["rendered_description"]
 
+    def get_subscription_color(self, stream_id: int) -> Optional[str]:
+        if stream_id in self.stream_dict:
+            return self.stream_dict[stream_id]["color"]
+        elif stream_id in self._unsubscribed_streams:
+            return self._unsubscribed_streams[stream_id]["color"]
+        return None
+
     def _subscribe_to_streams(self, subscriptions: List[Subscription]) -> None:
         def make_reduced_stream_data(stream: Subscription) -> StreamData:
             # stream_id has been changed to id.

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -887,7 +887,7 @@ class Model:
         """
         Returns True if topic is muted via muted_topics.
         """
-        stream_name = self.stream_dict[stream_id]["name"]
+        stream_name = self.get_stream_name(stream_id)
         topic_to_search = (stream_name, topic)
         return topic_to_search in self._muted_topics
 
@@ -979,7 +979,7 @@ class Model:
                 sub
                 for _, stream in self.stream_dict.items()
                 for sub in stream["subscribers"]
-                if stream["name"] == stream_name
+                if self.get_stream_name(stream["stream_id"]) == stream_name
                 if sub != self.user_id
             ]
 
@@ -1192,6 +1192,9 @@ class Model:
         id_list.extend(stream_id for stream_id in self._never_subscribed_streams)
         return id_list
 
+    def get_stream_name(self, stream_id: int) -> Optional[str]:
+        return self._get_stream_from_id(stream_id).get("name")
+
     def _subscribe_to_streams(self, subscriptions: List[Subscription]) -> None:
         def make_reduced_stream_data(stream: Subscription) -> StreamData:
             # stream_id has been changed to id.
@@ -1270,8 +1273,8 @@ class Model:
         display_error_if_present(response, self.controller)
 
     def stream_id_from_name(self, stream_name: str) -> int:
-        for stream_id, stream in self.stream_dict.items():
-            if stream["name"] == stream_name:
+        for stream_id in self.get_all_stream_ids():
+            if self.get_stream_name(stream_id) == stream_name:
                 return stream_id
         raise RuntimeError("Invalid stream name.")
 
@@ -1457,8 +1460,8 @@ class Model:
         )
 
     def is_valid_stream(self, stream_name: str) -> bool:
-        for stream in self.stream_dict.values():
-            if stream["name"] == stream_name:
+        for stream_id in self.get_all_stream_ids():
+            if self.get_stream_name(stream_id) == stream_name:
                 return True
         return False
 

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1227,6 +1227,9 @@ class Model:
     def is_stream_history_public_to_subscribers(self, stream_id: int) -> bool:
         return self._get_stream_from_id(stream_id)["history_public_to_subscribers"]
 
+    def get_stream_weekly_traffic(self, stream_id: int) -> Optional[int]:
+        return self._get_stream_from_id(stream_id)["stream_weekly_traffic"]
+
     def _subscribe_to_streams(self, subscriptions: List[Subscription]) -> None:
         def make_reduced_stream_data(stream: Subscription) -> StreamData:
             # stream_id has been changed to id.

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -261,11 +261,11 @@ class Model:
         self.cached_retention_text: Dict[int, str] = {}
         realm_message_retention_days = self.initial_data["realm_message_retention_days"]
         if self.server_feature_level is None or self.server_feature_level < 17:
-            for stream in self.stream_dict.values():
-                stream["message_retention_days"] = None
+            for stream_id in self.get_all_stream_ids():
+                self.set_stream_message_retention_days(stream_id, None)
 
-        for stream in self.stream_dict.values():
-            message_retention_days = stream["message_retention_days"]
+        for stream_id in self.get_all_stream_ids():
+            message_retention_days = self.get_stream_message_retention_days(stream_id)
             is_organization_default = message_retention_days is None
             final_msg_retention_days = (
                 realm_message_retention_days
@@ -275,7 +275,7 @@ class Model:
             message_retention_response = self.message_retention_days_response(
                 final_msg_retention_days, is_organization_default
             )
-            self.cached_retention_text[stream["stream_id"]] = message_retention_response
+            self.cached_retention_text[stream_id] = message_retention_response
 
     def get_focus_in_current_narrow(self) -> Optional[int]:
         """
@@ -1206,6 +1206,14 @@ class Model:
 
     def is_stream_web_public(self, stream_id: int) -> bool:
         return self._get_stream_from_id(stream_id)["is_web_public"]
+
+    def get_stream_message_retention_days(self, stream_id: int) -> Optional[int]:
+        return self._get_stream_from_id(stream_id).get("message_retention_days")
+
+    def set_stream_message_retention_days(
+        self, stream_id: int, value: Optional[int]
+    ) -> None:
+        self._get_stream_from_id(stream_id)["message_retention_days"] = value
 
     def _subscribe_to_streams(self, subscriptions: List[Subscription]) -> None:
         def make_reduced_stream_data(stream: Subscription) -> StreamData:

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1243,6 +1243,14 @@ class Model:
             return self._unsubscribed_streams[stream_id]["color"]
         return None
 
+    def get_subscription_email(self, stream_id: int) -> Optional[str]:
+        if stream_id in self.stream_dict:
+            return self.stream_dict[stream_id]["email_address"]
+        elif stream_id in self._unsubscribed_streams:
+            return self._unsubscribed_streams[stream_id]["email_address"]
+        else:
+            raise RuntimeError(f"Stream with id {stream_id} is not subscribed to!")
+
     def _subscribe_to_streams(self, subscriptions: List[Subscription]) -> None:
         def make_reduced_stream_data(stream: Subscription) -> StreamData:
             # stream_id has been changed to id.

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1221,6 +1221,9 @@ class Model:
     def get_stream_post_policy(self, stream_id: int) -> Optional[int]:
         return self._get_stream_from_id(stream_id).get("stream_post_policy")
 
+    def is_stream_announcement_only(self, stream_id: int) -> Optional[bool]:
+        return self._get_stream_from_id(stream_id).get("is_announcement_only")
+
     def _subscribe_to_streams(self, subscriptions: List[Subscription]) -> None:
         def make_reduced_stream_data(stream: Subscription) -> StreamData:
             # stream_id has been changed to id.

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1215,6 +1215,9 @@ class Model:
     ) -> None:
         self._get_stream_from_id(stream_id)["message_retention_days"] = value
 
+    def is_stream_invite_only(self, stream_id: int) -> bool:
+        return self._get_stream_from_id(stream_id)["invite_only"]
+
     def _subscribe_to_streams(self, subscriptions: List[Subscription]) -> None:
         def make_reduced_stream_data(stream: Subscription) -> StreamData:
             # stream_id has been changed to id.
@@ -1301,10 +1304,9 @@ class Model:
     def stream_access_type(self, stream_id: int) -> StreamAccessType:
         if stream_id not in self.stream_dict:
             raise RuntimeError("Invalid stream id.")
-        stream = self.stream_dict[stream_id]
         if self.is_stream_web_public(stream_id):
             return "web-public"
-        if stream["invite_only"]:
+        if self.is_stream_invite_only(stream_id):
             return "private"
         return "public"
 

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1230,6 +1230,9 @@ class Model:
     def get_stream_weekly_traffic(self, stream_id: int) -> Optional[int]:
         return self._get_stream_from_id(stream_id)["stream_weekly_traffic"]
 
+    def get_stream_rendered_description(self, stream_id: int) -> str:
+        return self._get_stream_from_id(stream_id)["rendered_description"]
+
     def _subscribe_to_streams(self, subscriptions: List[Subscription]) -> None:
         def make_reduced_stream_data(stream: Subscription) -> StreamData:
             # stream_id has been changed to id.

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1176,6 +1176,22 @@ class Model:
             stream["stream_id"]: stream for stream in never_subscribed_streams
         }
 
+    def _get_stream_from_id(self, stream_id: int) -> Union[Subscription, Stream]:
+        if stream_id in self.stream_dict:
+            return self.stream_dict[stream_id]
+        elif stream_id in self._unsubscribed_streams:
+            return self._unsubscribed_streams[stream_id]
+        elif stream_id in self._never_subscribed_streams:
+            return self._never_subscribed_streams[stream_id]
+        else:
+            raise RuntimeError(f"Stream with id {stream_id} does not exist!")
+
+    def get_all_stream_ids(self) -> List[int]:
+        id_list = list(self.stream_dict)
+        id_list.extend(stream_id for stream_id in self._unsubscribed_streams)
+        id_list.extend(stream_id for stream_id in self._never_subscribed_streams)
+        return id_list
+
     def _subscribe_to_streams(self, subscriptions: List[Subscription]) -> None:
         def make_reduced_stream_data(stream: Subscription) -> StreamData:
             # stream_id has been changed to id.

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1204,6 +1204,9 @@ class Model:
     def set_stream_date_created(self, stream_id: int, value: Optional[int]) -> None:
         self._get_stream_from_id(stream_id)["date_created"] = value
 
+    def is_stream_web_public(self, stream_id: int) -> bool:
+        return self._get_stream_from_id(stream_id)["is_web_public"]
+
     def _subscribe_to_streams(self, subscriptions: List[Subscription]) -> None:
         def make_reduced_stream_data(stream: Subscription) -> StreamData:
             # stream_id has been changed to id.
@@ -1291,7 +1294,7 @@ class Model:
         if stream_id not in self.stream_dict:
             raise RuntimeError("Invalid stream id.")
         stream = self.stream_dict[stream_id]
-        if stream.get("is_web_public", False):
+        if self.is_stream_web_public(stream_id):
             return "web-public"
         if stream["invite_only"]:
             return "private"

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -174,7 +174,7 @@ class Model:
 
         self.users = self.get_all_users()
 
-        self.stream_dict: Dict[int, Any] = {}
+        self.stream_dict: Dict[int, Subscription] = {}
         self._unsubscribed_streams: Dict[int, Subscription] = {}
         self._never_subscribed_streams: Dict[int, Stream] = {}
         self.muted_streams: Set[int] = set()

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1192,6 +1192,9 @@ class Model:
         id_list.extend(stream_id for stream_id in self._never_subscribed_streams)
         return id_list
 
+    def get_all_subscription_ids(self) -> List[int]:
+        return list(self.stream_dict)
+
     def get_stream_name(self, stream_id: int) -> Optional[str]:
         return self._get_stream_from_id(stream_id).get("name")
 

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1224,6 +1224,9 @@ class Model:
     def is_stream_announcement_only(self, stream_id: int) -> Optional[bool]:
         return self._get_stream_from_id(stream_id).get("is_announcement_only")
 
+    def is_stream_history_public_to_subscribers(self, stream_id: int) -> bool:
+        return self._get_stream_from_id(stream_id)["history_public_to_subscribers"]
+
     def _subscribe_to_streams(self, subscriptions: List[Subscription]) -> None:
         def make_reduced_stream_data(stream: Subscription) -> StreamData:
             # stream_id has been changed to id.

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -618,7 +618,7 @@ class WriteBox(urwid.Pile):
         )
 
         muted_streams = [
-            self.model.stream_dict[stream_id]["name"]
+            self.model.get_stream_name(stream_id)
             for stream_id in self.model.muted_streams
         ]
         matching_muted_streams = [
@@ -637,12 +637,10 @@ class WriteBox(urwid.Pile):
             else:
                 matched_streams.append(matching_muted_stream)
 
-        current_stream = self.model.stream_dict.get(self.stream_id, None)
-        if current_stream is not None:
-            current_stream_name = current_stream["name"]
-            if current_stream_name in matched_streams:
-                matched_streams.remove(current_stream_name)
-                matched_streams.insert(0, current_stream_name)
+        current_stream_name = self.model.get_stream_name(self.stream_id)
+        if current_stream_name is not None and current_stream_name in matched_streams:
+            matched_streams.remove(current_stream_name)
+            matched_streams.insert(0, current_stream_name)
 
         matched_stream_typeaheads = format_string(matched_streams, "#**{}**")
         return matched_stream_typeaheads, matched_streams

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -412,8 +412,7 @@ class WriteBox(urwid.Pile):
             stream_id = self.model.stream_id_from_name(new_text)
             stream_access_type = self.model.stream_access_type(stream_id)
             stream_marker = STREAM_ACCESS_TYPE[stream_access_type]["icon"]
-            stream = self.model.stream_dict[stream_id]
-            color = stream["color"]
+            color = self.model.get_subscription_color(stream_id)
         self.header_write_box[self.FOCUS_HEADER_PREFIX_STREAM].set_text(
             (color, stream_marker)
         )

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -306,7 +306,7 @@ class TopicButton(TopButton):
         view: Any,
         count: int,
     ) -> None:
-        self.stream_name = controller.model.stream_dict[stream_id]["name"]
+        self.stream_name = controller.model.get_stream_name(stream_id)
         self.topic_name = topic
         self.stream_id = stream_id
         self.model = controller.model
@@ -567,7 +567,7 @@ class MessageLinkButton(urwid.Button):
             stream_id = cast(int, model.stream_id_from_name(stream_name))
             parsed_link["stream"]["stream_id"] = stream_id
         else:
-            stream_name = cast(str, model.stream_dict[stream_id]["name"])
+            stream_name = cast(str, model.get_stream_name(stream_id))
             parsed_link["stream"]["stream_name"] = stream_name
 
         return ""

--- a/zulipterminal/ui_tools/messages.py
+++ b/zulipterminal/ui_tools/messages.py
@@ -150,7 +150,7 @@ class MessageBox(urwid.Pile):
 
     def stream_header(self) -> Any:
         assert self.stream_id is not None
-        color = self.model.stream_dict[self.stream_id]["color"]
+        color = self.model.get_subscription_color(self.stream_id)
         bar_color = f"s{color}"
         stream_title_markup = (
             "bar",
@@ -211,7 +211,7 @@ class MessageBox(urwid.Pile):
             text_to_fill = "Mentions"
         elif self.message["type"] == "stream":
             assert self.stream_id is not None
-            bar_color = self.model.stream_dict[self.stream_id]["color"]
+            bar_color = self.model.get_subscription_color(self.stream_id)
             bar_color = f"s{bar_color}"
             if len(curr_narrow) == 2 and curr_narrow[1][0] == "topic":
                 text_to_fill = (

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1292,8 +1292,10 @@ class StreamInfoView(PopUpView):
             )
         ]
 
-        if "stream_post_policy" in stream:
-            stream_policy = STREAM_POST_POLICY[stream["stream_post_policy"]]
+        if controller.model.get_stream_post_policy(self.stream_id):
+            stream_policy = STREAM_POST_POLICY[
+                controller.model.get_stream_post_policy(self.stream_id)
+            ]
         else:
             if stream.get("is_announcement_only"):
                 stream_policy = STREAM_POST_POLICY[2]

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1268,7 +1268,7 @@ class StreamInfoView(PopUpView):
     def __init__(self, controller: Any, stream_id: int) -> None:
         self.stream_id = stream_id
         self.controller = controller
-        stream = controller.model.stream_dict[stream_id]
+        stream = controller.model._subscribed_streams[stream_id]
 
         # New in feature level 30, server version 4.0
         stream_creation_date = controller.model.get_stream_date_created(self.stream_id)

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1310,7 +1310,7 @@ class StreamInfoView(PopUpView):
 
         availability_of_history = (
             "Public to Users"
-            if stream["history_public_to_subscribers"]
+            if controller.model.is_stream_history_public_to_subscribers(self.stream_id)
             else "Not Public to Users"
         )
         member_keys = ", ".join(map(repr, keys_for_command("STREAM_MEMBERS")))

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1317,7 +1317,7 @@ class StreamInfoView(PopUpView):
         self.stream_email = stream["email_address"]
         email_keys = ", ".join(map(repr, keys_for_command("COPY_STREAM_EMAIL")))
 
-        weekly_traffic = stream["stream_weekly_traffic"]
+        weekly_traffic = controller.model.get_stream_weekly_traffic(self.stream_id)
         weekly_msg_count = (
             "Stream created recently" if weekly_traffic is None else str(weekly_traffic)
         )

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1314,7 +1314,7 @@ class StreamInfoView(PopUpView):
             else "Not Public to Users"
         )
         member_keys = ", ".join(map(repr, keys_for_command("STREAM_MEMBERS")))
-        self.stream_email = stream["email_address"]
+        self.stream_email = controller.model.get_subscription_email(self.stream_id)
         email_keys = ", ".join(map(repr, keys_for_command("COPY_STREAM_EMAIL")))
 
         weekly_traffic = controller.model.get_stream_weekly_traffic(self.stream_id)

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -570,8 +570,9 @@ class MiddleColumnView(urwid.Frame):
             # For new streams with no previous conversation.
             if self.footer.focus is None:
                 stream_id = self.model.stream_id
-                stream_dict = self.model.stream_dict
-                self.footer.stream_box_view(caption=stream_dict[stream_id]["name"])
+                self.footer.stream_box_view(
+                    caption=self.model.get_stream_name(stream_id)
+                )
             self.set_focus("footer")
             self.footer.focus_position = 0
             return key
@@ -590,7 +591,7 @@ class MiddleColumnView(urwid.Frame):
                 return key
             stream_id, topic = stream_topic
             self.controller.narrow_to_topic(
-                stream_name=self.model.stream_dict[stream_id]["name"],
+                stream_name=self.model.get_stream_name(stream_id),
                 topic_name=topic,
             )
             return key

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1297,7 +1297,7 @@ class StreamInfoView(PopUpView):
                 controller.model.get_stream_post_policy(self.stream_id)
             ]
         else:
-            if stream.get("is_announcement_only"):
+            if controller.model.is_stream_announcement_only(self.stream_id):
                 stream_policy = STREAM_POST_POLICY[2]
             else:
                 stream_policy = STREAM_POST_POLICY[1]

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1300,7 +1300,7 @@ class StreamInfoView(PopUpView):
             else:
                 stream_policy = STREAM_POST_POLICY[1]
 
-        total_members = len(stream["subscribers"])
+        total_members = len(controller.model.get_stream_subscribers(self.stream_id))
 
         stream_access_type = controller.model.stream_access_type(stream_id)
         type_of_stream = STREAM_ACCESS_TYPE[stream_access_type]["description"]

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1323,7 +1323,7 @@ class StreamInfoView(PopUpView):
         )
 
         title = f"{stream_marker} {stream['name']}"
-        rendered_desc = stream["rendered_description"]
+        rendered_desc = controller.model.get_stream_rendered_description(self.stream_id)
         self.markup_desc, message_links, _ = MessageBox.transform_content(
             rendered_desc,
             self.controller.model.server_url,

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1271,7 +1271,7 @@ class StreamInfoView(PopUpView):
         stream = controller.model.stream_dict[stream_id]
 
         # New in feature level 30, server version 4.0
-        stream_creation_date = stream["date_created"]
+        stream_creation_date = controller.model.get_stream_date_created(self.stream_id)
         date_created = (
             [
                 (


### PR DESCRIPTION
<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?
This PR adds support for unsubscribed streams and never_subscribed streams in ZT. It creates new data structures and accessor methods to access them. This PR is needed for further work on reducing stream related issues and adding support for stream (un)subscription.

### Outstanding aspect(s)    <!-- DELETE SECTION IF EMPTY -->
<!-- In what ways is this not fully implemented/functioning? Compared to a discussion/issue? -->
<!-- Do you not understand something? Are you unsure about a certain approach? Want feedback? -->

### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [x] Discussed in **#zulip-terminal** in `Adding streams throws key error`
- [ ] Fully fixes #
- [x] Partially fixes issue #816 
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [x] Merge will enable work on #1387 

### How did you test this?
<!-- [x] all that apply -->
- [ ] Manually - Behavioral changes
- [ ] Manually - Visual changes
- [x] Adapting existing automated tests
- [x] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [x] It contains test additions for any new behavior
- [x] It flows clearly from a previous branch commit, and/or prepares for the next commit

### Visual changes    <!-- DELETE SECTION IF NO VISUAL CHANGE -->
<!-- Zulip tips at https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html -->
<!-- For video, try asciinema; after uploading, embed using
[![yourtitle](https://asciinema.org/a/<id>.png)](https://asciinema.org/a/<id>)
-->
<!-- NOTE: Attached videos/images will be clearer from smaller terminal windows -->
