### PR TITLE
Narrow symbols

### DIFF
--- a/zulipterminal/config/symbols.py
+++ b/zulipterminal/config/symbols.py
@@ -8,10 +8,17 @@ Terminal characters used to mark particular elements of the user interface
 # Suffix comments indicate: unicode name, codepoint (unicode block, version if not v1.1)
 
 INVALID_MARKER = "✗"  # BALLOT X, U+2717 (Dingbats)
+
+ALL_MESSAGES_MARKER = "≡"  # IDENTICAL TO, U+2261 (Mathematical operators)
+MENTIONED_MESSAGES_MARKER = "@"
+STARRED_MESSAGES_MARKER = "*"
+
 DIRECT_MESSAGE_MARKER = "§"  # SECTION SIGN, U+00A7 (Latin-1 supplement)
+
 STREAM_MARKER_PRIVATE = "P"
 STREAM_MARKER_PUBLIC = "#"
 STREAM_MARKER_WEB_PUBLIC = "⊚"  # CIRCLED RING OPERATOR, U+229A (Mathematical operators)
+
 STREAM_TOPIC_SEPARATOR = "▶"  # BLACK RIGHT-POINTING TRIANGLE, U+25B6 (Geometric shapes)
 
 # Range of block options for consideration: '█', '▓', '▒', '░'

--- a/zulipterminal/config/ui_sizes.py
+++ b/zulipterminal/config/ui_sizes.py
@@ -3,7 +3,7 @@ Fixed sizes of UI elements
 """
 
 TAB_WIDTH = 3
-LEFT_WIDTH = 29
+LEFT_WIDTH = 31
 RIGHT_WIDTH = 23
 
 # These affect popup width-scaling, dependent upon window width

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -13,7 +13,14 @@ from typing_extensions import TypedDict
 from zulipterminal.api_types import RESOLVED_TOPIC_PREFIX, EditPropagateMode, Message
 from zulipterminal.config.keys import is_command_key, primary_key_for_command
 from zulipterminal.config.regexes import REGEX_INTERNAL_LINK_STREAM_ID
-from zulipterminal.config.symbols import CHECK_MARK, MUTE_MARKER
+from zulipterminal.config.symbols import (
+    ALL_MESSAGES_MARKER,
+    CHECK_MARK,
+    DIRECT_MESSAGE_MARKER,
+    MENTIONED_MESSAGES_MARKER,
+    MUTE_MARKER,
+    STARRED_MESSAGES_MARKER,
+)
 from zulipterminal.config.ui_mappings import EDIT_MODE_CAPTIONS, STREAM_ACCESS_TYPE
 from zulipterminal.helper import StreamData, hash_util_decode, process_media
 from zulipterminal.urwid_types import urwid_MarkupTuple, urwid_Size
@@ -122,6 +129,7 @@ class HomeButton(TopButton):
 
         super().__init__(
             controller=controller,
+            prefix_markup=("title", ALL_MESSAGES_MARKER),
             label_markup=(None, button_text),
             suffix_markup=("unread_count", ""),
             show_function=controller.narrow_to_all_messages,
@@ -136,6 +144,7 @@ class PMButton(TopButton):
         super().__init__(
             controller=controller,
             label_markup=(None, button_text),
+            prefix_markup=("title", DIRECT_MESSAGE_MARKER),
             suffix_markup=("unread_count", ""),
             show_function=controller.narrow_to_all_pm,
             count=count,
@@ -148,6 +157,7 @@ class MentionedButton(TopButton):
 
         super().__init__(
             controller=controller,
+            prefix_markup=("title", MENTIONED_MESSAGES_MARKER),
             label_markup=(None, button_text),
             suffix_markup=("unread_count", ""),
             show_function=controller.narrow_to_all_mentions,
@@ -161,6 +171,7 @@ class StarredButton(TopButton):
 
         super().__init__(
             controller=controller,
+            prefix_markup=("title", STARRED_MESSAGES_MARKER),
             label_markup=(None, button_text),
             suffix_markup=("starred_count", ""),
             show_function=controller.narrow_to_all_starred,


### PR DESCRIPTION
<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?
Adding symbols to narrow buttons on the top left of the side UI. This is to improve UI visually.





### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [x] Discussed in **#zulip-terminal** in `topic`
- [ ] Fully fixes #
- [x] Partially fixes issue #1420 
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [ ] Manually - Behavioral changes
- [x] Manually - Visual changes
- [x] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [ ] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [ ] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [x ] It contains test additions for any new behavior
- [ ] It flows clearly from a previous branch commit, and/or prepares for the next commit

### Visual changes    <!-- DELETE SECTION IF NO VISUAL CHANGE -->
<!-- Zulip tips at https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html -->
<!-- For video, try asciinema; after uploading, embed using
[![yourtitle](https://asciinema.org/a/<id>.png)](https://asciinema.org/a/<id>)
-->
<!-- NOTE: Attached videos/images will be clearer from smaller terminal windows -->
Before:
<img width="382" alt="image" src="https://github.com/zulip/zulip-terminal/assets/77788985/90a9e8d0-a822-4798-b78f-630400d3a64e">

After: 
<img width="289" alt="image" src="https://github.com/zulip/zulip-terminal/assets/77788985/1a962cef-bb81-4e5f-876f-f8f881bc7de7">


