### PR TITLE
Upgrade spellcheckers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,10 @@ show_missing = true
 # See crate-ci/typos#744 and crate-ci/typos#773
 "O_WRONLY" = "O_WRONLY"
 
+[tool.typos.default.extend-words]
+# Allow iterm terminal emulator (ideally only per-file)
+"iterm" = "iterm"
+
 [tool.isort]
 py_version = 37
 # Use black for the default settings (with adjustments listed below)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,10 @@ precision = 1
 skip_covered = true
 show_missing = true
 
+[tool.typos.default.extend-identifiers]
+# See crate-ci/typos#744 and crate-ci/typos#773
+"O_WRONLY" = "O_WRONLY"
+
 [tool.isort]
 py_version = 37
 # Use black for the default settings (with adjustments listed below)

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ linting_deps = [
     "isort~=5.11.0",
     "black~=23.0",
     "ruff==0.0.267",
-    "codespell[toml]~=2.2.2",
+    "codespell[toml]~=2.2.5",
     "typos~=1.16.11",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ linting_deps = [
     "black~=23.0",
     "ruff==0.0.267",
     "codespell[toml]~=2.2.2",
-    "typos~=1.14.9",
+    "typos~=1.16.11",
 ]
 
 typing_deps = [

--- a/tools/run-spellcheck
+++ b/tools/run-spellcheck
@@ -32,7 +32,6 @@ EXCLUDE_FILES = [
     "tests/ui_tools/test_boxes.py",  # Word prefixes as part of autocomplete test
     "tests/config/test_themes.py",  # Wrong words as part of theme syntax test
     "tests/model/test_model.py",  # 2nd not recognized crate-ci/typos#466
-    "docs/FAQ.md",  # iterm2 is proper noun [term, item, interm]
     "tools/run-spellcheck",  # Exclude ourself due to notes
 ]
 


### PR DESCRIPTION
<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?

Other than keeping `codespell` and `typos` up to date with any extra spelling suggestions, the new version of `typos` allows configuration in `pyproject.toml`. Previous typos-specific workarounds were possible if adding a dedicated `typos.toml`, which I thought we'd previously added but avoided, which was the original motivation for looking at the latest typos version.

The pyproject.toml configuration is actually required for the upgrade due to `O_WRONLY` now appearing as a false positive. However, this also allows checking of the FAQ by typos, which was previously excluded from both tools due to the presence of `iterm`, by extending the allowed words list.

Ideally this would be simpler if tools added inline ignores (crate-ci/typos#316, codespell-project/codespell#1212), particularly if the format was common to multiple tools.

### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [ ] Discussed in **#zulip-terminal** in `topic`
- [ ] Fully fixes #
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [x] Manually - Behavioral changes
- [ ] Manually - Visual changes
- [ ] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [x] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [ ] It contains test additions for any new behavior
- [x] It flows clearly from a previous branch commit, and/or prepares for the next commit