### PR TITLE
boxes/views: Adopt urwid_readline for all editors.

### DIFF
--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -964,7 +964,7 @@ class MessageSearchBox(urwid.Pile):
         return key
 
 
-class PanelSearchBox(urwid.Edit):
+class PanelSearchBox(ReadlineEdit):
     """
     Search Box to search panel views in real-time.
     """

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -682,7 +682,7 @@ class RightColumnView(urwid.Frame):
             user_list is not None and search_box is None and new_text is None
         )  # _start_presence_updates.
 
-        # Return if the method is called by PanelSearchBox (urwid.Edit) while
+        # Return if the method is called by PanelSearchBox (ReadlineEdit) while
         # the search is inactive and user_list is None.
         # NOTE: The additional not user_list check is to not false trap
         # _start_presence_updates but allow it to update the user list.


### PR DESCRIPTION
### What does this PR do, and why?
Adopts urwid_readline.ReadlineEdit for all the editors in Zullip Terminal.
The panel search boxes are the only remaining editors not using urwid_readline.ReadlineEdit.

### External discussion & connections
- [x] Discussed in **#zulip-terminal** in [`Readline shortcuts in search boxes`](https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/Readline.20shortcuts.20in.20search.3F)
- [ ] Fully fixes #
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [x] Merge will enable work on #1484 

### How did you test this?
- [x] Manually - Behavioral changes
- [ ] Manually - Visual changes
- [ ] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [ ] It contains test additions for any new behavior
- [ ] It flows clearly from a previous branch commit, and/or prepares for the next commit
