### PR TITLE
Notify on alert words (#1301 rebase + tidy)

### DIFF
--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -2139,6 +2139,42 @@ class TestModel:
                 ["private"],
                 id="notified_private_since_private_message",
             ),  # No Stream setting so (stream/topic) muting limits streams
+            case(
+                5179,
+                {"flags": ["has_alert_word"]},
+                False,
+                True,
+                True,
+                ["private"],
+                id="not_notified_for_stream_since_topic/stream_both_muted",
+            ),
+            case(
+                5179,
+                {"flags": ["has_alert_word"]},
+                False,
+                True,
+                False,
+                ["private"],
+                id="not_notified_for_stream_since_stream_muted",
+            ),
+            case(
+                5179,
+                {"flags": ["has_alert_word"]},
+                False,
+                False,
+                True,
+                ["private"],
+                id="not_notified_for_stream_since_topic_muted",
+            ),
+            case(
+                5179,
+                {"flags": ["has_alert_word"]},
+                False,
+                False,
+                False,
+                ["stream", "private"],
+                id="notified_for_stream_since_topic/stream_both_not_muted",
+            ),
         ],
     )
     def test_notify_user__calling_message_type(

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1612,6 +1612,13 @@ class Model:
             ) or self.is_visual_notifications_enabled(stream_id):
                 recipient = "{display_recipient} -> {subject}".format(**message)
 
+            if "has_alert_word" in message["flags"]:
+                # Check if stream or topic is muted
+                topic = message.get("subject", "")
+                if not self.is_muted_stream(stream_id) and not self.is_muted_topic(
+                    stream_id, topic
+                ):
+                    recipient = "{display_recipient} -> {subject}".format(**message)
         if recipient:
             if hidden_content:
                 text = content


### PR DESCRIPTION
<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?

This takes #1301 and applies some tidying, following through with some of the changes I suggested.

Full notification logic remains incomplete for now, but this takes us closer.

Other than new features in the server, we do not take into account various user settings, which affects for example wildcard mentions.

@mounilKshah FYI Since you were involved in reviewing #1301, and I'm only testing this remotely right now.

### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [x] Discussed in **#zulip-terminal** in `Alert word handling #T588 #T1301` (originally)
- [ ] Fully fixes #
- [x] Partially fixes issues #588 #666
- [x] Builds upon previous unmerged work in PR #1301
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [ ] Manually - Behavioral changes
- [ ] Manually - Visual changes
- [x] Adapting existing automated tests
- [x] Adding automated tests for new behavior (or missing tests)
- [x] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [x] It contains test additions for any new behavior
- [x] It flows clearly from a previous branch commit, and/or prepares for the next commit