### PR TITLE
Add new help categories to remove parentheses (context) from help texts

### DIFF
--- a/docs/hotkeys.md
+++ b/docs/hotkeys.md
@@ -11,7 +11,6 @@
 |Copy information from About Menu to clipboard|<kbd>c</kbd>|
 |Redraw screen|<kbd>Ctrl</kbd> + <kbd>l</kbd>|
 |Quit|<kbd>Ctrl</kbd> + <kbd>c</kbd>|
-|Show/hide user information (from users list)|<kbd>i</kbd>|
 |New footer hotkey hint|<kbd>Tab</kbd>|
 
 ## Navigation
@@ -64,6 +63,12 @@
 |Toggle topics in a stream|<kbd>t</kbd>|
 |Mute/unmute streams|<kbd>m</kbd>|
 |Show/hide stream information & modify settings|<kbd>i</kbd>|
+
+## User list actions
+|Command|Key Combination|
+| :--- | :---: |
+|Show/hide user information|<kbd>i</kbd>|
+|Narrow to direct messages with user|<kbd>Enter</kbd>|
 
 ## Begin composing a message
 |Command|Key Combination|

--- a/docs/hotkeys.md
+++ b/docs/hotkeys.md
@@ -57,10 +57,6 @@
 |Toggle star status of the current message|<kbd>Ctrl</kbd> + <kbd>s</kbd> / <kbd>*</kbd>|
 |Show/hide message information|<kbd>i</kbd>|
 |Show/hide message sender information|<kbd>u</kbd>|
-|Show/hide edit history (from message information)|<kbd>e</kbd>|
-|View current message in browser (from message information)|<kbd>v</kbd>|
-|Show/hide full rendered message (from message information)|<kbd>f</kbd>|
-|Show/hide full raw message (from message information)|<kbd>r</kbd>|
 
 ## Stream list actions
 |Command|Key Combination|
@@ -121,4 +117,12 @@
 | :--- | :---: |
 |Show/hide stream members|<kbd>m</kbd>|
 |Copy stream email to clipboard|<kbd>c</kbd>|
+
+## Message information (press i to view info of a message)
+|Command|Key Combination|
+| :--- | :---: |
+|Show/hide edit history|<kbd>e</kbd>|
+|View current message in browser|<kbd>v</kbd>|
+|Show/hide full rendered message|<kbd>f</kbd>|
+|Show/hide full raw message|<kbd>r</kbd>|
 

--- a/docs/hotkeys.md
+++ b/docs/hotkeys.md
@@ -68,8 +68,6 @@
 |Toggle topics in a stream|<kbd>t</kbd>|
 |Mute/unmute streams|<kbd>m</kbd>|
 |Show/hide stream information & modify settings|<kbd>i</kbd>|
-|Show/hide stream members (from stream information)|<kbd>m</kbd>|
-|Copy stream email to clipboard (from stream information)|<kbd>c</kbd>|
 
 ## Begin composing a message
 |Command|Key Combination|
@@ -117,4 +115,10 @@
 |Paste last cut section|<kbd>Ctrl</kbd> + <kbd>y</kbd>|
 |Delete previous character|<kbd>Ctrl</kbd> + <kbd>h</kbd>|
 |Swap with previous character|<kbd>Ctrl</kbd> + <kbd>t</kbd>|
+
+## Stream information (press i to view info of a stream)
+|Command|Key Combination|
+| :--- | :---: |
+|Show/hide stream members|<kbd>m</kbd>|
+|Copy stream email to clipboard|<kbd>c</kbd>|
 

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -314,16 +314,16 @@ KEY_BINDINGS: Dict[str, KeyBinding] = {
     },
     'STREAM_MEMBERS': {
         'keys': ['m'],
-        'help_text': 'Show/hide stream members (from stream information)',
+        'help_text': 'Show/hide stream members',
         'excluded_from_random_tips': True,
-        'key_category': 'stream_list',
+        'key_category': 'stream_info',
     },
     'COPY_STREAM_EMAIL': {
         'keys': ['c'],
         'help_text':
-            'Copy stream email to clipboard (from stream information)',
+            'Copy stream email to clipboard',
         'excluded_from_random_tips': True,
-        'key_category': 'stream_list',
+        'key_category': 'stream_info',
     },
     'REDRAW': {
         'keys': ['ctrl l'],
@@ -456,6 +456,10 @@ HELP_CATEGORIES = {
     "compose_box": "Writing a message",
     "editor_navigation": "Editor: Navigation",
     "editor_text_manipulation": "Editor: Text Manipulation",
+    "stream_info": (
+        f"Stream information (press {KEY_BINDINGS['STREAM_INFO']['keys'][0]}"
+        f" to view info of a stream)"
+    ),
 }
 
 ZT_TO_URWID_CMD_MAPPING = {

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -337,8 +337,16 @@ KEY_BINDINGS: Dict[str, KeyBinding] = {
     },
     'USER_INFO': {
         'keys': ['i'],
-        'help_text': 'Show/hide user information (from users list)',
-        'key_category': 'general',
+        'help_text': 'Show/hide user information',
+        'key_category': 'user_list',
+    },
+    'NARROW_TO_USER_PM': {
+        # Added to clarify functionality of button activation,
+        # as opposed to opening user profile or other effects.
+        # Implementation uses ACTIVATE_BUTTON command.
+        'keys': ['enter'],
+        'help_text': 'Narrow to direct messages with user',
+        'key_category': 'user_list',
     },
     'BEGINNING_OF_LINE': {
         'keys': ['ctrl a', 'home'],
@@ -452,6 +460,7 @@ HELP_CATEGORIES = {
     "searching": "Searching",
     "msg_actions": "Message actions",
     "stream_list": "Stream list actions",
+    "user_list": "User list actions",
     "open_compose": "Begin composing a message",
     "compose_box": "Writing a message",
     "editor_navigation": "Editor: Navigation",

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -296,16 +296,16 @@ KEY_BINDINGS: Dict[str, KeyBinding] = {
     },
     'EDIT_HISTORY': {
         'keys': ['e'],
-        'help_text': 'Show/hide edit history (from message information)',
+        'help_text': 'Show/hide edit history',
         'excluded_from_random_tips': True,
-        'key_category': 'msg_actions',
+        'key_category': 'msg_info',
     },
     'VIEW_IN_BROWSER': {
         'keys': ['v'],
         'help_text':
-            'View current message in browser (from message information)',
+            'View current message in browser',
         'excluded_from_random_tips': True,
-        'key_category': 'msg_actions',
+        'key_category': 'msg_info',
     },
     'STREAM_INFO': {
         'keys': ['i'],
@@ -430,13 +430,13 @@ KEY_BINDINGS: Dict[str, KeyBinding] = {
     },
     'FULL_RENDERED_MESSAGE': {
         'keys': ['f'],
-        'help_text': 'Show/hide full rendered message (from message information)',
-        'key_category': 'msg_actions',
+        'help_text': 'Show/hide full rendered message',
+        'key_category': 'msg_info',
     },
     'FULL_RAW_MESSAGE': {
         'keys': ['r'],
-        'help_text': 'Show/hide full raw message (from message information)',
-        'key_category': 'msg_actions',
+        'help_text': 'Show/hide full raw message',
+        'key_category': 'msg_info',
     },
     'NEW_HINT': {
         'keys': ['tab'],
@@ -459,6 +459,10 @@ HELP_CATEGORIES = {
     "stream_info": (
         f"Stream information (press {KEY_BINDINGS['STREAM_INFO']['keys'][0]}"
         f" to view info of a stream)"
+    ),
+    "msg_info": (
+        f"Message information (press {KEY_BINDINGS['MSG_INFO']['keys'][0]}"
+        f" to view info of a message)"
     ),
 }
 


### PR DESCRIPTION
### What does this PR do, and why?
Adds the following new help categories to remove the corresponding context-suffixes (in parentheses) from help texts:
- Stream information ("from stream information" suffixes)
- Message information ("from message information" suffixes)
- User list actions ("from user list" suffixes)

That removes parantheses from all the help texts.

Each of the categories are added in their own commit, for readability.
A new command entry `NARROW_TO_USER_PM` is also added to the user list actions.

### Outstanding aspect(s)
This PR is about removing the contexts mentioned in parentheses as suffixes. And it removes all of them.
But, it also introduces new parentheses for the help category names itself.

I went with this because
1. There is not much repetition of the content in the parentheses
2. Length constraints apply to help texts, they don't wrap. But, help category names do wrap.
3. They add some needed clarity, on when/where the help category's hotkeys will work.

Feedback welcome!

### External discussion & connections
- [x] Discussed in **#zulip-terminal** in [`re-categorize`](https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/Re-Categorization.20of.20Hotkeys/near/1793697)
- [ ] Fully fixes #
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
- [ ] Manually - Behavioral changes
- [x] Manually - Visual changes
- [ ] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [x] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [ ] It contains test additions for any new behavior
- [x] It flows clearly from a previous branch commit, and/or prepares for the next commit

### Visual changes    
The information popup categories:
![image - info popups](https://github.com/zulip/zulip-terminal/assets/20315308/9fd542f6-8eea-4611-9ef4-0870836ee7f6)
The user list actions category:
![image - user list actions](https://github.com/zulip/zulip-terminal/assets/20315308/ee401b59-f010-41d7-bc90-f0d5f08aa5ed)
