### PR TITLE
Fix tests failing on WSL systems.

### DIFF
--- a/tests/helper/test_helper.py
+++ b/tests/helper/test_helper.py
@@ -573,6 +573,7 @@ def test_process_media(
     )
     mocked_open_media = mocker.patch(MODULE + ".open_media")
     mocker.patch(MODULE + ".PLATFORM", platform)
+    mocker.patch("zulipterminal.platform_code.PLATFORM", platform)
     mocker.patch("zulipterminal.core.Controller.show_media_confirmation_popup")
 
     process_media(controller, link)

--- a/tests/platform_code/test_platform_code.py
+++ b/tests/platform_code/test_platform_code.py
@@ -6,7 +6,7 @@ from zulipterminal.platform_code import (
     SupportedPlatforms,
     normalized_file_path,
     notify,
-    successful_GUI_return_code,
+    validate_GUI_exit_status,
 )
 
 
@@ -76,20 +76,25 @@ def test_notify_quotes(
 
 
 @pytest.mark.parametrize(
-    "platform, expected_return_code",
+    "platform, return_code, expected_return_value",
     [
-        ("Linux", 0),
-        ("MacOS", 0),
-        ("WSL", 1),
+        ("Linux", 0, "success"),
+        ("MacOS", 0, "success"),
+        ("WSL", 1, "success"),
+        ("Linux", 1, "failure"),
+        ("MacOS", 1, "failure"),
+        # NOTE: explorer.exe (WSL) always returns a non-zero exit code (1),
+        # so we do not test for it.
     ],
 )
-def test_successful_GUI_return_code(
+def test_validate_GUI_exit_status(
     mocker: MockerFixture,
     platform: SupportedPlatforms,
-    expected_return_code: int,
+    return_code: int,
+    expected_return_value: str,
 ) -> None:
     mocker.patch(MODULE + ".PLATFORM", platform)
-    assert successful_GUI_return_code() == expected_return_code
+    assert validate_GUI_exit_status(return_code) == expected_return_value
 
 
 @pytest.mark.parametrize(

--- a/zulipterminal/platform_code.py
+++ b/zulipterminal/platform_code.py
@@ -89,18 +89,19 @@ def notify(title: str, text: str) -> str:
     return ""
 
 
-def successful_GUI_return_code() -> int:  # noqa: N802 (allow upper case)
+def validate_GUI_exit_status(  # noqa: N802 (allow upper case)
+    exit_status: int,
+) -> Literal["success", "failure"]:
     """
     Returns success return code for GUI commands, which are OS specific.
     """
-    # WSL uses GUI return code as 1. Refer below link to know more:
-    # https://stackoverflow.com/questions/52423031/
-    # why-does-opening-an-explorer-window-and-selecting-a-file-through-pythons-subpro/
-    # 52423798#52423798
+    # NOTE: WSL (explorer.exe) always returns a non-zero exit code (1) for GUI commands.
+    # This is a known issue. Therefore, we consider it a success if the exit code is 1.
+    # For more information, see: https://github.com/microsoft/WSL/issues/6565
     if PLATFORM == "WSL":
-        return 1
+        return "success"
 
-    return 0
+    return "success" if exit_status == 0 else "failure"
 
 
 def normalized_file_path(path: str) -> str:

--- a/zulipterminal/platform_code.py
+++ b/zulipterminal/platform_code.py
@@ -112,3 +112,19 @@ def normalized_file_path(path: str) -> str:
         return path.replace("/", "\\")
 
     return path
+
+
+def process_media_tool() -> str:
+    """
+    Returns the media tool command as per platform.
+    """
+    if PLATFORM == "WSL":
+        tool = "explorer.exe"
+    elif PLATFORM == "Linux":
+        tool = "xdg-open"
+    elif PLATFORM == "MacOS":
+        tool = "open"
+    else:
+        tool = "invalid"
+
+    return tool


### PR DESCRIPTION
### What does this PR do, and why?

Addressed issues with file path separators `\\` and GUI return codes specific to WSL environments.

Fixes the failing of these tests on WSL environments, these have been failing for a while now but I just got used to ignoring them, decided to look into them today and fix. 😓 

![image](https://github.com/zulip/zulip-terminal/assets/110327345/4c672e63-2416-4df1-80b2-f876d626fc14)

<!-- See README for documentation, or ask in #zulip-terminal if unclear -->

### Outstanding aspect(s)    <!-- DELETE SECTION IF EMPTY -->
<!-- In what ways is this not fully implemented/functioning? Compared to a discussion/issue? -->
<!-- Do you not understand something? Are you unsure about a certain approach? Want feedback? -->
- [ ] 

### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [x] Discussed in **#zulip-terminal** in [WSL specific test fails](https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/WSL.20specific.20test.20fails/near/1817087)
- [ ] Fully fixes #
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [ ] Manually - Behavioral changes
- [ ] Manually - Visual changes
- [ ] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [ ] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [ ] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [ ] It has a commit summary describing the  motivation and reasoning for the change
- [ ] It individually passes linting and tests
- [ ] It contains test additions for any new behavior
- [ ] It flows clearly from a previous branch commit, and/or prepares for the next commit

### Visual changes    <!-- DELETE SECTION IF NO VISUAL CHANGE -->
<!-- Zulip tips at https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html -->
<!-- For video, try asciinema; after uploading, embed using
[![yourtitle](https://asciinema.org/a/<id>.png)](https://asciinema.org/a/<id>)
-->
<!-- NOTE: Attached videos/images will be clearer from smaller terminal windows -->
