### PR TITLE
Review original 1277 4

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -639,9 +639,9 @@ class TestTopicsView:
             topic_view.view, "saved_topic_in_stream_id", return_value=saved_topic_state
         )
 
-        topic_view.list_box.focus_position = topic_view._focus_position_for_topic_name()
+        new_focus_index = topic_view._focus_position_for_topic_name()
 
-        assert topic_view.list_box.focus_position == expected_focus_index
+        assert new_focus_index == expected_focus_index
 
     @pytest.mark.parametrize(
         "new_text, expected_log",

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -5,7 +5,7 @@ Defines the `View`, and controls where each component is displayed
 import random
 import re
 import time
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional
 
 import urwid
 
@@ -44,6 +44,7 @@ class View(urwid.WidgetWrap):
         self.unpinned_streams = self.model.unpinned_streams
         self.write_box = WriteBox(self)
         self.search_box = MessageSearchBox(self.controller)
+        self.stream_topic_map: Dict[int, Any] = {}
 
         self.message_view: Any = None
         self.displaying_selection_hint = False

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -44,12 +44,15 @@ class View(urwid.WidgetWrap):
         self.unpinned_streams = self.model.unpinned_streams
         self.write_box = WriteBox(self)
         self.search_box = MessageSearchBox(self.controller)
-        self.stream_topic_map: Dict[int, Any] = {}
+        self.stream_topic_map: Dict[int, Optional[str]] = {}
 
         self.message_view: Any = None
         self.displaying_selection_hint = False
 
         super().__init__(self.main_window())
+
+    def associate_stream_with_topic(self, stream_id: int, topic_name: str) -> None:
+        self.stream_topic_map[stream_id] = topic_name
 
     def left_column_view(self) -> Any:
         tab = TabView(

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -54,6 +54,9 @@ class View(urwid.WidgetWrap):
     def associate_stream_with_topic(self, stream_id: int, topic_name: str) -> None:
         self.stream_topic_map[stream_id] = topic_name
 
+    def saved_topic_in_stream_id(self, stream_id: int) -> Optional[str]:
+        return self.stream_topic_map.get(stream_id, None)
+
     def left_column_view(self) -> Any:
         tab = TabView(
             f"{AUTOHIDE_TAB_LEFT_ARROW} STREAMS & TOPICS {AUTOHIDE_TAB_LEFT_ARROW}"

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -348,6 +348,7 @@ class TopicButton(TopButton):
     def keypress(self, size: urwid_Size, key: str) -> Optional[str]:
         if is_command_key("TOGGLE_TOPIC", key):
             # Exit topic view
+            self.view.associate_stream_with_topic(self.stream_id, self.topic_name)
             self.view.left_panel.show_stream_view()
         return super().keypress(size, key)
 

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -419,12 +419,23 @@ class TopicsView(urwid.Frame):
                 urwid.Divider(SECTION_DIVIDER_LINE),
             ]
         )
+        self.list_box.focus_position = self._focus_position_for_topic_name()
         super().__init__(
             self.list_box,
             header=self.header_list,
         )
         self.search_lock = threading.Lock()
         self.empty_search = False
+
+    def _focus_position_for_topic_name(self) -> int:
+        self.saved_topic_state = self.view.saved_topic_in_stream_id(
+            self.stream_button.stream_id
+        )
+        if self.saved_topic_state is not None:
+            for index, topic in enumerate(self.log):
+                if topic.topic_name is self.saved_topic_state:
+                    return index
+        return 0
 
     @asynch
     def update_topics(self, search_box: Any, new_text: str) -> None:

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -428,12 +428,12 @@ class TopicsView(urwid.Frame):
         self.empty_search = False
 
     def _focus_position_for_topic_name(self) -> int:
-        self.saved_topic_state = self.view.saved_topic_in_stream_id(
+        saved_topic_state = self.view.saved_topic_in_stream_id(
             self.stream_button.stream_id
         )
-        if self.saved_topic_state is not None:
+        if saved_topic_state is not None:
             for index, topic in enumerate(self.log):
-                if topic.topic_name is self.saved_topic_state:
+                if topic.topic_name is saved_topic_state:
                     return index
         return 0
 

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -433,7 +433,7 @@ class TopicsView(urwid.Frame):
         )
         if saved_topic_state is not None:
             for index, topic in enumerate(self.log):
-                if topic.topic_name is saved_topic_state:
+                if topic.topic_name == saved_topic_state:
                     return index
         return 0
 


### PR DESCRIPTION
<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?



### Outstanding aspect(s)    <!-- DELETE SECTION IF EMPTY -->
<!-- In what ways is this not fully implemented/functioning? Compared to a discussion/issue? -->
<!-- Do you not understand something? Are you unsure about a certain approach? Want feedback? -->
- [ ] 

### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [ ] Discussed in **#zulip-terminal** in `topic`
- [ ] Fully fixes #
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [ ] Manually - Behavioral changes
- [ ] Manually - Visual changes
- [ ] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [ ] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [ ] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [ ] It has a commit summary describing the  motivation and reasoning for the change
- [ ] It individually passes linting and tests
- [ ] It contains test additions for any new behavior
- [ ] It flows clearly from a previous branch commit, and/or prepares for the next commit

### Visual changes    <!-- DELETE SECTION IF NO VISUAL CHANGE -->
<!-- Zulip tips at https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html -->
<!-- For video, try asciinema; after uploading, embed using
[![yourtitle](https://asciinema.org/a/<id>.png)](https://asciinema.org/a/<id>)
-->
<!-- NOTE: Attached videos/images will be clearer from smaller terminal windows -->
