### PR TITLE
Visual fix @topic mention

### DIFF
--- a/tests/ui_tools/test_messages.py
+++ b/tests/ui_tools/test_messages.py
@@ -114,6 +114,11 @@ class TestMessageBox:
                 [("msg_mention", "@A Group")],
                 id="group-mention",
             ),
+            case(
+                '<span class="topic-mention">@topic',
+                [("msg_mention", "@topic")],
+                id="topic-mention",
+            ),
             case("<code>some code", [("pygments:w", "some code")], id="inline-code"),
             case(
                 '<div class="codehilite" data-code-language="python">'

--- a/zulipterminal/ui_tools/messages.py
+++ b/zulipterminal/ui_tools/messages.py
@@ -442,9 +442,10 @@ class MessageBox(urwid.Pile):
 
                 markup.append(("msg_math", tag_text))
             elif tag == "span" and (
-                {"user-group-mention", "user-mention"} & set(tag_classes)
+                {"user-group-mention", "user-mention", "topic-mention"}
+                & set(tag_classes)
             ):
-                # USER MENTIONS & USER-GROUP MENTIONS
+                # USER, USER-GROUP & TOPIC MENTIONS
                 markup.append(("msg_mention", tag_text))
             elif tag == "a":
                 # LINKS


### PR DESCRIPTION
<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?
Makes the @topic mention behave like user mentions and user group mentions.

### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [ ] Discussed in **#zulip-terminal** in `topic`
- [x] Fully fixes #1418 
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [ ] Manually - Behavioral changes
- [x] Manually - Visual changes
- [ ] Adapting existing automated tests
- [x] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [x] It contains test additions for any new behavior
- [ ] It flows clearly from a previous branch commit, and/or prepares for the next commit

### Visual changes    <!-- DELETE SECTION IF NO VISUAL CHANGE -->
<!-- Zulip tips at https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html -->
<!-- For video, try asciinema; after uploading, embed using
[![yourtitle](https://asciinema.org/a/<id>.png)](https://asciinema.org/a/<id>)
-->
<!-- NOTE: Attached videos/images will be clearer from smaller terminal windows -->
Before Change:
![image](https://github.com/zulip/zulip-terminal/assets/69296186/8d5b7bd9-68ee-4788-b257-e04d7364f0aa)


After Change: 
![image](https://github.com/zulip/zulip-terminal/assets/69296186/a29b8c59-51bf-48b3-b848-2d22cd7c59df)

