### PR TITLE
Create new help categories related to opening compose box

### DIFF
--- a/docs/hotkeys.md
+++ b/docs/hotkeys.md
@@ -81,7 +81,7 @@
 |New message to a stream|<kbd>c</kbd>|
 |New message to a person or group of people|<kbd>x</kbd>|
 
-## Composing a Message
+## Writing a message
 |Command|Key Combination|
 | :--- | :---: |
 |Cycle through recipient and content boxes|<kbd>Tab</kbd>|

--- a/docs/hotkeys.md
+++ b/docs/hotkeys.md
@@ -8,7 +8,6 @@
 |Show/hide Help Menu|<kbd>?</kbd>|
 |Show/hide Markdown Help Menu|<kbd>Meta</kbd> + <kbd>m</kbd>|
 |Show/hide About Menu|<kbd>Meta</kbd> + <kbd>?</kbd>|
-|Open draft message saved in this session|<kbd>d</kbd>|
 |Copy information from About Menu to clipboard|<kbd>c</kbd>|
 |Redraw screen|<kbd>Ctrl</kbd> + <kbd>l</kbd>|
 |Quit|<kbd>Ctrl</kbd> + <kbd>c</kbd>|
@@ -47,13 +46,7 @@
 ## Message actions
 |Command|Key Combination|
 | :--- | :---: |
-|Reply to the current message|<kbd>r</kbd> / <kbd>Enter</kbd>|
-|Reply mentioning the sender of the current message|<kbd>@</kbd>|
-|Reply quoting the current message text|<kbd>></kbd>|
-|Reply directly to the sender of the current message|<kbd>R</kbd>|
 |Edit message's content or topic|<kbd>e</kbd>|
-|New message to a stream|<kbd>c</kbd>|
-|New message to a person or group of people|<kbd>x</kbd>|
 |Show/hide emoji picker for current message|<kbd>:</kbd>|
 |Narrow to the stream of the current message|<kbd>s</kbd>|
 |Narrow to the topic of the current message|<kbd>S</kbd>|
@@ -76,6 +69,17 @@
 |Show/hide stream information & modify settings|<kbd>i</kbd>|
 |Show/hide stream members (from stream information)|<kbd>m</kbd>|
 |Copy stream email to clipboard (from stream information)|<kbd>c</kbd>|
+
+## Begin composing a message
+|Command|Key Combination|
+| :--- | :---: |
+|Open draft message saved in this session|<kbd>d</kbd>|
+|Reply to the current message|<kbd>r</kbd> / <kbd>Enter</kbd>|
+|Reply mentioning the sender of the current message|<kbd>@</kbd>|
+|Reply quoting the current message text|<kbd>></kbd>|
+|Reply directly to the sender of the current message|<kbd>R</kbd>|
+|New message to a stream|<kbd>c</kbd>|
+|New message to a person or group of people|<kbd>x</kbd>|
 
 ## Composing a Message
 |Command|Key Combination|

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -139,28 +139,28 @@ KEY_BINDINGS: Dict[str, KeyBinding] = {
     'CYCLE_COMPOSE_FOCUS': {
         'keys': ['tab'],
         'help_text': 'Cycle through recipient and content boxes',
-        'key_category': 'msg_compose',
+        'key_category': 'compose_box',
     },
     'SEND_MESSAGE': {
         'keys': ['ctrl d', 'meta enter'],
         'help_text': 'Send a message',
-        'key_category': 'msg_compose',
+        'key_category': 'compose_box',
     },
     'SAVE_AS_DRAFT': {
         'keys': ['meta s'],
         'help_text': 'Save current message as a draft',
-        'key_category': 'msg_compose',
+        'key_category': 'compose_box',
     },
     'AUTOCOMPLETE': {
         'keys': ['ctrl f'],
         'help_text': ('Autocomplete @mentions, #stream_names, :emoji:'
                       ' and topics'),
-        'key_category': 'msg_compose',
+        'key_category': 'compose_box',
     },
     'AUTOCOMPLETE_REVERSE': {
         'keys': ['ctrl r'],
         'help_text': 'Cycle through autocomplete suggestions in reverse',
-        'key_category': 'msg_compose',
+        'key_category': 'compose_box',
     },
     'ADD_REACTION': {
         'keys': [':'],
@@ -180,12 +180,12 @@ KEY_BINDINGS: Dict[str, KeyBinding] = {
     'NARROW_MESSAGE_RECIPIENT': {
         'keys': ['meta .'],
         'help_text': 'Narrow to compose box message recipient',
-        'key_category': 'msg_compose',
+        'key_category': 'compose_box',
     },
     'EXIT_COMPOSE': {
         'keys': ['esc'],
         'help_text': 'Exit message compose box',
-        'key_category': 'msg_compose',
+        'key_category': 'compose_box',
     },
     'TOGGLE_NARROW': {
         'keys': ['z'],
@@ -426,7 +426,7 @@ KEY_BINDINGS: Dict[str, KeyBinding] = {
         # and to differentiate from other hotkeys using 'enter'.
         'keys': ['enter'],
         'help_text': 'Insert new line',
-        'key_category': 'msg_compose',
+        'key_category': 'compose_box',
     },
     'FULL_RENDERED_MESSAGE': {
         'keys': ['f'],
@@ -448,7 +448,7 @@ HELP_CATEGORIES = {
     "msg_actions": "Message actions",
     "stream_list": "Stream list actions",
     "open_compose": "Begin composing a message",
-    "msg_compose": "Composing a Message",
+    "compose_box": "Writing a message",
     "editor_navigation": "Editor: Navigation",
     "editor_text_manipulation": "Editor: Text Manipulation",
 }

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -49,7 +49,7 @@ KEY_BINDINGS: Dict[str, KeyBinding] = {
     'OPEN_DRAFT': {
         'keys': ['d'],
         'help_text': 'Open draft message saved in this session',
-        'key_category': 'general',
+        'key_category': 'open_compose',
     },
     'COPY_ABOUT_INFO': {
         'keys': ['c'],
@@ -104,22 +104,22 @@ KEY_BINDINGS: Dict[str, KeyBinding] = {
     'REPLY_MESSAGE': {
         'keys': ['r', 'enter'],
         'help_text': 'Reply to the current message',
-        'key_category': 'msg_actions',
+        'key_category': 'open_compose',
     },
     'MENTION_REPLY': {
         'keys': ['@'],
         'help_text': 'Reply mentioning the sender of the current message',
-        'key_category': 'msg_actions',
+        'key_category': 'open_compose',
     },
     'QUOTE_REPLY': {
         'keys': ['>'],
         'help_text': 'Reply quoting the current message text',
-        'key_category': 'msg_actions',
+        'key_category': 'open_compose',
     },
     'REPLY_AUTHOR': {
         'keys': ['R'],
         'help_text': 'Reply directly to the sender of the current message',
-        'key_category': 'msg_actions',
+        'key_category': 'open_compose',
     },
     'EDIT_MESSAGE': {
         'keys': ['e'],
@@ -129,12 +129,12 @@ KEY_BINDINGS: Dict[str, KeyBinding] = {
     'STREAM_MESSAGE': {
         'keys': ['c'],
         'help_text': 'New message to a stream',
-        'key_category': 'msg_actions',
+        'key_category': 'open_compose',
     },
     'PRIVATE_MESSAGE': {
         'keys': ['x'],
         'help_text': 'New message to a person or group of people',
-        'key_category': 'msg_actions',
+        'key_category': 'open_compose',
     },
     'CYCLE_COMPOSE_FOCUS': {
         'keys': ['tab'],
@@ -447,6 +447,7 @@ HELP_CATEGORIES = {
     "searching": "Searching",
     "msg_actions": "Message actions",
     "stream_list": "Stream list actions",
+    "open_compose": "Begin composing a message",
     "msg_compose": "Composing a Message",
     "editor_navigation": "Editor: Navigation",
     "editor_text_manipulation": "Editor: Text Manipulation",


### PR DESCRIPTION
### What does this PR do, and why?
Groups key bindings from message actions into the new categories:
- Compose: New Message
- Compose: Replies

And in the 2nd commit, suggests renaming the "Composing a message" category to "Writing a message" category, to improve clarity, in contrast with the newly added categories.

### External discussion & connections
- [x] Discussed in **#zulip-terminal** in `Re-Categorization of Hotkeys`
- [ ] Fully fixes #
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [x] Merge will enable work on #1484

### How did you test this?
- [ ] Manually - Behavioral changes
- [x] Manually - Visual changes
- [ ] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [ ] It contains test additions for any new behavior
- [ ] It flows clearly from a previous branch commit, and/or prepares for the next commit

### Visual Changes
![image](https://github.com/zulip/zulip-terminal/assets/20315308/6b38c06e-b926-4d0a-8fa6-29b4bf35de08)
