### PR TITLE
Add support for copying raw message.

### DIFF
--- a/docs/hotkeys.md
+++ b/docs/hotkeys.md
@@ -64,6 +64,7 @@
 |View current message in browser (from message information)|<kbd>v</kbd>|
 |Show/hide full rendered message (from message information)|<kbd>f</kbd>|
 |Show/hide full raw message (from message information)|<kbd>r</kbd>|
+|Copy message content to clipboard (from message information)|<kbd>c</kbd>|
 
 ## Stream list actions
 |Command|Key Combination|

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -557,6 +557,13 @@ class TestFullRawMsgView:
         assert self.full_raw_message.header.widget_list == msg_box.header
         assert self.full_raw_message.footer.widget_list == msg_box.footer
 
+        assert isinstance(self.full_raw_message.footer.widget_list[0], Text)
+        assert (
+            self.full_raw_message.footer.widget_list[0].text
+            == f"\nPress {keys_for_command('COPY_MESSAGE')}"
+            " to copy raw message content to clipboard"
+        )
+
     @pytest.mark.parametrize("key", keys_for_command("MSG_INFO"))
     def test_keypress_exit_popup(
         self, key: str, widget_size: Callable[[Widget], urwid_Size]
@@ -596,6 +603,21 @@ class TestFullRawMsgView:
             topic_links=OrderedDict(),
             message_links=OrderedDict(),
             time_mentions=list(),
+        )
+
+    @pytest.mark.parametrize(
+        "key",
+        {*keys_for_command("COPY_MESSAGE")},
+    )
+    def test_keypress_copy_full_raw_msg(
+        self, key: str, widget_size: Callable[[Widget], urwid_Size]
+    ) -> None:
+        size = widget_size(self.full_raw_message)
+
+        self.full_raw_message.keypress(size, key)
+
+        self.controller.copy_to_clipboard.assert_called_once_with(
+            self.full_raw_message.raw_message_content, "Message Content"
         )
 
 

--- a/tools/lint-hotkeys
+++ b/tools/lint-hotkeys
@@ -19,7 +19,7 @@ SCRIPT_NAME = PurePath(__file__).name
 HELP_TEXT_STYLE = re.compile(r"^[a-zA-Z /()',&@#:_-]*$")
 
 # Exclude keys from duplicate keys checking
-KEYS_TO_EXCLUDE = ["q", "e", "m", "r"]
+KEYS_TO_EXCLUDE = ["q", "e", "m", "r", "c"]
 
 
 def main(fix: bool) -> None:

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -405,6 +405,11 @@ KEY_BINDINGS: Dict[str, KeyBinding] = {
         'help_text': 'Show/hide full raw message (from message information)',
         'key_category': 'msg_actions',
     },
+    'COPY_MESSAGE': {
+        'keys': ['c'],
+        'help_text':'Copy message content to clipboard (from message information)',
+        'key_category': 'msg_actions',
+    },
 }
 # fmt: on
 

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1939,14 +1939,27 @@ class FullRawMsgView(PopUpView):
 
         # Get rendered message header and footer
         msg_box = MessageBox(message, controller.model, None)
+        msg_box.footer.append(
+            urwid.Text(
+                (
+                    "msg_bold",
+                    (
+                        f"\nPress {keys_for_command('COPY_MESSAGE')}"
+                        " to copy raw message content to clipboard"
+                    ),
+                ),
+                align="left",
+            )
+        )
 
         # Get raw message content widget list
-        response = controller.model.fetch_raw_message_content(message["id"])
-
-        if response is None:
+        self.raw_message_content = controller.model.fetch_raw_message_content(
+            message["id"]
+        )
+        if self.raw_message_content is None:
             return
 
-        body_list = [urwid.Text(response)]
+        body_list = [urwid.Text(self.raw_message_content)]
 
         super().__init__(
             controller,
@@ -1967,6 +1980,9 @@ class FullRawMsgView(PopUpView):
                 time_mentions=self.time_mentions,
             )
             return key
+        elif is_command_key("COPY_MESSAGE", key):
+            content = self.raw_message_content
+            self.controller.copy_to_clipboard(content, "Message Content")
         return super().keypress(size, key)
 
 


### PR DESCRIPTION
<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?
Adding a key to copy raw message content since manually copying text in a terminal is pretty difficult due to the bars on the sides. Implemented using preexisting `copy_to_clipboard` function.


### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [x] Discussed in **#zulip-terminal** in `topic`
- [ ] Fully fixes #
- [x] Partially fixes issue #546
- [ ] Builds upon previous unmerged work in PR #
- [x] Is a follow-up to work in PR #1365
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [x] Manually - Behavioral changes
- [x] Manually - Visual changes
- [x] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [ ] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [x] It contains test additions for any new behavior
- [x] It flows clearly from a previous branch commit, and/or prepares for the next commit

### Visual changes    <!-- DELETE SECTION IF NO VISUAL CHANGE -->
<!-- Zulip tips at https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html -->
<!-- For video, try asciinema; after uploading, embed using
[![yourtitle](https://asciinema.org/a/<id>.png)](https://asciinema.org/a/<id>)
-->
<!-- NOTE: Attached videos/images will be clearer from smaller terminal windows -->
<img width="1132" alt="Screenshot 2024-02-14 at 7 45 35 PM" src="https://github.com/zulip/zulip-terminal/assets/71403193/516d8325-4393-49db-91a8-53cf961c758f">

