### PR TITLE
External hotkey commands: tagging, linting and checking sync

### DIFF
--- a/tests/config/test_keys.py
+++ b/tests/config/test_keys.py
@@ -142,7 +142,7 @@ def test_display_key_for_urwid_key(urwid_key: str, display_key: str) -> None:
 
 
 COMMAND_TO_DISPLAY_KEYS = [
-    ("NEXT_LINE", ["Down", "Ctrl n"]),
+    ("SEND_MESSAGE", ["Ctrl d", "Meta Enter"]),
     ("TOGGLE_STAR_STATUS", ["Ctrl s", "*"]),
     ("ALL_PM", ["P"]),
 ]

--- a/tools/lint-hotkeys
+++ b/tools/lint-hotkeys
@@ -34,6 +34,7 @@ KEYS_TO_EXCLUDE = ["q", "e", "m", "r"]
 EXCLUDED_FILES = [
     KEYS_FILE,
     ZULIPTERMINAL / "config" / "regexes.py",
+    ZULIPTERMINAL / "cli" / "run.py",
 ]
 
 

--- a/tools/lint-hotkeys
+++ b/tools/lint-hotkeys
@@ -11,13 +11,18 @@ from zulipterminal.config.keys import (
     KEY_BINDINGS,
     display_keys_for_command,
 )
+from zulipterminal.config.regexes import REGEX_READLINE_COMMANDS
 
 
-KEYS_FILE = (
-    Path(__file__).resolve().parent.parent / "zulipterminal" / "config" / "keys.py"
-)
+# absolute path to zulip-terminal
+ROOT_DIRECTORY = Path(__file__).resolve().parent.parent
+
+# absolute path to zulip-terminal/zulipterminal to be passed as parameter
+ZULIPTERMINAL = ROOT_DIRECTORY / "zulipterminal"
+
+KEYS_FILE = ZULIPTERMINAL / "config" / "keys.py"
 KEYS_FILE_NAME = KEYS_FILE.name
-OUTPUT_FILE = Path(__file__).resolve().parent.parent / "docs" / "hotkeys.md"
+OUTPUT_FILE = ROOT_DIRECTORY / "docs" / "hotkeys.md"
 OUTPUT_FILE_NAME = OUTPUT_FILE.name
 SCRIPT_NAME = PurePath(__file__).name
 HELP_TEXT_STYLE = re.compile(r"^[a-zA-Z /()',&@#:_-]*$")
@@ -25,12 +30,62 @@ HELP_TEXT_STYLE = re.compile(r"^[a-zA-Z /()',&@#:_-]*$")
 # Exclude keys from duplicate keys checking
 KEYS_TO_EXCLUDE = ["q", "e", "m", "r"]
 
+# Exclude files from being checked for external command usage
+EXCLUDED_FILES = [
+    KEYS_FILE,
+    ZULIPTERMINAL / "config" / "regexes.py",
+]
+
 
 def main(fix: bool) -> None:
+    lint_all_external_commands()
     if fix:
         generate_hotkeys_file()
     else:
         lint_hotkeys_file()
+
+
+def lint_all_external_commands() -> None:
+    lint_external_commands_by_type(
+        regex_pattern=REGEX_READLINE_COMMANDS,
+        command_type="Urwid Readline",
+        suffix="READLINE_SUFFIX",
+    )
+    print("All external commands have been linted successfully.")
+
+
+def lint_external_commands_by_type(
+    regex_pattern: str, command_type: str, suffix: str
+) -> None:
+    """
+    Lint src directory for the usage of external commands
+    in the codebase by checking for their regex
+    """
+    error_flag = 0
+    for file_path in ZULIPTERMINAL.rglob("*.py"):
+        if file_path in EXCLUDED_FILES:
+            continue
+        with file_path.open() as f:
+            contents = f.read()
+            regex_matches = re.finditer(regex_pattern, contents)
+            suffix_matches = re.finditer(suffix, contents)
+            count_matches = sum(1 for _ in regex_matches) + sum(
+                1 for _ in suffix_matches
+            )
+            if count_matches > 0:
+                print(
+                    f"{file_path.name} contains {count_matches} mentions of {command_type} commands."
+                )
+                error_flag = 1
+    if error_flag == 1:
+        print(
+            f"{command_type} commands are not intended for direct use or modification."
+        )
+        print(
+            f"Please refer to {KEYS_FILE_NAME} for identifying the {command_type} commands."
+        )
+        print("Rerun this command after removing the usage of external commands.")
+        sys.exit(error_flag)
 
 
 def lint_hotkeys_file() -> None:

--- a/tools/lint-hotkeys
+++ b/tools/lint-hotkeys
@@ -11,7 +11,10 @@ from zulipterminal.config.keys import (
     KEY_BINDINGS,
     display_keys_for_command,
 )
-from zulipterminal.config.regexes import REGEX_READLINE_COMMANDS
+from zulipterminal.config.regexes import (
+    REGEX_READLINE_COMMANDS,
+    REGEX_TERMINAL_COMMANDS,
+)
 
 
 # absolute path to zulip-terminal
@@ -51,6 +54,11 @@ def lint_all_external_commands() -> None:
         regex_pattern=REGEX_READLINE_COMMANDS,
         command_type="Urwid Readline",
         suffix="READLINE_SUFFIX",
+    )
+    lint_external_commands_by_type(
+        regex_pattern=REGEX_TERMINAL_COMMANDS,
+        command_type="General terminal",
+        suffix="GENERAL_TERMINAL_SUFFIX",
     )
     print("All external commands have been linted successfully.")
 

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -18,6 +18,7 @@ from urwid.command_map import (
 
 
 READLINE_SUFFIX = "_READLINE"
+GENERAL_TERMINAL_SUFFIX = "_GENERAL_TERMINAL"
 
 
 class KeyBinding(TypedDict):
@@ -308,12 +309,12 @@ KEY_BINDINGS: Dict[str, KeyBinding] = {
         'excluded_from_random_tips': True,
         'key_category': 'stream_list',
     },
-    'REDRAW': {
+    'REDRAW' + GENERAL_TERMINAL_SUFFIX: {
         'keys': ['ctrl l'],
         'help_text': 'Redraw screen',
         'key_category': 'general',
     },
-    'QUIT': {
+    'QUIT' + GENERAL_TERMINAL_SUFFIX: {
         'keys': ['ctrl c'],
         'help_text': 'Quit',
         'key_category': 'general',

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -17,6 +17,9 @@ from urwid.command_map import (
 )
 
 
+READLINE_SUFFIX = "_READLINE"
+
+
 class KeyBinding(TypedDict):
     keys: List[str]
     help_text: str
@@ -320,82 +323,82 @@ KEY_BINDINGS: Dict[str, KeyBinding] = {
         'help_text': 'Show/hide user information (from users list)',
         'key_category': 'general',
     },
-    'BEGINNING_OF_LINE': {
+    'BEGINNING_OF_LINE' + READLINE_SUFFIX: {
         'keys': ['ctrl a', 'home'],
         'help_text': 'Start of line',
         'key_category': 'editor_navigation',
     },
-    'END_OF_LINE': {
+    'END_OF_LINE' + READLINE_SUFFIX: {
         'keys': ['ctrl e', 'end'],
         'help_text': 'End of line',
         'key_category': 'editor_navigation',
     },
-    'ONE_WORD_BACKWARD': {
+    'ONE_WORD_BACKWARD' + READLINE_SUFFIX: {
         'keys': ['meta b', 'shift left'],
         'help_text': 'Start of current or previous word',
         'key_category': 'editor_navigation',
     },
-    'ONE_WORD_FORWARD': {
+    'ONE_WORD_FORWARD' + READLINE_SUFFIX: {
         'keys': ['meta f', 'shift right'],
         'help_text': 'Start of next word',
         'key_category': 'editor_navigation',
     },
-    'PREV_LINE': {
+    'PREV_LINE' + READLINE_SUFFIX: {
         'keys': ['up', 'ctrl p'],
         'help_text': 'Previous line',
         'key_category': 'editor_navigation',
     },
-    'NEXT_LINE': {
+    'NEXT_LINE' + READLINE_SUFFIX: {
         'keys': ['down', 'ctrl n'],
         'help_text': 'Next line',
         'key_category': 'editor_navigation',
     },
-    'UNDO_LAST_ACTION': {
+    'UNDO_LAST_ACTION' + READLINE_SUFFIX: {
         'keys': ['ctrl _'],
         'help_text': 'Undo last action',
         'key_category': 'editor_text_manipulation',
     },
-    'CLEAR_MESSAGE': {
+    'CLEAR_MESSAGE' + READLINE_SUFFIX: {
         'keys': ['ctrl l'],
         'help_text': 'Clear text box',
         'key_category': 'editor_text_manipulation',
     },
-    'CUT_TO_END_OF_LINE': {
+    'CUT_TO_END_OF_LINE' + READLINE_SUFFIX: {
         'keys': ['ctrl k'],
         'help_text': 'Cut forwards to the end of the line',
         'key_category': 'editor_text_manipulation',
     },
-    'CUT_TO_START_OF_LINE': {
+    'CUT_TO_START_OF_LINE' + READLINE_SUFFIX: {
         'keys': ['ctrl u'],
         'help_text': 'Cut backwards to the start of the line',
         'key_category': 'editor_text_manipulation',
     },
-    'CUT_TO_END_OF_WORD': {
+    'CUT_TO_END_OF_WORD' + READLINE_SUFFIX: {
         'keys': ['meta d'],
         'help_text': 'Cut forwards to the end of the current word',
         'key_category': 'editor_text_manipulation',
     },
-    'CUT_TO_START_OF_WORD': {
+    'CUT_TO_START_OF_WORD' + READLINE_SUFFIX: {
         'keys': ['ctrl w', 'meta backspace'],
         'help_text': 'Cut backwards to the start of the current word',
         'key_category': 'editor_text_manipulation',
     },
-    'CUT_WHOLE_LINE': {
+    'CUT_WHOLE_LINE' + READLINE_SUFFIX: {
         'keys': ['meta x'],
         'help_text': 'Cut the current line',
         'key_category': 'editor_text_manipulation',
     },
-    'PASTE_LAST_CUT': {
+    'PASTE_LAST_CUT' + READLINE_SUFFIX: {
         'keys': ['ctrl y'],
         'help_text': 'Paste last cut section',
         'key_category': 'editor_text_manipulation',
     },
-    'DELETE_LAST_CHARACTER': {
+    'DELETE_LAST_CHARACTER' + READLINE_SUFFIX: {
         'keys': ['ctrl h'],
         'help_text': 'Delete previous character',
         'key_category': 'editor_text_manipulation',
     },
-    'TRANSPOSE_CHARACTERS': {
+    'TRANSPOSE_CHARACTERS' + READLINE_SUFFIX: {
         'keys': ['ctrl t'],
         'help_text': 'Swap with previous character',
         'key_category': 'editor_text_manipulation',

--- a/zulipterminal/config/regexes.py
+++ b/zulipterminal/config/regexes.py
@@ -7,7 +7,7 @@ Regular expression constants
 
 
 # (*) Stream and topic regexes
-from zulipterminal.config.keys import READLINE_SUFFIX
+from zulipterminal.config.keys import GENERAL_TERMINAL_SUFFIX, READLINE_SUFFIX
 
 
 REGEX_STREAM_NAME = r"([^*>]+)"
@@ -53,3 +53,5 @@ REGEX_INTERNAL_LINK_STREAM_ID = r"^[0-9]+-"
 
 # Example: UNDO_LAST_ACTION_READLINE
 REGEX_READLINE_COMMANDS = rf"([A-Z_]+{READLINE_SUFFIX})"
+# Example: REDRAW_GENERAL_TERMINAL
+REGEX_TERMINAL_COMMANDS = rf"^.*([A-Z_]+{GENERAL_TERMINAL_SUFFIX})"

--- a/zulipterminal/config/regexes.py
+++ b/zulipterminal/config/regexes.py
@@ -7,6 +7,9 @@ Regular expression constants
 
 
 # (*) Stream and topic regexes
+from zulipterminal.config.keys import READLINE_SUFFIX
+
+
 REGEX_STREAM_NAME = r"([^*>]+)"
 REGEX_TOPIC_NAME = r"([^*]*)"
 
@@ -46,3 +49,7 @@ REGEX_COLOR_VALID_FORMATS = (
 
 # Example: 6-test-stream
 REGEX_INTERNAL_LINK_STREAM_ID = r"^[0-9]+-"
+
+
+# Example: UNDO_LAST_ACTION_READLINE
+REGEX_READLINE_COMMANDS = rf"([A-Z_]+{READLINE_SUFFIX})"


### PR DESCRIPTION
### What does this PR do, and why?
- Identify external hotkey commands with a suffix (readline shortcuts and terminal shortcuts)
- Lint for the usage of external commands in the codebase. They're not intended for direct use or modification.
- Check sync of readline shortcuts with urwid_readline's keymap.

### External discussion & connections
- [ ] Discussed in **#zulip-terminal** in `topic`
- [ ] Fully fixes #
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #1494
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
- [x] Manually - Behavioral changes
- [ ] Manually - Visual changes
- [ ] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [ ] It contains test additions for any new behavior
- [x] It flows clearly from a previous branch commit, and/or prepares for the next commit

### Visual changes
Our shortcuts missing in Readline's keymap: 
![Screenshot from 2024-05-12 22-45-46](https://github.com/zulip/zulip-terminal/assets/20315308/a49aabb7-05c4-46b7-a11c-c71b8dabb00d)
On successful linting: 
![Screenshot from 2024-05-12 22-46-30](https://github.com/zulip/zulip-terminal/assets/20315308/dfe7cd1e-1335-47b2-909b-42604b519838)
Linting errors:
![Screenshot from 2024-05-12 22-47-02](https://github.com/zulip/zulip-terminal/assets/20315308/42ef6372-2c6b-4626-9092-bfb4cb39f0f8)
