### PR TITLE
gitlint: Add regex to ignore some long lines.

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -55,3 +55,6 @@ ignore=all
 # Ignore certain rules, you can reference them by their id or by their full name
 # Use 'all' to ignore all rules
 # ignore=T1,body-min-length
+
+[ignore-body-lines]
+regex=^(Co-authored-by:| *https?://\S+$)


### PR DESCRIPTION
<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?

This was motivated by the failure of a CI run on #1494, where I added a URL to the commit body.

This does not resolve issues for all previous commits where the B1 rule of long lines in the body would fail, but will allow some obvious common cases to pass.

Inspired by jorisroovers/gitlint#255, this should cover at least lines starting with:
- http or https [where URLs can be long]
- Co-authored-by: [where emails/names can be long]

The downside to this rule is that the line numbering is apparently offset, based on the gitlint documentation.
(https://jorisroovers.com/gitlint/latest/ignoring_commits/)

This was tested manually on the last 1500 commits on `main`, and limits the number of gitlint errors as expected for URLs. No changes are noted for Co-authored-by: at this time.

### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [ ] Discussed in **#zulip-terminal** in `topic`
- [ ] Fully fixes #
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [x] Manually - Behavioral changes
- [ ] Manually - Visual changes
- [ ] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [ ] It contains test additions for any new behavior
- [ ] It flows clearly from a previous branch commit, and/or prepares for the next commit
