### PR TITLE
Handle timeout exception when fetching raw message.

### DIFF
--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -1516,6 +1516,20 @@ class TestModel:
                 None,
                 True,
             ),
+            (
+                {
+                    "result": "success",
+                    "raw_content": "An exception occurred:"
+                    + "\n"
+                    + "The application should continue functioning, but you "
+                    + "may notice inconsistent behavior in this session.",
+                },
+                "An exception occurred:"
+                + "\n"
+                + "The application should continue functioning, but you "
+                + "may notice inconsistent behavior in this session.",
+                False,
+            ),
         ],
     )
     def test_fetch_raw_message_content(
@@ -1527,11 +1541,14 @@ class TestModel:
         display_error_called,
         message_id=1,
     ):
-        self.client.get_raw_message.return_value = response
+        self.client.call_endpoint.return_value = response
 
         return_value = model.fetch_raw_message_content(message_id)
 
-        self.client.get_raw_message.assert_called_once_with(message_id)
+        self.client.call_endpoint.assert_called_once_with(
+            f"/messages/{message_id}", method="GET", timeout=5
+        )
+        # self.client.get_raw_message.assert_called_once_with(message_id)
         assert self.display_error_if_present.called == display_error_called
         assert return_value == expected_raw_content
 

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -25,6 +25,7 @@ from typing import (
 )
 from urllib.parse import urlparse
 
+import requests
 import zulip
 from bs4 import BeautifulSoup
 from typing_extensions import TypedDict
@@ -858,7 +859,15 @@ class Model:
         """
         Fetches raw message content of a message using its ID.
         """
-        response = self.client.get_raw_message(message_id)
+        # response = self.client.get_raw_message(message_id)
+        response = dict()
+        try:
+            response = self.client.call_endpoint(
+                f"/messages/{message_id}", method="GET", timeout=5
+            )
+        except requests.exceptions.ReadTimeout:
+            raise
+
         if response["result"] == "success":
             return response["raw_content"]
         display_error_if_present(response, self.controller)

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1951,12 +1951,21 @@ class FullRawMsgView(PopUpView):
         msg_box = MessageBox(message, controller.model, None)
 
         # Get raw message content widget list
-        response = controller.model.fetch_raw_message_content(message["id"])
-
-        if response is None:
-            return
-
-        body_list = [urwid.Text(response)]
+        response = ("",)
+        try:
+            response = controller.model.fetch_raw_message_content(message["id"])
+            body_list = [urwid.Text(response)]
+        except Exception:
+            response = (
+                "An exception occurred:"
+                + "\n"
+                + "The application should continue functioning, but you "
+                + "may notice inconsistent behavior in this session.",
+            )
+            body_list = [urwid.Text(("area:error", response[0]))]
+            # response = ("area:error","Connection timed out. \nPlease try again later")
+            msg_box.header = []
+            msg_box.footer = []
 
         super().__init__(
             controller,


### PR DESCRIPTION
<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?
ZT freezes when connection is lost while fetching data from the server. This PR attempts to notify the user better about the connection loss by displaying an error message. 


### Outstanding aspect(s) 
<!-- In what ways is this not fully implemented/functioning? Compared to a discussion/issue? -->
<!-- Do you not understand something? Are you unsure about a certain approach? Want feedback? -->
We are still open to suggestion about new ways to notify users better about this error. Ideally we'd like to improve interactivity by displaying a loading message till connection comes back, if it does. 

### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [x] Discussed in **#zulip-terminal** in `topic` [ZT freezes while connection is lost #T1381](https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/ZT.20freezes.20while.20connection.20is.20lost.20.23T1381)
- [ ] Fully fixes #
- [x] Partially fixes issue #1381 
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [x] Manually - Behavioral changes
- [x] Manually - Visual changes
- [x] Adapting existing automated tests
- [x] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [x] It contains test additions for any new behavior
- [x] It flows clearly from a previous branch commit, and/or prepares for the next commit

### Visual changes    <!-- DELETE SECTION IF NO VISUAL CHANGE -->
<!-- Zulip tips at https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html -->
<!-- For video, try asciinema; after uploading, embed using
[![yourtitle](https://asciinema.org/a/<id>.png)](https://asciinema.org/a/<id>)
-->
<!-- NOTE: Attached videos/images will be clearer from smaller terminal windows -->
<img width="1093" alt="Screenshot 2024-04-23 at 1 22 51 AM" src="https://github.com/zulip/zulip-terminal/assets/71403193/7126c523-945f-4457-863e-6feedd847321">

