### PR TITLE
Add support for all streams minimal

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -416,6 +416,20 @@ def never_subscribed_streams_fixture() -> List[Stream]:
 
 
 @pytest.fixture
+def all_stream_ids(
+    streams_fixture: List[Subscription],
+    unsubscribed_streams_fixture: List[Subscription],
+    never_subscribed_streams_fixture: List[Stream],
+) -> List[int]:
+    return [
+        stream["stream_id"]
+        for stream in streams_fixture
+        + unsubscribed_streams_fixture
+        + never_subscribed_streams_fixture
+    ]
+
+
+@pytest.fixture
 def realm_emojis() -> Dict[str, Dict[str, Any]]:
     # Omitting source_url, author_id (server version 3.0),
     # author (server version < 3.0) since they are not used.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -233,7 +233,7 @@ def logged_on_user() -> Dict[str, Any]:
 
 
 @pytest.fixture
-def general_stream() -> Dict[str, Any]:
+def general_stream() -> Subscription:
     return {
         "name": "Some general stream",
         "date_created": 1472091253,
@@ -245,7 +245,6 @@ def general_stream() -> Dict[str, Any]:
         "audible_notifications": False,
         "description": "General Stream",
         "rendered_description": "General Stream",
-        "is_old_stream": True,
         "desktop_notifications": False,
         "stream_weekly_traffic": 0,
         "push_notifications": False,
@@ -253,13 +252,18 @@ def general_stream() -> Dict[str, Any]:
         "message_retention_days": 10,
         "subscribers": [1001, 11, 12],
         "history_public_to_subscribers": True,
+        "is_announcement_only": False,
+        "first_message_id": 1,
+        "email_notifications": False,
+        "wildcard_mentions_notify": False,
+        "is_web_public": False,
     }
 
 
 # This is a private stream;
 # only description/stream_id/invite_only/name/color vary from above
 @pytest.fixture
-def secret_stream() -> Dict[str, Any]:
+def secret_stream() -> Subscription:
     return {
         "description": "Some private stream",
         "stream_id": 99,
@@ -272,19 +276,23 @@ def secret_stream() -> Dict[str, Any]:
         "color": "#ccc",  # Color in '#xxx' format
         "is_muted": False,
         "audible_notifications": False,
-        "is_old_stream": True,
         "desktop_notifications": False,
         "stream_weekly_traffic": 0,
         "message_retention_days": -1,
         "push_notifications": False,
         "subscribers": [1001, 11],
         "history_public_to_subscribers": False,
+        "is_announcement_only": False,
+        "first_message_id": 1,
+        "email_notifications": False,
+        "wildcard_mentions_notify": False,
+        "is_web_public": False,
     }
 
 
 # Like public stream but with is_web_public=True
 @pytest.fixture
-def web_public_stream() -> Dict[str, Any]:
+def web_public_stream() -> Subscription:
     return {
         "description": "Some web public stream",
         "stream_id": 999,
@@ -297,7 +305,6 @@ def web_public_stream() -> Dict[str, Any]:
         "color": "#ddd",  # Color in '#xxx' format
         "is_muted": False,
         "audible_notifications": False,
-        "is_old_stream": True,
         "desktop_notifications": False,
         "stream_weekly_traffic": 0,
         "message_retention_days": -1,
@@ -305,15 +312,19 @@ def web_public_stream() -> Dict[str, Any]:
         "subscribers": [1001, 11],
         "history_public_to_subscribers": False,
         "is_web_public": True,
+        "is_announcement_only": False,
+        "first_message_id": 1,
+        "email_notifications": False,
+        "wildcard_mentions_notify": False,
     }
 
 
 @pytest.fixture
 def streams_fixture(
-    general_stream: Dict[str, Any],
-    secret_stream: Dict[str, Any],
-    web_public_stream: Dict[str, Any],
-) -> List[Dict[str, Any]]:
+    general_stream: Subscription,
+    secret_stream: Subscription,
+    web_public_stream: Subscription,
+) -> List[Subscription]:
     streams = [general_stream, secret_stream, web_public_stream]
     for i in range(1, 3):
         streams.append(
@@ -328,7 +339,6 @@ def streams_fixture(
                 "audible_notifications": False,
                 "description": f"A description of stream {i}",
                 "rendered_description": f"A description of stream {i}",
-                "is_old_stream": True,
                 "desktop_notifications": False,
                 "stream_weekly_traffic": 0,
                 "push_notifications": False,
@@ -336,6 +346,11 @@ def streams_fixture(
                 "email_address": f"stream{i}@example.com",
                 "subscribers": [1001, 11, 12],
                 "history_public_to_subscribers": True,
+                "is_announcement_only": False,
+                "first_message_id": 1,
+                "email_notifications": False,
+                "wildcard_mentions_notify": False,
+                "is_web_public": False,
             }
         )
     return deepcopy(streams)
@@ -933,7 +948,7 @@ def clean_custom_profile_data_fixture() -> List[CustomProfileData]:
 def initial_data(
     logged_on_user: Dict[str, Any],
     users_fixture: List[Dict[str, Any]],
-    streams_fixture: List[Dict[str, Any]],
+    streams_fixture: List[Subscription],
     unsubscribed_streams_fixture: List[Subscription],
     never_subscribed_streams_fixture: List[Stream],
     realm_emojis: Dict[str, Dict[str, Any]],
@@ -1462,7 +1477,7 @@ def user_id(logged_on_user: Dict[str, Any]) -> int:
 
 
 @pytest.fixture
-def stream_dict(streams_fixture: List[Dict[str, Any]]) -> Dict[int, Any]:
+def stream_dict(streams_fixture: List[Subscription]) -> Dict[int, Subscription]:
     return {stream["stream_id"]: stream for stream in streams_fixture}
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,8 @@ from zulipterminal.api_types import (
     CustomProfileField,
     Message,
     MessageType,
+    Stream,
+    Subscription,
 )
 from zulipterminal.config.keys import (
     ZT_TO_URWID_CMD_MAPPING,
@@ -337,6 +339,65 @@ def streams_fixture(
             }
         )
     return deepcopy(streams)
+
+
+@pytest.fixture
+def unsubscribed_streams_fixture() -> List[Subscription]:
+    unsubscribed_streams: List[Subscription] = []
+    for i in range(3, 5):
+        unsubscribed_streams.append(
+            {
+                "name": f"Stream {i}",
+                "date_created": 1472047124 + i,
+                "invite_only": False,
+                "color": "#b0a5fd",
+                "pin_to_top": False,
+                "stream_id": i,
+                "is_muted": False,
+                "audible_notifications": False,
+                "description": f"A description of stream {i}",
+                "rendered_description": f"A description of stream {i}",
+                "desktop_notifications": False,
+                "stream_weekly_traffic": 0,
+                "push_notifications": False,
+                "message_retention_days": i + 30,
+                "email_address": f"stream{i}@example.com",
+                "email_notifications": False,
+                "wildcard_mentions_notify": False,
+                "subscribers": [1001, 11, 12],
+                "history_public_to_subscribers": True,
+                "is_announcement_only": True,
+                "stream_post_policy": 0,
+                "is_web_public": True,
+                "first_message_id": None,
+            }
+        )
+    return deepcopy(unsubscribed_streams)
+
+
+@pytest.fixture
+def never_subscribed_streams_fixture() -> List[Stream]:
+    never_subscribed_streams: List[Stream] = []
+    for i in range(5, 7):
+        never_subscribed_streams.append(
+            {
+                "name": f"Stream {i}",
+                "date_created": 1472047124 + i,
+                "invite_only": False,
+                "stream_id": i,
+                "description": f"A description of stream {i}",
+                "rendered_description": f"A description of stream {i}",
+                "stream_weekly_traffic": 0,
+                "message_retention_days": i + 30,
+                "subscribers": [1001, 11, 12],
+                "history_public_to_subscribers": True,
+                "is_announcement_only": True,
+                "stream_post_policy": 0,
+                "is_web_public": True,
+                "first_message_id": None,
+            }
+        )
+    return deepcopy(never_subscribed_streams)
 
 
 @pytest.fixture
@@ -873,6 +934,8 @@ def initial_data(
     logged_on_user: Dict[str, Any],
     users_fixture: List[Dict[str, Any]],
     streams_fixture: List[Dict[str, Any]],
+    unsubscribed_streams_fixture: List[Subscription],
+    never_subscribed_streams_fixture: List[Stream],
     realm_emojis: Dict[str, Dict[str, Any]],
     custom_profile_fields_fixture: List[Dict[str, Union[str, int]]],
 ) -> Dict[str, Any]:
@@ -884,24 +947,7 @@ def initial_data(
         "email": logged_on_user["email"],
         "user_id": logged_on_user["user_id"],
         "realm_name": "Test Organization Name",
-        "unsubscribed": [
-            {
-                "audible_notifications": False,
-                "description": "announce",
-                "stream_id": 7,
-                "is_old_stream": True,
-                "desktop_notifications": False,
-                "pin_to_top": False,
-                "stream_weekly_traffic": 0,
-                "invite_only": False,
-                "name": "announce",
-                "push_notifications": False,
-                "email_address": "",
-                "color": "#bfd56f",
-                "is_muted": False,
-                "history_public_to_subscribers": True,
-            }
-        ],
+        "unsubscribed": unsubscribed_streams_fixture,
         "result": "success",
         "queue_id": "1522420755:786",
         "realm_users": users_fixture,
@@ -950,24 +996,7 @@ def initial_data(
         "subscriptions": streams_fixture,
         "msg": "",
         "max_message_id": 552761,
-        "never_subscribed": [
-            {
-                "invite_only": False,
-                "description": "Announcements from the Zulip GCI Mentors",
-                "stream_id": 87,
-                "name": "GCI announce",
-                "is_old_stream": True,
-                "stream_weekly_traffic": 0,
-            },
-            {
-                "invite_only": False,
-                "description": "General discussion",
-                "stream_id": 74,
-                "name": "GCI general",
-                "is_old_stream": True,
-                "stream_weekly_traffic": 0,
-            },
-        ],
+        "never_subscribed": never_subscribed_streams_fixture,
         "unread_msgs": {
             "pms": [
                 {"sender_id": 1, "unread_message_ids": [1, 2]},
@@ -1435,6 +1464,26 @@ def user_id(logged_on_user: Dict[str, Any]) -> int:
 @pytest.fixture
 def stream_dict(streams_fixture: List[Dict[str, Any]]) -> Dict[int, Any]:
     return {stream["stream_id"]: stream for stream in streams_fixture}
+
+
+@pytest.fixture
+def unsubscribed_streams(
+    unsubscribed_streams_fixture: List[Subscription],
+) -> Dict[int, Subscription]:
+    return {
+        unsubscribed_stream["stream_id"]: unsubscribed_stream
+        for unsubscribed_stream in unsubscribed_streams_fixture
+    }
+
+
+@pytest.fixture
+def never_subscribed_streams(
+    never_subscribed_streams_fixture: List[Stream],
+) -> Dict[int, Stream]:
+    return {
+        never_subscribed_stream["stream_id"]: never_subscribed_stream
+        for never_subscribed_stream in never_subscribed_streams_fixture
+    }
 
 
 @pytest.fixture(

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -9,6 +9,7 @@ import pytest
 from pytest import param as case
 from pytest_mock import MockerFixture
 
+from zulipterminal.api_types import Subscription
 from zulipterminal.config.themes import generate_theme
 from zulipterminal.core import Controller
 from zulipterminal.helper import Index
@@ -126,6 +127,7 @@ class TestController:
         mocker: MockerFixture,
         controller: Controller,
         index_stream: Index,
+        general_stream: Subscription,
         stream_id: int = 205,
         stream_name: str = "PTEST",
     ) -> None:
@@ -133,11 +135,9 @@ class TestController:
         controller.model.index = index_stream
         controller.view.message_view = mocker.patch("urwid.ListBox")
         controller.model.stream_dict = {
-            stream_id: {
-                "color": "#ffffff",
-                "name": stream_name,
-            }
+            stream_id: general_stream,
         }
+        controller.model.stream_dict[stream_id]["name"] = stream_name
         controller.model.muted_streams = set()
         mocker.patch(MODEL + ".is_muted_topic", return_value=False)
 
@@ -173,6 +173,7 @@ class TestController:
         initial_stream_id: Optional[int],
         anchor: Optional[int],
         expected_final_focus: int,
+        general_stream: Subscription,
         stream_name: str = "PTEST",
         topic_name: str = "Test",
         stream_id: int = 205,
@@ -186,11 +187,9 @@ class TestController:
         controller.model.stream_id = initial_stream_id
         controller.view.message_view = mocker.patch("urwid.ListBox")
         controller.model.stream_dict = {
-            stream_id: {
-                "color": "#ffffff",
-                "name": stream_name,
-            }
+            stream_id: general_stream,
         }
+        controller.model.stream_dict[stream_id]["name"] = stream_name
         controller.model.muted_streams = set()
         mocker.patch(MODEL + ".is_muted_topic", return_value=False)
 
@@ -255,7 +254,9 @@ class TestController:
         controller: Controller,
         index_all_messages: Index,
         anchor: Optional[int],
+        general_stream: Subscription,
         expected_final_focus_msg_id: int,
+        stream_id: int = 205,
     ) -> None:
         controller.model.narrow = [["stream", "PTEST"]]
         controller.model.index = index_all_messages
@@ -263,9 +264,7 @@ class TestController:
         controller.model.user_email = "some@email"
         controller.model.user_id = 1
         controller.model.stream_dict = {
-            205: {
-                "color": "#ffffff",
-            }
+            stream_id: general_stream,
         }
         controller.model.muted_streams = set()
         mocker.patch(MODEL + ".is_muted_topic", return_value=False)
@@ -302,7 +301,12 @@ class TestController:
         assert msg_ids == id_list
 
     def test_narrow_to_all_starred(
-        self, mocker: MockerFixture, controller: Controller, index_all_starred: Index
+        self,
+        mocker: MockerFixture,
+        controller: Controller,
+        index_all_starred: Index,
+        general_stream: Subscription,
+        stream_id: int = 205,
     ) -> None:
         controller.model.narrow = []
         controller.model.index = index_all_starred
@@ -312,9 +316,7 @@ class TestController:
         mocker.patch(MODEL + ".is_muted_topic", return_value=False)
         controller.model.user_email = "some@email"
         controller.model.stream_dict = {
-            205: {
-                "color": "#ffffff",
-            }
+            stream_id: general_stream,
         }
         controller.view.message_view = mocker.patch("urwid.ListBox")
 
@@ -329,7 +331,12 @@ class TestController:
         assert msg_ids == id_list
 
     def test_narrow_to_all_mentions(
-        self, mocker: MockerFixture, controller: Controller, index_all_mentions: Index
+        self,
+        mocker: MockerFixture,
+        controller: Controller,
+        index_all_mentions: Index,
+        general_stream: Subscription,
+        stream_id: int = 205,
     ) -> None:
         controller.model.narrow = []
         controller.model.index = index_all_mentions
@@ -339,9 +346,7 @@ class TestController:
         controller.model.user_email = "some@email"
         controller.model.user_id = 1
         controller.model.stream_dict = {
-            205: {
-                "color": "#ffffff",
-            }
+            stream_id: general_stream,
         }
         controller.view.message_view = mocker.patch("urwid.ListBox")
 

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -134,10 +134,9 @@ class TestController:
         controller.model.narrow = []
         controller.model.index = index_stream
         controller.view.message_view = mocker.patch("urwid.ListBox")
-        controller.model.stream_dict = {
-            stream_id: general_stream,
-        }
-        controller.model.stream_dict[stream_id]["name"] = stream_name
+        mocker.patch(MODEL + ".stream_name_from_id", return_value=stream_name)
+        mocker.patch(MODEL + ".stream_id_from_name", return_value=stream_id)
+        mocker.patch(MODEL + ".is_user_subscribed_to_stream", return_value=True)
         controller.model.muted_streams = set()
         mocker.patch(MODEL + ".is_muted_topic", return_value=False)
 
@@ -186,10 +185,9 @@ class TestController:
         controller.model.index = index_multiple_topic_msg
         controller.model.stream_id = initial_stream_id
         controller.view.message_view = mocker.patch("urwid.ListBox")
-        controller.model.stream_dict = {
-            stream_id: general_stream,
-        }
-        controller.model.stream_dict[stream_id]["name"] = stream_name
+        mocker.patch(MODEL + ".stream_name_from_id", return_value=stream_name)
+        mocker.patch(MODEL + ".stream_id_from_name", return_value=stream_id)
+        mocker.patch(MODEL + ".is_user_subscribed_to_stream", return_value=True)
         controller.model.muted_streams = set()
         mocker.patch(MODEL + ".is_muted_topic", return_value=False)
 
@@ -263,9 +261,7 @@ class TestController:
         controller.view.message_view = mocker.patch("urwid.ListBox")
         controller.model.user_email = "some@email"
         controller.model.user_id = 1
-        controller.model.stream_dict = {
-            stream_id: general_stream,
-        }
+        mocker.patch(MODEL + ".is_user_subscribed_to_stream", return_value=True)
         controller.model.muted_streams = set()
         mocker.patch(MODEL + ".is_muted_topic", return_value=False)
 
@@ -315,9 +311,7 @@ class TestController:
         # FIXME: Expand upon is_muted_topic().
         mocker.patch(MODEL + ".is_muted_topic", return_value=False)
         controller.model.user_email = "some@email"
-        controller.model.stream_dict = {
-            stream_id: general_stream,
-        }
+        mocker.patch(MODEL + ".is_user_subscribed_to_stream", return_value=True)
         controller.view.message_view = mocker.patch("urwid.ListBox")
 
         controller.narrow_to_all_starred()  # FIXME: Add id narrowing test
@@ -345,9 +339,7 @@ class TestController:
         mocker.patch(MODEL + ".is_muted_topic", return_value=False)
         controller.model.user_email = "some@email"
         controller.model.user_id = 1
-        controller.model.stream_dict = {
-            stream_id: general_stream,
-        }
+        mocker.patch(MODEL + ".is_user_subscribed_to_stream", return_value=True)
         controller.view.message_view = mocker.patch("urwid.ListBox")
 
         controller.narrow_to_all_mentions()  # FIXME: Add id narrowing test

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -1946,6 +1946,24 @@ class TestModel:
     def test_stream_name_from_id(self, model, stream_id, expected_stream_name):
         assert model.stream_name_from_id(stream_id) == expected_stream_name
 
+    @pytest.mark.parametrize(
+        "stream_id, expected_stream_color",
+        [
+            case(
+                1000,
+                "#baf",
+                id="Subscribed stream",
+            ),
+            case(
+                3,
+                "#baf",
+                id="Unsubscribed stream",
+            ),
+        ],
+    )
+    def test_subscription_color_from_id(self, model, stream_id, expected_stream_color):
+        assert model.subscription_color_from_id(stream_id) == expected_stream_color
+
     @pytest.mark.parametrize("muted", powerset([99, 1000]))
     @pytest.mark.parametrize("visual_notification_enabled", powerset([99, 1000]))
     def test__subscribe_to_streams(

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -63,6 +63,8 @@ class TestModel:
         realm_emojis_data,
         zulip_emoji,
         stream_dict,
+        unsubscribed_streams,
+        never_subscribed_streams,
     ):
         assert hasattr(model, "controller")
         assert hasattr(model, "client")
@@ -70,6 +72,8 @@ class TestModel:
         assert model._have_last_message == {}
         assert model.stream_id is None
         assert model.stream_dict == stream_dict
+        assert model._unsubscribed_streams == unsubscribed_streams
+        assert model._never_subscribed_streams == never_subscribed_streams
         assert model.recipients == frozenset()
         assert model.index == initial_index
         assert model.last_unread_pm is None

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -1923,6 +1923,29 @@ class TestModel:
         model._never_subscribed_streams = never_subscribed_streams
         assert model.get_all_stream_ids() == all_stream_ids
 
+    @pytest.mark.parametrize(
+        "stream_id, expected_stream_name",
+        [
+            case(
+                1000,
+                "Some general stream",
+                id="Subscribed stream",
+            ),
+            case(
+                3,
+                "Stream 3",
+                id="Unsubscribed stream",
+            ),
+            case(
+                5,
+                "Stream 5",
+                id="Never subscribed stream",
+            ),
+        ],
+    )
+    def test_stream_name_from_id(self, model, stream_id, expected_stream_name):
+        assert model.stream_name_from_id(stream_id) == expected_stream_name
+
     @pytest.mark.parametrize("muted", powerset([99, 1000]))
     @pytest.mark.parametrize("visual_notification_enabled", powerset([99, 1000]))
     def test__subscribe_to_streams(

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -1703,6 +1703,226 @@ class TestModel:
         assert model.user_dict == user_dict
         assert model.users == user_list
 
+    @pytest.mark.parametrize(
+        "stream_id, expected_value",
+        [
+            case(
+                1000,
+                {
+                    "name": "Some general stream",
+                    "date_created": None,
+                    "invite_only": False,
+                    "color": "#baf",
+                    "pin_to_top": False,
+                    "stream_id": 1000,
+                    "is_muted": False,
+                    "audible_notifications": False,
+                    "description": "General Stream",
+                    "rendered_description": "General Stream",
+                    "desktop_notifications": False,
+                    "stream_weekly_traffic": 0,
+                    "push_notifications": False,
+                    "email_address": "general@example.comm",
+                    "message_retention_days": None,
+                    "subscribers": [1001, 11, 12],
+                    "history_public_to_subscribers": True,
+                    "is_announcement_only": False,
+                    "first_message_id": 1,
+                    "email_notifications": False,
+                    "wildcard_mentions_notify": False,
+                    "is_web_public": False,
+                },
+                id="subscribed_stream",
+            ),
+            case(
+                3,
+                {
+                    "name": "Stream 3",
+                    "date_created": 1472047127,
+                    "invite_only": False,
+                    "color": "#b0a5fd",
+                    "pin_to_top": False,
+                    "stream_id": 3,
+                    "is_muted": False,
+                    "audible_notifications": False,
+                    "description": "A description of stream 3",
+                    "rendered_description": "A description of stream 3",
+                    "desktop_notifications": False,
+                    "stream_weekly_traffic": 0,
+                    "push_notifications": False,
+                    "message_retention_days": 33,
+                    "email_address": "stream3@example.com",
+                    "email_notifications": False,
+                    "wildcard_mentions_notify": False,
+                    "subscribers": [1001, 11, 12],
+                    "history_public_to_subscribers": True,
+                    "is_announcement_only": True,
+                    "stream_post_policy": 0,
+                    "is_web_public": True,
+                    "first_message_id": None,
+                },
+                id="unsubscribed_stream",
+            ),
+            case(
+                5,
+                {
+                    "name": "Stream 5",
+                    "date_created": 1472047129,
+                    "invite_only": False,
+                    "stream_id": 5,
+                    "description": "A description of stream 5",
+                    "rendered_description": "A description of stream 5",
+                    "stream_weekly_traffic": 0,
+                    "message_retention_days": 35,
+                    "subscribers": [1001, 11, 12],
+                    "history_public_to_subscribers": True,
+                    "is_announcement_only": True,
+                    "stream_post_policy": 0,
+                    "is_web_public": True,
+                    "first_message_id": None,
+                },
+                id="never_subscribed_stream",
+            ),
+        ],
+    )
+    def test__get_stream_from_id(
+        self,
+        model,
+        stream_id,
+        expected_value,
+        stream_dict,
+        unsubscribed_streams,
+        never_subscribed_streams,
+    ):
+        model.stream_dict = stream_dict
+        model._unsubscribed_streams = unsubscribed_streams
+        model._never_subscribed_streams = never_subscribed_streams
+        assert model._get_stream_from_id(stream_id) == expected_value
+
+    def test__get_stream_from_id__nonexistent_stream(
+        self,
+        model,
+        stream_dict,
+        unsubscribed_streams,
+        never_subscribed_streams,
+        stream_id=231,  # id 231 does not belong to any stream
+    ):
+        assert stream_id not in {
+            **stream_dict,
+            **unsubscribed_streams,
+            **never_subscribed_streams,
+        }
+        model.stream_dict = stream_dict
+        model._unsubscribed_streams = unsubscribed_streams
+        model._never_subscribed_streams = never_subscribed_streams
+        with pytest.raises(RuntimeError):
+            model._get_stream_from_id(stream_id)
+
+    @pytest.mark.parametrize(
+        "stream_id, expected_value",
+        [
+            case(
+                1000,
+                {
+                    "name": "Some general stream",
+                    "date_created": None,
+                    "invite_only": False,
+                    "color": "#baf",
+                    "pin_to_top": False,
+                    "stream_id": 1000,
+                    "is_muted": False,
+                    "audible_notifications": False,
+                    "description": "General Stream",
+                    "rendered_description": "General Stream",
+                    "desktop_notifications": False,
+                    "stream_weekly_traffic": 0,
+                    "push_notifications": False,
+                    "email_address": "general@example.comm",
+                    "message_retention_days": None,
+                    "subscribers": [1001, 11, 12],
+                    "history_public_to_subscribers": True,
+                    "is_announcement_only": False,
+                    "first_message_id": 1,
+                    "email_notifications": False,
+                    "wildcard_mentions_notify": False,
+                    "is_web_public": False,
+                },
+                id="subscribed_stream",
+            ),
+            case(
+                3,
+                {
+                    "name": "Stream 3",
+                    "date_created": 1472047127,
+                    "invite_only": False,
+                    "color": "#b0a5fd",
+                    "pin_to_top": False,
+                    "stream_id": 3,
+                    "is_muted": False,
+                    "audible_notifications": False,
+                    "description": "A description of stream 3",
+                    "rendered_description": "A description of stream 3",
+                    "desktop_notifications": False,
+                    "stream_weekly_traffic": 0,
+                    "push_notifications": False,
+                    "message_retention_days": 33,
+                    "email_address": "stream3@example.com",
+                    "email_notifications": False,
+                    "wildcard_mentions_notify": False,
+                    "subscribers": [1001, 11, 12],
+                    "history_public_to_subscribers": True,
+                    "is_announcement_only": True,
+                    "stream_post_policy": 0,
+                    "is_web_public": True,
+                    "first_message_id": None,
+                },
+                id="unsubscribed_stream",
+            ),
+        ],
+    )
+    def test__get_subscription_from_id(
+        self,
+        model,
+        stream_id,
+        expected_value,
+        stream_dict,
+        unsubscribed_streams,
+    ):
+        model.stream_dict = stream_dict
+        model._unsubscribed_streams = unsubscribed_streams
+        assert model._get_subscription_from_id(stream_id) == expected_value
+
+    @pytest.mark.parametrize(
+        "stream_id",
+        [case(5, id="never_subscribed_stream"), case(231, id="non-existent_stream")],
+    )
+    def test__get_subscription_from_id__nonexistent_subscription(
+        self,
+        model,
+        stream_dict,
+        unsubscribed_streams,
+        never_subscribed_streams,
+        stream_id,
+    ):
+        model.stream_dict = stream_dict
+        model._unsubscribed_streams = unsubscribed_streams
+        model._never_subscribed_streams = never_subscribed_streams
+        with pytest.raises(RuntimeError):
+            model._get_subscription_from_id(stream_id)
+
+    def test_get_all_stream_ids(
+        self,
+        model,
+        stream_dict,
+        unsubscribed_streams,
+        never_subscribed_streams,
+        all_stream_ids,
+    ):
+        model.stream_dict = stream_dict
+        model._unsubscribed_streams = unsubscribed_streams
+        model._never_subscribed_streams = never_subscribed_streams
+        assert model.get_all_stream_ids() == all_stream_ids
+
     @pytest.mark.parametrize("muted", powerset([99, 1000]))
     @pytest.mark.parametrize("visual_notification_enabled", powerset([99, 1000]))
     def test__subscribe_to_streams(

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -918,7 +918,7 @@ class TestMiddleColumnView:
         mocker.patch(MIDCOLVIEW + ".focus_position")
         mocker.patch.object(self.view, "message_view")
 
-        mid_col_view.model.stream_dict = {1: {"name": "stream"}}
+        mid_col_view.model.stream_name_from_id.return_value = "stream"
         mid_col_view.model.next_unread_topic_from_message_id.return_value = (1, "topic")
 
         return_value = mid_col_view.keypress(size, key)

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -695,7 +695,6 @@ class TestTopicsView:
     ):
         mocker.patch(SUBDIR + ".buttons.TopButton.__init__", return_value=None)
         set_focus_valign = mocker.patch(VIEWS + ".urwid.ListBox.set_focus_valign")
-        topic_view.view.controller.model.stream_dict = {86: {"name": "PTEST"}}
         topic_view.view.controller.model.is_muted_topic = mocker.Mock(
             return_value=False
         )

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -153,11 +153,11 @@ class TestWriteBox:
         is_valid_stream: bool,
         required_typeahead: Optional[str],
         topics: List[str],
-        stream_dict: Dict[int, Dict[str, Any]],
+        all_stream_ids: List[int],
     ) -> None:
         write_box.model.topics_in_stream.return_value = topics
         write_box.model.is_valid_stream.return_value = is_valid_stream
-        write_box.model.stream_dict = stream_dict
+        write_box.model.get_all_stream_ids.return_value = all_stream_ids
         write_box.model.muted_streams = set()
         typeahead_string = write_box.generic_autocomplete(text, state)
 
@@ -573,12 +573,12 @@ class TestWriteBox:
         state: Optional[int],
         footer_text: List[Any],
         text: str,
-        stream_dict: Dict[int, Dict[str, Any]],
+        all_stream_ids: List[int],
     ) -> None:
         write_box.view.set_typeahead_footer = mocker.patch(
             "zulipterminal.ui.View.set_typeahead_footer"
         )
-        write_box.model.stream_dict = stream_dict
+        write_box.model.get_all_stream_ids.return_value = all_stream_ids
         write_box.model.muted_streams = set()
         write_box.generic_autocomplete(text, state)
 
@@ -941,6 +941,7 @@ class TestWriteBox:
         state_and_required_typeahead: Dict[int, Optional[str]],
         stream_categories: Dict[str, Any],
         stream_dict: Dict[int, Dict[str, Any]],
+        all_stream_ids: List[int],
     ) -> None:
         streams_to_pin = (
             [{"name": stream_name} for stream_name in stream_categories["pinned"]]
@@ -951,12 +952,15 @@ class TestWriteBox:
             write_box.view.unpinned_streams.remove(stream)
         write_box.view.pinned_streams = streams_to_pin
         write_box.stream_id = stream_categories.get("current_stream", None)
-        write_box.model.stream_dict = stream_dict
         write_box.model.muted_streams = {
             stream["stream_id"]
             for stream in stream_dict.values()
             if stream["name"] in stream_categories.get("muted", set())
         }
+        write_box.model.get_all_stream_ids.return_value = all_stream_ids
+        write_box.model.stream_name_from_id.side_effect = lambda x: stream_dict[x][
+            "name"
+        ]
         states = state_and_required_typeahead.keys()
         required_typeaheads = list(state_and_required_typeahead.values())
         typeahead_strings = [

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -1282,7 +1282,9 @@ class TestWriteBox:
         expected_color: str,
     ) -> None:
         # FIXME: Refactor when we have ~ Model.is_private_stream
-        write_box.model.stream_dict = stream_dict
+        write_box.model.subscription_color_from_id.side_effect = lambda x: stream_dict[
+            x
+        ]["color"]
         write_box.model.is_valid_stream.return_value = is_valid_stream
         write_box.model.stream_id_from_name.return_value = stream_id
         write_box.model.stream_access_type.return_value = stream_access_type

--- a/tests/ui_tools/test_buttons.py
+++ b/tests/ui_tools/test_buttons.py
@@ -444,6 +444,8 @@ class TestTopicButton:
         top_button = mocker.patch(MODULE + ".TopButton.__init__")
         params = dict(controller=controller, count=count)
 
+        controller.model.stream_name_from_id.return_value = stream_name
+
         topic_button = TopicButton(
             stream_id=stream_id, topic=title, view=view, **params
         )
@@ -922,6 +924,7 @@ class TestMessageLinkButton:
             "is_user_subscribed_to_stream",
             "is_valid_stream",
             "stream_id_from_name_return_value",
+            "stream_name_from_id_return_value",
             "expected_parsed_link",
             "expected_error",
         ],
@@ -933,6 +936,7 @@ class TestMessageLinkButton:
                 True,
                 None,
                 None,
+                "Stream 1",
                 ParsedNarrowLink(
                     stream=DecodedStream(stream_id=1, stream_name="Stream 1")
                 ),
@@ -945,6 +949,7 @@ class TestMessageLinkButton:
                 False,
                 None,
                 None,
+                None,
                 ParsedNarrowLink(stream=DecodedStream(stream_id=462, stream_name=None)),
                 "The stream seems to be either unknown or unsubscribed",
             ),
@@ -955,6 +960,7 @@ class TestMessageLinkButton:
                 None,
                 True,
                 1,
+                None,
                 ParsedNarrowLink(
                     stream=DecodedStream(stream_id=1, stream_name="Stream 1")
                 ),
@@ -967,6 +973,7 @@ class TestMessageLinkButton:
                 None,
                 False,
                 None,
+                "foo",
                 ParsedNarrowLink(
                     stream=DecodedStream(stream_id=None, stream_name="foo")
                 ),
@@ -982,15 +989,14 @@ class TestMessageLinkButton:
     )
     def test__validate_and_patch_stream_data(
         self,
-        stream_dict: Dict[int, Any],
         parsed_link: ParsedNarrowLink,
         is_user_subscribed_to_stream: Optional[bool],
         is_valid_stream: Optional[bool],
         stream_id_from_name_return_value: Optional[int],
+        stream_name_from_id_return_value: Optional[str],
         expected_parsed_link: ParsedNarrowLink,
         expected_error: str,
     ) -> None:
-        self.controller.model.stream_dict = stream_dict
         self.controller.model.stream_id_from_name.return_value = (
             stream_id_from_name_return_value
         )
@@ -999,6 +1005,10 @@ class TestMessageLinkButton:
         )
         self.controller.model.is_valid_stream.return_value = is_valid_stream
         mocked_button = self.message_link_button()
+
+        mocked_button.model.stream_name_from_id.return_value = (
+            stream_name_from_id_return_value
+        )
 
         error = mocked_button._validate_and_patch_stream_data(parsed_link)
 

--- a/tests/ui_tools/test_buttons.py
+++ b/tests/ui_tools/test_buttons.py
@@ -434,11 +434,6 @@ class TestTopicButton:
         is_resolved: bool,
     ) -> None:
         controller = mocker.Mock()
-        controller.model.stream_dict = {
-            205: {"name": "PTEST"},
-            86: {"name": "Django"},
-            14: {"name": "GSoC"},
-        }
         controller.model.is_muted_topic = mocker.Mock(return_value=False)
         view = mocker.Mock()
         top_button = mocker.patch(MODULE + ".TopButton.__init__")
@@ -488,7 +483,6 @@ class TestTopicButton:
         controller.model.is_muted_topic = mocker.Mock(
             return_value=is_muted_topic_return_value
         )
-        controller.model.stream_dict = {205: {"name": stream_name}}
         view = mocker.Mock()
         TopicButton(
             stream_id=205,
@@ -899,14 +893,12 @@ class TestMessageLinkButton:
     )
     def test__validate_narrow_link(
         self,
-        stream_dict: Dict[int, Any],
         parsed_link: ParsedNarrowLink,
         is_user_subscribed_to_stream: Optional[bool],
         is_valid_stream: Optional[bool],
         topics_in_stream: Optional[List[str]],
         expected_error: str,
     ) -> None:
-        self.controller.model.stream_dict = stream_dict
         self.controller.model.is_user_subscribed_to_stream.return_value = (
             is_user_subscribed_to_stream
         )

--- a/tests/ui_tools/test_messages.py
+++ b/tests/ui_tools/test_messages.py
@@ -1026,11 +1026,7 @@ class TestMessageBox:
         assert_header_bar,
         assert_search_bar,
     ):
-        self.model.stream_dict = {
-            205: {
-                "color": "#bd6",
-            },
-        }
+        self.model.subscription_color_from_id.return_value = "#bd6"
         self.model.narrow = msg_narrow
         messages = messages_successful_response["messages"]
         current_message = messages[msg_type]

--- a/tests/ui_tools/test_messages.py
+++ b/tests/ui_tools/test_messages.py
@@ -754,11 +754,6 @@ class TestMessageBox:
         ],
     )
     def test_main_view(self, mocker, message, last_message):
-        self.model.stream_dict = {
-            5: {
-                "color": "#bd6",
-            },
-        }
         MessageBox(message, self.model, last_message)
 
     @pytest.mark.parametrize(
@@ -833,11 +828,6 @@ class TestMessageBox:
     def test_main_view_generates_stream_header(
         self, mocker, message, to_vary_in_last_message
     ):
-        self.model.stream_dict = {
-            5: {
-                "color": "#bd6",
-            },
-        }
         last_message = dict(message, **to_vary_in_last_message)
         msg_box = MessageBox(message, self.model, last_message)
         view_components = msg_box.main_view()

--- a/zulipterminal/api_types.py
+++ b/zulipterminal/api_types.py
@@ -204,14 +204,14 @@ class Message(TypedDict, total=False):
 
 
 ###############################################################################
-# In "subscriptions" response from:
+# In "subscriptions", "unsubscribed", and "never_subscribed" responses from:
 #   https://zulip.com/api/register-queue
 # Also directly from:
 #   https://zulip.com/api/get-events#subscription-add
 #   https://zulip.com/api/get-subscriptions (unused)
 
 
-class Subscription(TypedDict):
+class Stream(TypedDict):
     stream_id: int
     name: str
     description: str
@@ -219,6 +219,18 @@ class Subscription(TypedDict):
     date_created: int  # NOTE: new in Zulip 4.0 / ZFL 30
     invite_only: bool
     subscribers: List[int]
+
+    is_announcement_only: bool  # Deprecated in Zulip 3.0 -> stream_post_policy
+    stream_post_policy: int  # NOTE: new in Zulip 3.0 / ZFL 1
+
+    is_web_public: bool
+    message_retention_days: Optional[int]  # NOTE: new in Zulip 3.0 / ZFL 17
+    history_public_to_subscribers: bool
+    first_message_id: Optional[int]
+    stream_weekly_traffic: Optional[int]
+
+
+class Subscription(Stream):
     desktop_notifications: Optional[bool]
     email_notifications: Optional[bool]
     wildcard_mentions_notify: Optional[bool]
@@ -229,16 +241,8 @@ class Subscription(TypedDict):
 
     is_muted: bool
 
-    is_announcement_only: bool  # Deprecated in Zulip 3.0 -> stream_post_policy
-    stream_post_policy: int  # NOTE: new in Zulip 3.0 / ZFL 1
-
-    is_web_public: bool
     role: int  # NOTE: new in Zulip 4.0 / ZFL 31
     color: str
-    message_retention_days: Optional[int]  # NOTE: new in Zulip 3.0 / ZFL 17
-    history_public_to_subscribers: bool
-    first_message_id: Optional[int]
-    stream_weekly_traffic: Optional[int]
 
     # Deprecated fields
     # in_home_view: bool  # Replaced by is_muted in Zulip 2.1; still present in updates

--- a/zulipterminal/api_types.py
+++ b/zulipterminal/api_types.py
@@ -216,12 +216,18 @@ class Stream(TypedDict):
     name: str
     description: str
     rendered_description: str
-    date_created: int  # NOTE: new in Zulip 4.0 / ZFL 30
+
+    # NOTE: new in Zulip 4.0 / ZFL 30, server data may not contain this field,
+    # in which case ZT adds it and sets it to None.
+    date_created: NotRequired[Optional[int]]
+
     invite_only: bool
     subscribers: List[int]
 
     is_announcement_only: bool  # Deprecated in Zulip 3.0 -> stream_post_policy
-    stream_post_policy: int  # NOTE: new in Zulip 3.0 / ZFL 1
+
+    # NOTE: new in Zulip 3.0 / ZFL 1, server versions < 3.0 may not contain this field
+    stream_post_policy: NotRequired[int]
 
     is_web_public: bool
     message_retention_days: Optional[int]  # NOTE: new in Zulip 3.0 / ZFL 17
@@ -241,11 +247,15 @@ class Subscription(Stream):
 
     is_muted: bool
 
-    role: int  # NOTE: new in Zulip 4.0 / ZFL 31
     color: str
 
     # Deprecated fields
+
     # in_home_view: bool  # Replaced by is_muted in Zulip 2.1; still present in updates
+
+    # Introduced in Zulip 4.0 / ZFL 31, removed in Zulip 6.0 / ZFL 133;
+    # not actively used by ZT or Zulip web
+    # role: int
 
 
 ###############################################################################

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1320,6 +1320,10 @@ class Model:
         stream = self._get_stream_from_id(stream_id)
         return stream["name"]
 
+    def subscription_color_from_id(self, subscription_id: int) -> str:
+        subscription = self._get_subscription_from_id(subscription_id)
+        return canonicalize_color(subscription["color"])
+
     def _subscribe_to_streams(self, subscriptions: List[Subscription]) -> None:
         def make_reduced_stream_data(stream: Subscription) -> StreamData:
             # stream_id has been changed to id.

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1290,6 +1290,32 @@ class Model:
             stream["stream_id"]: stream for stream in never_subscribed_streams
         }
 
+    def _get_stream_from_id(self, stream_id: int) -> Stream:
+        if stream_id in self.stream_dict:
+            return cast(Stream, self.stream_dict[stream_id])
+        elif stream_id in self._unsubscribed_streams:
+            return cast(Stream, self._unsubscribed_streams[stream_id])
+        elif stream_id in self._never_subscribed_streams:
+            return self._never_subscribed_streams[stream_id]
+        else:
+            raise RuntimeError(f"Stream with id {stream_id} does not exist!")
+
+    def _get_subscription_from_id(self, subscription_id: int) -> Subscription:
+        if subscription_id in self.stream_dict:
+            return self.stream_dict[subscription_id]
+        elif subscription_id in self._unsubscribed_streams:
+            return self._unsubscribed_streams[subscription_id]
+        else:
+            raise RuntimeError(
+                f"Stream with id {subscription_id} does not exist or never subscribed to!"  # noqa: E501
+            )
+
+    def get_all_stream_ids(self) -> List[int]:
+        id_list = list(self.stream_dict)
+        id_list.extend(stream_id for stream_id in self._unsubscribed_streams)
+        id_list.extend(stream_id for stream_id in self._never_subscribed_streams)
+        return id_list
+
     def _subscribe_to_streams(self, subscriptions: List[Subscription]) -> None:
         def make_reduced_stream_data(stream: Subscription) -> StreamData:
             # stream_id has been changed to id.

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -177,7 +177,7 @@ class Model:
         self.users: List[MinimalUserData] = []
         self._update_users_data_from_initial_data()
 
-        self.stream_dict: Dict[int, Any] = {}
+        self.stream_dict: Dict[int, Subscription] = {}
         self._unsubscribed_streams: Dict[int, Subscription] = {}
         self._never_subscribed_streams: Dict[int, Stream] = {}
         self.muted_streams: Set[int] = set()

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -890,7 +890,7 @@ class Model:
         """
         Returns True if topic is muted via muted_topics.
         """
-        stream_name = self.stream_dict[stream_id]["name"]
+        stream_name = self.stream_name_from_id(stream_id)
         topic_to_search = (stream_name, topic)
         return topic_to_search in self._muted_topics
 
@@ -1315,6 +1315,10 @@ class Model:
         id_list.extend(stream_id for stream_id in self._unsubscribed_streams)
         id_list.extend(stream_id for stream_id in self._never_subscribed_streams)
         return id_list
+
+    def stream_name_from_id(self, stream_id: int) -> str:
+        stream = self._get_stream_from_id(stream_id)
+        return stream["name"]
 
     def _subscribe_to_streams(self, subscriptions: List[Subscription]) -> None:
         def make_reduced_stream_data(stream: Subscription) -> StreamData:

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -412,8 +412,7 @@ class WriteBox(urwid.Pile):
             stream_id = self.model.stream_id_from_name(new_text)
             stream_access_type = self.model.stream_access_type(stream_id)
             stream_marker = STREAM_ACCESS_TYPE[stream_access_type]["icon"]
-            stream = self.model.stream_dict[stream_id]
-            color = stream["color"]
+            color = self.model.subscription_color_from_id(stream_id)
         self.header_write_box[self.FOCUS_HEADER_PREFIX_STREAM].set_text(
             (color, stream_marker)
         )

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -618,7 +618,7 @@ class WriteBox(urwid.Pile):
         )
 
         muted_streams = [
-            self.model.stream_dict[stream_id]["name"]
+            self.model.stream_name_from_id(stream_id)
             for stream_id in self.model.muted_streams
         ]
         matching_muted_streams = [
@@ -637,9 +637,8 @@ class WriteBox(urwid.Pile):
             else:
                 matched_streams.append(matching_muted_stream)
 
-        current_stream = self.model.stream_dict.get(self.stream_id, None)
-        if current_stream is not None:
-            current_stream_name = current_stream["name"]
+        if self.stream_id in self.model.get_all_stream_ids():
+            current_stream_name = self.model.stream_name_from_id(self.stream_id)
             if current_stream_name in matched_streams:
                 matched_streams.remove(current_stream_name)
                 matched_streams.insert(0, current_stream_name)

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -317,7 +317,7 @@ class TopicButton(TopButton):
         view: Any,
         count: int,
     ) -> None:
-        self.stream_name = controller.model.stream_dict[stream_id]["name"]
+        self.stream_name = controller.model.stream_name_from_id(stream_id)
         self.topic_name = topic
         self.stream_id = stream_id
         self.model = controller.model
@@ -586,7 +586,7 @@ class MessageLinkButton(urwid.Button):
             stream_id = cast(int, model.stream_id_from_name(stream_name))
             parsed_link["stream"]["stream_id"] = stream_id
         else:
-            stream_name = cast(str, model.stream_dict[stream_id]["name"])
+            stream_name = cast(str, model.stream_name_from_id(stream_id))
             parsed_link["stream"]["stream_name"] = stream_name
 
         return ""

--- a/zulipterminal/ui_tools/messages.py
+++ b/zulipterminal/ui_tools/messages.py
@@ -155,7 +155,7 @@ class MessageBox(urwid.Pile):
 
     def stream_header(self) -> Any:
         assert self.stream_id is not None
-        color = self.model.stream_dict[self.stream_id]["color"]
+        color = self.model.subscription_color_from_id(self.stream_id)
         bar_color = f"s{color}"
         stream_access_type = self.model.stream_access_type(self.stream_id)
         stream_icon = STREAM_ACCESS_TYPE[stream_access_type]["icon"]
@@ -224,7 +224,7 @@ class MessageBox(urwid.Pile):
         elif self.message["type"] == "stream":
             assert self.stream_id is not None
 
-            bar_color = self.model.stream_dict[self.stream_id]["color"]
+            bar_color = self.model.subscription_color_from_id(self.stream_id)
             bar_color = f"s{bar_color}"
             stream_access_type = self.model.stream_access_type(self.stream_id)
             stream_icon = STREAM_ACCESS_TYPE[stream_access_type]["icon"]

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -590,8 +590,8 @@ class MiddleColumnView(urwid.Frame):
             # For new streams with no previous conversation.
             if self.footer.focus is None:
                 stream_id = self.model.stream_id
-                stream_dict = self.model.stream_dict
-                self.footer.stream_box_view(caption=stream_dict[stream_id]["name"])
+                stream_name = self.model.stream_name_from_id(stream_id)
+                self.footer.stream_box_view(caption=stream_name)
             self.set_focus("footer")
             self.footer.focus_position = 0
             return key
@@ -621,7 +621,7 @@ class MiddleColumnView(urwid.Frame):
 
             stream_id, topic = stream_topic
             self.controller.narrow_to_topic(
-                stream_name=self.model.stream_dict[stream_id]["name"],
+                stream_name=self.model.stream_name_from_id(stream_id),
                 topic_name=topic,
             )
             return key


### PR DESCRIPTION
<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?
This PR is very similar to #1408 and #1419 and combines elements of both. This PR keeps the initial commits from #1419 but replaces the general accessor methods with only an attribute-specific necessary method i.e "name".


### Outstanding aspect(s)    <!-- DELETE SECTION IF EMPTY -->
<!-- In what ways is this not fully implemented/functioning? Compared to a discussion/issue? -->
<!-- Do you not understand something? Are you unsure about a certain approach? Want feedback? -->
- [x] Could add more attribute accessor methods (like "color")

### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [x] Discussed in **#zulip-terminal** in [`Adding streams throws key error`](https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/Adding.20streams.20throws.20key.20error)
- [x] Fully fixes #816 
- [ ] Partially fixes issue #
- [x] Builds upon previous unmerged work in PR #1419 and PR #1408 
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [x] Merge will enable work on #1387 

### How did you test this?
<!-- [x] all that apply -->
- [ ] Manually - Behavioral changes
- [ ] Manually - Visual changes
- [x] Adapting existing automated tests
- [x] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [x] It contains test additions for any new behavior
- [x] It flows clearly from a previous branch commit, and/or prepares for the next commit

### Visual changes    <!-- DELETE SECTION IF NO VISUAL CHANGE -->
<!-- Zulip tips at https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html -->
<!-- For video, try asciinema; after uploading, embed using
[![yourtitle](https://asciinema.org/a/<id>.png)](https://asciinema.org/a/<id>)
-->
<!-- NOTE: Attached videos/images will be clearer from smaller terminal windows -->
