### PR TITLE
ZT crashing when viewing a message in the browser.

### DIFF
--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -406,15 +406,24 @@ class TestController:
         assert popup.call_args_list[0][0][1] == "area:error"
 
     @pytest.mark.parametrize(
-        "url",
+        "url, webbrowser_name, expected_webbrowser_name",
         [
-            "https://chat.zulip.org/#narrow/stream/test",
-            "https://chat.zulip.org/user_uploads/sent/abcd/efg.png",
-            "https://github.com/",
+            ("https://chat.zulip.org/#narrow/stream/test", "chrome", "chrome"),
+            (
+                "https://chat.zulip.org/user_uploads/sent/abcd/efg.png",
+                "mozilla",
+                "mozilla",
+            ),
+            ("https://github.com/", None, "default browser"),
         ],
     )
     def test_open_in_browser_success(
-        self, mocker: MockerFixture, controller: Controller, url: str
+        self,
+        mocker: MockerFixture,
+        controller: Controller,
+        url: str,
+        webbrowser_name: Optional[str],
+        expected_webbrowser_name: str,
     ) -> None:
         # Set DISPLAY environ to be able to run test in CI
         os.environ["DISPLAY"] = ":0"
@@ -422,11 +431,16 @@ class TestController:
         mock_get = mocker.patch(MODULE + ".webbrowser.get")
         mock_open = mock_get.return_value.open
 
+        if webbrowser_name is None:
+            del mock_get.return_value.name
+        else:
+            mock_get.return_value.name = webbrowser_name
+
         controller.open_in_browser(url)
 
         mock_open.assert_called_once_with(url)
         mocked_report_success.assert_called_once_with(
-            [f"The link was successfully opened using {mock_get.return_value.name}"]
+            [f"The link was successfully opened using {expected_webbrowser_name}"]
         )
 
     def test_open_in_browser_fail__no_browser_controller(

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -414,11 +414,14 @@ class Controller:
             # Suppress stdout and stderr when opening browser
             with suppress_output():
                 browser_controller.open(url)
+
+                # MacOS using Python version < 3.11 has no "name" attribute
+                # - https://github.com/python/cpython/issues/82828
+                # - https://github.com/python/cpython/issues/87590
+                # Use a default value if missing, for macOS, and potential later issues
+                browser_name = getattr(browser_controller, "name", "default browser")
                 self.report_success(
-                    [
-                        "The link was successfully opened using "
-                        f"{browser_controller.name}"
-                    ]
+                    [f"The link was successfully opened using {browser_name}"]
                 )
         except webbrowser.Error as e:
             # Set a footer text if no runnable browser is located


### PR DESCRIPTION
<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?

ZT crashes on MacOS when opening a message in browser due to an attribute error, where it tries to get 'name' to display the browser name. This might be an issue for other OS too.

Also refactored the test function name, since it had an extra '_'
### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [x] Discussed in **#zulip-terminal** in `ZT crashes trying to view message in browser #T1471 #T1472`
- [x] Fully fixes #1471 
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [x] Manually - Behavioral changes
- [x] Manually - Visual changes
- [ ] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [x] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [ ] It contains test additions for any new behavior
- [ ] It flows clearly from a previous branch commit, and/or prepares for the next commit

### Visual changes    <!-- DELETE SECTION IF NO VISUAL CHANGE -->
<!-- Zulip tips at https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html -->
<!-- For video, try asciinema; after uploading, embed using
[![yourtitle](https://asciinema.org/a/<id>.png)](https://asciinema.org/a/<id>)
-->
<!--NOTE: Attached videos/images will be clearer from smaller terminal windows -->

<img width="1440" alt="Screenshot 2024-02-15 at 10 13 09 PM" src="https://github.com/zulip/zulip-terminal/assets/71403193/42884f19-4f1f-477b-9c59-10e08edd9d16">