### PR TITLE
Make the ALL_MESSAGES command work globally

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -7,7 +7,7 @@ from urwid import Divider
 
 from zulipterminal.config.keys import keys_for_command, primary_key_for_command
 from zulipterminal.config.symbols import STATUS_ACTIVE
-from zulipterminal.helper import powerset
+from zulipterminal.helper import SearchStatus, powerset
 from zulipterminal.ui_tools.views import (
     SIDE_PANELS_MOUSE_SCROLL_LINES,
     LeftColumnView,
@@ -565,6 +565,7 @@ class TestStreamsView:
         mocker.patch.object(stream_view, "set_focus")
         mocker.patch(VIEWS + ".urwid.Frame.keypress")
         mocker.patch.object(stream_view.stream_search_box, "reset_search_text")
+        stream_view.search_status = SearchStatus.FILTERED
         stream_view.streams_btn_list = ["FOO", "foo", "fan", "boo", "BOO"]
         stream_view.focus_index_before_search = 3
 
@@ -731,6 +732,7 @@ class TestTopicsView:
         mocker.patch(VIEWS + ".TopicsView.set_focus")
         mocker.patch(VIEWS + ".urwid.Frame.keypress")
         mocker.patch.object(topic_view.topic_search_box, "reset_search_text")
+        topic_view.search_status = SearchStatus.FILTERED
         topic_view.topics_btn_list = ["FOO", "foo", "fan", "boo", "BOO"]
         topic_view.focus_index_before_search = 3
 
@@ -1112,6 +1114,7 @@ class TestRightColumnView:
         mocker.patch(VIEWS + ".RightColumnView.set_focus")
         mocker.patch(VIEWS + ".RightColumnView.set_body")
         mocker.patch.object(right_col_view.user_search, "reset_search_text")
+        right_col_view.search_status = SearchStatus.FILTERED
         right_col_view.users_btn_list = []
 
         right_col_view.keypress(size, key)

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -24,7 +24,7 @@ from zulipterminal.config.symbols import (
     STREAM_MARKER_WEB_PUBLIC,
 )
 from zulipterminal.config.ui_mappings import StreamAccessType
-from zulipterminal.helper import Index, MinimalUserData
+from zulipterminal.helper import Index, MinimalUserData, SearchStatus
 from zulipterminal.ui_tools.boxes import (
     MAX_MESSAGE_LENGTH_CONFIRMATION_POPUP,
     PanelSearchBox,
@@ -1903,8 +1903,8 @@ class TestPanelSearchBox:
         size = widget_size(panel_search_box)
         panel_search_box.panel_view.view.controller.is_in_editor_mode = lambda: True
         panel_search_box.panel_view.log = log
-        empty_search = not log
-        panel_search_box.panel_view.empty_search = empty_search
+        search_status = SearchStatus.FILTERED if log else SearchStatus.EMPTY
+        panel_search_box.panel_view.search_status = search_status
         panel_search_box.set_caption("")
         panel_search_box.edit_text = "key words"
 

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -7,6 +7,7 @@ import subprocess
 import time
 from collections import defaultdict
 from contextlib import contextmanager
+from enum import Enum
 from functools import partial, wraps
 from itertools import chain, combinations
 from re import ASCII, MULTILINE, findall, match
@@ -47,6 +48,12 @@ from zulipterminal.platform_code import (
 
 
 StreamAccessType = Literal["public", "private", "web-public"]
+
+
+class SearchStatus(Enum):
+    DEFAULT = 0
+    FILTERED = 1
+    EMPTY = 2
 
 
 class StreamData(TypedDict):

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -1042,7 +1042,10 @@ class PanelSearchBox(ReadlineEdit):
             self.reset_search_text()
             self.panel_view.set_focus("body")
             # Don't call 'Esc' when inside a popup search-box.
-            if not self.panel_view.view.controller.is_any_popup_open():
+            if (
+                not self.panel_view.view.controller.is_any_popup_open()
+                and self.panel_view.search_status != SearchStatus.DEFAULT
+            ):
                 self.panel_view.keypress(size, primary_key_for_command("CLEAR_SEARCH"))
         elif (
             is_command_key("EXECUTE_SEARCH", key)

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -36,6 +36,7 @@ from zulipterminal.config.symbols import (
 )
 from zulipterminal.config.ui_mappings import STREAM_ACCESS_TYPE
 from zulipterminal.helper import (
+    SearchStatus,
     asynch,
     format_string,
     match_emoji,
@@ -1043,7 +1044,10 @@ class PanelSearchBox(ReadlineEdit):
             # Don't call 'Esc' when inside a popup search-box.
             if not self.panel_view.view.controller.is_any_popup_open():
                 self.panel_view.keypress(size, primary_key_for_command("CLEAR_SEARCH"))
-        elif is_command_key("EXECUTE_SEARCH", key) and not self.panel_view.empty_search:
+        elif (
+            is_command_key("EXECUTE_SEARCH", key)
+            and self.panel_view.search_status != SearchStatus.EMPTY
+        ):
             self.panel_view.view.controller.exit_editor_mode()
             self.set_caption([("filter_results", " Search Results "), " "])
             self.panel_view.set_focus("body")

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -403,7 +403,10 @@ class StreamsView(urwid.Frame):
             self.stream_search_box.set_caption(" ")
             self.view.controller.enter_editor_mode_with(self.stream_search_box)
             return key
-        elif is_command_key("CLEAR_SEARCH", key):
+        elif (
+            is_command_key("CLEAR_SEARCH", key)
+            and self.search_status != SearchStatus.DEFAULT
+        ):
             self.stream_search_box.reset_search_text()
             self.log.clear()
             self.log.extend(self.streams_btn_list)
@@ -528,7 +531,10 @@ class TopicsView(urwid.Frame):
             self.topic_search_box.set_caption(" ")
             self.view.controller.enter_editor_mode_with(self.topic_search_box)
             return key
-        elif is_command_key("CLEAR_SEARCH", key):
+        elif (
+            is_command_key("CLEAR_SEARCH", key)
+            and self.search_status != SearchStatus.DEFAULT
+        ):
             self.topic_search_box.reset_search_text()
             self.log.clear()
             self.log.extend(self.topics_btn_list)
@@ -772,7 +778,10 @@ class RightColumnView(urwid.Frame):
             self.user_search.set_caption(" ")
             self.view.controller.enter_editor_mode_with(self.user_search)
             return key
-        elif is_command_key("CLEAR_SEARCH", key):
+        elif (
+            is_command_key("CLEAR_SEARCH", key)
+            and self.search_status != SearchStatus.DEFAULT
+        ):
             self.user_search.reset_search_text()
             self.allow_update_user_list = True
             self.body = UsersView(self.view.controller, self.users_btn_list)

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -36,6 +36,7 @@ from zulipterminal.config.ui_mappings import (
 )
 from zulipterminal.config.ui_sizes import LEFT_WIDTH
 from zulipterminal.helper import (
+    SearchStatus,
     TidiedUserInfo,
     asynch,
     match_emoji,
@@ -335,7 +336,7 @@ class StreamsView(urwid.Frame):
             ),
         )
         self.search_lock = threading.Lock()
-        self.empty_search = False
+        self.search_status = SearchStatus.DEFAULT
 
     @asynch
     def update_streams(self, search_box: Any, new_text: str) -> None:
@@ -352,7 +353,11 @@ class StreamsView(urwid.Frame):
             )[0]
 
             streams_display_num = len(streams_display)
-            self.empty_search = streams_display_num == 0
+            self.search_status = (
+                SearchStatus.EMPTY
+                if streams_display_num == 0
+                else SearchStatus.FILTERED
+            )
 
             # Add a divider to separate pinned streams from the rest.
             pinned_stream_names = [
@@ -371,7 +376,7 @@ class StreamsView(urwid.Frame):
                 streams_display.insert(first_unpinned_index, StreamsViewDivider())
 
             self.log.clear()
-            if not self.empty_search:
+            if self.search_status == SearchStatus.FILTERED:
                 self.log.extend(streams_display)
             else:
                 self.log.extend([self.stream_search_box.search_error])
@@ -404,6 +409,7 @@ class StreamsView(urwid.Frame):
             self.log.extend(self.streams_btn_list)
             self.set_focus("body")
             self.log.set_focus(self.focus_index_before_search)
+            self.search_status = SearchStatus.DEFAULT
             self.view.controller.update_screen()
             return key
         return super().keypress(size, key)
@@ -436,7 +442,7 @@ class TopicsView(urwid.Frame):
             header=self.header_list,
         )
         self.search_lock = threading.Lock()
-        self.empty_search = False
+        self.search_status = SearchStatus.DEFAULT
 
     def _focus_position_for_topic_name(self) -> int:
         saved_topic_state = self.view.saved_topic_in_stream_id(
@@ -461,10 +467,14 @@ class TopicsView(urwid.Frame):
                 for topic in self.topics_btn_list.copy()
                 if new_text in topic.topic_name.lower()
             ]
-            self.empty_search = len(topics_to_display) == 0
+            self.search_status = (
+                SearchStatus.EMPTY
+                if len(topics_to_display) == 0
+                else SearchStatus.FILTERED
+            )
 
             self.log.clear()
-            if not self.empty_search:
+            if self.search_status == SearchStatus.FILTERED:
                 self.log.extend(topics_to_display)
             else:
                 self.log.extend([self.topic_search_box.search_error])
@@ -524,6 +534,7 @@ class TopicsView(urwid.Frame):
             self.log.extend(self.topics_btn_list)
             self.set_focus("body")
             self.log.set_focus(self.focus_index_before_search)
+            self.search_status = SearchStatus.DEFAULT
             self.view.controller.update_screen()
             return key
         return super().keypress(size, key)
@@ -665,7 +676,7 @@ class RightColumnView(urwid.Frame):
 
         self.allow_update_user_list = True
         self.search_lock = threading.Lock()
-        self.empty_search = False
+        self.search_status = SearchStatus.DEFAULT
         super().__init__(self.users_view(), header=search_box)
 
     @asynch
@@ -706,10 +717,12 @@ class RightColumnView(urwid.Frame):
             else:
                 users_display = users
 
-            self.empty_search = len(users_display) == 0
+            self.search_status = (
+                SearchStatus.EMPTY if len(users_display) == 0 else SearchStatus.FILTERED
+            )
 
             # FIXME Update log directly?
-            if not self.empty_search:
+            if self.search_status != SearchStatus.EMPTY:
                 self.body = self.users_view(users_display)
             else:
                 self.body = UsersView(
@@ -765,6 +778,7 @@ class RightColumnView(urwid.Frame):
             self.body = UsersView(self.view.controller, self.users_btn_list)
             self.set_body(self.body)
             self.set_focus("body")
+            self.search_status = SearchStatus.DEFAULT
             self.view.controller.update_screen()
             return key
         elif is_command_key("GO_LEFT", key):
@@ -2027,7 +2041,7 @@ class EmojiPickerView(PopUpView):
         search_box = urwid.Pile(
             [self.emoji_search, urwid.Divider(SECTION_DIVIDER_LINE)]
         )
-        self.empty_search = False
+        self.search_status = SearchStatus.DEFAULT
         self.search_lock = threading.Lock()
         super().__init__(
             controller,
@@ -2073,10 +2087,14 @@ class EmojiPickerView(PopUpView):
             else:
                 self.emojis_display = self.emoji_buttons
 
-            self.empty_search = len(self.emojis_display) == 0
+            self.search_status = (
+                SearchStatus.EMPTY
+                if len(self.emojis_display) == 0
+                else SearchStatus.FILTERED
+            )
 
             body_content = self.emojis_display
-            if self.empty_search:
+            if self.search_status == SearchStatus.EMPTY:
                 body_content = [self.emoji_search.search_error]
 
             self.contents["body"] = (
@@ -2150,5 +2168,6 @@ class EmojiPickerView(PopUpView):
             self.emoji_search.reset_search_text()
             self.controller.exit_editor_mode()
             self.controller.exit_popup()
+            self.search_status = SearchStatus.DEFAULT
             return key
         return super().keypress(size, key)

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -415,6 +415,8 @@ class StreamsView(urwid.Frame):
             self.search_status = SearchStatus.DEFAULT
             self.view.controller.update_screen()
             return key
+        elif is_command_key("ALL_MESSAGES", key):
+            self.view.home_button.activate(key)
         return super().keypress(size, key)
 
 
@@ -543,6 +545,8 @@ class TopicsView(urwid.Frame):
             self.search_status = SearchStatus.DEFAULT
             self.view.controller.update_screen()
             return key
+        elif is_command_key("ALL_MESSAGES", key):
+            self.view.home_button.activate(key)
         return super().keypress(size, key)
 
 
@@ -790,6 +794,8 @@ class RightColumnView(urwid.Frame):
             self.search_status = SearchStatus.DEFAULT
             self.view.controller.update_screen()
             return key
+        elif is_command_key("ALL_MESSAGES", key):
+            self.view.home_button.activate(key)
         elif is_command_key("GO_LEFT", key):
             self.view.show_right_panel(visible=False)
         return super().keypress(size, key)
@@ -949,6 +955,8 @@ class LeftColumnView(urwid.Pile):
             return key
         elif is_command_key("GO_RIGHT", key):
             self.view.show_left_panel(visible=False)
+        elif is_command_key("ALL_MESSAGES", key) and self.get_focus() is self.menu_v:
+            self.view.home_button.activate(key)
         return super().keypress(size, key)
 
 


### PR DESCRIPTION
### What does this PR do, and why?

The keys for 'all messages' (`a`, `Esc`) did not work reliably except when a message is selected.
This PR makes its behavior consistent with the other menu button narrows - `P`, `#`, `f`.

This is implemented by first performing a refactor, to start tracking whether the list views are filtered or not.
Other approach and implementation details are part of the commit descriptions.
Several approaches were attempted before arriving at this one.

### Outstanding aspect(s)    
- Checking and verifying that I have not missed any edge cases is quite welcome.

**Miscellaneous reasoning details:**
- Splitting the GO_BACK commands into several commands is done in a separate PR, as the motivation for that PR is quite different, and does not directly tie in with this PR.
- The enum is placed in helper.py to avoid circular import issues.
- Since it's only more stringent conditional checks, I haven't particularly added tests for the 2nd commit.
- I have assigned higher priority to use `Esc` for RESET_SEARCH op over the ALL_MESSAGES command, when both are possible, as it is the only key to RESET_SEARCH. And since the focus is on the current panel, it also makes more sense to use that context.
- The Emoji Picker's search box doesn't matter to setting the changes for this PR - we don't want to track if it's filtered or not, we could leave the empty_search variable, but for the sake of uniformity and to completely remove all occurrences of empty_search, I have applied the same search_status refactor to it.

### External discussion & connections
- [x] Discussed in **#zulip-terminal** in [`#zulip-terminal > Make the ALL_MESSAGES command work everywhere`](https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/Make.20the.20ALL_MESSAGES.20command.20work.20everywhere/near/1784185)
- [x] Fully fixes #1505
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
- [x] Manually - Behavioral changes
- [ ] Manually - Visual changes
- [ ] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [ ] It contains test additions for any new behavior
- [x] It flows clearly from a previous branch commit, and/or prepares for the next commit

### Changes

#### Before:

`a` key
- If in message view, go to home view centering on that message

`Esc` key
- If in popup, exit the popup
- If in compose box, close it
- If in message view, reset search, go to home view centering on that message
- If in search box or stream/topic/user list, reset search and list, go to last selected button or the first button in the list

#### After:

`a` key
- If in message view, go to home view centering on that message
- **(NEW)** Else, go to home view's last read message

`Esc` key
- If in popup, exit the popup
- If in compose box, close it
- If in message view, reset search, go to home view centering on that message
- (**Made stringent**) If in search box or filtered stream/topic/user list, reset search and list, go to last selected button or the first button in the list
	- **(NEW)** If no search to reset, go to home view's last read message