### PR TITLE
github: Add simple issue templates & configuration

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_crash.md
+++ b/.github/ISSUE_TEMPLATE/01_crash.md
@@ -1,0 +1,39 @@
+---
+name: Bug report (major)
+about: A major bug which significantly impacts usability, eg. an unexpected quit, crash, freeze.
+labels: 'bug: crash',
+---
+
+### Bug description
+
+
+
+<!-- If discussed in #zulip-terminal or another channel on chat.zulip.org, paste link below: -->
+
+
+### How is the bug triggered?
+How can you reproduce the bug?
+1.
+
+
+### Does it produce a 'traceback' or 'exception'?
+<!-- Copy/paste it between the ``` lines below: -->
+```
+
+
+```
+
+### How are you running the application?
+Please include as many of the following as possible:
+- **Zulip-terminal version:**
+  eg. a specific version (0.7.0), or if running from `main` also ideally the git ref
+- **Zulip server version(s):**
+  eg. Zulip Cloud, the version you are running self-hosted, or the Zulip Community server (chat.zulip.org)
+- **Operating system (and version):**
+  eg. Debian Linux, Ubuntu Linux, macOS, WSL in Windows, Docker
+- **Python version (and implementation):**
+  eg. 3.8, 3.9, 3.10, ... (implementation is likely to be eg. CPython, or PyPy)
+
+If possible, please provide details from the `About` menu: (hotkey: Meta + ?)
+(this can provide some of the details above)
+

--- a/.github/ISSUE_TEMPLATE/02_bug.md
+++ b/.github/ISSUE_TEMPLATE/02_bug.md
@@ -1,0 +1,36 @@
+---
+name: Bug report
+about: A concrete bug report with steps to reproduce the behavior.
+labels: bug,
+---
+
+### Bug description
+
+
+
+<!-- If discussed in #zulip-terminal or another channel on chat.zulip.org, paste link below: -->
+
+
+### How is the bug triggered?
+How can you reproduce the bug?
+1.
+
+
+### What did you expect to happen?
+
+
+
+### How are you running the application?
+Please include as many of the following as possible:
+- **Zulip-terminal version:**
+  eg. a specific version (0.7.0), or if running from `main` also ideally the git ref
+- **Zulip server version(s):**
+  eg. Zulip Cloud, the version you are running self-hosted, or the Zulip Community server (chat.zulip.org)
+- **Operating system (and version):**
+  eg. Debian Linux, Ubuntu Linux, macOS, WSL in Windows, Docker
+- **Python version (and implementation):**
+  eg. 3.8, 3.9, 3.10, ... (implementation is likely to be eg. CPython, or PyPy)
+
+If possible, please provide details from the `About` menu: (hotkey: Meta + ?)
+(this can provide some of the details above)
+

--- a/.github/ISSUE_TEMPLATE/03_parity.md
+++ b/.github/ISSUE_TEMPLATE/03_parity.md
@@ -1,0 +1,25 @@
+---
+name: Feature request (a missing known Zulip feature)
+about: A request for a feature which is missing, but present in another Zulip client (eg. Web/Desktop/mobile).
+labels: 'missing feature',
+---
+
+### Description of feature missing from another Zulip client
+<!-- Is this an entire missing feature? Or part of the feature? -->
+
+
+
+<!-- If discussed in #zulip-terminal or another channel on chat.zulip.org, paste link below: -->
+
+
+### When was this feature first available in Zulip?
+If you know:
+- **Zulip version:**
+  (eg. 2.1, 5.0, 8.0, ..., or 'Zulip Cloud today')
+- **Zulip feature level:**
+  (see https://zulip.com/api/changelog)
+
+
+### Other details
+
+

--- a/.github/ISSUE_TEMPLATE/04_platform.md
+++ b/.github/ISSUE_TEMPLATE/04_platform.md
@@ -1,0 +1,19 @@
+---
+name: Feature suggestion
+about: A suggestion for an improvement, specific to the capabilities of the terminal environment.
+labels: enhancement,
+---
+
+<!--
+NOTE: If your proposed feature:
+1) is already available in Zulip, please use the other issue feature category
+2) would be of benefit to Zulip clients generally, please instead report it at:
+   https://github.com/zulip/zulip/issues/new/choose
+-->
+
+### Description of suggested feature
+
+
+
+<!-- If discussed in #zulip-terminal or another channel on chat.zulip.org, paste link below: -->
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Report broader Zulip issues (beyond Zulip-Terminal)
+    about: Includes links to best-practices for filing bug reports, feature requests, security vulnerabilities and more.
+    url: https://github.com/zulip/zulip/issues/new/choose
+  - name: Not sure?
+    about: 'Chat with us, using any of the Zulip clients, in #zulip-terminal on the Developer Community server (chat.zulip.org).'
+    url: https://zulip.com/development-community


### PR DESCRIPTION
<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?

This converts the basic issue filing system to use the GitHub template chooser.

The main feature at this point is to focus reporters on the scope of the issue:
- major bug (bug: crash)
- bug (bug)
- missing Zulip feature (missing feature)
- general feature/improvement (enhancement)

These should apply a corresponding default label to the issue, with the idea that this would provide an initial structure to fine-tune the labels, eg. a specific `parity` label to add to `missing feature`, which could also gain one of the `user` or `admin` sub-labels.

This already feels like an improvement over the current single blank 'template', though it may take time to see how it works in practice.

This takes some ideas from zulip/zulip#26000 and followups.

### Outstanding aspect(s)    <!-- DELETE SECTION IF EMPTY -->
<!-- In what ways is this not fully implemented/functioning? Compared to a discussion/issue? -->
<!-- Do you not understand something? Are you unsure about a certain approach? Want feedback? -->
- How do these categories look like, if you were filing an issue?

### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [x] Discussed in **#zulip-terminal** in `Issue types #T1488`
- [ ] Fully fixes #
- [x] Partially fixes issue #830 
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [ ] Manually - Behavioral changes
- [ ] Manually - Visual changes
- [ ] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [ ] It contains test additions for any new behavior
- [ ] It flows clearly from a previous branch commit, and/or prepares for the next commit