### PR TITLE
config/themes: Convert pygments styles to urwid compatible styles.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ setup(
         "urwid_readline>=0.13",
         "beautifulsoup4>=4.11.1",
         "lxml~=4.9.2",
-        "pygments~=2.15.1",
+        "pygments>=2.14.0,<2.18.0",
         "typing_extensions~=4.5.0",
         "python-dateutil>=2.8.2",
         "pytz>=2022.7.1",


### PR DESCRIPTION
<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?
Pygments 2.16.0 introduced a style to support a combination of bold and italic styling in pygments/pygments#2444. Both of our gruvbox themes and the light native theme gain a 'bold strong' style via pygments as a result, which urwid fails to parse and blocks the application from loading.

This work would represent a clean fix for #1431, which was temporarily fixed by pinning pygments at ~=2.15.1 in #1433. Pygments can be unpinned after this fix.

Add method `translate_styles` that manually converts the pygments `bold italic` style into the urwid-compatible `bold, italics`. 

In requirements, unpin pygments from `~=2.15.1` to `>=2.14.0,<2.18.0`.

### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [x] Discussed in **#zulip-terminal** in `Translate pygments styles into urwid #T1434 #T1452`
- [ ] Fully fixes #
- [x] Partially fixes issue #1434
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [x] Manually - Behavioral changes
- [ ] Manually - Visual changes
- [ ] Adapting existing automated tests
- [x] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [x] It contains test additions for any new behavior
- [x] It flows clearly from a previous branch commit, and/or prepares for the next commit
