### PR TITLE
ui: Add guest user suffix

### DIFF
--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -234,6 +234,7 @@ class TestController:
         }
 
         emails = [user_email]
+        mocker.patch.object(controller.model, "is_guest_user", return_value=False)
 
         controller.narrow_to_user(recipient_emails=emails)
 
@@ -269,6 +270,7 @@ class TestController:
         }
         controller.model.muted_streams = set()
         mocker.patch(MODEL + ".is_muted_topic", return_value=False)
+        mocker.patch.object(controller.model, "is_guest_user", return_value=False)
 
         controller.narrow_to_all_messages(contextual_message_id=anchor)
 
@@ -290,6 +292,7 @@ class TestController:
         controller.view.message_view = mocker.patch("urwid.ListBox")
         controller.model.user_id = 1
         controller.model.user_email = "some@email"
+        mocker.patch.object(controller.model, "is_guest_user", return_value=False)
 
         controller.narrow_to_all_pm()  # FIXME: Add id narrowing test
 
@@ -316,6 +319,7 @@ class TestController:
                 "color": "#ffffff",
             }
         }
+        mocker.patch.object(controller.model, "is_guest_user", return_value=False)
         controller.view.message_view = mocker.patch("urwid.ListBox")
 
         controller.narrow_to_all_starred()  # FIXME: Add id narrowing test
@@ -344,7 +348,7 @@ class TestController:
             }
         }
         controller.view.message_view = mocker.patch("urwid.ListBox")
-
+        mocker.patch.object(controller.model, "is_guest_user", return_value=False)
         controller.narrow_to_all_mentions()  # FIXME: Add id narrowing test
 
         assert controller.model.narrow == [["is", "mentioned"]]

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1075,6 +1075,7 @@ class TestRightColumnView:
     def test_users_view(self, users, users_btn_len, editor_mode, status, mocker):
         self.view.users = [{"user_id": 1, "status": status}]
         self.view.controller.is_in_editor_mode = lambda: editor_mode
+        mocker.patch.object(self.view.model, "is_guest_user", return_value=False)
         user_btn = mocker.patch(VIEWS + ".UserButton")
         users_view = mocker.patch(VIEWS + ".UsersView")
         right_col_view = RightColumnView(self.view)
@@ -1087,6 +1088,7 @@ class TestRightColumnView:
                 state_marker=STATUS_ACTIVE,
                 count=1,
                 is_current_user=False,
+                is_guest=False,
             )
         users_view.assert_called_once_with(
             self.view.controller, right_col_view.users_btn_list

--- a/tests/ui_tools/test_messages.py
+++ b/tests/ui_tools/test_messages.py
@@ -1072,11 +1072,11 @@ class TestMessageBox:
         "expected_header, to_vary_in_last_message",
         [
             (
-                [STATUS_INACTIVE, "alice", " ", "DAYDATETIME"],
+                [STATUS_INACTIVE, "alice", " ", " ", "DAYDATETIME"],
                 {"sender_full_name": "bob"},
             ),
-            ([" ", " ", " ", "DAYDATETIME"], {"timestamp": 1532103779}),
-            ([STATUS_INACTIVE, "alice", " ", "DAYDATETIME"], {"timestamp": 0}),
+            ([" ", " ", " ", " ", "DAYDATETIME"], {"timestamp": 1532103779}),
+            ([STATUS_INACTIVE, "alice", " ", " ", "DAYDATETIME"], {"timestamp": 0}),
         ],
         ids=[
             "show_author_as_authors_different",
@@ -1117,10 +1117,10 @@ class TestMessageBox:
 
         msg_box = MessageBox(this_msg, self.model, last_msg)
 
-        expected_header[2] = output_date_time
+        expected_header[3] = output_date_time
         if current_year > 2018:
-            expected_header[2] = "2018 - " + expected_header[2]
-        expected_header[3] = "*" if starred_msg == "this" else " "
+            expected_header[3] = "2018 - " + expected_header[3]
+        expected_header[4] = "*" if starred_msg == "this" else " "
 
         view_components = msg_box.main_view()
 
@@ -1811,12 +1811,14 @@ class TestMessageBox:
     )
     def test_reactions_view(
         self,
+        mocker,
         message_fixture,
         to_vary_in_each_message,
         expected_text,
         expected_attributes,
     ):
         self.model.user_id = 1
+        mocker.patch.object(self.model, "is_guest_user", return_value=False)
         varied_message = dict(message_fixture, **to_vary_in_each_message)
         msg_box = MessageBox(varied_message, self.model, None)
         reactions = to_vary_in_each_message["reactions"]

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -937,6 +937,7 @@ class TestMsgInfoView:
             "Tue Mar 13 10:55:22",
             "Tue Mar 13 10:55:37",
         ]
+        mocker.patch.object(self.controller.model, "is_guest_user", return_value=False)
         self.msg_info_view = MsgInfoView(
             self.controller,
             message_fixture,

--- a/zulipterminal/config/themes.py
+++ b/zulipterminal/config/themes.py
@@ -78,6 +78,7 @@ REQUIRED_STYLES = {
     'task:error'      : 'standout',
     'task:warning'    : 'standout',
     'ui_code'         : 'bold',
+    'guest_suffix'    : '',
 }
 
 REQUIRED_META = {

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -2094,3 +2094,12 @@ class Model:
                         self.controller.raise_exception_in_main_thread(
                             sys.exc_info(), critical=False
                         )
+
+    def is_guest_user(self, user_id: int) -> bool:
+        if self.initial_data.get("realm_enable_guest_user_indicator", None):
+            user = self.get_user_info(user_id)
+            if not user:
+                raise RuntimeError("Invalid user ID.")
+            role = user["role"]
+            return role == 600
+        return False

--- a/zulipterminal/themes/gruvbox_dark.py
+++ b/zulipterminal/themes/gruvbox_dark.py
@@ -74,6 +74,7 @@ STYLES = {
     'task:error'       : (Color.DARK0_HARD,            Color.BRIGHT_RED),
     'task:warning'     : (Color.DARK0_HARD,            Color.NEUTRAL_PURPLE),
     'ui_code'          : (Color.DARK0_HARD,            Color.LIGHT2),
+    'guest_suffix'    : (Color.LIGHT2,               Color.DARK0_HARD),
 }
 
 META = {

--- a/zulipterminal/themes/gruvbox_light.py
+++ b/zulipterminal/themes/gruvbox_light.py
@@ -73,6 +73,7 @@ STYLES = {
     'task:error'       : (Color.LIGHT0_HARD,            Color.FADED_RED),
     'task:warning'     : (Color.LIGHT0_HARD,            Color.NEUTRAL_PURPLE),
     'ui_code'          : (Color.LIGHT0_HARD,            Color.DARK2),
+    'guest_suffix'    : (Color.DARK2,               Color.LIGHT0_HARD),
 }
 
 META = {

--- a/zulipterminal/themes/zt_blue.py
+++ b/zulipterminal/themes/zt_blue.py
@@ -68,7 +68,8 @@ STYLES = {
     'task:error'      : (Color.WHITE,               Color.DARK_RED),
     'task:warning'    : (Color.WHITE,               Color.BROWN),
     'ui_code'         : (Color.DARK_BLUE,           Color.WHITE),
-}
+    'guest_suffix'    : (Color.WHITE,               Color.LIGHT_BLUE),
+    }
 
 META = {
     'pygments': {

--- a/zulipterminal/themes/zt_dark.py
+++ b/zulipterminal/themes/zt_dark.py
@@ -68,6 +68,7 @@ STYLES = {
     'task:error'      : (Color.WHITE,               Color.DARK_RED),
     'task:warning'    : (Color.WHITE,               Color.BROWN),
     'ui_code'         : (Color.BLACK,               Color.WHITE),
+    'guest_suffix'    : (Color.WHITE,               Color.BLACK),
 }
 
 META = {

--- a/zulipterminal/themes/zt_light.py
+++ b/zulipterminal/themes/zt_light.py
@@ -68,6 +68,7 @@ STYLES = {
     'task:error'      : (Color.WHITE,               Color.DARK_RED),
     'task:warning'    : (Color.BLACK,               Color.YELLOW),
     'ui_code'         : (Color.BLACK,               Color.LIGHT_GRAY),
+    'guest_suffix'    : (Color.DARK_GRAY,               Color.WHITE),
 }
 
 META = {

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -269,6 +269,7 @@ class UserButton(TopButton):
         color: Optional[str] = None,
         count: int,
         is_current_user: bool = False,
+        is_guest: bool = False,
     ) -> None:
         # Properties accessed externally
         self.email = user["email"]
@@ -290,6 +291,11 @@ class UserButton(TopButton):
         if is_current_user:
             self.suffix_style = "current_user"
             self.suffix_text = "(you)"
+            self.update_widget()
+
+        if is_guest:
+            self.suffix_style = "current_user"
+            self.suffix_text = "(guest)"
             self.update_widget()
 
     def _narrow_with_compose(self) -> None:

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -733,6 +733,7 @@ class RightColumnView(urwid.Frame):
                 user["user_id"], 0
             )
             is_current_user = user["user_id"] == self.view.model.user_id
+            is_guest = self.view.model.is_guest_user(user["user_id"])
             users_btn_list.append(
                 UserButton(
                     user=user,
@@ -742,6 +743,7 @@ class RightColumnView(urwid.Frame):
                     color=f"user_{status}",
                     count=unread_count,
                     is_current_user=is_current_user,
+                    is_guest=is_guest,
                 )
             )
         user_w = UsersView(self.view.controller, users_btn_list)


### PR DESCRIPTION
This commit is for adding guest user suffix in the UI if the user is a guest user and if realm_enable_guest_user_indicator setting is True. 
<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?
This PR Implements #1444  
The approach here is to update the function user_name_from_id to return the user's name with the suffix (guest) if the condition satisfies and calling the function in places where we display user's name.
The approach for Right column view is different from others we just pass the required arguments (realm_enable_guest_user_indicator  and is_guest) to UserButton and add suffix to the users name depending upon the arguments



### Outstanding aspect(s)    <!-- DELETE SECTION IF EMPTY -->
<!-- In what ways is this not fully implemented/functioning? Compared to a discussion/issue? -->
<!-- Do you not understand something? Are you unsure about a certain approach? Want feedback? -->
- [ ] wanted to know if my approach is right 
- [ ] other scenarios where the display change needs to be done
- [ ] will fix the test cases once approach is approved 

### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [x] Discussed in **#zulip-terminal** in `Add guest user suffix #T1444 #T1460`
- [ ] Fully fixes #
- [x] Partially fixes issue #1444
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [x] Manually - Behavioral changes
- [x] Manually - Visual changes
- [ ] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [ ] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [ ] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [ ] It individually passes linting and tests
- [ ] It contains test additions for any new behavior
- [ ] It flows clearly from a previous branch commit, and/or prepares for the next commit

### Visual changes    <!-- DELETE SECTION IF NO VISUAL CHANGE -->
<!-- Zulip tips at https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html -->
<!-- For video, try asciinema; after uploading, embed using
[![yourtitle](https://asciinema.org/a/<id>.png)](https://asciinema.org/a/<id>)
-->
<!-- NOTE: Attached videos/images will be clearer from smaller terminal windows -->
<img width="161" alt="Screenshot 2024-01-13 at 2 15 00 AM" src="https://github.com/zulip/zulip-terminal/assets/85862184/8c68b4ef-ba60-4bdc-933f-4d85686aaaae">
<img width="499" alt="Screenshot 2024-01-13 at 2 15 07 AM" src="https://github.com/zulip/zulip-terminal/assets/85862184/fbcb88e5-f80b-4c8b-adc1-81e7d53c602f">
<img width="272" alt="Screenshot 2024-01-13 at 2 15 24 AM" src="https://github.com/zulip/zulip-terminal/assets/85862184/6257e938-b1ed-406d-bb13-5ed907a4ffc3">
<img width="282" alt="Screenshot 2024-01-13 at 2 15 39 AM" src="https://github.com/zulip/zulip-terminal/assets/85862184/418c1bf2-fe76-4c7b-bf1d-f263b4d9002c">
<img width="470" alt="Screenshot 2024-01-13 at 2 20 13 AM" src="https://github.com/zulip/zulip-terminal/assets/85862184/9521bded-2de6-4137-8f51-ef02ab646f87">
