### PR TITLE
Improve the handling of editor actions as a help category

### DIFF
--- a/docs/hotkeys.md
+++ b/docs/hotkeys.md
@@ -87,12 +87,12 @@
 ## Editor: Navigation
 |Command|Key Combination|
 | :--- | :---: |
-|Jump to the beginning of line|<kbd>Ctrl</kbd> + <kbd>a</kbd> / <kbd>Home</kbd>|
-|Jump to the end of line|<kbd>Ctrl</kbd> + <kbd>e</kbd> / <kbd>End</kbd>|
-|Jump backward one word|<kbd>Meta</kbd> + <kbd>b</kbd> / <kbd>Shift</kbd> + <kbd>Left</kbd>|
-|Jump forward one word|<kbd>Meta</kbd> + <kbd>f</kbd> / <kbd>Shift</kbd> + <kbd>Right</kbd>|
-|Jump to the previous line|<kbd>Up</kbd> / <kbd>Ctrl</kbd> + <kbd>p</kbd>|
-|Jump to the next line|<kbd>Down</kbd> / <kbd>Ctrl</kbd> + <kbd>n</kbd>|
+|Start of line|<kbd>Ctrl</kbd> + <kbd>a</kbd> / <kbd>Home</kbd>|
+|End of line|<kbd>Ctrl</kbd> + <kbd>e</kbd> / <kbd>End</kbd>|
+|Start of current or previous word|<kbd>Meta</kbd> + <kbd>b</kbd> / <kbd>Shift</kbd> + <kbd>Left</kbd>|
+|Start of next word|<kbd>Meta</kbd> + <kbd>f</kbd> / <kbd>Shift</kbd> + <kbd>Right</kbd>|
+|Previous line|<kbd>Up</kbd> / <kbd>Ctrl</kbd> + <kbd>p</kbd>|
+|Next line|<kbd>Down</kbd> / <kbd>Ctrl</kbd> + <kbd>n</kbd>|
 
 ## Editor: Text Manipulation
 |Command|Key Combination|
@@ -105,6 +105,6 @@
 |Cut backwards to the start of the current word|<kbd>Ctrl</kbd> + <kbd>w</kbd> / <kbd>Meta</kbd> + <kbd>Backspace</kbd>|
 |Cut the current line|<kbd>Meta</kbd> + <kbd>x</kbd>|
 |Paste last cut section|<kbd>Ctrl</kbd> + <kbd>y</kbd>|
-|Delete previous character (to left)|<kbd>Ctrl</kbd> + <kbd>h</kbd>|
-|Transpose characters|<kbd>Ctrl</kbd> + <kbd>t</kbd>|
+|Delete previous character|<kbd>Ctrl</kbd> + <kbd>h</kbd>|
+|Swap with previous character|<kbd>Ctrl</kbd> + <kbd>t</kbd>|
 

--- a/docs/hotkeys.md
+++ b/docs/hotkeys.md
@@ -97,14 +97,14 @@
 ## Editor: Text Manipulation
 |Command|Key Combination|
 | :--- | :---: |
-|Delete previous character (to left)|<kbd>Ctrl</kbd> + <kbd>h</kbd>|
-|Transpose characters|<kbd>Ctrl</kbd> + <kbd>t</kbd>|
+|Undo last action|<kbd>Ctrl</kbd> + <kbd>_</kbd>|
+|Clear text box|<kbd>Ctrl</kbd> + <kbd>l</kbd>|
 |Cut forwards to the end of the line|<kbd>Ctrl</kbd> + <kbd>k</kbd>|
 |Cut backwards to the start of the line|<kbd>Ctrl</kbd> + <kbd>u</kbd>|
 |Cut forwards to the end of the current word|<kbd>Meta</kbd> + <kbd>d</kbd>|
 |Cut backwards to the start of the current word|<kbd>Ctrl</kbd> + <kbd>w</kbd> / <kbd>Meta</kbd> + <kbd>Backspace</kbd>|
 |Cut the current line|<kbd>Meta</kbd> + <kbd>x</kbd>|
 |Paste last cut section|<kbd>Ctrl</kbd> + <kbd>y</kbd>|
-|Undo last action|<kbd>Ctrl</kbd> + <kbd>_</kbd>|
-|Clear text box|<kbd>Ctrl</kbd> + <kbd>l</kbd>|
+|Delete previous character (to left)|<kbd>Ctrl</kbd> + <kbd>h</kbd>|
+|Transpose characters|<kbd>Ctrl</kbd> + <kbd>t</kbd>|
 

--- a/docs/hotkeys.md
+++ b/docs/hotkeys.md
@@ -83,10 +83,20 @@
 |Autocomplete @mentions, #stream_names, :emoji: and topics|<kbd>Ctrl</kbd> + <kbd>f</kbd>|
 |Cycle through autocomplete suggestions in reverse|<kbd>Ctrl</kbd> + <kbd>r</kbd>|
 |Narrow to compose box message recipient|<kbd>Meta</kbd> + <kbd>.</kbd>|
+
+## Editor: Navigation
+|Command|Key Combination|
+| :--- | :---: |
 |Jump to the beginning of line|<kbd>Ctrl</kbd> + <kbd>a</kbd> / <kbd>Home</kbd>|
 |Jump to the end of line|<kbd>Ctrl</kbd> + <kbd>e</kbd> / <kbd>End</kbd>|
 |Jump backward one word|<kbd>Meta</kbd> + <kbd>b</kbd> / <kbd>Shift</kbd> + <kbd>Left</kbd>|
 |Jump forward one word|<kbd>Meta</kbd> + <kbd>f</kbd> / <kbd>Shift</kbd> + <kbd>Right</kbd>|
+|Jump to the previous line|<kbd>Up</kbd> / <kbd>Ctrl</kbd> + <kbd>p</kbd>|
+|Jump to the next line|<kbd>Down</kbd> / <kbd>Ctrl</kbd> + <kbd>n</kbd>|
+
+## Editor: Text Manipulation
+|Command|Key Combination|
+| :--- | :---: |
 |Delete previous character (to left)|<kbd>Ctrl</kbd> + <kbd>h</kbd>|
 |Transpose characters|<kbd>Ctrl</kbd> + <kbd>t</kbd>|
 |Cut forwards to the end of the line|<kbd>Ctrl</kbd> + <kbd>k</kbd>|
@@ -96,7 +106,5 @@
 |Cut the current line|<kbd>Meta</kbd> + <kbd>x</kbd>|
 |Paste last cut section|<kbd>Ctrl</kbd> + <kbd>y</kbd>|
 |Undo last action|<kbd>Ctrl</kbd> + <kbd>_</kbd>|
-|Jump to the previous line|<kbd>Up</kbd> / <kbd>Ctrl</kbd> + <kbd>p</kbd>|
-|Jump to the next line|<kbd>Down</kbd> / <kbd>Ctrl</kbd> + <kbd>n</kbd>|
-|Clear compose box|<kbd>Ctrl</kbd> + <kbd>l</kbd>|
+|Clear text box|<kbd>Ctrl</kbd> + <kbd>l</kbd>|
 

--- a/docs/hotkeys.md
+++ b/docs/hotkeys.md
@@ -83,16 +83,17 @@
 |Autocomplete @mentions, #stream_names, :emoji: and topics|<kbd>Ctrl</kbd> + <kbd>f</kbd>|
 |Cycle through autocomplete suggestions in reverse|<kbd>Ctrl</kbd> + <kbd>r</kbd>|
 |Narrow to compose box message recipient|<kbd>Meta</kbd> + <kbd>.</kbd>|
-|Jump to the beginning of line|<kbd>Ctrl</kbd> + <kbd>a</kbd>|
-|Jump to the end of line|<kbd>Ctrl</kbd> + <kbd>e</kbd>|
-|Jump backward one word|<kbd>Meta</kbd> + <kbd>b</kbd>|
-|Jump forward one word|<kbd>Meta</kbd> + <kbd>f</kbd>|
+|Jump to the beginning of line|<kbd>Ctrl</kbd> + <kbd>a</kbd> / <kbd>Home</kbd>|
+|Jump to the end of line|<kbd>Ctrl</kbd> + <kbd>e</kbd> / <kbd>End</kbd>|
+|Jump backward one word|<kbd>Meta</kbd> + <kbd>b</kbd> / <kbd>Shift</kbd> + <kbd>Left</kbd>|
+|Jump forward one word|<kbd>Meta</kbd> + <kbd>f</kbd> / <kbd>Shift</kbd> + <kbd>Right</kbd>|
 |Delete previous character (to left)|<kbd>Ctrl</kbd> + <kbd>h</kbd>|
 |Transpose characters|<kbd>Ctrl</kbd> + <kbd>t</kbd>|
 |Cut forwards to the end of the line|<kbd>Ctrl</kbd> + <kbd>k</kbd>|
 |Cut backwards to the start of the line|<kbd>Ctrl</kbd> + <kbd>u</kbd>|
 |Cut forwards to the end of the current word|<kbd>Meta</kbd> + <kbd>d</kbd>|
-|Cut backwards to the start of the current word|<kbd>Ctrl</kbd> + <kbd>w</kbd>|
+|Cut backwards to the start of the current word|<kbd>Ctrl</kbd> + <kbd>w</kbd> / <kbd>Meta</kbd> + <kbd>Backspace</kbd>|
+|Cut the current line|<kbd>Meta</kbd> + <kbd>x</kbd>|
 |Paste last cut section|<kbd>Ctrl</kbd> + <kbd>y</kbd>|
 |Undo last action|<kbd>Ctrl</kbd> + <kbd>_</kbd>|
 |Jump to the previous line|<kbd>Up</kbd> / <kbd>Ctrl</kbd> + <kbd>p</kbd>|

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -321,22 +321,22 @@ KEY_BINDINGS: Dict[str, KeyBinding] = {
         'key_category': 'general',
     },
     'BEGINNING_OF_LINE': {
-        'keys': ['ctrl a'],
+        'keys': ['ctrl a', 'home'],
         'help_text': 'Jump to the beginning of line',
         'key_category': 'msg_compose',
     },
     'END_OF_LINE': {
-        'keys': ['ctrl e'],
+        'keys': ['ctrl e', 'end'],
         'help_text': 'Jump to the end of line',
         'key_category': 'msg_compose',
     },
     'ONE_WORD_BACKWARD': {
-        'keys': ['meta b'],
+        'keys': ['meta b', 'shift left'],
         'help_text': 'Jump backward one word',
         'key_category': 'msg_compose',
     },
     'ONE_WORD_FORWARD': {
-        'keys': ['meta f'],
+        'keys': ['meta f', 'shift right'],
         'help_text': 'Jump forward one word',
         'key_category': 'msg_compose',
     },
@@ -366,8 +366,13 @@ KEY_BINDINGS: Dict[str, KeyBinding] = {
         'key_category': 'msg_compose',
     },
     'CUT_TO_START_OF_WORD': {
-        'keys': ['ctrl w'],
+        'keys': ['ctrl w', 'meta backspace'],
         'help_text': 'Cut backwards to the start of the current word',
+        'key_category': 'msg_compose',
+    },
+    'CUT_WHOLE_LINE': {
+        'keys': ['meta x'],
+        'help_text': 'Cut the current line',
         'key_category': 'msg_compose',
     },
     'PASTE_LAST_CUT': {

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -322,32 +322,32 @@ KEY_BINDINGS: Dict[str, KeyBinding] = {
     },
     'BEGINNING_OF_LINE': {
         'keys': ['ctrl a', 'home'],
-        'help_text': 'Jump to the beginning of line',
+        'help_text': 'Start of line',
         'key_category': 'editor_navigation',
     },
     'END_OF_LINE': {
         'keys': ['ctrl e', 'end'],
-        'help_text': 'Jump to the end of line',
+        'help_text': 'End of line',
         'key_category': 'editor_navigation',
     },
     'ONE_WORD_BACKWARD': {
         'keys': ['meta b', 'shift left'],
-        'help_text': 'Jump backward one word',
+        'help_text': 'Start of current or previous word',
         'key_category': 'editor_navigation',
     },
     'ONE_WORD_FORWARD': {
         'keys': ['meta f', 'shift right'],
-        'help_text': 'Jump forward one word',
+        'help_text': 'Start of next word',
         'key_category': 'editor_navigation',
     },
     'PREV_LINE': {
         'keys': ['up', 'ctrl p'],
-        'help_text': 'Jump to the previous line',
+        'help_text': 'Previous line',
         'key_category': 'editor_navigation',
     },
     'NEXT_LINE': {
         'keys': ['down', 'ctrl n'],
-        'help_text': 'Jump to the next line',
+        'help_text': 'Next line',
         'key_category': 'editor_navigation',
     },
     'UNDO_LAST_ACTION': {
@@ -392,12 +392,12 @@ KEY_BINDINGS: Dict[str, KeyBinding] = {
     },
     'DELETE_LAST_CHARACTER': {
         'keys': ['ctrl h'],
-        'help_text': 'Delete previous character (to left)',
+        'help_text': 'Delete previous character',
         'key_category': 'editor_text_manipulation',
     },
     'TRANSPOSE_CHARACTERS': {
         'keys': ['ctrl t'],
-        'help_text': 'Transpose characters',
+        'help_text': 'Swap with previous character',
         'key_category': 'editor_text_manipulation',
     },
     'FULL_RENDERED_MESSAGE': {

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -340,14 +340,24 @@ KEY_BINDINGS: Dict[str, KeyBinding] = {
         'help_text': 'Jump forward one word',
         'key_category': 'editor_navigation',
     },
-    'DELETE_LAST_CHARACTER': {
-        'keys': ['ctrl h'],
-        'help_text': 'Delete previous character (to left)',
+    'PREV_LINE': {
+        'keys': ['up', 'ctrl p'],
+        'help_text': 'Jump to the previous line',
+        'key_category': 'editor_navigation',
+    },
+    'NEXT_LINE': {
+        'keys': ['down', 'ctrl n'],
+        'help_text': 'Jump to the next line',
+        'key_category': 'editor_navigation',
+    },
+    'UNDO_LAST_ACTION': {
+        'keys': ['ctrl _'],
+        'help_text': 'Undo last action',
         'key_category': 'editor_text_manipulation',
     },
-    'TRANSPOSE_CHARACTERS': {
-        'keys': ['ctrl t'],
-        'help_text': 'Transpose characters',
+    'CLEAR_MESSAGE': {
+        'keys': ['ctrl l'],
+        'help_text': 'Clear text box',
         'key_category': 'editor_text_manipulation',
     },
     'CUT_TO_END_OF_LINE': {
@@ -380,24 +390,14 @@ KEY_BINDINGS: Dict[str, KeyBinding] = {
         'help_text': 'Paste last cut section',
         'key_category': 'editor_text_manipulation',
     },
-    'UNDO_LAST_ACTION': {
-        'keys': ['ctrl _'],
-        'help_text': 'Undo last action',
+    'DELETE_LAST_CHARACTER': {
+        'keys': ['ctrl h'],
+        'help_text': 'Delete previous character (to left)',
         'key_category': 'editor_text_manipulation',
     },
-    'PREV_LINE': {
-        'keys': ['up', 'ctrl p'],
-        'help_text': 'Jump to the previous line',
-        'key_category': 'editor_navigation',
-    },
-    'NEXT_LINE': {
-        'keys': ['down', 'ctrl n'],
-        'help_text': 'Jump to the next line',
-        'key_category': 'editor_navigation',
-    },
-    'CLEAR_MESSAGE': {
-        'keys': ['ctrl l'],
-        'help_text': 'Clear text box',
+    'TRANSPOSE_CHARACTERS': {
+        'keys': ['ctrl t'],
+        'help_text': 'Transpose characters',
         'key_category': 'editor_text_manipulation',
     },
     'FULL_RENDERED_MESSAGE': {

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -323,82 +323,82 @@ KEY_BINDINGS: Dict[str, KeyBinding] = {
     'BEGINNING_OF_LINE': {
         'keys': ['ctrl a', 'home'],
         'help_text': 'Jump to the beginning of line',
-        'key_category': 'msg_compose',
+        'key_category': 'editor_navigation',
     },
     'END_OF_LINE': {
         'keys': ['ctrl e', 'end'],
         'help_text': 'Jump to the end of line',
-        'key_category': 'msg_compose',
+        'key_category': 'editor_navigation',
     },
     'ONE_WORD_BACKWARD': {
         'keys': ['meta b', 'shift left'],
         'help_text': 'Jump backward one word',
-        'key_category': 'msg_compose',
+        'key_category': 'editor_navigation',
     },
     'ONE_WORD_FORWARD': {
         'keys': ['meta f', 'shift right'],
         'help_text': 'Jump forward one word',
-        'key_category': 'msg_compose',
+        'key_category': 'editor_navigation',
     },
     'DELETE_LAST_CHARACTER': {
         'keys': ['ctrl h'],
         'help_text': 'Delete previous character (to left)',
-        'key_category': 'msg_compose',
+        'key_category': 'editor_text_manipulation',
     },
     'TRANSPOSE_CHARACTERS': {
         'keys': ['ctrl t'],
         'help_text': 'Transpose characters',
-        'key_category': 'msg_compose',
+        'key_category': 'editor_text_manipulation',
     },
     'CUT_TO_END_OF_LINE': {
         'keys': ['ctrl k'],
         'help_text': 'Cut forwards to the end of the line',
-        'key_category': 'msg_compose',
+        'key_category': 'editor_text_manipulation',
     },
     'CUT_TO_START_OF_LINE': {
         'keys': ['ctrl u'],
         'help_text': 'Cut backwards to the start of the line',
-        'key_category': 'msg_compose',
+        'key_category': 'editor_text_manipulation',
     },
     'CUT_TO_END_OF_WORD': {
         'keys': ['meta d'],
         'help_text': 'Cut forwards to the end of the current word',
-        'key_category': 'msg_compose',
+        'key_category': 'editor_text_manipulation',
     },
     'CUT_TO_START_OF_WORD': {
         'keys': ['ctrl w', 'meta backspace'],
         'help_text': 'Cut backwards to the start of the current word',
-        'key_category': 'msg_compose',
+        'key_category': 'editor_text_manipulation',
     },
     'CUT_WHOLE_LINE': {
         'keys': ['meta x'],
         'help_text': 'Cut the current line',
-        'key_category': 'msg_compose',
+        'key_category': 'editor_text_manipulation',
     },
     'PASTE_LAST_CUT': {
         'keys': ['ctrl y'],
         'help_text': 'Paste last cut section',
-        'key_category': 'msg_compose',
+        'key_category': 'editor_text_manipulation',
     },
     'UNDO_LAST_ACTION': {
         'keys': ['ctrl _'],
         'help_text': 'Undo last action',
-        'key_category': 'msg_compose',
+        'key_category': 'editor_text_manipulation',
     },
     'PREV_LINE': {
         'keys': ['up', 'ctrl p'],
         'help_text': 'Jump to the previous line',
-        'key_category': 'msg_compose',
+        'key_category': 'editor_navigation',
     },
     'NEXT_LINE': {
         'keys': ['down', 'ctrl n'],
         'help_text': 'Jump to the next line',
-        'key_category': 'msg_compose',
+        'key_category': 'editor_navigation',
     },
     'CLEAR_MESSAGE': {
         'keys': ['ctrl l'],
-        'help_text': 'Clear compose box',
-        'key_category': 'msg_compose',
+        'help_text': 'Clear text box',
+        'key_category': 'editor_text_manipulation',
     },
     'FULL_RENDERED_MESSAGE': {
         'keys': ['f'],
@@ -420,6 +420,8 @@ HELP_CATEGORIES = {
     "msg_actions": "Message actions",
     "stream_list": "Stream list actions",
     "msg_compose": "Composing a Message",
+    "editor_navigation": "Editor: Navigation",
+    "editor_text_manipulation": "Editor: Text Manipulation",
 }
 
 ZT_TO_URWID_CMD_MAPPING = {


### PR DESCRIPTION
### What does this PR do, and why?
Improves the usage of urwid_readline hotkey commands.

Now that all editors support readline shortcuts after the merge of #1492,
all the readline shortcuts have been grouped into their own category.

Add missing key combinations, commands.
Re-categorize, re-order the keybindings.
Improve the help texts.

### External discussion & connections
- [x] Discussed in **#zulip-terminal** in [`Re-categorization of hotkeys`](https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/Re-Categorization.20of.20Hotkeys/near/1793560) and [`Readline shortcuts in search`](https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/Readline.20shortcuts.20in.20search.3F.20.23T1492/near/1794294)`
- [ ] Fully fixes #
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [x] Is a follow-up to work in PR #1492 
- [ ] Requires merge of PR #
- [x] Merge will enable work on #1498

### How did you test this?
- [ ] Manually - Behavioral changes
- [x] Manually - Visual changes
- [ ] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the motivation and reasoning for the change
- [x] It individually passes linting and tests
- [ ] It contains test additions for any new behavior
- [x] It flows clearly from a previous branch commit, and/or prepares for the next commit

### Visual changes (Outdated)
![image](https://github.com/zulip/zulip-terminal/assets/20315308/5babfa1a-0999-4a9a-bfc5-43146ea9a5ad)
