### PR TITLE
Disable cycling to recipients when editing PM

### DIFF
--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -421,7 +421,7 @@ class TestWriteBox:
             ),
         ],
     )
-    def test_update_recipients(
+    def test_update_recipients_from_emails_in_widget(
         self,
         write_box: WriteBox,
         header: str,
@@ -432,7 +432,7 @@ class TestWriteBox:
         assert write_box.to_write_box is not None
         write_box.to_write_box.edit_text = header
 
-        write_box.update_recipients(write_box.to_write_box)
+        write_box.update_recipients_from_emails_in_widget(write_box.to_write_box)
 
         assert write_box.recipient_emails == expected_recipient_emails
         assert write_box.recipient_user_ids == expected_recipient_user_ids

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -1663,6 +1663,16 @@ class TestWriteBox:
                 "HEADER_BOX_RECIPIENT",
                 id="message_to_recipient_box",
             ),
+            case(
+                "CONTAINER_MESSAGE",
+                "MESSAGE_BOX_BODY",
+                "private",
+                True,
+                True,
+                "CONTAINER_MESSAGE",
+                "MESSAGE_BOX_BODY",
+                id="private_edit_box-no_cycle",
+            ),
         ],
     )
     @pytest.mark.parametrize("tab_key", keys_for_command("CYCLE_COMPOSE_FOCUS"))
@@ -1683,13 +1693,14 @@ class TestWriteBox:
     ) -> None:
         mocker.patch(WRITEBOX + "._set_stream_write_box_style")
 
+        if message_being_edited:
+            write_box.msg_edit_state = _MessageEditState(
+                message_id=10, old_topic="some old topic"
+            )
         if box_type == "stream":
             if message_being_edited:
                 mocker.patch(MODULE + ".EditModeButton")
                 write_box.stream_box_edit_view(stream_id)
-                write_box.msg_edit_state = _MessageEditState(
-                    message_id=10, old_topic="some old topic"
-                )
             else:
                 write_box.stream_box_view(stream_id)
         else:

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -222,6 +222,15 @@ class WriteBox(urwid.Pile):
             self.recipient_emails = []
             return ""
 
+    def private_box_edit_view(
+        self,
+        *,
+        recipient_user_ids: Optional[List[int]] = None,
+    ) -> None:
+        self.recipient_info = self.update_recipients_from_user_ids(recipient_user_ids)
+        self.to_write_box = urwid.Text("To: " + self.recipient_info)
+        self._setup_common_private_compose()
+
     def private_box_view(
         self,
         *,

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -173,40 +173,10 @@ class WriteBox(urwid.Pile):
             self.idle_status_tracking = False
             self.sent_start_typing_status = False
 
-    def private_box_view(
-        self,
-        *,
-        recipient_user_ids: Optional[List[int]] = None,
-    ) -> None:
+    def _setup_common_private_compose(self) -> None:
         self.set_editor_mode()
 
         self.compose_box_status = "open_with_private"
-
-        if recipient_user_ids:
-            self._set_regular_and_typing_recipient_user_ids(recipient_user_ids)
-            self.recipient_emails = [
-                self.model.user_id_email_dict[user_id]
-                for user_id in self.recipient_user_ids
-            ]
-            recipient_info = ", ".join(
-                [
-                    f"{self.model.user_dict[email]['full_name']} <{email}>"
-                    for email in self.recipient_emails
-                ]
-            )
-        else:
-            self._set_regular_and_typing_recipient_user_ids(None)
-            self.recipient_emails = []
-            recipient_info = ""
-
-        self.send_next_typing_update = datetime.now()
-        self.to_write_box = ReadlineEdit("To: ", edit_text=recipient_info)
-        self.to_write_box.enable_autocomplete(
-            func=self._to_box_autocomplete,
-            key=primary_key_for_command("AUTOCOMPLETE"),
-            key_reverse=primary_key_for_command("AUTOCOMPLETE_REVERSE"),
-        )
-        self.to_write_box.set_completer_delims("")
 
         self.msg_write_box = ReadlineEdit(
             multiline=True, max_char=self.model.max_message_length
@@ -232,6 +202,37 @@ class WriteBox(urwid.Pile):
         ]
         self.focus_position = self.FOCUS_CONTAINER_MESSAGE
 
+    def private_box_view(
+        self,
+        *,
+        recipient_user_ids: Optional[List[int]] = None,
+    ) -> None:
+        if recipient_user_ids:
+            self._set_regular_and_typing_recipient_user_ids(recipient_user_ids)
+            self.recipient_emails = [
+                self.model.user_id_email_dict[user_id]
+                for user_id in self.recipient_user_ids
+            ]
+            recipient_info = ", ".join(
+                [
+                    f"{self.model.user_dict[email]['full_name']} <{email}>"
+                    for email in self.recipient_emails
+                ]
+            )
+        else:
+            self._set_regular_and_typing_recipient_user_ids(None)
+            self.recipient_emails = []
+            recipient_info = ""
+
+        self.send_next_typing_update = datetime.now()
+        self.to_write_box = ReadlineEdit("To: ", edit_text=recipient_info)
+        self.to_write_box.enable_autocomplete(
+            func=self._to_box_autocomplete,
+            key=primary_key_for_command("AUTOCOMPLETE"),
+            key_reverse=primary_key_for_command("AUTOCOMPLETE_REVERSE"),
+        )
+        self.to_write_box.set_completer_delims("")
+        self._setup_common_private_compose()
         start_period_delta = timedelta(
             milliseconds=self.model.typing_started_wait_period
         )

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -265,7 +265,7 @@ class WriteBox(urwid.Pile):
 
         urwid.connect_signal(self.msg_write_box, "change", on_type_send_status)
 
-    def update_recipients(self, write_box: ReadlineEdit) -> None:
+    def update_recipients_from_emails_in_widget(self, write_box: ReadlineEdit) -> None:
         self.recipient_emails = re.findall(REGEX_RECIPIENT_EMAIL, write_box.edit_text)
         self._set_regular_and_typing_recipient_user_ids(
             [self.model.user_dict[email]["user_id"] for email in self.recipient_emails]
@@ -761,7 +761,7 @@ class WriteBox(urwid.Pile):
                     )
                     if not all_valid:
                         return key
-                    self.update_recipients(self.to_write_box)
+                    self.update_recipients_from_emails_in_widget(self.to_write_box)
                     if self.recipient_user_ids:
                         success = self.model.send_private_message(
                             recipients=self.recipient_user_ids,
@@ -815,7 +815,7 @@ class WriteBox(urwid.Pile):
                     )
                     if not all_valid:
                         return key
-                    self.update_recipients(self.to_write_box)
+                    self.update_recipients_from_emails_in_widget(self.to_write_box)
                     this_draft: Composition = PrivateComposition(
                         type="private",
                         to=self.recipient_user_ids,
@@ -893,7 +893,7 @@ class WriteBox(urwid.Pile):
                     # We extract recipients' user_ids and emails only once we know
                     # that all the recipients are valid, to avoid including any
                     # invalid ones.
-                    self.update_recipients(self.to_write_box)
+                    self.update_recipients_from_emails_in_widget(self.to_write_box)
 
             if not self.msg_body_edit_enabled:
                 return key

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -905,7 +905,13 @@ class WriteBox(urwid.Pile):
             if self.focus_position == self.FOCUS_CONTAINER_HEADER:
                 self.focus_position = self.FOCUS_CONTAINER_MESSAGE
             else:
-                self.focus_position = self.FOCUS_CONTAINER_HEADER
+                if self.compose_box_status == "open_with_stream":
+                    self.focus_position = self.FOCUS_CONTAINER_HEADER
+                if (
+                    self.compose_box_status == "open_with_private"
+                    and self.msg_edit_state is None
+                ):
+                    self.focus_position = self.FOCUS_CONTAINER_HEADER
             if self.compose_box_status == "open_with_stream":
                 if self.msg_edit_state is not None:
                     header.focus_col = self.FOCUS_HEADER_BOX_TOPIC

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -202,18 +202,16 @@ class WriteBox(urwid.Pile):
         ]
         self.focus_position = self.FOCUS_CONTAINER_MESSAGE
 
-    def private_box_view(
-        self,
-        *,
-        recipient_user_ids: Optional[List[int]] = None,
-    ) -> None:
+    def update_recipients_from_user_ids(
+        self, recipient_user_ids: Optional[List[int]] = None
+    ) -> str:
         if recipient_user_ids:
             self._set_regular_and_typing_recipient_user_ids(recipient_user_ids)
             self.recipient_emails = [
                 self.model.user_id_email_dict[user_id]
                 for user_id in self.recipient_user_ids
             ]
-            recipient_info = ", ".join(
+            return ", ".join(
                 [
                     f"{self.model.user_dict[email]['full_name']} <{email}>"
                     for email in self.recipient_emails
@@ -222,9 +220,15 @@ class WriteBox(urwid.Pile):
         else:
             self._set_regular_and_typing_recipient_user_ids(None)
             self.recipient_emails = []
-            recipient_info = ""
+            return ""
 
+    def private_box_view(
+        self,
+        *,
+        recipient_user_ids: Optional[List[int]] = None,
+    ) -> None:
         self.send_next_typing_update = datetime.now()
+        recipient_info = self.update_recipients_from_user_ids(recipient_user_ids)
         self.to_write_box = ReadlineEdit("To: ", edit_text=recipient_info)
         self.to_write_box.enable_autocomplete(
             func=self._to_box_autocomplete,

--- a/zulipterminal/ui_tools/messages.py
+++ b/zulipterminal/ui_tools/messages.py
@@ -1096,7 +1096,9 @@ class MessageBox(urwid.Pile):
                     )
 
             if self.message["type"] == "private":
-                self.keypress(size, primary_key_for_command("REPLY_MESSAGE"))
+                self.model.controller.view.write_box.private_box_edit_view(
+                    recipient_user_ids=self.recipient_ids,
+                )
             elif self.message["type"] == "stream":
                 self.model.controller.view.write_box.stream_box_edit_view(
                     stream_id=self.stream_id,


### PR DESCRIPTION
<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?

This is a rebase and simplification of #1280. It's the missing piece to resolve #774.

In comparison to the previous work
- heavily restructured the commits and refined/clarified the descriptions.
- I also decided to use a more "high level" approach to testing, testing less the internal calls, rather than the overall expected resulting structure.
- The error message when pressing tab I removed as well, because I thought it was not a real "error", but maybe it's more user friendly than noisy? 

### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [x] Discussed in **#zulip-terminal** in [`Disable PM recipient cycling on edit #T774 #T1280`](https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/Disable.20PM.20recipient.20cycling.20on.20edit.20.23T774.20.23T1280)
- [x] Fully fixes #774
- [ ] Partially fixes issue #
- [x] Builds upon previous unmerged work in PR #1280 
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [x] Manually - Behavioral changes
- [ ] Manually - Visual changes
- [x] Adapting existing automated tests
- [x] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [ ] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [ ] It individually passes linting and tests
- [x] It contains test additions for any new behavior
- [x] It flows clearly from a previous branch commit, and/or prepares for the next commit
