### PR TITLE
Fix ZT crash with an Index Error.

### DIFF
--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -1454,14 +1454,14 @@ class TestModel:
         )
 
         # Setup mocks before calling get_messages
-        messages_successful_response["anchor"] = 0
         self.client.get_messages.return_value = messages_successful_response
         mocker.patch(MODULE + ".index_messages", return_value=index_all_messages)
 
         model = Model(self.controller)
+        messages_successful_response["anchor"] = 0
         model.get_messages(num_before=num_before, num_after=num_after, anchor=0)
         self.client.get_messages.return_value = messages_successful_response
-        assert model.index["pointer"][repr(model.narrow)] == 0
+        assert repr(model.narrow) not in model.index["pointer"]
 
         # TEST `query_range` < no of messages received
         # RESET model._have_last_message value

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -763,7 +763,14 @@ class Model:
             self.index = index_messages(response["messages"], self, self.index)
             narrow_str = repr(self.narrow)
             if first_anchor and response["anchor"] != 10000000000000000:
-                self.index["pointer"][narrow_str] = response["anchor"]
+                msg_id_list = self.get_message_ids_in_current_narrow()
+                sorted_msg_id_list = sorted(
+                    msg_id_list, key=lambda id: self.index["messages"][id]["timestamp"]
+                )
+                if response["anchor"] in sorted_msg_id_list:
+                    self.index["pointer"][narrow_str] = sorted_msg_id_list.index(
+                        response["anchor"]
+                    )
             if "found_newest" in response:
                 just_found_last_msg = response["found_newest"]
             else:


### PR DESCRIPTION
<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?
This PR fixes the Index Error mentioned in  #1226. The PR resolves this by setting the focus pointer to the message index instead of the message ID. Other functions depending on the focus pointer also treat it as the message index, so the change in this PR keeps its usage consistent.


### Outstanding aspect(s)    <!-- DELETE SECTION IF EMPTY -->
<!-- In what ways is this not fully implemented/functioning? Compared to a discussion/issue? -->
<!-- Do you not understand something? Are you unsure about a certain approach? Want feedback? -->
- [ ] 

### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [x] Discussed in **#zulip-terminal** in `IndexError while starting.`
- [x] Fully fixes #1226 
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [x] Manually - Behavioral changes
- [ ] Manually - Visual changes
- [x] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [ ] It contains test additions for any new behavior
- [x] It flows clearly from a previous branch commit, and/or prepares for the next commit
