### PR TITLE
Add title-to-title scroll feature to Help Menu

### DIFF
--- a/docs/hotkeys.md
+++ b/docs/hotkeys.md
@@ -26,6 +26,8 @@
 |Scroll down|<kbd>PgDn</kbd> / <kbd>J</kbd>|
 |Go to bottom / Last message|<kbd>End</kbd> / <kbd>G</kbd>|
 |Trigger the selected entry|<kbd>Enter</kbd> / <kbd>Space</kbd>|
+|Go to previous help category|<kbd>p</kbd>|
+|Go to next help category|<kbd>n</kbd>|
 
 ## Switching Messages View
 |Command|Key Combination|

--- a/tools/lint-hotkeys
+++ b/tools/lint-hotkeys
@@ -23,7 +23,7 @@ SCRIPT_NAME = PurePath(__file__).name
 HELP_TEXT_STYLE = re.compile(r"^[a-zA-Z /()',&@#:_-]*$")
 
 # Exclude keys from duplicate keys checking
-KEYS_TO_EXCLUDE = ["q", "e", "m", "r", "Esc"]
+KEYS_TO_EXCLUDE = ["q", "e", "m", "r", "Esc", "p", "n"]
 
 
 def main(fix: bool) -> None:

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -101,6 +101,18 @@ KEY_BINDINGS: Dict[str, KeyBinding] = {
         'help_text': 'Trigger the selected entry',
         'key_category': 'navigation',
     },
+    'GO_TO_PREVIOUS_TITLE': {
+        'keys': ['p'],
+        'help_text': 'Go to previous help category',
+        'key_category': 'navigation',
+        'excluded_from_random_tips': True,
+    },
+    'GO_TO_NEXT_TITLE': {
+        'keys': ['n'],
+        'help_text': 'Go to next help category',
+        'key_category': 'navigation',
+        'excluded_from_random_tips': True,
+    },
     'REPLY_MESSAGE': {
         'keys': ['r', 'enter'],
         'help_text': 'Reply to the current message',

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1261,6 +1261,33 @@ class HelpView(PopUpView):
 
         super().__init__(controller, widgets, "HELP", popup_width, title)
 
+        self.category_start_positions = [
+            index
+            for index, widget in enumerate(self.log)
+            if isinstance(widget, urwid.Text)
+            and widget.get_text()[1]
+            and widget.get_text()[1][0][0] == "popup_category"
+        ]
+
+    def keypress(self, size: urwid_Size, key: str) -> str:
+        if is_command_key("GO_TO_NEXT_TITLE", key):
+            focus_position = self.log.get_focus()[1]
+            last_visible_position = focus_position + size[1] - 1  # type: ignore[misc]
+            last_help_entry = len(self.log) - 1
+            if last_help_entry > last_visible_position:
+                for category_start_position in self.category_start_positions:
+                    if category_start_position > focus_position:
+                        self.log.set_focus(category_start_position)
+                        break
+
+        elif is_command_key("GO_TO_PREVIOUS_TITLE", key):
+            focus_position = self.log.get_focus()[1]
+            for category_start_position in reversed(self.category_start_positions):
+                if category_start_position < focus_position:
+                    self.log.set_focus(category_start_position)
+                    break
+        return super().keypress(size, key)
+
 
 class MarkdownHelpView(PopUpView):
     def __init__(self, controller: Any, title: str) -> None:


### PR DESCRIPTION
### What does this PR do, and why?
Adds 2 new commands to refocus to view the previous/next help category section.

Hotkeys linting exclusion updated.
Hotkeys document regenerated.

Why?
This could be helpful when we have several help menu sections.

### Outstanding aspect(s)
- Would need to come up with a better way to display the navigation keys inside the Help Menu.
This merely adds the functionality. The prompting for the user can be improved.
- We could add an extra field to key bindings - something like `exclude_from_help_menu` to remove entries like these from being listed in the help menu. Currently, these are probably the only 2 commands that may need to be removed from the help menu, but with the addition of contexts, there may be more.
- Does not add any tests

### External discussion & connections
- [x] Discussed in **#zulip-terminal** in [`New hotkeys to scroll title-to-title in Help Menu #T1527`](https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/New.20hotkeys.20to.20scroll.20title-to-title.20in.20Help.20Menu.20#T1527)
- [ ] Fully fixes #
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #
- [x] Merge may or may not help with work on #1516 

### How did you test this?
- [x] Manually - Behavioral changes
- [ ] Manually - Visual changes
- [ ] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [ ] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [ ] It contains test additions for any new behavior
- [ ] It flows clearly from a previous branch commit, and/or prepares for the next commit
