### PR TITLE
Add manual cycling of random hints in footer

### DIFF
--- a/docs/hotkeys.md
+++ b/docs/hotkeys.md
@@ -13,6 +13,7 @@
 |Redraw screen|<kbd>Ctrl</kbd> + <kbd>l</kbd>|
 |Quit|<kbd>Ctrl</kbd> + <kbd>c</kbd>|
 |Show/hide user information (from users list)|<kbd>i</kbd>|
+|New footer hotkey hint|<kbd>Tab</kbd>|
 
 ## Navigation
 |Command|Key Combination|

--- a/tests/ui/test_ui.py
+++ b/tests/ui/test_ui.py
@@ -341,6 +341,23 @@ class TestView:
         assert returned_key == key
         assert view.body.focus_col == 1
 
+    @pytest.mark.parametrize("key", keys_for_command("NEW_HINT"))
+    def test_keypress_NEW_HINT(
+        self,
+        view: View,
+        mocker: MockerFixture,
+        key: str,
+        widget_size: Callable[[Widget], urwid_Box],
+    ) -> None:
+        size = widget_size(view)
+        set_footer_text = mocker.patch(VIEW + ".set_footer_text")
+        mocker.patch(CONTROLLER + ".is_in_editor_mode", return_value=False)
+
+        returned_key = view.keypress(size, key)
+
+        set_footer_text.assert_called_once_with()
+        assert returned_key == key
+
     @pytest.mark.parametrize("key", keys_for_command("SEARCH_PEOPLE"))
     @pytest.mark.parametrize("autohide", [True, False], ids=["autohide", "no_autohide"])
     def test_keypress_autohide_users(

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -438,6 +438,11 @@ KEY_BINDINGS: Dict[str, KeyBinding] = {
         'help_text': 'Show/hide full raw message (from message information)',
         'key_category': 'msg_actions',
     },
+    'NEW_HINT': {
+        'keys': ['tab'],
+        'help_text': 'New footer hotkey hint',
+        'key_category': 'general',
+    },
 }
 # fmt: on
 

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -328,6 +328,9 @@ class View(urwid.WidgetWrap):
         elif is_command_key("MARKDOWN_HELP", key):
             self.controller.show_markdown_help()
             return key
+        elif is_command_key("NEW_HINT", key):
+            self.set_footer_text()
+            return key
         return super().keypress(size, key)
 
     def mouse_event(


### PR DESCRIPTION
### What does this PR do, and why?
Enables cycling through random hints in the footer.
- Using a hotkey to manually go to next hint
- Periodically cycle through footer hints automatically

This is in preparation to #1484, where we add contexts and the footer displays only the context-specific hotkey hints.

### Outstanding aspect(s)
- If this is good, the next step could involve making the footer's cycle period a user setting.
- Deciding the hotkey to go to next hint: I've currently used `Tab`, but that's subject to change on discussion.
- Deciding the default cycle period: I've currently set it to 30 seconds, but we could increase it.

### External discussion & connections
- [x] Discussed in **#zulip-terminal** in [`Adding context to hotkeys`](https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/Adding.20context.20to.20hotkeys.20.23T1484.20.23T515/near/1787539), [`Cycling through footer hints`](https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/Cycling.20through.20footer.20hints), [T1484's review](https://github.com/zulip/zulip-terminal/pull/1484/#:~:text=One%20helpful%20change%20would%20be%20to%20address%20the%20%27cycling%27%20issue%20sooner%20rather%20than%20later)
- [ ] Fully fixes #
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
- [x] Manually - Behavioral changes
- [ ] Manually - Visual changes
- [ ] Adapting existing automated tests
- [x] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [ ] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [x] It contains test additions for any new behavior
- [x] It flows clearly from a previous branch commit, and/or prepares for the next commit