### PR TITLE
Unify confirmation popups into popup framework

### DIFF
--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -477,6 +477,9 @@ class TestController:
         stream_name: str = "PTEST",
     ) -> None:
         pop_up = mocker.patch(MODULE + ".PopUpConfirmationView")
+        pop_up.return_value.width = 30
+        pop_up.return_value.height = 6
+
         text = mocker.patch(MODULE + ".urwid.Text")
         partial = mocker.patch(MODULE + ".partial")
         controller.model.muted_streams = muted_streams
@@ -484,7 +487,7 @@ class TestController:
 
         controller.stream_muting_confirmation_popup(stream_id, stream_name)
 
-        text.assert_called_with(
+        text.assert_any_call(
             ("bold", f"Confirm {action} of stream '{stream_name}' ?"),
             "center",
         )

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -119,8 +119,8 @@ class TestPopUpView:
             self.command,
             self.width,
             self.title,
-            self.header,
-            self.footer,
+            header=self.header,
+            footer=self.footer,
         )
 
     def test_init(self, mocker: MockerFixture) -> None:

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -45,11 +45,20 @@ class TestPopUpConfirmationView:
     @pytest.fixture
     def popup_view(self, mocker: MockerFixture) -> PopUpConfirmationView:
         self.controller = mocker.Mock()
+        self.controller.maximum_popup_dimensions.return_value = (70, 25)
+
+        self.text = Text("Some question?")
+
         self.callback = mocker.Mock()
+
         self.list_walker = mocker.patch(LISTWALKER, return_value=[])
+
         self.divider = mocker.patch(MODULE + ".urwid.Divider")
-        self.text = mocker.patch(MODULE + ".urwid.Text")
+        self.divider.return_value.rows.return_value = 1
+
         self.wrapper_w = mocker.patch(MODULE + ".urwid.WidgetWrap")
+        self.wrapper_w.return_value.rows.return_value = 1
+
         return PopUpConfirmationView(
             self.controller,
             self.text,
@@ -68,6 +77,7 @@ class TestPopUpConfirmationView:
         self, mocker: MockerFixture, popup_view: PopUpConfirmationView
     ) -> None:
         popup_view.exit_popup_yes(mocker.Mock())
+
         self.callback.assert_called_once_with()
         assert self.controller.exit_popup.called
 
@@ -75,11 +85,12 @@ class TestPopUpConfirmationView:
         self, mocker: MockerFixture, popup_view: PopUpConfirmationView
     ) -> None:
         popup_view.exit_popup_no(mocker.Mock())
+
         self.callback.assert_not_called()
         assert self.controller.exit_popup.called
 
     @pytest.mark.parametrize("key", keys_for_command("EXIT_POPUP"))
-    def test_exit_popup_EXIT_POPUP(
+    def test_keypress__EXIT_POPUP(
         self,
         popup_view: PopUpConfirmationView,
         key: str,
@@ -87,6 +98,7 @@ class TestPopUpConfirmationView:
     ) -> None:
         size = widget_size(popup_view)
         popup_view.keypress(size, key)
+
         self.callback.assert_not_called()
         assert self.controller.exit_popup.called
 

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -492,9 +492,7 @@ class Controller:
                 "?",
             ]
         )
-        self.loop.widget = PopUpConfirmationView(
-            self, question, callback, location="center"
-        )
+        self.loop.widget = PopUpConfirmationView(self, question, callback)
 
     def search_messages(self, text: str) -> None:
         # Search for a text in messages
@@ -521,9 +519,7 @@ class Controller:
             "center",
         )
         save_draft = partial(self.model.save_draft, draft)
-        self.loop.widget = PopUpConfirmationView(
-            self, question, save_draft, location="center"
-        )
+        self.loop.widget = PopUpConfirmationView(self, question, save_draft)
 
     def stream_muting_confirmation_popup(
         self, stream_id: int, stream_name: str
@@ -547,9 +543,7 @@ class Controller:
             "center",
         )
         write_box = self.view.write_box
-        popup_view = PopUpConfirmationView(
-            self, question, write_box.exit_compose_box, location="center"
-        )
+        popup_view = PopUpConfirmationView(self, question, write_box.exit_compose_box)
         self.loop.widget = popup_view
 
     def copy_to_clipboard(self, text: str, text_category: str) -> None:
@@ -665,9 +659,7 @@ class Controller:
             ("bold", " Please confirm that you wish to exit Zulip-Terminal "),
             "center",
         )
-        popup_view = PopUpConfirmationView(
-            self, question, self.deregister_client, location="center"
-        )
+        popup_view = PopUpConfirmationView(self, question, self.deregister_client)
         self.loop.widget = popup_view
         self.loop.run()
 

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -222,15 +222,21 @@ class Controller:
         return max_popup_cols, max_popup_rows
 
     def show_pop_up(self, to_show: Any, style: str) -> None:
+        if to_show.title is not None:
+            # +2 to height, due to title enhancement
+            # TODO: Ideally this would be in PopUpFrame
+            extra_height = 2
+        else:
+            extra_height = 0
+
         self.loop.widget = urwid.Overlay(
             PopUpFrame(to_show, to_show.title, style),
             self.view,
             align="center",
             valign="middle",
             # +2 to both of the following, due to LineBox
-            # +2 to height, due to title enhancement
             width=to_show.width + 2,
-            height=to_show.height + 4,
+            height=to_show.height + 2 + extra_height,
         )
 
     def is_any_popup_open(self) -> bool:

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -19,7 +19,6 @@ import zulip
 from typing_extensions import Literal
 
 from zulipterminal.api_types import Composition, Message
-from zulipterminal.config.symbols import POPUP_CONTENT_BORDER, POPUP_TOP_LINE
 from zulipterminal.config.themes import ThemeSpec
 from zulipterminal.config.ui_sizes import (
     MAX_LINEAR_SCALING_WIDTH,
@@ -42,6 +41,7 @@ from zulipterminal.ui_tools.views import (
     MsgInfoView,
     NoticeView,
     PopUpConfirmationView,
+    PopUpFrame,
     StreamInfoView,
     StreamMembersView,
     UserInfoView,
@@ -222,16 +222,8 @@ class Controller:
         return max_popup_cols, max_popup_rows
 
     def show_pop_up(self, to_show: Any, style: str) -> None:
-        text = urwid.Text(to_show.title, align="center")
-        title_map = urwid.AttrMap(urwid.Filler(text), style)
-        title_box_adapter = urwid.BoxAdapter(title_map, height=1)
-        title_top = urwid.AttrMap(urwid.Divider(POPUP_TOP_LINE), "popup_border")
-        title = urwid.Pile([title_top, title_box_adapter])
-
-        content = urwid.LineBox(to_show, **POPUP_CONTENT_BORDER)
-
         self.loop.widget = urwid.Overlay(
-            urwid.AttrMap(urwid.Frame(header=title, body=content), "popup_border"),
+            PopUpFrame(to_show, to_show.title, style),
             self.view,
             align="center",
             valign="middle",

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -492,7 +492,8 @@ class Controller:
                 "?",
             ]
         )
-        self.loop.widget = PopUpConfirmationView(self, question, callback)
+        popup = PopUpConfirmationView(self, question, callback)
+        self.show_pop_up(popup, "area:msg")
 
     def search_messages(self, text: str) -> None:
         # Search for a text in messages
@@ -519,7 +520,9 @@ class Controller:
             "center",
         )
         save_draft = partial(self.model.save_draft, draft)
-        self.loop.widget = PopUpConfirmationView(self, question, save_draft)
+
+        popup = PopUpConfirmationView(self, question, save_draft)
+        self.show_pop_up(popup, "area:msg")
 
     def stream_muting_confirmation_popup(
         self, stream_id: int, stream_name: str
@@ -531,7 +534,8 @@ class Controller:
             "center",
         )
         mute_this_stream = partial(self.model.toggle_stream_muted_status, stream_id)
-        self.loop.widget = PopUpConfirmationView(self, question, mute_this_stream)
+        popup = PopUpConfirmationView(self, question, mute_this_stream)
+        self.show_pop_up(popup, "area:msg")
 
     def exit_compose_confirmation_popup(self) -> None:
         question = urwid.Text(
@@ -543,8 +547,9 @@ class Controller:
             "center",
         )
         write_box = self.view.write_box
+
         popup_view = PopUpConfirmationView(self, question, write_box.exit_compose_box)
-        self.loop.widget = popup_view
+        self.show_pop_up(popup_view, "area:msg")
 
     def copy_to_clipboard(self, text: str, text_category: str) -> None:
         try:
@@ -659,9 +664,10 @@ class Controller:
             ("bold", " Please confirm that you wish to exit Zulip-Terminal "),
             "center",
         )
+
         popup_view = PopUpConfirmationView(self, question, self.deregister_client)
-        self.loop.widget = popup_view
-        self.loop.run()
+        self.show_pop_up(popup_view, "area:msg")
+        self.loop.run()  # Appears necessary to return control from signal handler
 
     def _raise_exception(self, *args: Any, **kwargs: Any) -> Literal[True]:
         if self._exception_info is not None:

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -957,6 +957,7 @@ class PopUpView(urwid.Frame):
         command: str,
         requested_width: int,
         title: str,
+        *,
         header: Optional[Any] = None,
         footer: Optional[Any] = None,
     ) -> None:
@@ -1294,7 +1295,9 @@ class MarkdownHelpView(PopUpView):
             [("", rendered_menu_content)], column_widths
         )
 
-        super().__init__(controller, body, "MARKDOWN_HELP", popup_width, title, header)
+        super().__init__(
+            controller, body, "MARKDOWN_HELP", popup_width, title, header=header
+        )
 
 
 PopUpConfirmationViewLocation = Literal["top-left", "center"]
@@ -1932,8 +1935,8 @@ class FullRenderedMsgView(PopUpView):
             "MSG_INFO",
             max_cols,
             title,
-            urwid.Pile(msg_box.header),
-            urwid.Pile(msg_box.footer),
+            header=urwid.Pile(msg_box.header),
+            footer=urwid.Pile(msg_box.footer),
         )
 
     def keypress(self, size: urwid_Size, key: str) -> str:
@@ -1984,8 +1987,8 @@ class FullRawMsgView(PopUpView):
             "MSG_INFO",
             max_cols,
             title,
-            urwid.Pile(msg_box.header),
-            urwid.Pile(msg_box.footer),
+            header=urwid.Pile(msg_box.header),
+            footer=urwid.Pile(msg_box.footer),
         )
 
     def keypress(self, size: urwid_Size, key: str) -> str:

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -952,16 +952,18 @@ PopUpViewTableContent = Sequence[Tuple[str, Sequence[Union[str, Tuple[str, Any]]
 
 
 class PopUpFrame(urwid.AttrMap):
-    def __init__(self, body: Any, title: str, style: str) -> None:
-        text = urwid.Text(title, align="center")
-        title_map = urwid.AttrMap(urwid.Filler(text), style)
-        title_box_adapter = urwid.BoxAdapter(title_map, height=1)
-        title_top = urwid.AttrMap(urwid.Divider(POPUP_TOP_LINE), "popup_border")
-        frame_title = urwid.Pile([title_top, title_box_adapter])
-
+    def __init__(self, body: Any, title: Optional[str], style: str) -> None:
         content = urwid.LineBox(body, **POPUP_CONTENT_BORDER)
 
-        titled_content = urwid.Frame(body=content, header=frame_title)
+        if title is not None:
+            text = urwid.Text(title, align="center")
+            title_map = urwid.AttrMap(urwid.Filler(text), style)
+            title_box_adapter = urwid.BoxAdapter(title_map, height=1)
+            title_top = urwid.AttrMap(urwid.Divider(POPUP_TOP_LINE), "popup_border")
+            frame_title = urwid.Pile([title_top, title_box_adapter])
+            titled_content = urwid.Frame(body=content, header=frame_title)
+        else:
+            titled_content = urwid.Frame(body=content)
 
         super().__init__(titled_content, "popup_border")
 

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -36,7 +36,6 @@ from zulipterminal.config.ui_mappings import (
     STREAM_ACCESS_TYPE,
     STREAM_POST_POLICY,
 )
-from zulipterminal.config.ui_sizes import LEFT_WIDTH
 from zulipterminal.helper import (
     TidiedUserInfo,
     asynch,
@@ -1319,16 +1318,12 @@ class MarkdownHelpView(PopUpView):
         )
 
 
-PopUpConfirmationViewLocation = Literal["top-left", "center"]
-
-
 class PopUpConfirmationView(urwid.Overlay):
     def __init__(
         self,
         controller: Any,
         question: Any,
         success_callback: Callable[[], None],
-        location: PopUpConfirmationViewLocation = "top-left",
     ) -> None:
         self.controller = controller
         self.success_callback = success_callback
@@ -1341,26 +1336,17 @@ class PopUpConfirmationView(urwid.Overlay):
         widgets = [question, urwid.Divider(), wrapped_widget]
         prompt = urwid.LineBox(urwid.ListBox(urwid.SimpleFocusListWalker(widgets)))
 
-        if location == "top-left":
-            align = "left"
-            valign = "top"
-            width = LEFT_WIDTH + 1
-            height = 8
-        else:
-            align = "center"
-            valign = "middle"
-
-            max_cols, max_rows = controller.maximum_popup_dimensions()
-            # +2 to compensate for the LineBox characters.
-            width = min(max_cols, max(question.pack()[0], len("Yes"), len("No"))) + 2
-            height = min(max_rows, sum(widget.rows((width,)) for widget in widgets)) + 2
+        max_cols, max_rows = controller.maximum_popup_dimensions()
+        # +2 to compensate for the LineBox characters.
+        width = min(max_cols, max(question.pack()[0], len("Yes"), len("No"))) + 2
+        height = min(max_rows, sum(widget.rows((width,)) for widget in widgets)) + 2
 
         urwid.Overlay.__init__(
             self,
             prompt,
             self.controller.view,
-            align=align,
-            valign=valign,
+            align="center",
+            valign="middle",
             width=width,
             height=height,
         )

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -24,6 +24,8 @@ from zulipterminal.config.symbols import (
     CHECK_MARK,
     COLUMN_TITLE_BAR_LINE,
     PINNED_STREAMS_DIVIDER,
+    POPUP_CONTENT_BORDER,
+    POPUP_TOP_LINE,
     SECTION_DIVIDER_LINE,
 )
 from zulipterminal.config.ui_mappings import (
@@ -947,6 +949,21 @@ class TabView(urwid.WidgetWrap):
 # FIXME: This type could be improved, as Any isn't too explicit and clear.
 # (this was previously str, but some types passed in can be more complex)
 PopUpViewTableContent = Sequence[Tuple[str, Sequence[Union[str, Tuple[str, Any]]]]]
+
+
+class PopUpFrame(urwid.AttrMap):
+    def __init__(self, body: Any, title: str, style: str) -> None:
+        text = urwid.Text(title, align="center")
+        title_map = urwid.AttrMap(urwid.Filler(text), style)
+        title_box_adapter = urwid.BoxAdapter(title_map, height=1)
+        title_top = urwid.AttrMap(urwid.Divider(POPUP_TOP_LINE), "popup_border")
+        frame_title = urwid.Pile([title_top, title_box_adapter])
+
+        content = urwid.LineBox(body, **POPUP_CONTENT_BORDER)
+
+        titled_content = urwid.Frame(body=content, header=frame_title)
+
+        super().__init__(titled_content, "popup_border")
 
 
 class PopUpView(urwid.Frame):

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -950,7 +950,7 @@ class TabView(urwid.WidgetWrap):
 PopUpViewTableContent = Sequence[Tuple[str, Sequence[Union[str, Tuple[str, Any]]]]]
 
 
-class PopUpFrame(urwid.AttrMap):
+class PopUpFrame(urwid.WidgetDecoration, urwid.WidgetWrap):
     def __init__(self, body: Any, title: Optional[str], style: str) -> None:
         content = urwid.LineBox(body, **POPUP_CONTENT_BORDER)
 
@@ -964,7 +964,10 @@ class PopUpFrame(urwid.AttrMap):
         else:
             titled_content = urwid.Frame(body=content)
 
-        super().__init__(titled_content, "popup_border")
+        styled = urwid.AttrMap(titled_content, "popup_border")
+
+        urwid.WidgetDecoration.__init__(self, body)
+        urwid.WidgetWrap.__init__(self, styled)
 
 
 class PopUpView(urwid.Frame):

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1318,7 +1318,7 @@ class MarkdownHelpView(PopUpView):
         )
 
 
-class PopUpConfirmationView(urwid.Overlay):
+class PopUpConfirmationView(urwid.Frame):
     def __init__(
         self,
         controller: Any,
@@ -1334,22 +1334,17 @@ class PopUpConfirmationView(urwid.Overlay):
         display_widget = urwid.GridFlow([yes, no], 3, 5, 1, "center")
         wrapped_widget = urwid.WidgetWrap(display_widget)
         widgets = [question, urwid.Divider(), wrapped_widget]
-        prompt = urwid.LineBox(urwid.ListBox(urwid.SimpleFocusListWalker(widgets)))
+        prompt = urwid.ListBox(urwid.SimpleFocusListWalker(widgets))
+
+        self.title = None
 
         max_cols, max_rows = controller.maximum_popup_dimensions()
-        # +2 to compensate for the LineBox characters.
-        width = min(max_cols, max(question.pack()[0], len("Yes"), len("No"))) + 2
-        height = min(max_rows, sum(widget.rows((width,)) for widget in widgets)) + 2
-
-        urwid.Overlay.__init__(
-            self,
-            prompt,
-            self.controller.view,
-            align="center",
-            valign="middle",
-            width=width,
-            height=height,
+        self.width = min(max_cols, max(question.pack()[0], len("Yes"), len("No")))
+        self.height = min(
+            max_rows, sum(widget.rows((self.width,)) for widget in widgets)
         )
+
+        super().__init__(prompt)
 
     def exit_popup_yes(self, args: Any) -> None:
         self.success_callback()


### PR DESCRIPTION
<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?

This incrementally improves the popup code until a point where the confirmation popups can be handled in the same way as others and improved upon:
- extract the border styling from core.py and into a new `PopUpFrame` class in view.py
- extend `PopUpFrame` to handle title-less cases (ie. for confirmation popups)
- simplify confirmation popups to not support locations other than center, easing integration
- migrate `ConfirmationPopUpView` from an `Overlay` to a `Frame`, and other changes to enable use of `show_pop_up` just like other popups

Other than simplifying the code, this also results in confirmation popups acquiring a solid edge, as with regular popups.

### Outstanding aspect(s)    <!-- DELETE SECTION IF EMPTY -->
<!-- In what ways is this not fully implemented/functioning? Compared to a discussion/issue? -->
<!-- Do you not understand something? Are you unsure about a certain approach? Want feedback? -->
- [ ] Last commit needs more consideration
- [ ] Nesting of popups into frame suggests frame could be an urwid container/decorator class
- [ ] Confirm ability to style popup borders
- [ ] Select appropriate popup borders for different confirmation popups?

### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [ ] Discussed in **#zulip-terminal** in `topic`
- [ ] Fully fixes #
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [ ] Manually - Behavioral changes
- [ ] Manually - Visual changes
- [ ] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [ ] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [ ] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [ ] It has a commit summary describing the  motivation and reasoning for the change
- [ ] It individually passes linting and tests
- [ ] It contains test additions for any new behavior
- [ ] It flows clearly from a previous branch commit, and/or prepares for the next commit

### Visual changes    <!-- DELETE SECTION IF NO VISUAL CHANGE -->
<!-- Zulip tips at https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html -->
<!-- For video, try asciinema; after uploading, embed using
[![yourtitle](https://asciinema.org/a/<id>.png)](https://asciinema.org/a/<id>)
-->
<!-- NOTE: Attached videos/images will be clearer from smaller terminal windows -->
