### PR TITLE
[WIP] Add help text on how to interact with message links.

### DIFF
--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -183,6 +183,43 @@ class TestPopUpView:
     @pytest.mark.parametrize(
         [
             "contents",
+            "expected_popup_width",
+            "expected_column_width",
+        ],
+        [
+            case(
+                [
+                    (
+                        "Viewing Actions",
+                        [
+                            ("Open in web browser", "[]"),
+                            ("Full rendered message", "[]"),
+                            ("Full raw message", "[]"),
+                        ],
+                    )
+                ],
+                25,
+                [21, 2],
+                id="heading_widget_with_row",
+            ),
+            case([("", "")], 17, [], id="widget_with_str"),
+        ],
+    )
+    def test_calculate_table_widths(
+        self,
+        contents: PopUpViewTableContent,
+        expected_popup_width: int,
+        expected_column_width: List[int],
+    ) -> None:
+        popup_width, column_width = self.pop_up_view.calculate_table_widths(
+            contents, len(self.title)
+        )
+        assert popup_width == expected_popup_width
+        assert column_width == expected_column_width
+
+    @pytest.mark.parametrize(
+        [
+            "contents",
             "expected_widget_type",
         ],
         [

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -4,7 +4,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 import pytest
 from pytest import param as case
 from pytest_mock import MockerFixture
-from urwid import Columns, Pile, Text, Widget
+from urwid import AttrWrap, Columns, Pile, Text, Widget
 
 from zulipterminal.api_types import Message
 from zulipterminal.config.keys import is_command_key, keys_for_command
@@ -24,6 +24,7 @@ from zulipterminal.ui_tools.views import (
     MsgInfoView,
     PopUpConfirmationView,
     PopUpView,
+    PopUpViewTableContent,
     StreamInfoView,
     StreamMembersView,
     UserInfoView,
@@ -178,6 +179,42 @@ class TestPopUpView:
         self.pop_up_view.keypress(size, navigation_key)
 
         self.super_keypress.assert_called_once_with(size, navigation_key)
+
+    @pytest.mark.parametrize(
+        [
+            "contents",
+            "expected_widget_type",
+        ],
+        [
+            case(
+                [
+                    (
+                        "Viewing Actions",
+                        [
+                            ("Open in web browser", "[]"),
+                            ("Full rendered message", "[]"),
+                            ("Full raw message", "[]"),
+                        ],
+                    )
+                ],
+                [Text, AttrWrap, AttrWrap, AttrWrap],
+                id="heading_widget_with_row",
+            ),
+            case([("", "")], [], id="widget_with_str"),
+        ],
+    )
+    def test_make_table_with_categories__instances(
+        self,
+        contents: PopUpViewTableContent,
+        expected_widget_type: List[Any],
+    ) -> None:
+        popup_width, column_widths = self.pop_up_view.calculate_table_widths(
+            contents, len(self.title)
+        )
+        widgets = self.pop_up_view.make_table_with_categories(contents, column_widths)
+        assert len(widgets) == len(expected_widget_type)
+        for widget, expected_type in zip(widgets, expected_widget_type):
+            assert isinstance(widget, expected_type)
 
 
 class TestAboutView:

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -203,6 +203,12 @@ class TestPopUpView:
                 id="heading_widget_with_row",
             ),
             case([("", "")], 17, [], id="widget_with_str"),
+            case(
+                [(("Message Links", "interact with links"), [])],
+                21,
+                [],
+                id="heading_widget_with_help_text",
+            ),
         ],
     )
     def test_calculate_table_widths(

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -201,6 +201,11 @@ class TestPopUpView:
                 id="heading_widget_with_row",
             ),
             case([("", "")], [], id="widget_with_str"),
+            case(
+                [(("Message Links", "interact with links"), [])],
+                [Columns],
+                id="heading_widget_with_help_text",
+            ),
         ],
     )
     def test_make_table_with_categories__instances(

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -115,7 +115,7 @@ class MessageView(urwid.ListBox):
         self.log = ModListWalker(contents=self.main_view(), action=self.read_message)
 
         super().__init__(self.log)
-        self.set_focus(self.focus_msg)
+        # self.set_focus(self.focus_msg) #Commenting this to resolve issue 1226
         # if loading new/old messages - True
         self.old_loading = False
         self.new_loading = False

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -946,7 +946,9 @@ class TabView(urwid.WidgetWrap):
 
 # FIXME: This type could be improved, as Any isn't too explicit and clear.
 # (this was previously str, but some types passed in can be more complex)
-PopUpViewTableContent = Sequence[Tuple[str, Sequence[Union[str, Tuple[str, Any]]]]]
+PopUpViewTableContent = Sequence[
+    Tuple[Union[str, Tuple[str, str]], Sequence[Union[str, Tuple[str, Any]]]]
+]
 
 
 class PopUpView(urwid.Frame):
@@ -1042,7 +1044,19 @@ class PopUpView(urwid.Frame):
             if category:
                 if len(widgets) > 0:  # Separate categories with newline.
                     widgets.append(urwid.Text(""))
-                widgets.append(urwid.Text(("popup_category", category)))
+                if isinstance(category, tuple):
+                    label, data = category
+                    widgets.append(
+                        urwid.Columns(
+                            [
+                                urwid.Text(("popup_category", label)),
+                                urwid.Text(("popup_category", f"{data} "), "right"),
+                            ],
+                            dividechars=dividechars,
+                        )
+                    )
+                else:
+                    widgets.append(urwid.Text(("popup_category", category)))
             for index, row in enumerate(content):
                 if isinstance(row, str) and row:
                     widgets.append(urwid.Text(row))

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1011,8 +1011,14 @@ class PopUpView(urwid.Frame):
         category_width = 0
         text_width = 0
         strip_widths = []
+        category_row_width = 0
         for category, content in contents:
             category_width = max(category_width, len(category))
+            if isinstance(category, tuple):
+                max_category_length = [
+                    len(max(text.split("\n"), key=len)) for text in category
+                ]
+                category_row_width = max(max_category_length)
             for row in content:
                 if isinstance(row, str):
                     # Measure the longest line if the text is separated by
@@ -1026,9 +1032,11 @@ class PopUpView(urwid.Frame):
                     ]
                     strip_widths.append(max_row_lengths)
         column_widths = [max(width) for width in zip(*strip_widths)]
-
         popup_width = max(
-            sum(column_widths) + dividechars, title_width, category_width, text_width
+            sum(column_widths, category_row_width) + dividechars,
+            title_width,
+            category_width,
+            text_width,
         )
         return (popup_width, column_widths)
 

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1593,7 +1593,7 @@ class MsgInfoView(PopUpView):
         full_raw_message_keys = "[{}]".format(
             ", ".join(map(str, display_keys_for_command("FULL_RAW_MESSAGE")))
         )
-        msg_info = [
+        msg_info: PopUpViewTableContent = [
             (
                 "",
                 [
@@ -1603,6 +1603,9 @@ class MsgInfoView(PopUpView):
                 ],
             )
         ]
+
+        # msg_info is list thus allows append
+        assert isinstance(msg_info, list)
 
         # actions for message info popup
         viewing_actions = (
@@ -1629,7 +1632,18 @@ class MsgInfoView(PopUpView):
             msg_info[1][1].append(("Edit History", keys))
         # Render the category using the existing table methods if links exist.
         if message_links:
-            msg_info.append(("Message Links", []))
+            interact_with_link_keys = "[{}]".format(
+                ", ".join(map(str, display_keys_for_command("ENTER")))
+            )
+            msg_info.append(
+                (
+                    (
+                        "Message Links",
+                        f"Interact with links {interact_with_link_keys}",
+                    ),
+                    [],
+                )
+            )
         if topic_links:
             msg_info.append(("Topic Links", []))
         if time_mentions:


### PR DESCRIPTION
<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?

### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [x] Discussed in [Open external links with browser #T1440](https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/Open.20external.20links.20with.20browser.20.23T1440)
- [ ] Fully fixes #
- [x] Partially fixes issue #1372 
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [x] Manually - Behavioral changes
- [x] Manually - Visual changes
- [ ] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [ ] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [ ] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [ ] It has a commit summary describing the  motivation and reasoning for the change
- [ ] It individually passes linting and tests
- [ ] It contains test additions for any new behavior
- [ ] It flows clearly from a previous branch commit, and/or prepares for the next commit

### Visual changes    <!-- DELETE SECTION IF NO VISUAL CHANGE -->
<!-- Zulip tips at https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html -->
<!-- For video, try asciinema; after uploading, embed using
[![yourtitle](https://asciinema.org/a/<id>.png)](https://asciinema.org/a/<id>)
-->
<!-- NOTE: Attached videos/images will be clearer from smaller terminal windows -->
<img width="599" alt="Screenshot 2024-03-28 at 11 38 11 PM" src="https://github.com/zulip/zulip-terminal/assets/71403193/f0128b9b-bedd-42d7-ac9b-37a70145dfab">

