### PR TITLE
Add DM panel to the left side view (rebased #1416)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -869,6 +869,15 @@ def clean_custom_profile_data_fixture() -> List[CustomProfileData]:
 
 
 @pytest.fixture
+def sorted_recent_dms_fixture() -> List[Dict[str, Any]]:
+    return [
+        {"max_message_id": 4, "user_ids": []},
+        {"max_message_id": 3, "user_ids": [2]},
+        {"max_message_id": 2, "user_ids": [1]},
+    ]
+
+
+@pytest.fixture
 def initial_data(
     logged_on_user: Dict[str, Any],
     users_fixture: List[Dict[str, Any]],
@@ -1050,6 +1059,11 @@ def initial_data(
         "zulip_feature_level": MINIMUM_SUPPORTED_SERVER_VERSION[1],
         "starred_messages": [1117554, 1117558, 1117574],
         "custom_profile_fields": custom_profile_fields_fixture,
+        "recent_private_conversations": [
+            {"max_message_id": 4, "user_ids": []},
+            {"max_message_id": 2, "user_ids": [1]},
+            {"max_message_id": 3, "user_ids": [2]},
+        ],
     }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1469,6 +1469,7 @@ def classified_unread_counts() -> Dict[str, Any]:
     return {
         "all_msg": 12,
         "all_pms": 8,
+        "all_stream_msg": 4,
         "unread_topics": {
             (1000, "Some general unread topic"): 3,
             (99, "Some private unread topic"): 1,

--- a/tests/helper/test_helper.py
+++ b/tests/helper/test_helper.py
@@ -288,6 +288,7 @@ def test_sort_unread_topics(
             [["Some general stream", "Some general unread topic"]],
             {
                 "all_msg": 8,
+                "all_stream_msg": 0,
                 "streams": {99: 1},
                 "unread_topics": {(99, "Some private unread topic"): 1},
                 "all_mentions": 0,
@@ -298,17 +299,30 @@ def test_sort_unread_topics(
             [["Secret stream", "Some private unread topic"]],
             {
                 "all_msg": 8,
+                "all_stream_msg": 0,
                 "streams": {1000: 3},
                 "unread_topics": {(1000, "Some general unread topic"): 3},
                 "all_mentions": 0,
             },
         ),
         ({1}, [], {"all_mentions": 0}),
+        (
+            {},
+            [["Some general stream", "Some general unread topic"]],
+            {
+                "all_msg": 9,
+                "all_stream_msg": 1,
+                "streams": {99: 1},
+                "unread_topics": {(99, "Some private unread topic"): 1},
+                "all_mentions": 0,
+            },
+        ),
     ],
     ids=[
         "mute_private_stream_mute_general_stream_topic",
         "mute_general_stream_mute_private_stream_topic",
         "no_mute_some_other_stream_muted",
+        "mute_general_stream_topic",
     ],
 )
 def test_classify_unread_counts(

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -69,6 +69,7 @@ class TestModel:
         realm_emojis_data,
         zulip_emoji,
         stream_dict,
+        sorted_recent_dms_fixture,
     ):
         assert hasattr(model, "controller")
         assert hasattr(model, "client")
@@ -94,6 +95,7 @@ class TestModel:
         assert model.users == []
         self.classify_unread_counts.assert_called_once_with(model)
         assert model.unread_counts == []
+        assert model.recent_dms == sorted_recent_dms_fixture
         assert model.active_emoji_data == OrderedDict(
             sorted(
                 {**unicode_emojis, **realm_emojis_data, **zulip_emoji}.items(),
@@ -261,6 +263,7 @@ class TestModel:
             "user_settings",
             "realm_emoji",
             "custom_profile_fields",
+            "recent_private_conversations",
             "zulip_version",
         ]
         model.client.register.assert_called_once_with(

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -1921,6 +1921,7 @@ class TestModel:
         )
         model.notify_user = mocker.Mock()
         event = {"type": "message", "message": message_fixture}
+        model.user_id = 5140
 
         model._handle_message_event(event)
 
@@ -1940,6 +1941,7 @@ class TestModel:
         )
         model.notify_user = mocker.Mock()
         event = {"type": "message", "message": message_fixture}
+        model.user_id = 5140
 
         model._handle_message_event(event)
 
@@ -1967,6 +1969,7 @@ class TestModel:
             "message": message_fixture,
             "flags": ["read", "mentioned"],
         }
+        model.user_id = 5140
 
         model._handle_message_event(event)
 
@@ -2096,6 +2099,7 @@ class TestModel:
         mocker.patch(MODULE + ".index_messages", return_value={})
         mocker.patch(MODULE + ".create_msg_box_list", return_value=["msg_w"])
         set_count = mocker.patch(MODULE + ".set_count")
+        mocker.patch(MODEL + "._update_recent_dms")
         self.controller.view.message_view = mocker.Mock(log=[])
         (
             self.controller.view.left_panel.is_in_topic_view_with_stream_id.return_value

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1156,6 +1156,7 @@ class TestLeftColumnView:
         starred_button = mocker.patch(VIEWS + ".StarredButton")
         mocker.patch(VIEWS + ".urwid.ListBox")
         mocker.patch(VIEWS + ".urwid.SimpleFocusListWalker")
+        mocker.patch(VIEWS + ".urwid.LineBox")
         mocker.patch(VIEWS + ".StreamButton.mark_muted")
         left_col_view = LeftColumnView(self.view)
         home_button.assert_called_once_with(
@@ -1167,15 +1168,20 @@ class TestLeftColumnView:
         )
 
     @pytest.mark.parametrize("pinned", powerset([1, 2, 99, 999, 1000]))
-    def test_streams_view(self, mocker, streams, pinned):
+    def test_stream_panel(self, mocker, streams, pinned):
         self.view.unpinned_streams = [s for s in streams if s["id"] not in pinned]
         self.view.pinned_streams = [s for s in streams if s["id"] in pinned]
         stream_button = mocker.patch(VIEWS + ".StreamButton")
+        stream_panel_button = mocker.patch(VIEWS + ".StreamPanelButton")
         mocker.patch(VIEWS + ".StreamsView")
         mocker.patch(VIEWS + ".urwid.LineBox")
         divider = mocker.patch(VIEWS + ".StreamsViewDivider")
 
         LeftColumnView(self.view)
+
+        stream_panel_button.assert_called_once_with(
+            controller=self.view.controller, count=mocker.ANY
+        )
 
         if pinned:
             assert divider.called

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -488,7 +488,7 @@ class TestStreamsView:
         assert stream_view.streams_btn_list == self.streams_btn_list
         assert stream_view.stream_search_box
         self.stream_search_box.assert_called_once_with(
-            stream_view, "SEARCH_STREAMS", stream_view.update_streams
+            stream_view, "SEARCH_STREAMS", stream_view.update_streams, label="streams"
         )
 
     @pytest.mark.parametrize(
@@ -605,7 +605,7 @@ class TestTopicsView:
         assert topic_view.view == self.view
         assert topic_view.topic_search_box
         self.topic_search_box.assert_called_once_with(
-            topic_view, "SEARCH_TOPICS", topic_view.update_topics
+            topic_view, "SEARCH_TOPICS", topic_view.update_topics, label="topics"
         )
         self.header_list.assert_called_once_with(
             [

--- a/tests/ui_tools/test_buttons.py
+++ b/tests/ui_tools/test_buttons.py
@@ -16,6 +16,7 @@ from zulipterminal.ui_tools.buttons import (
     PMButton,
     StarredButton,
     StreamButton,
+    StreamPanelButton,
     TopButton,
     TopicButton,
     UserButton,
@@ -196,6 +197,17 @@ class TestStarredButton:
     ) -> None:
         starred_button = StarredButton(controller=mocker.Mock(), count=count)
         assert starred_button.suffix_style == "starred_count"
+
+
+class TestStreamPanelButton:
+    def test_button_text_length(self, mocker: MockerFixture, count: int = 10) -> None:
+        stream_panel_button = StreamPanelButton(controller=mocker.Mock(), count=count)
+        assert len(stream_panel_button.label_text) == 20
+
+    def test_button_text_title(self, mocker: MockerFixture, count: int = 10) -> None:
+        stream_panel_button = StreamPanelButton(controller=mocker.Mock(), count=count)
+        title_text = stream_panel_button.label_text[:-3].strip()
+        assert title_text == "Stream messages"
 
 
 class TestStreamButton:

--- a/zulipterminal/config/symbols.py
+++ b/zulipterminal/config/symbols.py
@@ -13,7 +13,9 @@ ALL_MESSAGES_MARKER = "≡"  # IDENTICAL TO, U+2261 (Mathematical operators)
 MENTIONED_MESSAGES_MARKER = "@"
 STARRED_MESSAGES_MARKER = "*"
 
+# Used in View buttons, and short form of DMs (not for streams)
 DIRECT_MESSAGE_MARKER = "§"  # SECTION SIGN, U+00A7 (Latin-1 supplement)
+STREAM_MESSAGE_MARKER = ">"
 
 STREAM_MARKER_PRIVATE = "P"
 STREAM_MARKER_PUBLIC = "#"

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -136,6 +136,7 @@ initial_index = Index(
 class UnreadCounts(TypedDict):
     all_msg: int
     all_pms: int
+    all_stream_msg: int
     all_mentions: int
     unread_topics: Dict[Tuple[int, str], int]  # stream_id, topic
     unread_pms: Dict[int, int]  # sender_id
@@ -239,6 +240,7 @@ def _set_count_in_view(
     user_buttons_list = controller.view.user_w.users_btn_list
     all_msg = controller.view.home_button
     all_pm = controller.view.pm_button
+    all_stream = controller.view.stream_button
     all_mentioned = controller.view.mentioned_button
     for message in changed_messages:
         user_id = message["sender_id"]
@@ -272,6 +274,9 @@ def _set_count_in_view(
                 for topic_button in topic_buttons_list:
                     if topic_button.topic_name == msg_topic:
                         topic_button.update_count(topic_button.count + new_count)
+            if add_to_counts:
+                unread_counts["all_stream_msg"] += new_count
+            all_stream.update_count(unread_counts["all_stream_msg"])
         else:
             for user_button in user_buttons_list:
                 if user_button.user_id == user_id:
@@ -488,6 +493,7 @@ def classify_unread_counts(model: Any) -> UnreadCounts:
     unread_counts = UnreadCounts(
         all_msg=0,
         all_pms=0,
+        all_stream_msg=0,
         all_mentions=0,
         unread_topics=dict(),
         unread_pms=dict(),
@@ -520,6 +526,7 @@ def classify_unread_counts(model: Any) -> UnreadCounts:
             unread_counts["streams"][stream_id] += count
         if stream_id not in model.muted_streams:
             unread_counts["all_msg"] += count
+            unread_counts["all_stream_msg"] += count
 
     # store unread count of group pms in `unread_huddles`
     for group_pm in unread_msg_counts["huddles"]:

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1350,6 +1350,28 @@ class Model:
             reverse=True,
         )
 
+    def _update_recent_dms(self, message: Message) -> None:
+        """
+        Updates the list of recent direct message conversations.
+        """
+        msg_id = message["id"]
+        user_ids = [recipient["id"] for recipient in message["display_recipient"]]
+        user_ids.remove(self.user_id)
+        replaced = False
+        for dm in self.recent_dms:
+            if set(dm["user_ids"]) == set(user_ids) and msg_id > dm["max_message_id"]:
+                dm["max_message_id"] = msg_id
+                replaced = True
+                break
+        if not replaced:
+            self.recent_dms.append(
+                {
+                    "user_ids": user_ids,
+                    "max_message_id": msg_id,
+                }
+            )
+        self._sort_recent_dms()
+
     def _subscribe_to_streams(self, subscriptions: List[Subscription]) -> None:
         def make_reduced_stream_data(stream: Subscription) -> StreamData:
             # stream_id has been changed to id.
@@ -1710,6 +1732,8 @@ class Model:
                         message["stream_id"], message["subject"], message["sender_id"]
                     )
                     self.controller.update_screen()
+        elif message["type"] == "private":
+            self._update_recent_dms(message)
 
         # We can notify user regardless of whether UI is rendered or not,
         # but depend upon the UI to indicate failures.

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -142,6 +142,7 @@ class Model:
             "user_settings",
             "realm_emoji",
             "custom_profile_fields",
+            "recent_private_conversations",
             # zulip_version and zulip_feature_level are always returned in
             # POST /register from Feature level 3.
             "zulip_version",
@@ -179,6 +180,11 @@ class Model:
         self._cross_realm_bots_by_id: Dict[int, RealmUser] = {}
         self.users: List[MinimalUserData] = []
         self._update_users_data_from_initial_data()
+
+        self.recent_dms: List[Dict[str, Any]] = self.initial_data[
+            "recent_private_conversations"
+        ]
+        self._sort_recent_dms()
 
         self.stream_dict: Dict[int, Any] = {}
         self.muted_streams: Set[int] = set()
@@ -1334,6 +1340,15 @@ class Model:
             raise RuntimeError("Invalid user ID.")
 
         return self.user_dict[user_email]["full_name"]
+
+    def _sort_recent_dms(self) -> None:
+        """
+        Sorts the list of recent direct message conversations.
+        """
+        self.recent_dms.sort(
+            key=lambda conversation: conversation["max_message_id"],
+            reverse=True,
+        )
 
     def _subscribe_to_streams(self, subscriptions: List[Subscription]) -> None:
         def make_reduced_stream_data(stream: Subscription) -> StreamData:

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -970,13 +970,24 @@ class PanelSearchBox(ReadlineEdit):
     """
 
     def __init__(
-        self, panel_view: Any, search_command: str, update_function: Callable[..., None]
+        self,
+        panel_view: Any,
+        search_command: str,
+        update_function: Callable[..., None],
+        label: Optional[str] = None,
     ) -> None:
         self.panel_view = panel_view
         self.search_command = search_command
-        self.search_text = (
-            f" Search [{', '.join(display_keys_for_command(search_command))}]: "
-        )
+        if label:
+            self.search_text = (
+                f" Search {label} "
+                f"[{', '.join(display_keys_for_command(search_command))}]: "
+            )
+        else:
+            self.search_text = (
+                f" Search "
+                f"[{', '.join(display_keys_for_command(search_command))}]: "
+            )
         self.search_error = urwid.AttrMap(
             urwid.Text([" ", INVALID_MARKER, " No Results"]), "search_error"
         )

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -148,7 +148,7 @@ class HomeButton(TopButton):
         )
 
 
-class PMButton(TopButton):
+class DMPanelButton(TopButton):
     def __init__(self, *, controller: Any, count: int) -> None:
         button_text = f"Direct messages  [{primary_display_key_for_command('ALL_PM')}]"
 

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -21,6 +21,7 @@ from zulipterminal.config.symbols import (
     ALL_MESSAGES_MARKER,
     CHECK_MARK,
     DIRECT_MESSAGE_MARKER,
+    STREAM_MESSAGE_MARKER,
     MENTIONED_MESSAGES_MARKER,
     MUTE_MARKER,
     STARRED_MESSAGES_MARKER,
@@ -163,6 +164,7 @@ class StreamPanelButton(TopButton):
         super().__init__(
             controller=controller,
             label_markup=(None, button_text),
+            prefix_markup=("title", STREAM_MESSAGE_MARKER),
             suffix_markup=("unread_count", ""),
             show_function=lambda: None,
             count=count,

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -149,7 +149,9 @@ class HomeButton(TopButton):
 
 
 class DMPanelButton(TopButton):
-    def __init__(self, *, controller: Any, count: int) -> None:
+    def __init__(
+        self, *, controller: Any, count: int, show_function: Callable[[], Any]
+    ) -> None:
         button_text = f"Direct messages  [{primary_display_key_for_command('ALL_PM')}]"
 
         super().__init__(
@@ -157,25 +159,33 @@ class DMPanelButton(TopButton):
             label_markup=(None, button_text),
             prefix_markup=("title", DIRECT_MESSAGE_MARKER),
             suffix_markup=("unread_count", ""),
-            show_function=controller.narrow_to_all_pm,
+            show_function=show_function,
             count=count,
         )
 
+    def activate(self, key: Any) -> None:
+        self.show_function()
+
 
 class StreamPanelButton(TopButton):
-    def __init__(self, *, controller: Any, count: int) -> None:
-        button_text = "Stream messages     "
+    def __init__(
+        self, *, controller: Any, count: int, show_function: Callable[[], Any]
+    ) -> None:
+        button_text = "Stream messages  [S]"
         super().__init__(
             controller=controller,
             label_markup=(None, button_text),
             prefix_markup=("title", STREAM_MESSAGE_MARKER),
             suffix_markup=("unread_count", ""),
-            show_function=lambda: None,
+            show_function=show_function,
             count=count,
         )
 
     def selectable(self) -> bool:
         return False
+
+    def activate(self, key: Any) -> None:
+        self.show_function()
 
 
 class MentionedButton(TopButton):

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -163,6 +163,9 @@ class DMPanelButton(TopButton):
             count=count,
         )
 
+    def selectable(self) -> bool:
+        return False
+
     def activate(self, key: Any) -> None:
         self.show_function()
 

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -26,7 +26,11 @@ from zulipterminal.config.symbols import (
     MUTE_MARKER,
     STARRED_MESSAGES_MARKER,
 )
-from zulipterminal.config.ui_mappings import EDIT_MODE_CAPTIONS, STREAM_ACCESS_TYPE
+from zulipterminal.config.ui_mappings import (
+    EDIT_MODE_CAPTIONS,
+    STATE_ICON,
+    STREAM_ACCESS_TYPE,
+)
 from zulipterminal.helper import StreamData, hash_util_decode, process_media
 from zulipterminal.urwid_types import urwid_MarkupTuple, urwid_Size
 
@@ -283,6 +287,38 @@ class StreamButton(TopButton):
         elif is_command_key("STREAM_INFO", key):
             self.model.controller.show_stream_info(self.stream_id)
         return super().keypress(size, key)
+
+
+class DMButton(TopButton):
+    def __init__(
+        self,
+        *,
+        dm_data: Dict[str, Any],
+        controller: Any,
+        view: Any,
+        state_marker: str,
+        color: Optional[str] = None,
+        count: int,
+    ) -> None:
+        self.model = controller.model
+        self.count = count
+        self.view = view
+        self.users: str = dm_data["users"]
+        self.user_emails: List[str] = dm_data["emails"]
+        self.dm_type: str = dm_data["type"]
+
+        narrow_function = partial(
+            controller.narrow_to_user,
+            recipient_emails=self.user_emails,
+        )
+        super().__init__(
+            controller=controller,
+            prefix_markup=(color, state_marker),
+            label_markup=(None, self.users),
+            suffix_markup=("unread_count", count),
+            show_function=narrow_function,
+            count=count,
+        )
 
 
 class UserButton(TopButton):

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -157,6 +157,18 @@ class PMButton(TopButton):
         )
 
 
+class StreamPanelButton(TopButton):
+    def __init__(self, *, controller: Any, count: int) -> None:
+        button_text = "Stream messages     "
+        super().__init__(
+            controller=controller,
+            label_markup=(None, button_text),
+            suffix_markup=("unread_count", ""),
+            show_function=lambda: None,
+            count=count,
+        )
+
+
 class MentionedButton(TopButton):
     def __init__(self, *, controller: Any, count: int) -> None:
         button_text = (

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -168,6 +168,9 @@ class StreamPanelButton(TopButton):
             count=count,
         )
 
+    def selectable(self) -> bool:
+        return False
+
 
 class MentionedButton(TopButton):
     def __init__(self, *, controller: Any, count: int) -> None:

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -322,8 +322,9 @@ class StreamsViewDivider(urwid.Divider):
 class StreamPanel(urwid.Pile):
     def __init__(self, submenu_view: List[Any], view: Any) -> None:
         self.view = view
+        count = self.view.model.unread_counts.get("all_stream_msg", 0)
         self.view.stream_button = StreamPanelButton(
-            controller=self.view.controller, count=0
+            controller=self.view.controller, count=count
         )
         self._contents = [
             ("pack", self.view.stream_button),

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -53,6 +53,7 @@ from zulipterminal.ui_tools.buttons import (
     PMButton,
     StarredButton,
     StreamButton,
+    StreamPanelButton,
     TopicButton,
     UserButton,
 )
@@ -316,6 +317,21 @@ class StreamsViewDivider(urwid.Divider):
         self.stream_id = -1
         self.stream_name = ""
         super().__init__(div_char=PINNED_STREAMS_DIVIDER)
+
+
+class StreamPanel(urwid.Pile):
+    def __init__(self, submenu_view: List[Any], view: Any) -> None:
+        self.view = view
+        self.view.stream_button = StreamPanelButton(
+            controller=self.view.controller, count=0
+        )
+        self._contents = [
+            ("pack", self.view.stream_button),
+            ("pack", urwid.Divider(div_char=SECTION_DIVIDER_LINE)),
+            submenu_view,
+        ]
+
+        super().__init__(self.contents, focus_item=2)
 
 
 class StreamsView(urwid.Frame):
@@ -783,9 +799,13 @@ class LeftColumnView(urwid.Pile):
         self.controller = view.controller
         self.menu_v = self.menu_view()
         self.stream_v = self.streams_view()
-
+        self.stream_panel = self.streams_panel(self.stream_v)
         self.is_in_topic_view = False
-        contents = [(4, self.menu_v), self.stream_v]
+        contents = [
+            (4, self.menu_v),
+            ("pack", urwid.Divider(COLUMN_TITLE_BAR_LINE)),
+            self.stream_panel,
+        ]
         super().__init__(contents)
 
     def menu_view(self) -> Any:
@@ -813,6 +833,10 @@ class LeftColumnView(urwid.Pile):
         ]
         w = urwid.ListBox(urwid.SimpleFocusListWalker(menu_btn_list))
         return w
+
+    def streams_panel(self, submenu_view: Any) -> Any:
+        self.view.stream_p = StreamPanel(submenu_view, self.view)
+        return self.view.stream_p
 
     def streams_view(self) -> Any:
         streams_btn_list = [
@@ -845,20 +869,7 @@ class LeftColumnView(urwid.Pile):
         }
 
         self.view.stream_w = StreamsView(streams_btn_list, self.view)
-        w = urwid.LineBox(
-            self.view.stream_w,
-            title="Streams",
-            title_attr="column_title",
-            tlcorner=COLUMN_TITLE_BAR_LINE,
-            tline=COLUMN_TITLE_BAR_LINE,
-            trcorner=COLUMN_TITLE_BAR_LINE,
-            blcorner="",
-            rline="",
-            lline="",
-            bline="",
-            brcorner="",
-        )
-        return w
+        return self.view.stream_w
 
     def topics_view(self, stream_button: Any) -> Any:
         stream_id = stream_button.stream_id
@@ -877,20 +888,7 @@ class LeftColumnView(urwid.Pile):
         ]
 
         self.view.topic_w = TopicsView(topics_btn_list, self.view, stream_button)
-        w = urwid.LineBox(
-            self.view.topic_w,
-            title="Topics",
-            title_attr="column_title",
-            tlcorner=COLUMN_TITLE_BAR_LINE,
-            tline=COLUMN_TITLE_BAR_LINE,
-            trcorner=COLUMN_TITLE_BAR_LINE,
-            blcorner="",
-            rline="",
-            lline="",
-            bline="",
-            brcorner="",
-        )
-        return w
+        return self.view.topic_w
 
     def is_in_topic_view_with_stream_id(self, stream_id: int) -> bool:
         return (
@@ -905,12 +903,14 @@ class LeftColumnView(urwid.Pile):
 
     def show_stream_view(self) -> None:
         self.is_in_topic_view = False
-        self.contents[1] = (self.stream_v, self.options(height_type="weight"))
+        self.stream_panel = self.streams_panel(self.stream_v)
+        self.contents[2] = (self.stream_panel, self.options(height_type="weight"))
 
     def show_topic_view(self, stream_button: Any) -> None:
         self.is_in_topic_view = True
-        self.contents[1] = (
-            self.topics_view(stream_button),
+        self.stream_panel = self.streams_panel(self.topics_view(stream_button))
+        self.contents[2] = (
+            self.stream_panel,
             self.options(height_type="weight"),
         )
 
@@ -918,7 +918,8 @@ class LeftColumnView(urwid.Pile):
         if is_command_key("SEARCH_STREAMS", key) or is_command_key(
             "SEARCH_TOPICS", key
         ):
-            self.focus_position = 1
+            self.focus_position = 2
+            self.view.stream_p.focus_position = 2
             if self.is_in_topic_view:
                 self.view.topic_w.keypress(size, key)
             else:

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -342,7 +342,10 @@ class StreamsView(urwid.Frame):
         self.focus_index_before_search = 0
         list_box = urwid.ListBox(self.log)
         self.stream_search_box = PanelSearchBox(
-            self, "SEARCH_STREAMS", self.update_streams
+            self,
+            "SEARCH_STREAMS",
+            self.update_streams,
+            label="streams",
         )
         super().__init__(
             list_box,
@@ -436,7 +439,10 @@ class TopicsView(urwid.Frame):
         self.focus_index_before_search = 0
         self.list_box = urwid.ListBox(self.log)
         self.topic_search_box = PanelSearchBox(
-            self, "SEARCH_TOPICS", self.update_topics
+            self,
+            "SEARCH_TOPICS",
+            self.update_topics,
+            label="topics",
         )
         self.header_list = urwid.Pile(
             [

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -47,11 +47,11 @@ from zulipterminal.server_url import near_message_url
 from zulipterminal.ui_tools.boxes import PanelSearchBox
 from zulipterminal.ui_tools.buttons import (
     DMButton,
+    DMPanelButton,
     EmojiButton,
     HomeButton,
     MentionedButton,
     MessageLinkButton,
-    PMButton,
     StarredButton,
     StreamButton,
     StreamPanelButton,
@@ -311,7 +311,9 @@ class DMPanel(urwid.Pile):
     def __init__(self, submenu_view: List[Any], view: Any) -> None:
         self.view = view
         count = self.view.model.unread_counts.get("all_pms", 0)
-        self.view.pm_button = PMButton(controller=self.view.controller, count=count)
+        self.view.pm_button = DMPanelButton(
+            controller=self.view.controller, count=count
+        )
 
         self._contents = [
             ("pack", self.view.pm_button),

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -306,6 +306,31 @@ class MessageView(urwid.ListBox):
         self.model.mark_message_ids_as_read(read_msg_ids)
 
 
+class DMPanel(urwid.Pile):
+    def __init__(self, submenu_view: List[Any], view: Any) -> None:
+        self.view = view
+        count = self.view.model.unread_counts.get("all_pms", 0)
+        self.view.pm_button = PMButton(controller=self.view.controller, count=count)
+
+        self._contents = [
+            ("pack", self.view.pm_button),
+            ("pack", urwid.Divider(div_char=SECTION_DIVIDER_LINE)),
+            submenu_view,
+        ]
+
+        super().__init__(self.contents)
+
+
+class DMView(urwid.Frame):
+    def __init__(self, dm_btn_list: List[Any], view: Any) -> None:
+        self.view = view
+        self.log = urwid.SimpleFocusListWalker(dm_btn_list)
+        self.dm_btn_list = dm_btn_list
+        self.focus_index_before_search = 0
+        list_box = urwid.ListBox(self.log)
+        super().__init__(list_box)
+
+
 class StreamsViewDivider(urwid.Divider):
     """
     A custom urwid.Divider to visually separate pinned and unpinned streams.


### PR DESCRIPTION
<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?

This is an update on the current work in #1416.

Currently this only includes a few small fixups over #1416, that may be included or not:
- Make the new stream messages button not selectable (cannot receive focus)
- Adds a simple `>` prefix for the new Stream messages button as `STREAM_MESSAGE_MARKER`
- Make the DM messages button not selectable (cannot receive focus) [for now]

The way this is currently structured, this could be merged in two chunks (note that the summary of each chunk is not on a commit-wise basis):
- up to and including my `symbols/buttons` commit
  - adds the data for the total stream messages into a new (non-selectable) button
  - changes the left panel structure to have a simple dividing line from the top-left view buttons, rather than a `---Streams---` or `---Topics---` title
  - clarifies the context after that change by specifying 'Search topics' and 'Search streams' rather than the previous 'Search' in the panel search box
- that plus the rest of the commits
  - Moves the Direct messages button into a section with its own solid line separating it
  - Adds lots of model support for DM data, and updating it
  - Adjusts hotkeys so that from the left panel, `S` shows the view after the first PR chunk (above), with `P` switching to a view with the `P` view fully expanded
  - The fully expanded `P` view shows conversations with unreads, and user status
    (group conversations are included, unlike in the user list)
  - position in the DM list (and stream list) is preserved on switching between them

An additional UI 'chunk' could be to do the first bullet of the last chunk distinct from the data and view changes, but this change is currently combined with one of the later commits in the second chunk. That last chunk could also be split into data and UI updates, potentially.

### Feedback sought
Manual testing and feedback on:
1. the first chunk (eg. `git rebase -i` and 'edit' on the 'symbols/buttons' commit)
  - This is the anticipated UI direction to enable the full PR to merge
  - how does it feel during use?
  - does stream/topic switching look good?
  - how does it compare to `main` for you?
2. the full PR
  - This is the current plan for the first iteration of showing DM conversations
  - See previous conversations for motivation for this design:
    - https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/Private.20messages.20sidepanel.20.23T1416
    - https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/DM.20Side.20Panel
  - Note the outstanding (known) aspects below!
  - How does it look and work for you? Is anything clearly broken? any other improvements?

### Outstanding aspect(s)    <!-- DELETE SECTION IF EMPTY -->
<!-- In what ways is this not fully implemented/functioning? Compared to a discussion/issue? -->
<!-- Do you not understand something? Are you unsure about a certain approach? Want feedback? -->
- [ ] `P` for DM feed functionality is currently removed, even from message context; it would be useful to retain this feature generally? [discuss]
  - [ ] Even the `P` DM feed button is not usable right now, for simplicity
- [ ] From the user list, `P` changes the left panel view, but doesn't re-focus; that's clearly buggy, but should it do something like that? [discuss]
- [ ] `S` now works differently in left panel (new view-change) vs message context (zoom-in); is that OK?
- [ ] While position in the stream list, and in any connected topic list, is preserved upon switching to/from the DM list, if the topic list was shown previously then it instead shows the stream list, which seems inconsistent? (eg. streams -`t`-> topics -`P`-> DMs -`S`-> streams)
- [ ] Sort user names in DM list like web app?
- [ ] Ensure DM list status symbols are updated
- [ ] Use 'huddle' symbols for conversations with >2 people (eg. ∷)

Note that not all of these are necessary for a full merge and could belong in follow-ups, but some relate to what seems like buggy, inconsistent or reduced behavior.

### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [x] Discussed in **#zulip-terminal** in `Private messages sidepanel #T1416` and `DM Side Panel`
- [ ] Fully fixes #
- [x] Partially fixes issue #1197 
- [x] Builds upon previous unmerged work in PR #1416 
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [ ] Manually - Behavioral changes
- [ ] Manually - Visual changes
- [ ] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [ ] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [ ] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [ ] It has a commit summary describing the  motivation and reasoning for the change
- [ ] It individually passes linting and tests
- [ ] It contains test additions for any new behavior
- [ ] It flows clearly from a previous branch commit, and/or prepares for the next commit

### Visual changes    <!-- DELETE SECTION IF NO VISUAL CHANGE -->
<!-- Zulip tips at https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html -->
<!-- For video, try asciinema; after uploading, embed using
[![yourtitle](https://asciinema.org/a/<id>.png)](https://asciinema.org/a/<id>)
-->
<!-- NOTE: Attached videos/images will be clearer from smaller terminal windows -->
