### PR TITLE
Add support for copying code snippets

### DIFF
--- a/docs/hotkeys.md
+++ b/docs/hotkeys.md
@@ -62,6 +62,7 @@
 |Toggle star status of the current message|<kbd>Ctrl</kbd> + <kbd>s</kbd> / <kbd>*</kbd>|
 |Show/hide message information|<kbd>i</kbd>|
 |Show/hide message sender information|<kbd>u</kbd>|
+|Copy code block to clipboard (from message information)|<kbd>c</kbd>|
 
 ## Stream list actions
 |Command|Key Combination|

--- a/tools/lint-hotkeys
+++ b/tools/lint-hotkeys
@@ -23,7 +23,7 @@ SCRIPT_NAME = PurePath(__file__).name
 HELP_TEXT_STYLE = re.compile(r"^[a-zA-Z /()',&@#:_-]*$")
 
 # Exclude keys from duplicate keys checking
-KEYS_TO_EXCLUDE = ["q", "e", "m", "r", "Esc"]
+KEYS_TO_EXCLUDE = ["q", "e", "m", "r", "Esc", "c"]
 
 
 def main(fix: bool) -> None:

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -443,6 +443,13 @@ KEY_BINDINGS: Dict[str, KeyBinding] = {
         'help_text': 'Show/hide full raw message',
         'key_category': 'msg_info',
     },
+    'COPY_CODE_BLOCK': {
+        'keys': ['c'],
+        'help_text':
+            'Copy code block to clipboard (from message information)',
+        'excluded_from_random_tips': True,
+        'key_category': 'msg_actions'
+    },
     'NEW_HINT': {
         'keys': ['tab'],
         'help_text': 'New footer hotkey hint',

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -563,6 +563,13 @@ class Controller:
         try:
             pyperclip.copy(text)
             clipboard_text = pyperclip.paste()
+
+            # Replace '\r\n' (CRLF) with '\n' for consistent comparison in WSL.
+            # os.linesep() cannot be used since WSL has '\n' line endings (POSIX) and
+            # the '\r\n' line endings are due to interaction with Windows clipboard.
+            if PLATFORM == "WSL":
+                clipboard_text = clipboard_text.replace("\r\n", "\n")
+
             if clipboard_text == text:
                 self.report_success([f"{text_category} copied successfully"])
             else:

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -268,6 +268,7 @@ class Controller:
         topic_links: Dict[str, Tuple[str, int, bool]],
         message_links: Dict[str, Tuple[str, int, bool]],
         time_mentions: List[Tuple[str, str]],
+        code_blocks: List[Tuple[str, List[Tuple[str, str]]]],
     ) -> None:
         msg_info_view = MsgInfoView(
             self,
@@ -276,6 +277,7 @@ class Controller:
             topic_links,
             message_links,
             time_mentions,
+            code_blocks,
         )
         self.show_pop_up(msg_info_view, "area:msg")
 
@@ -347,6 +349,7 @@ class Controller:
         topic_links: Dict[str, Tuple[str, int, bool]],
         message_links: Dict[str, Tuple[str, int, bool]],
         time_mentions: List[Tuple[str, str]],
+        code_blocks: List[Tuple[str, List[Tuple[str, str]]]],
     ) -> None:
         self.show_pop_up(
             FullRenderedMsgView(
@@ -355,6 +358,7 @@ class Controller:
                 topic_links,
                 message_links,
                 time_mentions,
+                code_blocks,
                 f"Full rendered message {SCROLL_PROMPT}",
             ),
             "area:msg",
@@ -366,6 +370,7 @@ class Controller:
         topic_links: Dict[str, Tuple[str, int, bool]],
         message_links: Dict[str, Tuple[str, int, bool]],
         time_mentions: List[Tuple[str, str]],
+        code_blocks: List[Tuple[str, List[Tuple[str, str]]]],
     ) -> None:
         self.show_pop_up(
             FullRawMsgView(
@@ -374,6 +379,7 @@ class Controller:
                 topic_links,
                 message_links,
                 time_mentions,
+                code_blocks,
                 f"Full raw message {SCROLL_PROMPT}",
             ),
             "area:msg",
@@ -385,6 +391,7 @@ class Controller:
         topic_links: Dict[str, Tuple[str, int, bool]],
         message_links: Dict[str, Tuple[str, int, bool]],
         time_mentions: List[Tuple[str, str]],
+        code_blocks: List[Tuple[str, List[Tuple[str, str]]]],
     ) -> None:
         self.show_pop_up(
             EditHistoryView(
@@ -393,6 +400,7 @@ class Controller:
                 topic_links,
                 message_links,
                 time_mentions,
+                code_blocks,
                 f"Edit History {SCROLL_PROMPT}",
             ),
             "area:msg",

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -752,6 +752,13 @@ class CodeBlockButton(urwid.Button):
             )
         self.display_code = [("pygments:w", self.caption)] + self.display_code
 
+    def keypress(self, size: urwid_Size, key: str) -> Optional[str]:
+        if is_command_key("COPY_CODE_BLOCK", key):
+            urwid.emit_signal(
+                self, "click", lambda button: self.copy_to_clipboard(self.block_list)
+            )
+        return super().keypress(size, key)
+
 
 class EditModeButton(urwid.Button):
     def __init__(self, *, controller: Any, width: int) -> None:

--- a/zulipterminal/ui_tools/messages.py
+++ b/zulipterminal/ui_tools/messages.py
@@ -63,6 +63,7 @@ class MessageBox(urwid.Pile):
         self.message_links: Dict[str, Tuple[str, int, bool]] = dict()
         self.topic_links: Dict[str, Tuple[str, int, bool]] = dict()
         self.time_mentions: List[Tuple[str, str]] = list()
+        self.code_blocks: List[Tuple[str, List[Tuple[str, str]]]] = list()
         self.last_message = last_message
         # if this is the first message
         if self.last_message is None:
@@ -371,12 +372,22 @@ class MessageBox(urwid.Pile):
     @classmethod
     def soup2markup(
         cls, soup: Any, metadata: Dict[str, Any], **state: Any
-    ) -> Tuple[List[Any], Dict[str, Tuple[str, int, bool]], List[Tuple[str, str]]]:
+    ) -> Tuple[
+        List[Any],
+        Dict[str, Tuple[str, int, bool]],
+        List[Tuple[str, str]],
+        List[Tuple[str, List[Tuple[str, str]]]],
+    ]:
         # Ensure a string is provided, in case the soup finds none
         # This could occur if eg. an image is removed or not shown
         markup: List[Union[str, Tuple[Optional[str], Any]]] = [""]
         if soup is None:  # This is not iterable, so return promptly
-            return markup, metadata["message_links"], metadata["time_mentions"]
+            return (
+                markup,
+                metadata["message_links"],
+                metadata["time_mentions"],
+                metadata["code_blocks"],
+            )
         unrendered_tags = {  # In pairs of 'tag_name': 'text'
             # TODO: Some of these could be implemented
             "br": "",  # No indicator of absence
@@ -552,6 +563,8 @@ class MessageBox(urwid.Pile):
                 if code_soup is None:
                     code_soup = element.pre
 
+                code_block = []
+
                 for code_element in code_soup.contents:
                     code_text = (
                         code_element.text
@@ -562,10 +575,18 @@ class MessageBox(urwid.Pile):
                     if code_element.name == "span":
                         if len(code_text) == 0:
                             continue
-                        css_style = code_element.attrs.get("class", ["w"])
-                        markup.append((f"pygments:{css_style[0]}", code_text))
+                        css_style = (
+                            f"pygments:{code_element.attrs.get('class', ['w'])[0]}"
+                        )
                     else:
-                        markup.append(("pygments:w", code_text))
+                        css_style = "pygments:w"
+
+                    markup.append((css_style, code_text))
+                    code_block.append((css_style, code_text))
+
+                code_language = element.attrs.get("data-code-language")
+
+                metadata["code_blocks"].append((code_language, code_block))
             elif tag in ("strong", "em"):
                 # BOLD & ITALIC
                 markup.append(("msg_bold", tag_text))
@@ -634,7 +655,12 @@ class MessageBox(urwid.Pile):
                 metadata["time_mentions"].append((time_string, source_text))
             else:
                 markup.extend(cls.soup2markup(element, metadata)[0])
-        return markup, metadata["message_links"], metadata["time_mentions"]
+        return (
+            markup,
+            metadata["message_links"],
+            metadata["time_mentions"],
+            metadata["code_blocks"],
+        )
 
     def main_view(self) -> List[Any]:
         # Recipient Header
@@ -730,11 +756,13 @@ class MessageBox(urwid.Pile):
             )
 
         # Transform raw message content into markup (As needed by urwid.Text)
-        content, self.message_links, self.time_mentions = self.transform_content(
-            self.message["content"], self.model.server_url
-        )
+        (
+            content,
+            self.message_links,
+            self.time_mentions,
+            self.code_blocks,
+        ) = self.transform_content(self.message["content"], self.model.server_url)
         self.content.set_text(content)
-
         if self.message["id"] in self.model.index["edited_messages"]:
             edited_label_size = 7
             left_padding = 1
@@ -819,6 +847,7 @@ class MessageBox(urwid.Pile):
         Tuple[None, Any],
         Dict[str, Tuple[str, int, bool]],
         List[Tuple[str, str]],
+        List[Tuple[str, List[Tuple[str, str]]]],
     ]:
         soup = BeautifulSoup(content, "lxml")
         body = soup.find(name="body")
@@ -827,13 +856,16 @@ class MessageBox(urwid.Pile):
             server_url=server_url,
             message_links=dict(),
             time_mentions=list(),
+            code_blocks=list(),
         )  # type: Dict[str, Any]
 
         if isinstance(body, Tag) and body.find(name="blockquote"):
             metadata["bq_len"] = cls.indent_quoted_content(soup, QUOTED_TEXT_MARKER)
 
-        markup, message_links, time_mentions = cls.soup2markup(body, metadata)
-        return (None, markup), message_links, time_mentions
+        markup, message_links, time_mentions, code_blocks = cls.soup2markup(
+            body, metadata
+        )
+        return (None, markup), message_links, time_mentions, code_blocks
 
     @staticmethod
     def indent_quoted_content(soup: Any, padding_char: str) -> int:
@@ -1121,7 +1153,11 @@ class MessageBox(urwid.Pile):
             self.model.controller.view.middle_column.set_focus("footer")
         elif is_command_key("MSG_INFO", key):
             self.model.controller.show_msg_info(
-                self.message, self.topic_links, self.message_links, self.time_mentions
+                self.message,
+                self.topic_links,
+                self.message_links,
+                self.time_mentions,
+                self.code_blocks,
             )
         elif is_command_key("ADD_REACTION", key):
             self.model.controller.show_emoji_picker(self.message)

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1423,7 +1423,7 @@ class StreamInfoView(PopUpView):
 
         title = f"{stream_marker} {stream['name']}"
         rendered_desc = stream["rendered_description"]
-        self.markup_desc, message_links, _ = MessageBox.transform_content(
+        self.markup_desc, message_links, _, _ = MessageBox.transform_content(
             rendered_desc,
             self.controller.model.server_url,
         )


### PR DESCRIPTION
<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?
Introduces the ability to copy code snippets, building upon the groundwork laid by @yuktasarode, @kingjuno, and @neiljp in previous pull requests: #1134 #1353.

This PR incorporates feedback from earlier pull requests. It introduces the `k` keybinding for copying code from a Message Information Popup.  This PR also resolves the previous issue of a flashing cursor on the button.

Additionally, it includes a minor refactoring in copy_to_clipboard to address return carriage differences in WSL.

### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [x] Discussed in **#zulip-terminal** in `Copy code snippets #T1353 #T1134 (fix #T1123)`
- [x] Fully fixes #1123
- [ ] Partially fixes issue #
- [x] Builds upon previous unmerged work in PR #1353
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [x] Manually - Behavioral changes
- [x] Manually - Visual changes
- [x] Adapting existing automated tests
- [x] Adding automated tests for new behavior (or missing tests)
- [x] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [x] It contains test additions for any new behavior
- [x] It flows clearly from a previous branch commit, and/or prepares for the next commit

https://github.com/zulip/zulip-terminal/assets/110327345/91606268-c1d9-46d8-b6d0-43d9e50deb66



