### PR TITLE
Added the read_by_sender 

### DIFF
--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -773,7 +773,7 @@ class TestModel:
 
         result = model.send_private_message(recipients, content)
 
-        req = dict(type="private", to=recipients, content=content)
+        req = dict(type="private", to=recipients, content=content, read_by_sender=True)
         self.client.send_message.assert_called_once_with(req)
 
         assert result == return_value
@@ -810,7 +810,13 @@ class TestModel:
 
         result = model.send_stream_message(stream, topic, content)
 
-        req = dict(type="stream", to=stream, subject=topic, content=content)
+        req = dict(
+            type="stream",
+            to=stream,
+            subject=topic,
+            content=content,
+            read_by_sender=True,
+        )
         self.client.send_message.assert_called_once_with(req)
 
         assert result == return_value

--- a/zulipterminal/api_types.py
+++ b/zulipterminal/api_types.py
@@ -93,6 +93,7 @@ class PrivateComposition(TypedDict):
     type: DirectMessageString
     content: str
     to: List[int]  # User ids
+    read_by_sender: bool  # New in ZFL 236, Zulip 8.0
 
 
 class StreamComposition(TypedDict):
@@ -100,6 +101,7 @@ class StreamComposition(TypedDict):
     content: str
     to: str  # stream name  # TODO: Migrate to using int (stream id)
     subject: str  # TODO: Migrate to using topic
+    read_by_sender: bool  # New in ZFL 236, Zulip 8.0
 
 
 Composition = Union[PrivateComposition, StreamComposition]

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -541,6 +541,7 @@ class Model:
                 type="private",
                 to=recipients,
                 content=content,
+                read_by_sender=True,
             )
             response = self.client.send_message(composition)
             display_error_if_present(response, self.controller)
@@ -557,6 +558,7 @@ class Model:
             to=stream,
             subject=topic,
             content=content,
+            read_by_sender=True,
         )
         response = self.client.send_message(composition)
         display_error_if_present(response, self.controller)

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -820,6 +820,7 @@ class WriteBox(urwid.Pile):
                         type="private",
                         to=self.recipient_user_ids,
                         content=self.msg_write_box.edit_text,
+                        read_by_sender=True,
                     )
                 elif self.compose_box_status == "open_with_stream":
                     this_draft = StreamComposition(
@@ -827,6 +828,7 @@ class WriteBox(urwid.Pile):
                         to=self.stream_write_box.edit_text,
                         content=self.msg_write_box.edit_text,
                         subject=self.title_write_box.edit_text,
+                        read_by_sender=True,
                     )
                 saved_draft = self.model.session_draft_message()
                 if not saved_draft:


### PR DESCRIPTION
### What does this PR do, and why?

Introduction of the read_for_sender flag.


### External discussion & connections
- [x] Discussed in **#zulip-terminal** in `api add read_by_sender #T1459 #T1456`
- [x] Fully fixes #1456
- [ ] Partially fixes issue #
- [x] Builds upon previous unmerged work in PR #1457 
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
- [x] Manually - Behavioral changes
- [x] Manually - Visual changes
- [x] Adapting existing automated tests
- [x] Adding automated tests for new behavior (or missing tests)
- [x] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [ ] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [ ] It has a commit summary describing the  motivation and reasoning for the change
- [ ] It individually passes linting and tests
- [ ] It contains test additions for any new behavior
- [ ] It flows clearly from a previous branch commit, and/or prepares for the next commit


