### PR TITLE
Standardize hotkey help text

### DIFF
--- a/docs/hotkeys.md
+++ b/docs/hotkeys.md
@@ -12,7 +12,7 @@
 |Open draft message saved in this session|<kbd>d</kbd>|
 |Redraw screen|<kbd>Ctrl</kbd> + <kbd>l</kbd>|
 |Quit|<kbd>Ctrl</kbd> + <kbd>c</kbd>|
-|View user information (from users list)|<kbd>i</kbd>|
+|Show/hide user information (from users list)|<kbd>i</kbd>|
 
 ## Navigation
 |Command|Key Combination|
@@ -39,7 +39,7 @@
 |Search messages|<kbd>/</kbd>|
 |Search streams|<kbd>q</kbd>|
 |Search topics in a stream|<kbd>q</kbd>|
-|Search emojis from emoji picker popup|<kbd>p</kbd>|
+|Search emojis from emoji picker|<kbd>p</kbd>|
 
 ## Message actions
 |Command|Key Combination|
@@ -51,13 +51,13 @@
 |Edit message's content or topic|<kbd>e</kbd>|
 |New message to a stream|<kbd>c</kbd>|
 |New message to a person or group of people|<kbd>x</kbd>|
-|Show/hide emoji picker popup for current message|<kbd>:</kbd>|
+|Show/hide emoji picker for current message|<kbd>:</kbd>|
 |Narrow to the stream of the current message|<kbd>s</kbd>|
 |Narrow to the topic of the current message|<kbd>S</kbd>|
 |Narrow to a topic/direct-chat, or stream/all-direct-messages|<kbd>z</kbd>|
 |Toggle first emoji reaction on selected message|<kbd>=</kbd>|
-|Add/remove thumbs-up reaction to the current message|<kbd>+</kbd>|
-|Add/remove star status of the current message|<kbd>Ctrl</kbd> + <kbd>s</kbd> / <kbd>*</kbd>|
+|Toggle thumbs-up reaction to the current message|<kbd>+</kbd>|
+|Toggle star status of the current message|<kbd>Ctrl</kbd> + <kbd>s</kbd> / <kbd>*</kbd>|
 |Show/hide message information|<kbd>i</kbd>|
 |Show/hide message sender information|<kbd>u</kbd>|
 |Show/hide edit history (from message information)|<kbd>e</kbd>|

--- a/docs/hotkeys.md
+++ b/docs/hotkeys.md
@@ -5,14 +5,14 @@
 ## General
 |Command|Key Combination|
 | :--- | :---: |
-|Show/hide help menu|<kbd>?</kbd>|
-|Show/hide markdown help menu|<kbd>Meta</kbd> + <kbd>m</kbd>|
-|Show/hide about menu|<kbd>Meta</kbd> + <kbd>?</kbd>|
-|Go Back|<kbd>Esc</kbd>|
+|Show/hide Help Menu|<kbd>?</kbd>|
+|Show/hide Markdown Help Menu|<kbd>Meta</kbd> + <kbd>m</kbd>|
+|Show/hide About Menu|<kbd>Meta</kbd> + <kbd>?</kbd>|
+|Go back|<kbd>Esc</kbd>|
 |Open draft message saved in this session|<kbd>d</kbd>|
 |Redraw screen|<kbd>Ctrl</kbd> + <kbd>l</kbd>|
 |Quit|<kbd>Ctrl</kbd> + <kbd>c</kbd>|
-|View user information (From Users list)|<kbd>i</kbd>|
+|View user information (from users list)|<kbd>i</kbd>|
 
 ## Navigation
 |Command|Key Combination|
@@ -35,11 +35,11 @@
 ## Searching
 |Command|Key Combination|
 | :--- | :---: |
-|Search Users|<kbd>w</kbd>|
-|Search Messages|<kbd>/</kbd>|
-|Search Streams|<kbd>q</kbd>|
+|Search users|<kbd>w</kbd>|
+|Search messages|<kbd>/</kbd>|
+|Search streams|<kbd>q</kbd>|
 |Search topics in a stream|<kbd>q</kbd>|
-|Search emojis from Emoji-picker popup|<kbd>p</kbd>|
+|Search emojis from emoji picker popup|<kbd>p</kbd>|
 
 ## Message actions
 |Command|Key Combination|
@@ -51,7 +51,7 @@
 |Edit message's content or topic|<kbd>e</kbd>|
 |New message to a stream|<kbd>c</kbd>|
 |New message to a person or group of people|<kbd>x</kbd>|
-|Show/hide Emoji picker popup for current message|<kbd>:</kbd>|
+|Show/hide emoji picker popup for current message|<kbd>:</kbd>|
 |Narrow to the stream of the current message|<kbd>s</kbd>|
 |Narrow to the topic of the current message|<kbd>S</kbd>|
 |Narrow to a topic/direct-chat, or stream/all-direct-messages|<kbd>z</kbd>|
@@ -69,7 +69,7 @@
 |Command|Key Combination|
 | :--- | :---: |
 |Toggle topics in a stream|<kbd>t</kbd>|
-|Mute/unmute Streams|<kbd>m</kbd>|
+|Mute/unmute streams|<kbd>m</kbd>|
 |Show/hide stream information & modify settings|<kbd>i</kbd>|
 |Show/hide stream members (from stream information)|<kbd>m</kbd>|
 |Copy stream email to clipboard (from stream information)|<kbd>c</kbd>|

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -154,7 +154,7 @@ KEY_BINDINGS: Dict[str, KeyBinding] = {
     },
     'ADD_REACTION': {
         'keys': [':'],
-        'help_text': 'Show/hide emoji picker popup for current message',
+        'help_text': 'Show/hide emoji picker for current message',
         'key_category': 'msg_actions',
     },
     'STREAM_NARROW': {
@@ -240,7 +240,7 @@ KEY_BINDINGS: Dict[str, KeyBinding] = {
     },
     'SEARCH_EMOJIS': {
         'keys': ['p'],
-        'help_text': 'Search emojis from emoji picker popup',
+        'help_text': 'Search emojis from emoji picker',
         'excluded_from_random_tips': True,
         'key_category': 'searching',
     },
@@ -256,12 +256,12 @@ KEY_BINDINGS: Dict[str, KeyBinding] = {
     },
     'THUMBS_UP': {
         'keys': ['+'],
-        'help_text': 'Add/remove thumbs-up reaction to the current message',
+        'help_text': 'Toggle thumbs-up reaction to the current message',
         'key_category': 'msg_actions',
     },
     'TOGGLE_STAR_STATUS': {
         'keys': ['ctrl s', '*'],
-        'help_text': 'Add/remove star status of the current message',
+        'help_text': 'Toggle star status of the current message',
         'key_category': 'msg_actions',
     },
     'MSG_INFO': {
@@ -317,7 +317,7 @@ KEY_BINDINGS: Dict[str, KeyBinding] = {
     },
     'USER_INFO': {
         'keys': ['i'],
-        'help_text': 'View user information (from users list)',
+        'help_text': 'Show/hide user information (from users list)',
         'key_category': 'general',
     },
     'BEGINNING_OF_LINE': {

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -31,23 +31,23 @@ KEY_BINDINGS: Dict[str, KeyBinding] = {
 
     'HELP': {
         'keys': ['?'],
-        'help_text': 'Show/hide help menu',
+        'help_text': 'Show/hide Help Menu',
         'excluded_from_random_tips': True,
         'key_category': 'general',
     },
     'MARKDOWN_HELP': {
         'keys': ['meta m'],
-        'help_text': 'Show/hide markdown help menu',
+        'help_text': 'Show/hide Markdown Help Menu',
         'key_category': 'general',
     },
     'ABOUT': {
         'keys': ['meta ?'],
-        'help_text': 'Show/hide about menu',
+        'help_text': 'Show/hide About Menu',
         'key_category': 'general',
     },
     'GO_BACK': {
         'keys': ['esc'],
-        'help_text': 'Go Back',
+        'help_text': 'Go back',
         'excluded_from_random_tips': False,
         'key_category': 'general',
     },
@@ -154,7 +154,7 @@ KEY_BINDINGS: Dict[str, KeyBinding] = {
     },
     'ADD_REACTION': {
         'keys': [':'],
-        'help_text': 'Show/hide Emoji picker popup for current message',
+        'help_text': 'Show/hide emoji picker popup for current message',
         'key_category': 'msg_actions',
     },
     'STREAM_NARROW': {
@@ -220,17 +220,17 @@ KEY_BINDINGS: Dict[str, KeyBinding] = {
     },
     'SEARCH_PEOPLE': {
         'keys': ['w'],
-        'help_text': 'Search Users',
+        'help_text': 'Search users',
         'key_category': 'searching',
     },
     'SEARCH_MESSAGES': {
         'keys': ['/'],
-        'help_text': 'Search Messages',
+        'help_text': 'Search messages',
         'key_category': 'searching',
     },
     'SEARCH_STREAMS': {
         'keys': ['q'],
-        'help_text': 'Search Streams',
+        'help_text': 'Search streams',
         'key_category': 'searching',
     },
     'SEARCH_TOPICS': {
@@ -240,13 +240,13 @@ KEY_BINDINGS: Dict[str, KeyBinding] = {
     },
     'SEARCH_EMOJIS': {
         'keys': ['p'],
-        'help_text': 'Search emojis from Emoji-picker popup',
+        'help_text': 'Search emojis from emoji picker popup',
         'excluded_from_random_tips': True,
         'key_category': 'searching',
     },
     'TOGGLE_MUTE_STREAM': {
         'keys': ['m'],
-        'help_text': 'Mute/unmute Streams',
+        'help_text': 'Mute/unmute streams',
         'key_category': 'stream_list',
     },
     'ENTER': {
@@ -317,7 +317,7 @@ KEY_BINDINGS: Dict[str, KeyBinding] = {
     },
     'USER_INFO': {
         'keys': ['i'],
-        'help_text': 'View user information (From Users list)',
+        'help_text': 'View user information (from users list)',
         'key_category': 'general',
     },
     'BEGINNING_OF_LINE': {


### PR DESCRIPTION
### What does this PR do, and why?
Improves the conformity of help descriptions.

### Outstanding aspect(s)
[ ] Usage of 'the' needs to be made uniform too. This has not yet been addressed.

### External discussion & connections
- [x] Discussed in **#zulip-terminal** inside `re-categorize` [here](https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/Re-Categorization.20of.20Hotkeys/near/1793558) and [here](https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/Re-Categorization.20of.20Hotkeys/near/1797363)
- [ ] Fully fixes #
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
- [ ] Manually - Behavioral changes
- [x] Manually - Visual changes
- [ ] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [ ] It contains test additions for any new behavior
- [ ] It flows clearly from a previous branch commit, and/or prepares for the next commit