### PR TITLE
Detect terminal text-based-browsers better and block them

### DIFF
--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -427,6 +427,8 @@ class TestController:
     ) -> None:
         # Set DISPLAY environ to be able to run test in CI
         os.environ["DISPLAY"] = ":0"
+        # Set TERM environ to be able to check text-browsers
+        os.environ["TERM"] = "xterm-256color"
         mocked_report_success = mocker.patch(MODULE + ".Controller.report_success")
         mock_get = mocker.patch(MODULE + ".webbrowser.get")
         mock_open = mock_get.return_value.open
@@ -447,6 +449,7 @@ class TestController:
         self, mocker: MockerFixture, controller: Controller
     ) -> None:
         os.environ["DISPLAY"] = ":0"
+        os.environ["TERM"] = "xterm-256color"
         error = "No runnable browser found"
         mocked_report_error = mocker.patch(MODULE + ".Controller.report_error")
         mocker.patch(MODULE + ".webbrowser.get").side_effect = webbrowser.Error(error)

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -410,6 +410,8 @@ class Controller:
         try:
             # Checks for a runnable browser in the system and returns
             # its browser controller, if found, else reports an error
+            term = os.environ.get("TERM")  # Saving the original value
+            del os.environ["TERM"]  # Temporarily deleting variable
             browser_controller = webbrowser.get()
             # Suppress stdout and stderr when opening browser
             with suppress_output():
@@ -424,6 +426,8 @@ class Controller:
                     [f"The link was successfully opened using {browser_name}"]
                 )
         except webbrowser.Error as e:
+            if isinstance(term, str):
+                os.environ["TERM"] = term  # resetting
             # Set a footer text if no runnable browser is located
             self.report_error([f"ERROR: {e}"])
 


### PR DESCRIPTION
<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?
Opening links in browser for users using text-based browsers results in ZT being frozen indefinitely. This might be because of the loop to open link in browser clashing with urwid loop. 

This PR blocks out text-browsers better than what it used to earlier. It does so by temporarily unsetting TERM environ so text-browsers aren't detected.
This results in an exception which displays an error for text-browsers.

### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [x] Discussed in **#zulip-terminal** in `topic` [Opening URLs can freeze terminal #T1475](https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/Opening.20URLs.20can.20freeze.20terminal.20.23T1475)
- [x] Fully fixes #1475 
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [x] Manually - Behavioral changes
- [x] Manually - Visual changes
- [x] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [ ] It contains test additions for any new behavior
- [ ] It flows clearly from a previous branch commit, and/or prepares for the next commit
