### PR TITLE
Copy traceback from the Exception popup

### DIFF
--- a/docs/hotkeys.md
+++ b/docs/hotkeys.md
@@ -9,6 +9,7 @@
 |Show/hide Markdown Help Menu|<kbd>Meta</kbd> + <kbd>m</kbd>|
 |Show/hide About Menu|<kbd>Meta</kbd> + <kbd>?</kbd>|
 |Copy information from About Menu to clipboard|<kbd>c</kbd>|
+|Copy traceback from Exception Popup to clipboard|<kbd>c</kbd>|
 |Redraw screen|<kbd>Ctrl</kbd> + <kbd>l</kbd>|
 |Quit|<kbd>Ctrl</kbd> + <kbd>c</kbd>|
 |New footer hotkey hint|<kbd>Tab</kbd>|

--- a/tools/lint-hotkeys
+++ b/tools/lint-hotkeys
@@ -23,7 +23,7 @@ SCRIPT_NAME = PurePath(__file__).name
 HELP_TEXT_STYLE = re.compile(r"^[a-zA-Z /()',&@#:_-]*$")
 
 # Exclude keys from duplicate keys checking
-KEYS_TO_EXCLUDE = ["q", "e", "m", "r", "Esc"]
+KEYS_TO_EXCLUDE = ["q", "e", "m", "r", "Esc", "c"]
 
 
 def main(fix: bool) -> None:

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -56,6 +56,12 @@ KEY_BINDINGS: Dict[str, KeyBinding] = {
         'help_text': 'Copy information from About Menu to clipboard',
         'key_category': 'general',
     },
+    'COPY_TRACEBACK': {
+        'keys': ['c'],
+        'help_text': 'Copy traceback from Exception Popup to clipboard',
+        'excluded_from_random_tips': True,
+        'key_category': 'general',
+    },
     'EXIT_POPUP': {
         'keys': ['esc'],
         'help_text': 'Close popup',

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -299,7 +299,7 @@ class Controller:
         stream_members_view = StreamMembersView(self, stream_id)
         self.show_pop_up(stream_members_view, "area:stream")
 
-    def popup_with_message(self, text: str, width: int) -> None:
+    def show_popup_with_message(self, text: str, width: int) -> None:
         self.show_pop_up(NoticeView(self, text, width, "NOTICE"), "area:error")
 
     def show_exception_popup(self, text: str, width: int, traceback: str) -> None:

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -19,6 +19,7 @@ import zulip
 from typing_extensions import Literal
 
 from zulipterminal.api_types import Composition, Message
+from zulipterminal.config.keys import primary_display_key_for_command
 from zulipterminal.config.symbols import POPUP_CONTENT_BORDER, POPUP_TOP_LINE
 from zulipterminal.config.themes import ThemeSpec
 from zulipterminal.config.ui_sizes import (
@@ -35,6 +36,7 @@ from zulipterminal.ui_tools.views import (
     EditHistoryView,
     EditModeView,
     EmojiPickerView,
+    ExceptionView,
     FullRawMsgView,
     FullRenderedMsgView,
     HelpView,
@@ -299,6 +301,11 @@ class Controller:
 
     def popup_with_message(self, text: str, width: int) -> None:
         self.show_pop_up(NoticeView(self, text, width, "NOTICE"), "area:error")
+
+    def show_exception_popup(self, text: str, width: int, traceback: str) -> None:
+        self.show_pop_up(
+            ExceptionView(self, text, width, "EXCEPTION", traceback), "area:error"
+        )
 
     def show_about(self) -> None:
         self.show_pop_up(
@@ -709,8 +716,12 @@ class Controller:
                     + "\n\n"
                     + "Details of the exception can be found in "
                     + exception_logfile
+                    + "\n\n"
+                    + f"Press [{primary_display_key_for_command('COPY_TRACEBACK')}]"
+                    + " to copy traceback to clipboard."
                 )
-                self.popup_with_message(message, width=80)
+                full_traceback = "".join(traceback.format_exception(*exc))
+                self.show_exception_popup(message, traceback=full_traceback, width=80)
                 self._exception_info = None
         return True  # If don't raise, retain pipe
 

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1716,7 +1716,7 @@ class Model:
             notice = notice_template.format(
                 failed_command, primary_display_key_for_command("EXIT_POPUP")
             )
-            self.controller.popup_with_message(notice, width=50)
+            self.controller.show_popup_with_message(notice, width=50)
             self.controller.update_screen()
             self._notified_user_of_notification_failure = True
 

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1076,6 +1076,24 @@ class NoticeView(PopUpView):
         super().__init__(controller, widgets, "EXIT_POPUP", width, title)
 
 
+class ExceptionView(NoticeView):
+    def __init__(
+        self,
+        controller: Any,
+        notice_text: Any,
+        width: int,
+        title: str,
+        traceback: str,
+    ) -> None:
+        self.traceback = traceback
+        super().__init__(controller, notice_text, width, title)
+
+    def keypress(self, size: urwid_Size, key: str) -> str:
+        if is_command_key("COPY_TRACEBACK", key):
+            self.controller.copy_to_clipboard(self.traceback, "Traceback")
+        return super().keypress(size, key)
+
+
 class AboutView(PopUpView):
     def __init__(
         self,


### PR DESCRIPTION
Allow copying traceback from the Exception has occurred popup.

### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [x] Discussed in **#zulip-terminal** in `View object has no attribute topic_w`
- [ ] Fully fixes # 
- [x] Partially fixes issue #1493
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [x] Manually - Behavioral changes
- [x] Manually - Visual changes
- [ ] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [ ] It contains test additions for any new behavior
- [x] It flows clearly from a previous branch commit, and/or prepares for the next commit

### Visual changes    <!-- DELETE SECTION IF NO VISUAL CHANGE -->
| Before | After |
|--------|--------|
| ![image](https://github.com/zulip/zulip-terminal/assets/110327345/6160edc8-965c-45e4-a139-aa181138ca3c)| ![image](https://github.com/zulip/zulip-terminal/assets/110327345/49e57e35-43c3-418f-bec1-6c4693f887a6)|
| Traceback copy feature wasn't available before | ![image](https://github.com/zulip/zulip-terminal/assets/110327345/a7e85cc5-c7e9-4181-88a7-d582d84fe851)|
