### PR TITLE
Improve handling Esc during message compose

### DIFF
--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -1559,27 +1559,21 @@ class TestWriteBox:
             )
 
     @pytest.mark.parametrize(
-        "key, current_typeahead_mode, expected_typeahead_mode, expect_footer_was_reset",
+        "key, current_typeahead_mode, expected_typeahead_mode",
         [
-            # footer does not reset
-            (primary_key_for_command("AUTOCOMPLETE"), False, False, False),
-            (primary_key_for_command("AUTOCOMPLETE_REVERSE"), False, False, False),
-            (primary_key_for_command("AUTOCOMPLETE"), True, True, False),
-            (primary_key_for_command("AUTOCOMPLETE_REVERSE"), True, True, False),
-            # footer resets
-            (primary_key_for_command("EXIT_COMPOSE"), True, False, True),
-            ("space", True, False, True),
-            ("k", True, False, True),
+            (primary_key_for_command("AUTOCOMPLETE"), False, False),
+            (primary_key_for_command("AUTOCOMPLETE_REVERSE"), False, False),
+            (primary_key_for_command("AUTOCOMPLETE"), True, True),
+            (primary_key_for_command("AUTOCOMPLETE_REVERSE"), True, True),
         ],
     )
-    def test_keypress_typeahead_mode_autocomplete_key(
+    def test__keypress_typeahead_mode_autocomplete_key_footer_no_reset(
         self,
         mocker: MockerFixture,
         write_box: WriteBox,
         widget_size: Callable[[Widget], urwid_Size],
         current_typeahead_mode: bool,
         expected_typeahead_mode: bool,
-        expect_footer_was_reset: bool,
         key: str,
     ) -> None:
         write_box.msg_write_box = mocker.Mock(edit_text="")
@@ -1589,11 +1583,35 @@ class TestWriteBox:
         write_box.keypress(size, key)
 
         assert write_box.is_in_typeahead_mode == expected_typeahead_mode
-        if expect_footer_was_reset:
-            # We may prefer called-once in future, but the key part is that we do reset
-            assert self.view.set_footer_text.called
-        else:
-            assert not self.view.set_footer_text.called
+        assert not self.view.set_footer_text.called
+
+    @pytest.mark.parametrize(
+        "key, current_typeahead_mode, expected_typeahead_mode",
+        [
+            (primary_key_for_command("EXIT_COMPOSE"), True, False),
+            ("space", True, False),
+            ("k", True, False),
+        ],
+    )
+    def test__keypress_typeahead_mode_autocomplete_key_footer_reset(
+        self,
+        mocker: MockerFixture,
+        write_box: WriteBox,
+        widget_size: Callable[[Widget], urwid_Size],
+        current_typeahead_mode: bool,
+        expected_typeahead_mode: bool,
+        key: str,
+    ) -> None:
+        write_box.msg_write_box = mocker.Mock(edit_text="")
+        write_box.is_in_typeahead_mode = current_typeahead_mode
+        size = widget_size(write_box)
+
+        write_box.keypress(size, key)
+
+        assert write_box.is_in_typeahead_mode == expected_typeahead_mode
+
+        # We may prefer called-once in future, but the key part is that we do reset
+        assert self.view.set_footer_text.called
 
     @pytest.mark.parametrize(
         [

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -532,6 +532,21 @@ class Controller:
         mute_this_stream = partial(self.model.toggle_stream_muted_status, stream_id)
         self.loop.widget = PopUpConfirmationView(self, question, mute_this_stream)
 
+    def exit_compose_confirmation_popup(self) -> None:
+        question = urwid.Text(
+            (
+                "bold",
+                "Please confirm that you wish to exit the compose box.\n"
+                "(You can save the message as a draft upon returning to compose)",
+            ),
+            "center",
+        )
+        write_box = self.view.write_box
+        popup_view = PopUpConfirmationView(
+            self, question, write_box.exit_compose_box, location="center"
+        )
+        self.loop.widget = popup_view
+
     def copy_to_clipboard(self, text: str, text_category: str) -> None:
         try:
             pyperclip.copy(text)

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -515,10 +515,17 @@ class Controller:
 
     def save_draft_confirmation_popup(self, draft: Composition) -> None:
         question = urwid.Text(
-            "Save this message as a draft? (This will overwrite the existing draft.)"
+            (
+                "bold",
+                "Save this message as a draft? "
+                "(This will overwrite the existing draft.)",
+            ),
+            "center",
         )
         save_draft = partial(self.model.save_draft, draft)
-        self.loop.widget = PopUpConfirmationView(self, question, save_draft)
+        self.loop.widget = PopUpConfirmationView(
+            self, question, save_draft, location="center"
+        )
 
     def stream_muting_confirmation_popup(
         self, stream_id: int, stream_name: str

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -709,6 +709,12 @@ class WriteBox(urwid.Pile):
 
         return emoji_typeahead, emojis
 
+    def exit_compose_box(self) -> None:
+        self._set_compose_attributes_to_defaults()
+        self.view.controller.exit_editor_mode()
+        self.main_view(False)
+        self.view.middle_column.set_focus("body")
+
     def keypress(self, size: urwid_Size, key: str) -> Optional[str]:
         if self.is_in_typeahead_mode and not (
             is_command_key("AUTOCOMPLETE", key)
@@ -800,10 +806,7 @@ class WriteBox(urwid.Pile):
                     )
         elif is_command_key("EXIT_COMPOSE", key):
             self.send_stop_typing_status()
-            self._set_compose_attributes_to_defaults()
-            self.view.controller.exit_editor_mode()
-            self.main_view(False)
-            self.view.middle_column.set_focus("body")
+            self.exit_compose_box()
         elif is_command_key("MARKDOWN_HELP", key):
             self.view.controller.show_markdown_help()
             return key

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -715,14 +715,16 @@ class WriteBox(urwid.Pile):
         self.main_view(False)
         self.view.middle_column.set_focus("body")
 
+    def _set_default_footer_after_autocomplete(self) -> None:
+        self.is_in_typeahead_mode = False
+        self.view.set_footer_text()
+
     def keypress(self, size: urwid_Size, key: str) -> Optional[str]:
         if self.is_in_typeahead_mode and not (
             is_command_key("AUTOCOMPLETE", key)
             or is_command_key("AUTOCOMPLETE_REVERSE", key)
         ):
-            # set default footer when done with autocomplete
-            self.is_in_typeahead_mode = False
-            self.view.set_footer_text()
+            self._set_default_footer_after_autocomplete()
 
         if is_command_key("SEND_MESSAGE", key):
             self.send_stop_typing_status()


### PR DESCRIPTION
<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?
Uses the existing confirmation popup to confirm whether user wants to exit the compose box upon pressing `Esc`, Enabling the user to go back and save their draft from compose.


### Outstanding aspect(s)    <!-- DELETE SECTION IF EMPTY -->
<!-- In what ways is this not fully implemented/functioning? Compared to a discussion/issue? -->
<!-- Do you not understand something? Are you unsure about a certain approach? Want feedback? -->
- [ ] 

### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [x] Discussed in **#zulip-terminal** in `Improve handling Esc during msg compose #T1342 #T1362 #T1442`
- [x] Fully fixes #1342 
- [ ] Partially fixes issue #
- [x] Builds upon previous unmerged work in PR #1362 
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [x] Manually - Behavioral changes
- [x] Manually - Visual changes
- [ ] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [ ] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [ ] It has a commit summary describing the  motivation and reasoning for the change
- [ ] It individually passes linting and tests
- [ ] It contains test additions for any new behavior
- [ ] It flows clearly from a previous branch commit, and/or prepares for the next commit

### Visual changes    <!-- DELETE SECTION IF NO VISUAL CHANGE -->
<!-- Zulip tips at https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html -->
<!-- For video, try asciinema; after uploading, embed using
[![yourtitle](https://asciinema.org/a/<id>.png)](https://asciinema.org/a/<id>)
-->
<!-- NOTE: Attached videos/images will be clearer from smaller terminal windows -->
