### PR TITLE
Add support for old format for narrow links

### DIFF
--- a/tests/ui_tools/test_buttons.py
+++ b/tests/ui_tools/test_buttons.py
@@ -687,30 +687,30 @@ class TestMessageLinkButton:
                 id="subject_narrow_link",
             ),
             case(
-                "/#narrow/stream/1-Stream-1/near/1",
+                "/#narrow/stream/1-Stream-1/near/987",
                 ParsedNarrowLink(
                     narrow="stream:near",
-                    message_id=1,
+                    message_id=987,
                     stream=DecodedStream(stream_id=1, stream_name=None),
                 ),
                 id="stream_near_narrow_link",
             ),
             case(
-                "/#narrow/stream/1-Stream-1/topic/foo/near/1",
+                "/#narrow/stream/1-Stream-1/topic/foo/near/789",
                 ParsedNarrowLink(
                     narrow="stream:topic:near",
                     topic_name="foo",
-                    message_id=1,
+                    message_id=789,
                     stream=DecodedStream(stream_id=1, stream_name=None),
                 ),
                 id="topic_near_narrow_link",
             ),
             case(
-                "/#narrow/stream/1-Stream-1/subject/foo/near/1",
+                "/#narrow/stream/1-Stream-1/subject/foo/near/654",
                 ParsedNarrowLink(
                     narrow="stream:topic:near",
                     topic_name="foo",
-                    message_id=1,
+                    message_id=654,
                     stream=DecodedStream(stream_id=1, stream_name=None),
                 ),
                 id="subject_near_narrow_link",

--- a/tests/ui_tools/test_buttons.py
+++ b/tests/ui_tools/test_buttons.py
@@ -653,70 +653,80 @@ class TestMessageLinkButton:
     @pytest.mark.parametrize(
         "link, expected_parsed_link",
         [
-            (
-                SERVER_URL + "/#narrow/stream/1-Stream-1",
+            case(
+                "/#narrow/stream/1-Stream-1",
                 ParsedNarrowLink(
                     narrow="stream", stream=DecodedStream(stream_id=1, stream_name=None)
                 ),
+                id="modern_stream_narrow_link",
             ),
-            (
-                SERVER_URL + "/#narrow/stream/Stream.201",
+            case(
+                "/#narrow/stream/Stream.201",
                 ParsedNarrowLink(
                     narrow="stream",
                     stream=DecodedStream(stream_id=None, stream_name="Stream 1"),
                 ),
+                id="deprecated_stream_narrow_link",
             ),
-            (
-                SERVER_URL + "/#narrow/stream/1-Stream-1/topic/foo.20bar",
+            case(
+                "/#narrow/stream/1-Stream-1/topic/foo.20bar",
                 ParsedNarrowLink(
                     narrow="stream:topic",
                     topic_name="foo bar",
                     stream=DecodedStream(stream_id=1, stream_name=None),
                 ),
+                id="topic_narrow_link",
             ),
-            (
-                SERVER_URL + "/#narrow/stream/1-Stream-1/near/1",
+            case(
+                "/#narrow/stream/1-Stream-1/near/1",
                 ParsedNarrowLink(
                     narrow="stream:near",
                     message_id=1,
                     stream=DecodedStream(stream_id=1, stream_name=None),
                 ),
+                id="stream_near_narrow_link",
             ),
-            (
-                SERVER_URL + "/#narrow/stream/1-Stream-1/topic/foo/near/1",
+            case(
+                "/#narrow/stream/1-Stream-1/topic/foo/near/1",
                 ParsedNarrowLink(
                     narrow="stream:topic:near",
                     topic_name="foo",
                     message_id=1,
                     stream=DecodedStream(stream_id=1, stream_name=None),
                 ),
+                id="topic_near_narrow_link",
             ),
-            (SERVER_URL + "/#narrow/foo", ParsedNarrowLink()),
-            (SERVER_URL + "/#narrow/stream/", ParsedNarrowLink()),
-            (SERVER_URL + "/#narrow/stream/1-Stream-1/topic/", ParsedNarrowLink()),
-            (SERVER_URL + "/#narrow/stream/1-Stream-1//near/", ParsedNarrowLink()),
-            (
-                SERVER_URL + "/#narrow/stream/1-Stream-1/topic/foo/near/",
+            case(
+                "/#narrow/foo",
                 ParsedNarrowLink(),
+                id="invalid_narrow_link_1",
             ),
-        ],
-        ids=[
-            "modern_stream_narrow_link",
-            "deprecated_stream_narrow_link",
-            "topic_narrow_link",
-            "stream_near_narrow_link",
-            "topic_near_narrow_link",
-            "invalid_narrow_link_1",
-            "invalid_narrow_link_2",
-            "invalid_narrow_link_3",
-            "invalid_narrow_link_4",
-            "invalid_narrow_link_5",
+            case(
+                "/#narrow/stream/",
+                ParsedNarrowLink(),
+                id="invalid_narrow_link_2",
+            ),
+            case(
+                "/#narrow/stream/1-Stream-1/topic/",
+                ParsedNarrowLink(),
+                id="invalid_narrow_link_3",
+            ),
+            case(
+                "/#narrow/stream/1-Stream-1//near/",
+                ParsedNarrowLink(),
+                id="invalid_narrow_link_4",
+            ),
+            case(
+                "/#narrow/stream/1-Stream-1/topic/foo/near/",
+                ParsedNarrowLink(),
+                id="invalid_narrow_link_5",
+            ),
         ],
     )
     def test__parse_narrow_link(
         self, link: str, expected_parsed_link: ParsedNarrowLink
     ) -> None:
-        return_value = MessageLinkButton._parse_narrow_link(link)
+        return_value = MessageLinkButton._parse_narrow_link(SERVER_URL + link)
 
         assert return_value == expected_parsed_link
 

--- a/tests/ui_tools/test_buttons.py
+++ b/tests/ui_tools/test_buttons.py
@@ -678,6 +678,15 @@ class TestMessageLinkButton:
                 id="topic_narrow_link",
             ),
             case(
+                "/#narrow/stream/1-Stream-1/subject/foo.20bar",
+                ParsedNarrowLink(
+                    narrow="stream:topic",
+                    topic_name="foo bar",
+                    stream=DecodedStream(stream_id=1, stream_name=None),
+                ),
+                id="subject_narrow_link",
+            ),
+            case(
                 "/#narrow/stream/1-Stream-1/near/1",
                 ParsedNarrowLink(
                     narrow="stream:near",
@@ -697,6 +706,16 @@ class TestMessageLinkButton:
                 id="topic_near_narrow_link",
             ),
             case(
+                "/#narrow/stream/1-Stream-1/subject/foo/near/1",
+                ParsedNarrowLink(
+                    narrow="stream:topic:near",
+                    topic_name="foo",
+                    message_id=1,
+                    stream=DecodedStream(stream_id=1, stream_name=None),
+                ),
+                id="subject_near_narrow_link",
+            ),
+            case(
                 "/#narrow/foo",
                 ParsedNarrowLink(),
                 id="invalid_narrow_link_1",
@@ -712,14 +731,24 @@ class TestMessageLinkButton:
                 id="invalid_narrow_link_3",
             ),
             case(
-                "/#narrow/stream/1-Stream-1//near/",
+                "/#narrow/stream/1-Stream-1/subject/",
                 ParsedNarrowLink(),
                 id="invalid_narrow_link_4",
             ),
             case(
-                "/#narrow/stream/1-Stream-1/topic/foo/near/",
+                "/#narrow/stream/1-Stream-1//near/",
                 ParsedNarrowLink(),
                 id="invalid_narrow_link_5",
+            ),
+            case(
+                "/#narrow/stream/1-Stream-1/topic/foo/near/",
+                ParsedNarrowLink(),
+                id="invalid_narrow_link_6",
+            ),
+            case(
+                "/#narrow/stream/1-Stream-1/subject/foo/near/",
+                ParsedNarrowLink(),
+                id="invalid_narrow_link_7",
             ),
         ],
     )

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -493,12 +493,17 @@ class MessageLinkButton(urwid.Button):
         """
         # NOTE: The optional stream_id link version is deprecated. The extended
         # support is for old messages.
+        # NOTE: Support for narrow links with subject instead of topic is also added
         # We expect the fragment to be one of the following types:
         # a. narrow/stream/[{stream_id}-]{stream-name}
         # b. narrow/stream/[{stream_id}-]{stream-name}/near/{message_id}
         # c. narrow/stream/[{stream_id}-]{stream-name}/topic/
         #    {encoded.20topic.20name}
-        # d. narrow/stream/[{stream_id}-]{stream-name}/topic/
+        # d. narrow/stream/[{stream_id}-]{stream-name}/subject/
+        #    {encoded.20topic.20name}
+        # e. narrow/stream/[{stream_id}-]{stream-name}/topic/
+        #    {encoded.20topic.20name}/near/{message_id}
+        # f. narrow/stream/[{stream_id}-]{stream-name}/subject/
         #    {encoded.20topic.20name}/near/{message_id}
         fragments = urlparse(link.rstrip("/")).fragment.split("/")
         len_fragments = len(fragments)
@@ -509,7 +514,9 @@ class MessageLinkButton(urwid.Button):
             parsed_link = dict(narrow="stream", stream=stream_data)
 
         elif (
-            len_fragments == 5 and fragments[1] == "stream" and fragments[3] == "topic"
+            len_fragments == 5
+            and fragments[1] == "stream"
+            and (fragments[3] == "topic" or fragments[3] == "subject")
         ):
             stream_data = cls._decode_stream_data(fragments[2])
             topic_name = hash_util_decode(fragments[4])
@@ -527,7 +534,7 @@ class MessageLinkButton(urwid.Button):
         elif (
             len_fragments == 7
             and fragments[1] == "stream"
-            and fragments[3] == "topic"
+            and (fragments[3] == "topic" or fragments[3] == "subject")
             and fragments[5] == "near"
         ):
             stream_data = cls._decode_stream_data(fragments[2])


### PR DESCRIPTION
### What does this PR do, and why?
This PR contains commit which extends support to the old format for narrow links 
which existed before server version 2.1.0

[#zulip-terminal > Support old narrow links format #T1422 #T1424](https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/Support.20old.20narrow.20links.20format.20.23T1422.20.23T1424)
[#api-documentation > Narrow URL formats](https://chat.zulip.org/#narrow/stream/412-api-documentation/topic/Narrow.20URL.20formats)

### External discussion & connections
- [ ] Discussed in **#zulip-terminal** in `Support old narrow links format #T1422 #T1424`
- [x] Fully fixes #1422 
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
- [x] Manually - Behavioral changes
- [ ] Manually - Visual changes
- [x] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [ ] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [ ] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [x] It contains test additions for any new behavior
- [ ] It flows clearly from a previous branch commit, and/or prepares for the next commit
