### PR TITLE
FIX #1456 added the read_by_sender to send a message

### DIFF
--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -755,11 +755,11 @@ class TestModel:
     )
     @pytest.mark.parametrize("recipients", [[5179], [5179, 5180]])
     def test_send_private_message(
-        self, mocker, model, recipients, response, return_value, content="hi!"
+        self, mocker, model, recipients, response, return_value, content="hi!",read_by_sender=True
     ):
         self.client.send_message = mocker.Mock(return_value=response)
 
-        result = model.send_private_message(recipients, content)
+        result = model.send_private_message(recipients, content,read_by_sender)
 
         req = dict(type="private", to=recipients, content=content)
         self.client.send_message.assert_called_once_with(req)
@@ -772,10 +772,10 @@ class TestModel:
             )
 
     def test_send_private_message_with_no_recipients(
-        self, model, content="hi!", recipients=[]
+        self, model, content="hi!", recipients=[],read_by_sender=True
     ):
         with pytest.raises(RuntimeError):
-            model.send_private_message(recipients, content)
+            model.send_private_message(recipients, content, read_by_sender)
 
     @pytest.mark.parametrize(
         "response, return_value",
@@ -793,10 +793,11 @@ class TestModel:
         content="hi!",
         stream="foo",
         topic="bar",
+        read_by_sender=True,
     ):
         self.client.send_message = mocker.Mock(return_value=response)
 
-        result = model.send_stream_message(stream, topic, content)
+        result = model.send_stream_message(stream, topic, content, read_by_sender)
 
         req = dict(type="stream", to=stream, subject=topic, content=content)
         self.client.send_message.assert_called_once_with(req)

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -530,12 +530,13 @@ class Model:
         else:
             raise RuntimeError("Empty recipient list.")
 
-    def send_private_message(self, recipients: List[int], content: str) -> bool:
+    def send_private_message(self, recipients: List[int], content: str,read_by_sender: bool =True) -> bool:
         if recipients:
             composition = PrivateComposition(
                 type="private",
                 to=recipients,
                 content=content,
+                read_by_sender=read_by_sender,
             )
             response = self.client.send_message(composition)
             display_error_if_present(response, self.controller)
@@ -546,12 +547,13 @@ class Model:
         else:
             raise RuntimeError("Empty recipients list.")
 
-    def send_stream_message(self, stream: str, topic: str, content: str) -> bool:
+    def send_stream_message(self, stream: str, topic: str, content: str,read_by_sender: bool =True) -> bool:
         composition = StreamComposition(
             type="stream",
             to=stream,
             subject=topic,
             content=content,
+            read_by_sender=read_by_sender,
         )
         response = self.client.send_message(composition)
         display_error_if_present(response, self.controller)


### PR DESCRIPTION
### What does this PR do, and why?

This pull request addresses the addition of the read_for_sender flag functionality in the Zulip Terminal, inspired by the changes made in the Zulip Flutter project ([#456](https://github.com/zulip/zulip-flutter/pull/456/commits/d30383c9372bb676d822452a2239b838d67b7880#)).

Changes:

Introduction of the read_for_sender flag.



### External discussion & connections
- [ ] Discussed in **#zulip-terminal** in `topic`
- [x] Fully fixes #
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
- [x] Manually - Behavioral changes
- [x] Manually - Visual changes
- [x] Adapting existing automated tests
- [x] Adding automated tests for new behavior (or missing tests)
- [x] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [x] It contains test additions for any new behavior
- [x] It flows clearly from a previous branch commit, and/or prepares for the next commit