### PR TITLE
Lint the validity of help categories

### DIFF
--- a/tools/lint-hotkeys
+++ b/tools/lint-hotkeys
@@ -39,7 +39,7 @@ def lint_hotkeys_file() -> None:
     existing OUTPUT_FILE
     """
     hotkeys_file_string = get_hotkeys_file_string()
-    error_flag = 0 if is_every_key_category_valid() else 1
+    error_flag = not is_every_key_category_valid()
     # To lint keys description
     categories = read_help_categories()
     for action in HELP_CATEGORIES:
@@ -53,7 +53,7 @@ def lint_hotkeys_file() -> None:
                     f"Description - ({help_text}) for key combination - [{various_key_combinations}]\n"
                     "It should contain only alphabets, spaces and special characters except ."
                 )
-                error_flag = 1
+                error_flag = True
         # Check key combination duplication
         check_duplicate_keys_list = [
             key for key in check_duplicate_keys_list if key not in KEYS_TO_EXCLUDE
@@ -67,8 +67,8 @@ def lint_hotkeys_file() -> None:
             print(
                 f"Duplicate key combination for keys {duplicate_keys} for category ({HELP_CATEGORIES[action]}) detected"
             )
-            error_flag = 1
-    if error_flag == 1:
+            error_flag = True
+    if error_flag:
         print(f"Rerun this command after resolving errors in config/{KEYS_FILE_NAME}")
     else:
         print("No hotkeys linting errors")
@@ -76,7 +76,7 @@ def lint_hotkeys_file() -> None:
             print(
                 f"Run './tools/{SCRIPT_NAME} --fix' to update {OUTPUT_FILE_NAME} file"
             )
-            error_flag = 1
+            error_flag = True
     sys.exit(error_flag)
 
 

--- a/tools/lint-hotkeys
+++ b/tools/lint-hotkeys
@@ -39,8 +39,8 @@ def lint_hotkeys_file() -> None:
     existing OUTPUT_FILE
     """
     hotkeys_file_string = get_hotkeys_file_string()
+    error_flag = 0 if is_every_key_category_valid() else 1
     # To lint keys description
-    error_flag = 0
     categories = read_help_categories()
     for action in HELP_CATEGORIES:
         check_duplicate_keys_list: List[str] = []
@@ -89,6 +89,24 @@ def generate_hotkeys_file() -> None:
     output_file_matches_string(hotkeys_file_string)
     write_hotkeys_file(hotkeys_file_string)
     print(f"Hot Keys list saved in {OUTPUT_FILE}")
+
+
+def is_every_key_category_valid() -> bool:
+    """
+    Check for typos in key categories in KEYS_FILE
+    """
+    error_flag = False
+    for key, binding in KEY_BINDINGS.items():
+        key_category = binding.get("key_category")
+        if key_category not in HELP_CATEGORIES:
+            print(
+                f"Invalid key_category '{key_category}' for key '{key}'."
+                f" Choose a category from:\n{', '.join(HELP_CATEGORIES.keys())}\n"
+            )
+            error_flag = True
+    if not error_flag:
+        print("All key bindings have valid categories.")
+    return not error_flag
 
 
 def get_hotkeys_file_string() -> str:


### PR DESCRIPTION
### What does this PR do, and why?
Check for typos in category names.
Previously, these typos would go unnoticed, with the key binding going missing from the help menu.

### Outstanding aspect(s)    
- Feedback welcome on the formatting and phrasing of the error message printed
- This could be put on hold for the moment and be merged along with the major changes we will be doing to lint-hotkeys after the addition of contexts. But, that might take a while.

### External discussion & connections
- [ ] Discussed in **#zulip-terminal** in `topic`
- [ ] Fully fixes #
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
- [x] Manually - Behavioral changes
- [ ] Manually - Visual changes
- [ ] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [ ] It contains test additions for any new behavior
- [ ] It flows clearly from a previous branch commit, and/or prepares for the next commit

### Visual changes
![image](https://github.com/zulip/zulip-terminal/assets/20315308/ebe265c5-9525-40e0-a320-f99df9d060b7)
