### PR TITLE
Use Hyperlink widget for links in message info popup.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -105,5 +105,6 @@ setup(
         "pytz>=2022.7.1",
         "tzlocal>=2.1",
         "pyperclip>=1.8.1",
+        "urwidgets>=0.1,<0.2",
     ],
 )

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -8,6 +8,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, cast
 from urllib.parse import urljoin, urlparse
 
 import urwid
+import urwidgets
 from typing_extensions import TypedDict
 
 from zulipterminal.api_types import RESOLVED_TOPIC_PREFIX, EditPropagateMode
@@ -442,7 +443,12 @@ class MessageLinkButton(urwid.Button):
         Overrides the existing button widget for custom styling.
         """
         # Set cursor position next to len(caption) to avoid the cursor.
-        icon = urwid.SelectableIcon(caption, cursor_position=len(caption) + 1)
+        icon = urwid.Pile(
+            widget_list=[
+                urwid.SelectableIcon(caption, cursor_position=len(caption) + 1),
+                urwidgets.Hyperlink(uri=self.link),
+            ]
+        )
         self._w = urwid.AttrMap(icon, display_attr, focus_map="selected")
 
     def handle_link(self, *_: Any) -> None:

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1599,7 +1599,7 @@ class MsgInfoView(PopUpView):
         for index, link in enumerate(links):
             text, link_index, _ = links[link]
             if text:
-                caption = f"{link_index}: {text}\n{link}"
+                caption = f"{link_index}: {text}"
             else:
                 caption = f"{link_index}: {link}"
             link_width = max(link_width, len(max(caption.split("\n"), key=len)))


### PR DESCRIPTION
<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?
This PR introduces the [Hyperlink](https://urwidgets.readthedocs.io/en/stable/api.html#urwidgets.Hyperlink) widget for message links in message information popups. This solves the issue of long urls being force-wrapped which results in them not being clickable from ZT.

### Outstanding aspect(s)    <!-- DELETE SECTION IF EMPTY -->
<!-- In what ways is this not fully implemented/functioning? Compared to a discussion/issue? -->
<!-- Do you not understand something? Are you unsure about a certain approach? Want feedback? -->
- The focus on the currently selected link is a bit off. It doesn't cover the link.

### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [x] Discussed in **#zulip-terminal** in [`Hyperlink support using OSC-8 escape sequences`](https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/Hyperlink.20support.20using.20OSC-8.20escape.20sequences)
- [ ] Fully fixes #
- [x] Partially fixes issue #1368 
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [x] Manually - Behavioral changes
- [x] Manually - Visual changes
- [ ] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [ ] It individually passes linting and tests
- [ ] It contains test additions for any new behavior
- [ ] It flows clearly from a previous branch commit, and/or prepares for the next commit

### Visual changes    <!-- DELETE SECTION IF NO VISUAL CHANGE -->
<!-- Zulip tips at https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html -->
<!-- For video, try asciinema; after uploading, embed using
[![yourtitle](https://asciinema.org/a/<id>.png)](https://asciinema.org/a/<id>)
-->
<!-- NOTE: Attached videos/images will be clearer from smaller terminal windows -->
![image](https://github.com/zulip/zulip-terminal/assets/44305101/4635aa0a-35f7-4989-a2ba-f0f181687a51)

