### PR TITLE
Added Exit Confirmation Popup

### DIFF
--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -619,10 +619,18 @@ class Controller:
     def deregister_client(self) -> None:
         queue_id = self.model.queue_id
         self.client.deregister(queue_id, 1.0)
+        sys.exit(0)
 
     def exit_handler(self, signum: int, frame: Any) -> None:
-        self.deregister_client()
-        sys.exit(0)
+        question = urwid.Text(
+            ("bold", " Please confirm that you wish to exit Zulip-Terminal "),
+            "center",
+        )
+        popup_view = PopUpConfirmationView(
+            self, question, self.deregister_client, location="center"
+        )
+        self.loop.widget = popup_view
+        self.loop.run()
 
     def _raise_exception(self, *args: Any, **kwargs: Any) -> Literal[True]:
         if self._exception_info is not None:


### PR DESCRIPTION
<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?
Displays a confirmation popup when the (^C) interrupt signal is encountered, seeking confirmation prior to exiting the terminal client.

### Outstanding aspect(s)    <!-- DELETE SECTION IF EMPTY -->
<!-- In what ways is this not fully implemented/functioning? Compared to a discussion/issue? -->
<!-- Do you not understand something? Are you unsure about a certain approach? Want feedback? -->
- [ ] 

### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [ ] Discussed in **#zulip-terminal** in `topic`
- [ ] Fully fixes #
- [x] Partially fixes issue #1341
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [x] Manually - Behavioral changes
- [x] Manually - Visual changes
- [x] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [ ] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [ ] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [ ] It contains test additions for any new behavior
- [ ] It flows clearly from a previous branch commit, and/or prepares for the next commit

### Visual changes    <!-- DELETE SECTION IF NO VISUAL CHANGE -->

https://github.com/zulip/zulip-terminal/assets/110327345/f95a3f00-88ec-40cb-91ae-5ec8890a5985


