### PR TITLE
Updated the AboutView popup with Exit confirmation setting

### DIFF
--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -200,6 +200,7 @@ class TestAboutView:
             notify_enabled=False,
             autohide_enabled=False,
             maximum_footlinks=3,
+            exit_confirmation_enabled=False,
         )
 
     @pytest.mark.parametrize(
@@ -241,6 +242,7 @@ class TestAboutView:
             notify_enabled=False,
             autohide_enabled=False,
             maximum_footlinks=3,
+            exit_confirmation_enabled=False,
         )
 
         assert len(about_view.feature_level_content) == (

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -307,6 +307,7 @@ class Controller:
                 notify_enabled=self.notify_enabled,
                 autohide_enabled=self.autohide,
                 maximum_footlinks=self.maximum_footlinks,
+                exit_confirmation_enabled=self.exit_confirmation,
             ),
             "area:help",
         )

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1086,6 +1086,7 @@ class AboutView(PopUpView):
         autohide_enabled: bool,
         maximum_footlinks: int,
         notify_enabled: bool,
+        exit_confirmation_enabled: bool,
     ) -> None:
         self.feature_level_content = (
             [("Feature level", str(server_feature_level))]
@@ -1103,6 +1104,10 @@ class AboutView(PopUpView):
                     ("Maximum footlinks", str(maximum_footlinks)),
                     ("Color depth", str(color_depth)),
                     ("Notifications", "enabled" if notify_enabled else "disabled"),
+                    (
+                        "Exit confirmation",
+                        "enabled" if exit_confirmation_enabled else "disabled",
+                    ),
                 ],
             ),
             (


### PR DESCRIPTION
Tests updated.

<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?
Added the Exit confirmation setting to the AboutView popup.


### Outstanding aspect(s)    <!-- DELETE SECTION IF EMPTY -->
<!-- In what ways is this not fully implemented/functioning? Compared to a discussion/issue? -->
<!-- Do you not understand something? Are you unsure about a certain approach? Want feedback? -->
- [ ] 

### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [ ] Discussed in **#zulip-terminal** in `topic`
- [ ] Fully fixes #
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [x] Is a follow-up to work in PR #1432
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [ ] Manually - Behavioral changes
- [x] Manually - Visual changes
- [x] Adapting existing automated tests
- [x] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [ ] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [x] It contains test additions for any new behavior
- [x] It flows clearly from a previous branch commit, and/or prepares for the next commit

