### PR TITLE
Support server-customized presence parameters.

### DIFF
--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -14,6 +14,8 @@ from zulipterminal.model import (
     MAX_MESSAGE_LENGTH,
     MAX_STREAM_NAME_LENGTH,
     MAX_TOPIC_NAME_LENGTH,
+    PRESENCE_OFFLINE_THRESHOLD_SECS,
+    PRESENCE_PING_INTERVAL_SECS,
     TYPING_STARTED_EXPIRY_PERIOD,
     TYPING_STARTED_WAIT_PERIOD,
     TYPING_STOPPED_WAIT_PERIOD,
@@ -1439,6 +1441,60 @@ class TestModel:
         assert model.typing_started_wait_period == typing_started_wait
         assert model.typing_stopped_wait_period == typing_stopped_wait
         assert model.typing_started_expiry_period == typing_started_expiry
+
+    @pytest.mark.parametrize(
+        "feature_level, to_vary_in_initial_data, "
+        "expected_offline_threshold, expected_presence_ping_interval",
+        [
+            (0, {}, PRESENCE_OFFLINE_THRESHOLD_SECS, PRESENCE_PING_INTERVAL_SECS),
+            (157, {}, PRESENCE_OFFLINE_THRESHOLD_SECS, PRESENCE_PING_INTERVAL_SECS),
+            (
+                164,
+                {
+                    "server_presence_offline_threshold_seconds": 200,
+                    "server_presence_ping_interval_seconds": 100,
+                },
+                200,
+                100,
+            ),
+        ],
+        ids=[
+            "Zulip_2.1_ZFL_0_hard_coded",
+            "Zulip_6.2_ZFL_157_hard_coded",
+            "Zulip_7.0_ZFL_164_server_provided",
+        ],
+    )
+    def test__store_server_presence_intervals(
+        self,
+        model,
+        initial_data,
+        feature_level,
+        to_vary_in_initial_data,
+        expected_offline_threshold,
+        expected_presence_ping_interval,
+    ):
+        # Ensure inputs are not the defaults, to avoid the test accidentally passing
+        assert (
+            to_vary_in_initial_data.get("server_presence_offline_threshold_seconds")
+            != PRESENCE_OFFLINE_THRESHOLD_SECS
+        )
+        assert (
+            to_vary_in_initial_data.get("server_presence_ping_interval_seconds")
+            != PRESENCE_PING_INTERVAL_SECS
+        )
+
+        initial_data.update(to_vary_in_initial_data)
+        model.initial_data = initial_data
+        model.server_feature_level = feature_level
+
+        model._store_server_presence_intervals()
+
+        assert (
+            model.server_presence_offline_threshold_secs == expected_offline_threshold
+        )
+        assert (
+            model.server_presence_ping_interval_secs == expected_presence_ping_interval
+        )
 
     def test_get_message_false_first_anchor(
         self,

--- a/zulipterminal/api_types.py
+++ b/zulipterminal/api_types.py
@@ -35,6 +35,14 @@ MAX_MESSAGE_LENGTH: Final = 10000
 
 
 ###############################################################################
+# These values are in the register response from ZFL 164
+# Before this feature level, they had the listed default (fixed) values
+
+PRESENCE_OFFLINE_THRESHOLD_SECS: Final = 140
+PRESENCE_PING_INTERVAL_SECS: Final = 60
+
+
+###############################################################################
 # Core message types (used in Composition and Message below)
 
 DirectMessageString = Literal["private"]

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -34,6 +34,8 @@ from zulipterminal.api_types import (
     MAX_MESSAGE_LENGTH,
     MAX_STREAM_NAME_LENGTH,
     MAX_TOPIC_NAME_LENGTH,
+    PRESENCE_OFFLINE_THRESHOLD_SECS,
+    PRESENCE_PING_INTERVAL_SECS,
     TYPING_STARTED_EXPIRY_PERIOD,
     TYPING_STARTED_WAIT_PERIOD,
     TYPING_STOPPED_WAIT_PERIOD,
@@ -79,9 +81,6 @@ from zulipterminal.helper import (
 )
 from zulipterminal.platform_code import notify
 from zulipterminal.ui_tools.utils import create_msg_box_list
-
-
-OFFLINE_THRESHOLD_SECS = 140
 
 
 class ServerConnectionFailure(Exception):
@@ -445,7 +444,7 @@ class Model:
                     view = self.controller.view
                     view.users_view.update_user_list(user_list=self.users)
                     view.middle_column.update_message_list_status_markers()
-            time.sleep(60)
+            time.sleep(PRESENCE_PING_INTERVAL_SECS)
 
     @asynch
     def toggle_message_reaction(
@@ -1202,7 +1201,7 @@ class Model:
                 *
                 * Out of the ClientPresence objects found in `presence`, we
                 * consider only those with a timestamp newer than
-                * OFFLINE_THRESHOLD_SECS; then of
+                * PRESENCE_OFFLINE_THRESHOLD_SECS; then of
                 * those, return the one that has the greatest UserStatus, where
                 * `active` > `idle` > `offline`.
                 *
@@ -1216,7 +1215,7 @@ class Model:
                     timestamp = client[1]["timestamp"]
                     if client_name == "aggregated":
                         continue
-                    elif (time.time() - timestamp) < OFFLINE_THRESHOLD_SECS:
+                    elif (time.time() - timestamp) < PRESENCE_OFFLINE_THRESHOLD_SECS:
                         if status == "active":
                             aggregate_status = "active"
                         if status == "idle" and aggregate_status != "active":


### PR DESCRIPTION

<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?

Instead of hard-coded constants, uses server provided values, falling back to the original constants when server version is lower.

### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [x] Discussed in **#zulip-terminal** in `Support server-customized presence parameters #T1421 #T1463`
- [x] Fully fixes #1421 
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [ ] Manually - Behavioral changes
- [ ] Manually - Visual changes
- [x] Adapting existing automated tests
- [x] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [x] It contains test additions for any new behavior
- [x] It flows clearly from a previous branch commit, and/or prepares for the next commit