### PR TITLE
Enhance the behaviour of `Esc` in the Emoji-picker popup

### DIFF
--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -2124,11 +2124,25 @@ class EmojiPickerView(PopUpView):
             self.emoji_search.set_caption(" ")
             self.controller.enter_editor_mode_with(self.emoji_search)
             return key
-        elif is_command_key("GO_BACK", key) or is_command_key("ADD_REACTION", key):
+        elif is_command_key("ADD_REACTION", key):
             for emoji_code, emoji_name in self.selected_emojis.items():
                 self.controller.model.toggle_message_reaction(self.message, emoji_name)
             self.emoji_search.reset_search_text()
             self.controller.exit_editor_mode()
             self.controller.exit_popup()
+            return key
+        elif is_command_key("GO_BACK", key):
+            if self.controller.is_in_editor_mode():
+                if self.emoji_search.get_edit_text() == "":
+                    self.keypress(size, primary_key_for_command("ADD_REACTION"))
+                else:
+                    self.emoji_search.reset_search_text()
+            else:
+                selected_emoji_button = self.emojis_display[self.get_focus_path()[-1]]
+                if selected_emoji_button.is_selected(selected_emoji_button.emoji_name):
+                    self.keypress(size, primary_key_for_command("ADD_REACTION"))
+                else:
+                    self.set_focus("header")
+                    self.controller.enter_editor_mode_with(self.emoji_search)
             return key
         return super().keypress(size, key)


### PR DESCRIPTION
### What does this PR do, and why?

Previously, pressing Esc anytime when the emoji picker is in use will exit the popup.

Now, different behaviours are supported depending on the state.

**1. Escaping from a non-empty searchbox clears it** (This is useful since some other editors support using the `Ctrl l` shortcut to clear the editor, but there's none for the emoji-picker popup).
**2. Escaping from an empty searchbox closes the popup.**

**3. Escaping from the emoji list exits you out of the popup, if the selected emoji button was toggled after the last search** (Allow users to exit the popup as soon as they have made some changes (either newly selected or newly deselected)).
**4. Otherwise, it takes you back to the searchbox and retains the last search text.** (the user has not made changes or is still navigating in the emoji picker, so allow them to return to the search box without exiting the popup)

### External discussion & connections
- [x] Discussed in **#zulip-terminal** in [`Enhance Escape key behaviour in Emoji-Picker popup`](https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/Enhance.20.60Escape.60.20key.20behaviour.20in.20Emoji-Picker.20popup.20.23T1491/near/1789095)
- [ ] Fully fixes #
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
- [x] Manually - Behavioral changes
- [ ] Manually - Visual changes
- [ ] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [ ] It contains test additions for any new behavior
- [ ] It flows clearly from a previous branch commit, and/or prepares for the next commit