### PR TITLE
Bugfix: Avoid crash when "c" is pressed in Empty Narrow

### DIFF
--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -591,7 +591,10 @@ class MiddleColumnView(urwid.Frame):
             if self.footer.focus is None:
                 stream_id = self.model.stream_id
                 stream_dict = self.model.stream_dict
-                self.footer.stream_box_view(caption=stream_dict[stream_id]["name"])
+                if stream_id is None:
+                    self.footer.stream_box_view(0)
+                else:
+                    self.footer.stream_box_view(caption=stream_dict[stream_id]["name"])
             self.set_focus("footer")
             self.footer.focus_position = 0
             return key


### PR DESCRIPTION
<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?
Fixes #1453 

Discussion:
https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/ZT.20crashes.20when.20pressing.20.22c.22.20in.20empty.20stream



### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [x] Discussed in **#zulip-terminal** in `ZT crashes when pressing "c" in empty stream`
- [x] Fully fixes #1453 
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [x] Manually - Behavioral changes
- [x] Manually - Visual changes
- [x] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [x] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [ ] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [ ] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [] It contains test additions for any new behavior
- [x] It flows clearly from a previous branch commit, and/or prepares for the next commit

### Visual changes    <!-- DELETE SECTION IF NO VISUAL CHANGE -->
<!-- Zulip tips at https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html -->
<!-- For video, try asciinema; after uploading, embed using
[![yourtitle](https://asciinema.org/a/<id>.png)](https://asciinema.org/a/<id>)
-->
<!-- NOTE: Attached videos/images will be clearer from smaller terminal windows -->
