### PR TITLE
Migration of zuliprc location to a config directory

### DIFF
--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -398,6 +398,7 @@ def test_main_cannot_write_zuliprc_given_good_credentials(
     # This is default base path to use
     zuliprc_path = os.path.join(str(tmp_path), path_to_use, "zuliprc")
     mocker.patch(MODULE + ".HOME_PATH_ZULIPRC", zuliprc_path)
+    mocker.patch(MODULE + ".CONFIG_PATH", os.path.join(str(tmp_path), "config"))
 
     # Give some arbitrary input and fake that it's always valid
     mocker.patch.object(builtins, "input", lambda _: "text\n")

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -135,6 +135,7 @@ def test_main_help(capsys: CaptureFixture[str], options: str) -> None:
         "--theme THEME, -t THEME",
         "-h, --help",
         "-d, --debug",
+        "--list-accounts",
         "--list-themes",
         "--profile",
         "--config-file CONFIG_FILE, -c CONFIG_FILE",

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -387,7 +387,6 @@ def unreadable_dir(tmp_path: Path) -> Generator[Tuple[Path, Path], None, None]:
     ids=["valid_path_but_cannot_be_written_to", "path_does_not_exist"],
 )
 def test_main_cannot_write_zuliprc_given_good_credentials(
-    monkeypatch: pytest.MonkeyPatch,
     capsys: CaptureFixture[str],
     mocker: MockerFixture,
     unreadable_dir: Tuple[Path, Path],
@@ -397,8 +396,8 @@ def test_main_cannot_write_zuliprc_given_good_credentials(
     tmp_path, unusable_path = unreadable_dir
 
     # This is default base path to use
-    zuliprc_path = os.path.join(str(tmp_path), path_to_use)
-    monkeypatch.setenv("HOME", zuliprc_path)
+    zuliprc_path = os.path.join(str(tmp_path), path_to_use, "zuliprc")
+    mocker.patch(MODULE + ".HOME_PATH_ZULIPRC", zuliprc_path)
 
     # Give some arbitrary input and fake that it's always valid
     mocker.patch.object(builtins, "input", lambda _: "text\n")
@@ -415,7 +414,7 @@ def test_main_cannot_write_zuliprc_given_good_credentials(
     expected_line = (
         "\x1b[91m"
         f"{expected_exception}: zuliprc could not be created "
-        f"at {os.path.join(zuliprc_path, 'zuliprc')}"
+        f"at {zuliprc_path}"
         "\x1b[0m"
     )
     assert lines[-1] == expected_line

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -135,6 +135,7 @@ def test_main_help(capsys: CaptureFixture[str], options: str) -> None:
         "--theme THEME, -t THEME",
         "-h, --help",
         "-d, --debug",
+        "-n, --new-account",
         "--list-accounts",
         "--list-themes",
         "--profile",

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -285,7 +285,10 @@ def get_api_key(realm_url: str) -> Optional[Tuple[str, str, str]]:
     return None
 
 
-def fetch_zuliprc(zuliprc_path: str) -> None:
+def login_and_save(zuliprc_path: str) -> None:
+    """
+    Prompts the user for their login credentials and saves them to a zuliprc file.
+    """
     print(
         f"{in_color('red', f'zuliprc file was not found at {zuliprc_path}')}"
         f"\nPlease enter your credentials to login into your Zulip organization."
@@ -347,7 +350,7 @@ def parse_zuliprc(zuliprc_str: str) -> Dict[str, SettingData]:
     zuliprc_path = path.expanduser(zuliprc_str)
     while not path.exists(zuliprc_path):
         try:
-            fetch_zuliprc(zuliprc_path)
+            login_and_save(zuliprc_path)
         # Invalid user inputs (e.g. pressing arrow keys) may cause ValueError
         except (OSError, ValueError):
             # Remove zuliprc file if created.

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -11,6 +11,7 @@ import sys
 import traceback
 from enum import Enum
 from os import path, remove
+from pathlib import Path
 from typing import Dict, List, NamedTuple, Optional, Tuple
 
 import requests
@@ -28,6 +29,9 @@ from zulipterminal.core import Controller
 from zulipterminal.model import ServerConnectionFailure
 from zulipterminal.platform_code import detected_platform, detected_python_in_full
 from zulipterminal.version import ZT_VERSION
+
+
+HOME_PATH_ZULIPRC = str(Path.home() / "zuliprc")
 
 
 class ConfigSource(Enum):
@@ -136,7 +140,7 @@ def parse_args(argv: List[str]) -> argparse.Namespace:
         "-c",
         action="store",
         help="config file downloaded from your zulip "
-        "organization (default: ~/zuliprc)",
+        f"organization (default: {HOME_PATH_ZULIPRC})",
     )
     parser.add_argument(
         "--theme",
@@ -312,7 +316,7 @@ def login_and_save(zuliprc_path: Optional[str]) -> str:
     # for adding "/api"
     realm_url = realm_url.rstrip("/")
     login_data = get_api_key(realm_url)
-    zuliprc_path = zuliprc_path or path.expanduser("~/zuliprc")
+    zuliprc_path = zuliprc_path or path.expanduser(HOME_PATH_ZULIPRC)
 
     while login_data is None:
         print(in_color("red", "\nIncorrect Email(or Username) or Password!\n"))

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -346,7 +346,12 @@ def _write_zuliprc(
         return f"{ex.__class__.__name__}: zuliprc could not be created at {to_path}"
 
 
-def parse_zuliprc(zuliprc_str: str) -> Dict[str, SettingData]:
+def resolve_to_valid_path(zuliprc_str: str) -> str:
+    """
+    Returns the path to a valid zuliprc file.
+    If none are found or the path provided is invalid, prompts the user to login
+    and returns the path to the created zuliprc file.
+    """
     zuliprc_path = path.expanduser(zuliprc_str)
     while not path.exists(zuliprc_path):
         try:
@@ -360,7 +365,10 @@ def parse_zuliprc(zuliprc_str: str) -> Dict[str, SettingData]:
         except EOFError:
             # Assume that the user pressed Ctrl+D and continue the loop
             print("\n")
+    return zuliprc_path
 
+
+def parse_zuliprc(zuliprc_path: str) -> Dict[str, SettingData]:
     mode = os.stat(zuliprc_path).st_mode
     is_readable_by_group_or_others = mode & (stat.S_IRWXG | stat.S_IRWXO)
 
@@ -458,6 +466,7 @@ def main(options: Optional[List[str]] = None) -> None:
         zuliprc_path = args.config_file
     else:
         zuliprc_path = "~/zuliprc"
+    zuliprc_path = resolve_to_valid_path(zuliprc_path)
 
     print(
         "Detected:"

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -142,6 +142,12 @@ def parse_args(argv: List[str]) -> argparse.Namespace:
         "to fetch its configuration",
     )
     parser.add_argument(
+        "-n",
+        "--new-account",
+        action="store_true",
+        help="login to a new account",
+    )
+    parser.add_argument(
         "--list-accounts",
         action="store_true",
         help="list the aliases of all your zulip accounts, and exit",
@@ -381,7 +387,7 @@ def _write_zuliprc(
         return f"{ex.__class__.__name__}: zuliprc could not be created at {to_path}"
 
 
-def resolve_to_valid_path(zuliprc_str: Optional[str]) -> str:
+def resolve_to_valid_path(zuliprc_str: Optional[str], is_new_account: bool) -> str:
     """
     Returns the path to a valid zuliprc file.
     If a path is not provided by the user, searches the default locations.
@@ -394,12 +400,13 @@ def resolve_to_valid_path(zuliprc_str: Optional[str]) -> str:
         else path.expanduser(zuliprc_str)
     )
     while zuliprc_path is None or not path.exists(zuliprc_path):
-        print(
-            f"{in_color('red', 'zuliprc file was not found')}"
-            f"{in_color('red', f' at {zuliprc_path}')}"
-            if zuliprc_path
-            else "."
-        )
+        if not is_new_account:
+            print(
+                f"{in_color('red', 'zuliprc file was not found')}"
+                f"{in_color('red', f' at {zuliprc_path}')}"
+                if zuliprc_path
+                else "."
+            )
         try:
             zuliprc_path = login_and_save()
         # Invalid user inputs (e.g. pressing arrow keys) may cause ValueError
@@ -555,7 +562,7 @@ def main(options: Optional[List[str]] = None) -> None:
             )
     if args.config_file:
         zuliprc_path = args.config_file
-    zuliprc_path = resolve_to_valid_path(zuliprc_path)
+    zuliprc_path = resolve_to_valid_path(zuliprc_path, args.new_account)
 
     print(
         "Detected:"

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -134,6 +134,14 @@ def parse_args(argv: List[str]) -> argparse.Namespace:
         description=description, formatter_class=formatter_class
     )
     parser.add_argument(
+        "account-alias",
+        nargs="?",
+        action="store",
+        default="",
+        help="specify the chosen alias of your zulip account "
+        "to fetch its configuration",
+    )
+    parser.add_argument(
         "-v",
         "--version",
         action="store_true",
@@ -514,6 +522,13 @@ def main(options: Optional[List[str]] = None) -> None:
         sys.exit(0)
 
     zuliprc_path = None
+    account_alias = getattr(args, "account-alias")
+    if account_alias:
+        if args.config_file:
+            exit_with_error("Cannot use account-alias and --config-file together")
+        zuliprc_path = os.path.join(CONFIG_PATH, account_alias, "zuliprc")
+        if not path.exists(zuliprc_path):
+            exit_with_error(f"Account alias {account_alias} not found")
     if args.config_file:
         zuliprc_path = args.config_file
     zuliprc_path = resolve_to_valid_path(zuliprc_path)

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -142,6 +142,11 @@ def parse_args(argv: List[str]) -> argparse.Namespace:
         "to fetch its configuration",
     )
     parser.add_argument(
+        "--list-accounts",
+        action="store_true",
+        help="list the aliases of all your zulip accounts, and exit",
+    )
+    parser.add_argument(
         "-v",
         "--version",
         action="store_true",
@@ -483,6 +488,17 @@ def list_themes() -> str:
     )
 
 
+def list_accounts() -> str:
+    if not path.exists(CONFIG_PATH):
+        exit_with_error(f"Config folder not found at {CONFIG_PATH}.")
+    valid_accounts = [file.parent.name for file in Path(CONFIG_PATH).glob("*/zuliprc")]
+    if len(valid_accounts) == 0:
+        exit_with_error("No accounts found.")
+    return "Configurations for the following accounts are available:\n  " "\n  ".join(
+        valid_accounts
+    )
+
+
 def main(options: Optional[List[str]] = None) -> None:
     """
     Launch Zulip Terminal.
@@ -519,6 +535,10 @@ def main(options: Optional[List[str]] = None) -> None:
 
     if args.list_themes:
         print(list_themes())
+        sys.exit(0)
+
+    if args.list_accounts:
+        print(list_accounts())
         sys.exit(0)
 
     zuliprc_path = None

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -318,15 +318,11 @@ def get_api_key(realm_url: str) -> Optional[Tuple[str, str, str, str]]:
     return None
 
 
-def login_and_save(zuliprc_path: Optional[str]) -> str:
+def login_and_save() -> str:
     """
     Prompts the user for their login credentials and saves them to a zuliprc file.
     """
     print(
-        f"{in_color('red', 'zuliprc file was not found')}"
-        f"{in_color('red', f' at {zuliprc_path}')}"
-        if zuliprc_path
-        else "."
         f"\nPlease enter your credentials to login into your Zulip organization."
         f"\n"
         f"\nNOTE: The {in_color('blue', 'Zulip server URL')}"
@@ -398,8 +394,14 @@ def resolve_to_valid_path(zuliprc_str: Optional[str]) -> str:
         else path.expanduser(zuliprc_str)
     )
     while zuliprc_path is None or not path.exists(zuliprc_path):
+        print(
+            f"{in_color('red', 'zuliprc file was not found')}"
+            f"{in_color('red', f' at {zuliprc_path}')}"
+            if zuliprc_path
+            else "."
+        )
         try:
-            zuliprc_path = login_and_save(zuliprc_path)
+            zuliprc_path = login_and_save()
         # Invalid user inputs (e.g. pressing arrow keys) may cause ValueError
         except (OSError, ValueError):
             # Remove zuliprc file if created.

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -548,7 +548,9 @@ def main(options: Optional[List[str]] = None) -> None:
             exit_with_error("Cannot use account-alias and --config-file together")
         zuliprc_path = os.path.join(CONFIG_PATH, account_alias, "zuliprc")
         if not path.exists(zuliprc_path):
-            exit_with_error(f"Account alias {account_alias} not found")
+            exit_with_error(
+                f"Account alias {account_alias} not found\n" f"{list_accounts()}"
+            )
     if args.config_file:
         zuliprc_path = args.config_file
     zuliprc_path = resolve_to_valid_path(zuliprc_path)

--- a/zulipterminal/platform_code.py
+++ b/zulipterminal/platform_code.py
@@ -2,8 +2,10 @@
 Detection of supported platforms & platform-specific functions
 """
 
+import os
 import platform
 import subprocess
+from pathlib import Path
 from typing import Tuple
 
 from typing_extensions import Literal
@@ -87,6 +89,14 @@ def notify(title: str, text: str) -> str:
             # This likely means the notification command could not be found
             return command_list[0]
     return ""
+
+
+def xdg_config_home() -> Path:
+    """Return a Path corresponding to XDG_CONFIG_HOME."""
+    config_home = os.environ.get("XDG_CONFIG_HOME")
+    if config_home and Path(config_home).is_absolute():
+        return Path(config_home)
+    return Path.home() / ".config"
 
 
 def successful_GUI_return_code() -> int:  # noqa: N802 (allow upper case)


### PR DESCRIPTION
### What does this PR do, and why?

Adds the following features:

- Support recognizing zuliprc from multiple select locations. 
  - `~/zuliprc`
  - the user's downloads directory
  - the user's config directory

- Move zuliprc creation into user's config directory.
The new path would look like `.config/zulip-terminal/zuliprc`.

- Create realm-wise zuliprc files in the configuration directory.
Each realm gets its own directory.
The new directory structure would look like:
```
<user's config directory>/zulip-terminal/
  org1-name/zuliprc
  org2-name/zuliprc
  zuliprc
```

- Add new positional argument - prefix of realm name to get its configuration.
New command examples:
`zulip-term zuli`
`zulip-term "full organization name"`

- Add -o argument to list realms with stored zuliprc.
```
$zulip-term -o
The following organizations are available:
  Zulip Community
  Another Organization
```

- Add -n argument to login to a realm, and create config.
```
$zulip-term -n
Please enter your credentials to login into your Zulip organization.
```

<details>
<summary>What does this PR do, and why? (expired)</summary>

### What does this PR do, and why?
Moves config location to 'XDG_CONFIG/zulip/'.
Makes zuliprc files dot files - .zuliprc.
Use independent org.zuliprc files for each organization.

Does not yet separate the zterm config from the api config.
Does not yet update the documents (README.md, FAQ.md, etc).
New tests not added.

The code is not yet meant for review.
This is only a draft to play around with the configuration in order to finalize what behavior is desired.
</details>

### External discussion & connections
- [x] Discussed in **#zulip-terminal** in `Moving config`
- [ ] Fully fixes #
- [x] Partially fixes issue #678
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
- [x] Manually - Behavioral changes
- [ ] Manually - Visual changes
- [x] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the motivation and reasoning for the change
- [x] It individually passes linting and tests
- [ ] It contains test additions for any new behavior
- [x] It flows clearly from a previous branch commit, and/or prepares for the next commit