### PR TITLE
Group narrowing commands and improve descriptions

### DIFF
--- a/docs/hotkeys.md
+++ b/docs/hotkeys.md
@@ -32,8 +32,8 @@
 | :--- | :---: |
 |Narrow to the stream of the current message|<kbd>s</kbd>|
 |Narrow to the topic of the current message|<kbd>S</kbd>|
-|Narrow to compose box message recipient|<kbd>Meta</kbd> + <kbd>.</kbd>|
 |Narrow to a topic/direct-chat, or stream/all-direct-messages|<kbd>z</kbd>|
+|Narrow to compose box message recipient|<kbd>Meta</kbd> + <kbd>.</kbd>|
 |Narrow to all messages|<kbd>a</kbd> / <kbd>Esc</kbd>|
 |Narrow to all direct messages|<kbd>P</kbd>|
 |Narrow to all starred messages|<kbd>f</kbd>|

--- a/docs/hotkeys.md
+++ b/docs/hotkeys.md
@@ -30,14 +30,14 @@
 ## Switching Messages View
 |Command|Key Combination|
 | :--- | :---: |
-|Narrow to the stream of the current message|<kbd>s</kbd>|
-|Narrow to the topic of the current message|<kbd>S</kbd>|
-|Narrow to a topic/direct-chat, or stream/all-direct-messages|<kbd>z</kbd>|
-|Narrow to compose box message recipient|<kbd>Meta</kbd> + <kbd>.</kbd>|
-|Narrow to all messages|<kbd>a</kbd> / <kbd>Esc</kbd>|
-|Narrow to all direct messages|<kbd>P</kbd>|
-|Narrow to all starred messages|<kbd>f</kbd>|
-|Narrow to messages in which you're mentioned|<kbd>#</kbd>|
+|View the stream of the current message|<kbd>s</kbd>|
+|View the topic of the current message|<kbd>S</kbd>|
+|Zoom in/out the message's conversation context|<kbd>z</kbd>|
+|Switch message view to the compose box target|<kbd>Meta</kbd> + <kbd>.</kbd>|
+|View all messages|<kbd>a</kbd> / <kbd>Esc</kbd>|
+|View all direct messages|<kbd>P</kbd>|
+|View all starred messages|<kbd>f</kbd>|
+|View all messages in which you're mentioned|<kbd>#</kbd>|
 |Next unread topic|<kbd>n</kbd>|
 |Next unread direct message|<kbd>p</kbd>|
 

--- a/docs/hotkeys.md
+++ b/docs/hotkeys.md
@@ -26,6 +26,14 @@
 |Scroll down|<kbd>PgDn</kbd> / <kbd>J</kbd>|
 |Go to bottom / Last message|<kbd>End</kbd> / <kbd>G</kbd>|
 |Trigger the selected entry|<kbd>Enter</kbd> / <kbd>Space</kbd>|
+
+## Switching Messages View
+|Command|Key Combination|
+| :--- | :---: |
+|Narrow to the stream of the current message|<kbd>s</kbd>|
+|Narrow to the topic of the current message|<kbd>S</kbd>|
+|Narrow to compose box message recipient|<kbd>Meta</kbd> + <kbd>.</kbd>|
+|Narrow to a topic/direct-chat, or stream/all-direct-messages|<kbd>z</kbd>|
 |Narrow to all messages|<kbd>a</kbd> / <kbd>Esc</kbd>|
 |Narrow to all direct messages|<kbd>P</kbd>|
 |Narrow to all starred messages|<kbd>f</kbd>|
@@ -49,9 +57,6 @@
 | :--- | :---: |
 |Edit message's content or topic|<kbd>e</kbd>|
 |Show/hide emoji picker for current message|<kbd>:</kbd>|
-|Narrow to the stream of the current message|<kbd>s</kbd>|
-|Narrow to the topic of the current message|<kbd>S</kbd>|
-|Narrow to a topic/direct-chat, or stream/all-direct-messages|<kbd>z</kbd>|
 |Toggle first emoji reaction on selected message|<kbd>=</kbd>|
 |Toggle thumbs-up reaction to the current message|<kbd>+</kbd>|
 |Toggle star status of the current message|<kbd>Ctrl</kbd> + <kbd>s</kbd> / <kbd>*</kbd>|
@@ -90,7 +95,6 @@
 |Save current message as a draft|<kbd>Meta</kbd> + <kbd>s</kbd>|
 |Autocomplete @mentions, #stream_names, :emoji: and topics|<kbd>Ctrl</kbd> + <kbd>f</kbd>|
 |Cycle through autocomplete suggestions in reverse|<kbd>Ctrl</kbd> + <kbd>r</kbd>|
-|Narrow to compose box message recipient|<kbd>Meta</kbd> + <kbd>.</kbd>|
 |Exit message compose box|<kbd>Esc</kbd>|
 |Insert new line|<kbd>Enter</kbd>|
 

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -170,17 +170,17 @@ KEY_BINDINGS: Dict[str, KeyBinding] = {
     'STREAM_NARROW': {
         'keys': ['s'],
         'help_text': 'Narrow to the stream of the current message',
-        'key_category': 'msg_actions',
+        'key_category': 'narrowing',
     },
     'TOPIC_NARROW': {
         'keys': ['S'],
         'help_text': 'Narrow to the topic of the current message',
-        'key_category': 'msg_actions',
+        'key_category': 'narrowing',
     },
     'NARROW_MESSAGE_RECIPIENT': {
         'keys': ['meta .'],
         'help_text': 'Narrow to compose box message recipient',
-        'key_category': 'compose_box',
+        'key_category': 'narrowing',
     },
     'EXIT_COMPOSE': {
         'keys': ['esc'],
@@ -191,7 +191,7 @@ KEY_BINDINGS: Dict[str, KeyBinding] = {
         'keys': ['z'],
         'help_text':
             'Narrow to a topic/direct-chat, or stream/all-direct-messages',
-        'key_category': 'msg_actions',
+        'key_category': 'narrowing',
     },
     'REACTION_AGREEMENT': {
         'keys': ['='],
@@ -206,32 +206,32 @@ KEY_BINDINGS: Dict[str, KeyBinding] = {
     'ALL_MESSAGES': {
         'keys': ['a', 'esc'],
         'help_text': 'Narrow to all messages',
-        'key_category': 'navigation',
+        'key_category': 'narrowing',
     },
     'ALL_PM': {
         'keys': ['P'],
         'help_text': 'Narrow to all direct messages',
-        'key_category': 'navigation',
+        'key_category': 'narrowing',
     },
     'ALL_STARRED': {
         'keys': ['f'],
         'help_text': 'Narrow to all starred messages',
-        'key_category': 'navigation',
+        'key_category': 'narrowing',
     },
     'ALL_MENTIONS': {
         'keys': ['#'],
         'help_text': "Narrow to messages in which you're mentioned",
-        'key_category': 'navigation',
+        'key_category': 'narrowing',
     },
     'NEXT_UNREAD_TOPIC': {
         'keys': ['n'],
         'help_text': 'Next unread topic',
-        'key_category': 'navigation',
+        'key_category': 'narrowing',
     },
     'NEXT_UNREAD_PM': {
         'keys': ['p'],
         'help_text': 'Next unread direct message',
-        'key_category': 'navigation',
+        'key_category': 'narrowing',
     },
     'SEARCH_PEOPLE': {
         'keys': ['w'],
@@ -449,6 +449,7 @@ KEY_BINDINGS: Dict[str, KeyBinding] = {
 HELP_CATEGORIES = {
     "general": "General",
     "navigation": "Navigation",
+    "narrowing": "Switching Messages View",
     "searching": "Searching",
     "msg_actions": "Message actions",
     "stream_list": "Stream list actions",

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -169,23 +169,23 @@ KEY_BINDINGS: Dict[str, KeyBinding] = {
     },
     'STREAM_NARROW': {
         'keys': ['s'],
-        'help_text': 'Narrow to the stream of the current message',
+        'help_text': 'View the stream of the current message',
         'key_category': 'narrowing',
     },
     'TOPIC_NARROW': {
         'keys': ['S'],
-        'help_text': 'Narrow to the topic of the current message',
+        'help_text': 'View the topic of the current message',
         'key_category': 'narrowing',
     },
     'TOGGLE_NARROW': {
         'keys': ['z'],
         'help_text':
-            'Narrow to a topic/direct-chat, or stream/all-direct-messages',
+            "Zoom in/out the message's conversation context",
         'key_category': 'narrowing',
     },
     'NARROW_MESSAGE_RECIPIENT': {
         'keys': ['meta .'],
-        'help_text': 'Narrow to compose box message recipient',
+        'help_text': 'Switch message view to the compose box target',
         'key_category': 'narrowing',
     },
     'EXIT_COMPOSE': {
@@ -205,22 +205,22 @@ KEY_BINDINGS: Dict[str, KeyBinding] = {
     },
     'ALL_MESSAGES': {
         'keys': ['a', 'esc'],
-        'help_text': 'Narrow to all messages',
+        'help_text': 'View all messages',
         'key_category': 'narrowing',
     },
     'ALL_PM': {
         'keys': ['P'],
-        'help_text': 'Narrow to all direct messages',
+        'help_text': 'View all direct messages',
         'key_category': 'narrowing',
     },
     'ALL_STARRED': {
         'keys': ['f'],
-        'help_text': 'Narrow to all starred messages',
+        'help_text': 'View all starred messages',
         'key_category': 'narrowing',
     },
     'ALL_MENTIONS': {
         'keys': ['#'],
-        'help_text': "Narrow to messages in which you're mentioned",
+        'help_text': "View all messages in which you're mentioned",
         'key_category': 'narrowing',
     },
     'NEXT_UNREAD_TOPIC': {

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -177,6 +177,12 @@ KEY_BINDINGS: Dict[str, KeyBinding] = {
         'help_text': 'Narrow to the topic of the current message',
         'key_category': 'narrowing',
     },
+    'TOGGLE_NARROW': {
+        'keys': ['z'],
+        'help_text':
+            'Narrow to a topic/direct-chat, or stream/all-direct-messages',
+        'key_category': 'narrowing',
+    },
     'NARROW_MESSAGE_RECIPIENT': {
         'keys': ['meta .'],
         'help_text': 'Narrow to compose box message recipient',
@@ -186,12 +192,6 @@ KEY_BINDINGS: Dict[str, KeyBinding] = {
         'keys': ['esc'],
         'help_text': 'Exit message compose box',
         'key_category': 'compose_box',
-    },
-    'TOGGLE_NARROW': {
-        'keys': ['z'],
-        'help_text':
-            'Narrow to a topic/direct-chat, or stream/all-direct-messages',
-        'key_category': 'narrowing',
     },
     'REACTION_AGREEMENT': {
         'keys': ['='],


### PR DESCRIPTION
### What does this PR do, and why?
- Groups commands that switch narrows
- Improves their help descriptions

### Outstanding aspect(s)
Feedback on the following are needed:
- name of the chosen help category
- order of the commands within the narrowing category
- help descriptions

### External discussion & connections
- [x] Discussed in **#zulip-terminal** in [`re-categorization`](https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/Re-Categorization.20of.20Hotkeys/near/1793697)
- [ ] Fully fixes #
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
- [ ] Manually - Behavioral changes
- [x] Manually - Visual changes
- [ ] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [x] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [ ] It contains test additions for any new behavior
- [x] It flows clearly from a previous branch commit, and/or prepares for the next commit

### Visual changes
![image](https://github.com/zulip/zulip-terminal/assets/20315308/aa728bd0-7945-4138-a21e-8442675477aa)
