### PR TITLE
feat: Open http and https link in browser

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -231,7 +231,7 @@ depending on the type of link:
   from message content such as `#**announce>terminal releases**`)
   * the active narrow will be changed to the stream or topic (from version 0.6.0)
 - *External links* (eg. a website, file from a website)
-  * no internal action is supported at this time
+  * open in browser if it is a website, otherwise no internal action is supported at this time
 
 Any method supported by your terminal emulator to select and copy text should
 also be suitable to extract these links.

--- a/tests/ui_tools/test_buttons.py
+++ b/tests/ui_tools/test_buttons.py
@@ -588,11 +588,12 @@ class TestMessageLinkButton:
             "link",
             "handle_narrow_link_called",
             "process_media_called",
+            "open_in_browser_called",
         ],
         [
-            (SERVER_URL + "/#narrow/stream/1-Stream-1", True, False),
-            (SERVER_URL + "/user_uploads/some/path/image.png", False, True),
-            ("https://foo.com", False, False),
+            (SERVER_URL + "/#narrow/stream/1-Stream-1", True, False, False),
+            (SERVER_URL + "/user_uploads/some/path/image.png", False, True, False),
+            ("https://foo.com", False, False, True),
         ],
         ids=[
             "internal_narrow_link",
@@ -606,6 +607,7 @@ class TestMessageLinkButton:
         link: str,
         handle_narrow_link_called: bool,
         process_media_called: bool,
+        open_in_browser_called: bool,
     ) -> None:
         self.controller.model.server_url = SERVER_URL
         self.handle_narrow_link = mocker.patch(MSGLINKBUTTON + ".handle_narrow_link")
@@ -617,6 +619,7 @@ class TestMessageLinkButton:
 
         assert self.handle_narrow_link.called == handle_narrow_link_called
         assert self.process_media.called == process_media_called
+        assert self.controller.open_in_browser.called == open_in_browser_called
 
     @pytest.mark.parametrize(
         "stream_data, expected_response",

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -469,6 +469,8 @@ class MessageLinkButton(urwid.Button):
             if self.controller.is_any_popup_open():
                 self.controller.exit_popup()
             process_media(self.controller, self.link)
+        elif self.link.startswith(("https://", "http://")):
+            self.controller.open_in_browser(self.link)
 
     @staticmethod
     def _decode_stream_data(encoded_stream_data: str) -> DecodedStream:


### PR DESCRIPTION
<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?
Make the external link in message info pop-up to be opened in the browser when hit `Enter`


### How did you test this?
<!-- [x] all that apply -->
- [x] Manually - Behavioral changes
- [ ] Manually - Visual changes
- [x] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [x] It contains test additions for any new behavior
- [x] It flows clearly from a previous branch commit, and/or prepares for the next commit
