### PR TITLE
Rename "All Messages" to "Combined Feed"

### DIFF
--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -155,6 +155,33 @@ class TestModel:
         assert set(model._user_settings) == expected_keys
 
     @pytest.mark.parametrize(
+        "zulip_feature_level, expected_name",
+        [
+            (
+                0,
+                "All messages",
+            ),
+            (
+                255,
+                "Combined feed",
+            ),
+        ],
+    )
+    def test_init_combined_feed_name(
+        self, mocker, zulip_feature_level, initial_data, expected_name
+    ):
+        mocker.patch(MODEL + ".get_messages", return_value="")
+        initial_data["zulip_feature_level"] = zulip_feature_level
+        self.client.register = mocker.Mock(return_value=initial_data)
+        combined_feed = mocker.patch(
+            "zulipterminal.helper.CombinedFeed.set_combined_feed_name"
+        )
+
+        Model(self.controller)
+
+        combined_feed.assert_called_with(expected_name)
+
+    @pytest.mark.parametrize(
         "server_response, locally_processed_data, zulip_feature_level",
         [
             (

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -507,6 +507,10 @@ URWID_KEY_TO_DISPLAY_KEY_MAPPING = {
 }
 
 
+def update_combined_feed() -> None:
+    KEY_BINDINGS["ALL_MESSAGES"]["help_text"] = "Narrow to combined feed"
+
+
 def display_key_for_urwid_key(urwid_key: str) -> str:
     """
     Returns a displayable user-centric format of the urwid key.

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -66,6 +66,19 @@ class EmojiData(TypedDict):
 NamedEmojiData = Dict[str, EmojiData]
 
 
+class CombinedFeed:
+    CombinedFeedType = Literal["Combined feed", "All messages"]
+    _combined_feed_name: CombinedFeedType = "All messages"
+
+    @classmethod
+    def get_combined_feed_name(cls) -> CombinedFeedType:
+        return cls._combined_feed_name
+
+    @classmethod
+    def set_combined_feed_name(cls, value: CombinedFeedType) -> None:
+        cls._combined_feed_name = value
+
+
 class CustomProfileData(TypedDict):
     label: str
     value: Union[str, List[int]]

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -58,10 +58,14 @@ from zulipterminal.api_types import (
     UpdateMessageContentEvent,
     UpdateMessagesLocationEvent,
 )
-from zulipterminal.config.keys import primary_display_key_for_command
+from zulipterminal.config.keys import (
+    primary_display_key_for_command,
+    update_combined_feed,
+)
 from zulipterminal.config.symbols import STREAM_TOPIC_SEPARATOR
 from zulipterminal.config.ui_mappings import EDIT_TOPIC_POLICY, ROLE_BY_ID, STATE_ICON
 from zulipterminal.helper import (
+    CombinedFeed,
     CustomProfileData,
     MinimalUserData,
     NamedEmojiData,
@@ -194,6 +198,11 @@ class Model:
         if self.server_feature_level < 30:
             for stream in self.stream_dict.values():
                 stream["date_created"] = None
+
+        CombinedFeed.set_combined_feed_name("All messages")
+        if self.server_feature_level >= 255:
+            CombinedFeed.set_combined_feed_name("Combined feed")
+            update_combined_feed()
 
         self.normalize_and_cache_message_retention_text()
 

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -26,7 +26,12 @@ from zulipterminal.config.symbols import (
     STARRED_MESSAGES_MARKER,
 )
 from zulipterminal.config.ui_mappings import EDIT_MODE_CAPTIONS, STREAM_ACCESS_TYPE
-from zulipterminal.helper import StreamData, hash_util_decode, process_media
+from zulipterminal.helper import (
+    CombinedFeed,
+    StreamData,
+    hash_util_decode,
+    process_media,
+)
 from zulipterminal.urwid_types import urwid_MarkupTuple, urwid_Size
 
 
@@ -130,7 +135,8 @@ class TopButton(urwid.Button):
 class HomeButton(TopButton):
     def __init__(self, *, controller: Any, count: int) -> None:
         button_text = (
-            f"All messages     [{primary_display_key_for_command('ALL_MESSAGES')}]"
+            f"{f'{CombinedFeed.get_combined_feed_name()}'.ljust(17)}"
+            f"[{primary_display_key_for_command('ALL_MESSAGES')}]"
         )
 
         super().__init__(

--- a/zulipterminal/ui_tools/messages.py
+++ b/zulipterminal/ui_tools/messages.py
@@ -29,7 +29,7 @@ from zulipterminal.config.symbols import (
     TIME_MENTION_MARKER,
 )
 from zulipterminal.config.ui_mappings import STATE_ICON, STREAM_ACCESS_TYPE
-from zulipterminal.helper import get_unused_fence
+from zulipterminal.helper import CombinedFeed, get_unused_fence
 from zulipterminal.server_url import near_message_url
 from zulipterminal.ui_tools.tables import render_table
 from zulipterminal.urwid_types import urwid_MarkupTuple, urwid_Size
@@ -214,7 +214,8 @@ class MessageBox(urwid.Pile):
         else:
             self.model.controller.view.search_box.text_box.set_edit_text("")
         if curr_narrow == []:
-            text_to_fill = f" {ALL_MESSAGES_MARKER} All messages "
+            text_to_fill = f" {ALL_MESSAGES_MARKER} "
+            f"{CombinedFeed.get_combined_feed_name()} "
         elif len(curr_narrow) == 1 and curr_narrow[0][1] == "private":
             text_to_fill = f" {DIRECT_MESSAGE_MARKER} All direct messages "
         elif len(curr_narrow) == 1 and curr_narrow[0][1] == "starred":


### PR DESCRIPTION
### What does this PR do, and why?
Rename "All Messages" to "Combined Feed" if the ZFL >= 255.

Done as part of a pair programming session.

### External discussion & connections
- [x] Discussed in **#zulip-terminal** in `Combined Feed Renaming`
- [ ] Fully fixes #
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
- [ ] Manually - Behavioral changes
- [x] Manually - Visual changes
- [x] Adapting existing automated tests
- [x] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [ ] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [ ] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [ ] It contains test additions for any new behavior
- [ ] It flows clearly from a previous branch commit, and/or prepares for the next commit
