### PR TITLE
Group message data

### DIFF
--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -1014,10 +1014,7 @@ class TestMsgInfoView:
 
         if self.msg_info_view.show_edit_history_label:
             self.controller.show_edit_history.assert_called_once_with(
-                message=self.message,
-                topic_links=OrderedDict(),
-                message_links=OrderedDict(),
-                time_mentions=list(),
+                message=self.message
             )
         else:
             self.controller.show_edit_history.assert_not_called()
@@ -1031,10 +1028,7 @@ class TestMsgInfoView:
         self.msg_info_view.keypress(size, key)
 
         self.controller.show_full_rendered_message.assert_called_once_with(
-            message=self.message,
-            topic_links=OrderedDict(),
-            message_links=OrderedDict(),
-            time_mentions=list(),
+            message=self.message
         )
 
     @pytest.mark.parametrize("key", keys_for_command("FULL_RAW_MESSAGE"))
@@ -1046,10 +1040,7 @@ class TestMsgInfoView:
         self.msg_info_view.keypress(size, key)
 
         self.controller.show_full_raw_message.assert_called_once_with(
-            message=self.message,
-            topic_links=OrderedDict(),
-            message_links=OrderedDict(),
-            time_mentions=list(),
+            message=self.message
         )
 
     @pytest.mark.parametrize(

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -503,9 +503,6 @@ class TestFullRenderedMsgView:
         self.full_rendered_message = FullRenderedMsgView(
             controller=self.controller,
             message=self.message,
-            topic_links=OrderedDict(),
-            message_links=OrderedDict(),
-            time_mentions=list(),
             title="Full Rendered Message",
         )
 
@@ -513,9 +510,6 @@ class TestFullRenderedMsgView:
         assert self.full_rendered_message.title == "Full Rendered Message"
         assert self.full_rendered_message.controller == self.controller
         assert self.full_rendered_message.message == self.message
-        assert self.full_rendered_message.topic_links == OrderedDict()
-        assert self.full_rendered_message.message_links == OrderedDict()
-        assert self.full_rendered_message.time_mentions == list()
         assert self.full_rendered_message.header.widget_list == msg_box.header
         assert self.full_rendered_message.footer.widget_list == msg_box.footer
 
@@ -574,9 +568,6 @@ class TestFullRawMsgView:
         self.full_raw_message = FullRawMsgView(
             controller=self.controller,
             message=self.message,
-            topic_links=OrderedDict(),
-            message_links=OrderedDict(),
-            time_mentions=list(),
             title="Full Raw Message",
         )
 
@@ -584,9 +575,6 @@ class TestFullRawMsgView:
         assert self.full_raw_message.title == "Full Raw Message"
         assert self.full_raw_message.controller == self.controller
         assert self.full_raw_message.message == self.message
-        assert self.full_raw_message.topic_links == OrderedDict()
-        assert self.full_raw_message.message_links == OrderedDict()
-        assert self.full_raw_message.time_mentions == list()
         assert self.full_raw_message.header.widget_list == msg_box.header
         assert self.full_raw_message.footer.widget_list == msg_box.footer
 
@@ -644,18 +632,12 @@ class TestEditHistoryView:
         self.edit_history_view = EditHistoryView(
             controller=self.controller,
             message=self.message,
-            topic_links=OrderedDict(),
-            message_links=OrderedDict(),
-            time_mentions=list(),
             title="Edit History",
         )
 
     def test_init(self) -> None:
         assert self.edit_history_view.controller == self.controller
         assert self.edit_history_view.message == self.message
-        assert self.edit_history_view.topic_links == OrderedDict()
-        assert self.edit_history_view.message_links == OrderedDict()
-        assert self.edit_history_view.time_mentions == list()
         self.controller.model.fetch_message_history.assert_called_once_with(
             message_id=self.message["id"],
         )

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -975,27 +975,28 @@ class TestMsgInfoView:
             "Tue Mar 13 10:55:22",
             "Tue Mar 13 10:55:37",
         ]
+        self.message = message_fixture
         self.msg_info_view = MsgInfoView(
             self.controller,
-            message_fixture,
+            self.message,
             "Message Information",
             OrderedDict(),
             OrderedDict(),
             list(),
         )
 
-    def test_init(self, message_fixture: Message) -> None:
-        assert self.msg_info_view.msg == message_fixture
+    def test_init(self) -> None:
+        assert self.msg_info_view.msg == self.message
         assert self.msg_info_view.topic_links == OrderedDict()
         assert self.msg_info_view.message_links == OrderedDict()
         assert self.msg_info_view.time_mentions == list()
 
-    def test_pop_up_info_order(self, message_fixture: Message) -> None:
+    def test_pop_up_info_order(self) -> None:
         topic_links = OrderedDict([("https://bar.com", ("topic", 1, True))])
         message_links = OrderedDict([("image.jpg", ("image", 1, True))])
         msg_info_view = MsgInfoView(
             self.controller,
-            message_fixture,
+            self.message,
             title="Message Information",
             topic_links=topic_links,
             message_links=message_links,
@@ -1029,7 +1030,6 @@ class TestMsgInfoView:
     )
     def test_keypress_edit_history(
         self,
-        message_fixture: Message,
         key: str,
         widget_size: Callable[[Widget], urwid_Size],
         realm_allow_edit_history: bool,
@@ -1041,21 +1041,13 @@ class TestMsgInfoView:
         self.controller.model.initial_data = {
             "realm_allow_edit_history": realm_allow_edit_history,
         }
-        msg_info_view = MsgInfoView(
-            self.controller,
-            message_fixture,
-            title="Message Information",
-            topic_links=OrderedDict(),
-            message_links=OrderedDict(),
-            time_mentions=list(),
-        )
-        size = widget_size(msg_info_view)
+        size = widget_size(self.msg_info_view)
 
-        msg_info_view.keypress(size, key)
+        self.msg_info_view.keypress(size, key)
 
-        if msg_info_view.show_edit_history_label:
+        if self.msg_info_view.show_edit_history_label:
             self.controller.show_edit_history.assert_called_once_with(
-                message=message_fixture,
+                message=self.message,
                 topic_links=OrderedDict(),
                 message_links=OrderedDict(),
                 time_mentions=list(),
@@ -1065,25 +1057,14 @@ class TestMsgInfoView:
 
     @pytest.mark.parametrize("key", keys_for_command("FULL_RENDERED_MESSAGE"))
     def test_keypress_full_rendered_message(
-        self,
-        message_fixture: Message,
-        key: str,
-        widget_size: Callable[[Widget], urwid_Size],
+        self, key: str, widget_size: Callable[[Widget], urwid_Size]
     ) -> None:
-        msg_info_view = MsgInfoView(
-            self.controller,
-            message_fixture,
-            title="Message Information",
-            topic_links=OrderedDict(),
-            message_links=OrderedDict(),
-            time_mentions=list(),
-        )
-        size = widget_size(msg_info_view)
+        size = widget_size(self.msg_info_view)
 
-        msg_info_view.keypress(size, key)
+        self.msg_info_view.keypress(size, key)
 
         self.controller.show_full_rendered_message.assert_called_once_with(
-            message=message_fixture,
+            message=self.message,
             topic_links=OrderedDict(),
             message_links=OrderedDict(),
             time_mentions=list(),
@@ -1091,25 +1072,14 @@ class TestMsgInfoView:
 
     @pytest.mark.parametrize("key", keys_for_command("FULL_RAW_MESSAGE"))
     def test_keypress_full_raw_message(
-        self,
-        message_fixture: Message,
-        key: str,
-        widget_size: Callable[[Widget], urwid_Size],
+        self, key: str, widget_size: Callable[[Widget], urwid_Size]
     ) -> None:
-        msg_info_view = MsgInfoView(
-            self.controller,
-            message_fixture,
-            title="Message Information",
-            topic_links=OrderedDict(),
-            message_links=OrderedDict(),
-            time_mentions=list(),
-        )
-        size = widget_size(msg_info_view)
+        size = widget_size(self.msg_info_view)
 
-        msg_info_view.keypress(size, key)
+        self.msg_info_view.keypress(size, key)
 
         self.controller.show_full_raw_message.assert_called_once_with(
-            message=message_fixture,
+            message=self.message,
             topic_links=OrderedDict(),
             message_links=OrderedDict(),
             time_mentions=list(),

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -520,14 +520,14 @@ class TestFullRenderedMsgView:
         assert self.full_rendered_message.footer.widget_list == msg_box.footer
 
     @pytest.mark.parametrize("key", keys_for_command("MSG_INFO"))
-    def test_keypress_exit_popup(
+    def test_keypress_exit_all_popups(
         self, key: str, widget_size: Callable[[Widget], urwid_Size]
     ) -> None:
         size = widget_size(self.full_rendered_message)
 
         self.full_rendered_message.keypress(size, key)
 
-        assert self.controller.exit_popup.called
+        assert self.controller.exit_all_popups.called
 
     def test_keypress_exit_popup_invalid_key(
         self, widget_size: Callable[[Widget], urwid_Size]
@@ -546,19 +546,14 @@ class TestFullRenderedMsgView:
             *keys_for_command("EXIT_POPUP"),
         },
     )
-    def test_keypress_show_msg_info(
+    def test_keypress_exit_to_msg_info(
         self, key: str, widget_size: Callable[[Widget], urwid_Size]
     ) -> None:
         size = widget_size(self.full_rendered_message)
 
         self.full_rendered_message.keypress(size, key)
 
-        self.controller.show_msg_info.assert_called_once_with(
-            msg=self.message,
-            topic_links=OrderedDict(),
-            message_links=OrderedDict(),
-            time_mentions=list(),
-        )
+        assert self.controller.exit_popup.called
 
 
 class TestFullRawMsgView:
@@ -596,14 +591,14 @@ class TestFullRawMsgView:
         assert self.full_raw_message.footer.widget_list == msg_box.footer
 
     @pytest.mark.parametrize("key", keys_for_command("MSG_INFO"))
-    def test_keypress_exit_popup(
+    def test_keypress_exit_all_popups(
         self, key: str, widget_size: Callable[[Widget], urwid_Size]
     ) -> None:
         size = widget_size(self.full_raw_message)
 
         self.full_raw_message.keypress(size, key)
 
-        assert self.controller.exit_popup.called
+        assert self.controller.exit_all_popups.called
 
     def test_keypress_exit_popup_invalid_key(
         self, widget_size: Callable[[Widget], urwid_Size]
@@ -622,19 +617,14 @@ class TestFullRawMsgView:
             *keys_for_command("EXIT_POPUP"),
         },
     )
-    def test_keypress_show_msg_info(
+    def test_keypress_exit_to_msg_info(
         self, key: str, widget_size: Callable[[Widget], urwid_Size]
     ) -> None:
         size = widget_size(self.full_raw_message)
 
         self.full_raw_message.keypress(size, key)
 
-        self.controller.show_msg_info.assert_called_once_with(
-            msg=self.message,
-            topic_links=OrderedDict(),
-            message_links=OrderedDict(),
-            time_mentions=list(),
-        )
+        assert self.controller.exit_popup.called
 
 
 class TestEditHistoryView:
@@ -671,14 +661,14 @@ class TestEditHistoryView:
         )
 
     @pytest.mark.parametrize("key", keys_for_command("MSG_INFO"))
-    def test_keypress_exit_popup(
+    def test_keypress_exit_all_popups(
         self, key: str, widget_size: Callable[[Widget], urwid_Size]
     ) -> None:
         size = widget_size(self.edit_history_view)
 
         self.edit_history_view.keypress(size, key)
 
-        assert self.controller.exit_popup.called
+        assert self.controller.exit_all_popups.called
 
     def test_keypress_exit_popup_invalid_key(
         self, widget_size: Callable[[Widget], urwid_Size]
@@ -700,12 +690,7 @@ class TestEditHistoryView:
 
         self.edit_history_view.keypress(size, key)
 
-        self.controller.show_msg_info.assert_called_once_with(
-            msg=self.message,
-            topic_links=OrderedDict(),
-            message_links=OrderedDict(),
-            time_mentions=list(),
-        )
+        assert self.controller.exit_popup.called
 
     @pytest.mark.parametrize(
         "snapshot",

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -86,6 +86,7 @@ class Controller:
         self.notify_enabled = notify
         self.maximum_footlinks = maximum_footlinks
         self.editor_command = editor_command
+        self.popup_stack: List[urwid.Widget] = []
 
         self.debug_path = debug_path
 
@@ -226,6 +227,8 @@ class Controller:
         return max_popup_cols, max_popup_rows
 
     def show_pop_up(self, to_show: Any, style: str) -> None:
+        self.popup_stack.append(self.loop.widget)
+
         text = urwid.Text(to_show.title, align="center")
         title_map = urwid.AttrMap(urwid.Filler(text), style)
         title_box_adapter = urwid.BoxAdapter(title_map, height=1)
@@ -249,6 +252,10 @@ class Controller:
         return isinstance(self.loop.widget, urwid.Overlay)
 
     def exit_popup(self) -> None:
+        self.loop.widget = self.popup_stack.pop()
+
+    def exit_all_popups(self) -> None:
+        self.popup_stack.clear()
         self.loop.widget = self.view
 
     def show_help(self) -> None:

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -348,61 +348,23 @@ class Controller:
             "area:user",
         )
 
-    def show_full_rendered_message(
-        self,
-        message: Message,
-        topic_links: Dict[str, Tuple[str, int, bool]],
-        message_links: Dict[str, Tuple[str, int, bool]],
-        time_mentions: List[Tuple[str, str]],
-    ) -> None:
+    def show_full_rendered_message(self, message: Message) -> None:
         self.show_pop_up(
             FullRenderedMsgView(
-                self,
-                message,
-                topic_links,
-                message_links,
-                time_mentions,
-                f"Full rendered message {SCROLL_PROMPT}",
+                self, message, f"Full rendered message {SCROLL_PROMPT}"
             ),
             "area:msg",
         )
 
-    def show_full_raw_message(
-        self,
-        message: Message,
-        topic_links: Dict[str, Tuple[str, int, bool]],
-        message_links: Dict[str, Tuple[str, int, bool]],
-        time_mentions: List[Tuple[str, str]],
-    ) -> None:
+    def show_full_raw_message(self, message: Message) -> None:
         self.show_pop_up(
-            FullRawMsgView(
-                self,
-                message,
-                topic_links,
-                message_links,
-                time_mentions,
-                f"Full raw message {SCROLL_PROMPT}",
-            ),
+            FullRawMsgView(self, message, f"Full raw message {SCROLL_PROMPT}"),
             "area:msg",
         )
 
-    def show_edit_history(
-        self,
-        message: Message,
-        topic_links: Dict[str, Tuple[str, int, bool]],
-        message_links: Dict[str, Tuple[str, int, bool]],
-        time_mentions: List[Tuple[str, str]],
-    ) -> None:
+    def show_edit_history(self, message: Message) -> None:
         self.show_pop_up(
-            EditHistoryView(
-                self,
-                message,
-                topic_links,
-                message_links,
-                time_mentions,
-                f"Edit History {SCROLL_PROMPT}",
-            ),
-            "area:msg",
+            EditHistoryView(self, message, f"Edit History {SCROLL_PROMPT}"), "area:msg"
         )
 
     def open_in_browser(self, url: str) -> None:

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -25,7 +25,7 @@ from zulipterminal.config.ui_sizes import (
     MAX_LINEAR_SCALING_WIDTH,
     MIN_SUPPORTED_POPUP_WIDTH,
 )
-from zulipterminal.helper import asynch, suppress_output
+from zulipterminal.helper import MessageInfoPopupContent, asynch, suppress_output
 from zulipterminal.model import Model
 from zulipterminal.platform_code import PLATFORM
 from zulipterminal.ui import Screen, View
@@ -270,19 +270,10 @@ class Controller:
         self.show_pop_up(EditModeView(self, button), "area:msg")
 
     def show_msg_info(
-        self,
-        msg: Message,
-        topic_links: Dict[str, Tuple[str, int, bool]],
-        message_links: Dict[str, Tuple[str, int, bool]],
-        time_mentions: List[Tuple[str, str]],
+        self, msg: Message, message_info_content: MessageInfoPopupContent
     ) -> None:
         msg_info_view = MsgInfoView(
-            self,
-            msg,
-            f"Message Information {SCROLL_PROMPT}",
-            topic_links,
-            message_links,
-            time_mentions,
+            self, msg, f"Message Information {SCROLL_PROMPT}", message_info_content
         )
         self.show_pop_up(msg_info_view, "area:msg")
 

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -57,6 +57,12 @@ class StreamData(TypedDict):
     description: str
 
 
+class MessageInfoPopupContent(TypedDict):
+    topic_links: Dict[str, Tuple[str, int, bool]]
+    message_links: Dict[str, Tuple[str, int, bool]]
+    time_mentions: List[Tuple[str, str]]
+
+
 class EmojiData(TypedDict):
     code: str
     aliases: List[str]

--- a/zulipterminal/ui_tools/messages.py
+++ b/zulipterminal/ui_tools/messages.py
@@ -29,7 +29,7 @@ from zulipterminal.config.symbols import (
     TIME_MENTION_MARKER,
 )
 from zulipterminal.config.ui_mappings import STATE_ICON, STREAM_ACCESS_TYPE
-from zulipterminal.helper import get_unused_fence
+from zulipterminal.helper import MessageInfoPopupContent, get_unused_fence
 from zulipterminal.server_url import near_message_url
 from zulipterminal.ui_tools.tables import render_table
 from zulipterminal.urwid_types import urwid_MarkupTuple, urwid_Size
@@ -1121,7 +1121,12 @@ class MessageBox(urwid.Pile):
             self.model.controller.view.middle_column.set_focus("footer")
         elif is_command_key("MSG_INFO", key):
             self.model.controller.show_msg_info(
-                self.message, self.topic_links, self.message_links, self.time_mentions
+                self.message,
+                MessageInfoPopupContent(
+                    topic_links=self.topic_links,
+                    message_links=self.message_links,
+                    time_mentions=self.time_mentions,
+                ),
             )
         elif is_command_key("ADD_REACTION", key):
             self.model.controller.show_emoji_picker(self.message)

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1725,30 +1725,15 @@ class MsgInfoView(PopUpView):
 
     def keypress(self, size: urwid_Size, key: str) -> str:
         if is_command_key("EDIT_HISTORY", key) and self.show_edit_history_label:
-            self.controller.show_edit_history(
-                message=self.msg,
-                topic_links=self.topic_links,
-                message_links=self.message_links,
-                time_mentions=self.time_mentions,
-            )
+            self.controller.show_edit_history(message=self.msg)
         elif is_command_key("VIEW_IN_BROWSER", key):
             url = near_message_url(self.server_url[:-1], self.msg)
             self.controller.open_in_browser(url)
         elif is_command_key("FULL_RENDERED_MESSAGE", key):
-            self.controller.show_full_rendered_message(
-                message=self.msg,
-                topic_links=self.topic_links,
-                message_links=self.message_links,
-                time_mentions=self.time_mentions,
-            )
+            self.controller.show_full_rendered_message(message=self.msg)
             return key
         elif is_command_key("FULL_RAW_MESSAGE", key):
-            self.controller.show_full_raw_message(
-                message=self.msg,
-                topic_links=self.topic_links,
-                message_links=self.message_links,
-                time_mentions=self.time_mentions,
-            )
+            self.controller.show_full_raw_message(message=self.msg)
             return key
         return super().keypress(size, key)
 

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1585,7 +1585,7 @@ class MsgInfoView(PopUpView):
         self.time_mentions = time_mentions
         self.server_url = controller.model.server_url
         date_and_time = controller.model.formatted_local_time(
-            msg["timestamp"], show_seconds=True, show_year=True
+            self.msg["timestamp"], show_seconds=True, show_year=True
         )
         view_in_browser_keys = "[{}]".format(
             ", ".join(map(str, display_keys_for_command("VIEW_IN_BROWSER")))
@@ -1602,8 +1602,8 @@ class MsgInfoView(PopUpView):
                 "",
                 [
                     ("Date & Time", date_and_time),
-                    ("Sender", msg["sender_full_name"]),
-                    ("Sender's Email ID", msg["sender_email"]),
+                    ("Sender", self.msg["sender_full_name"]),
+                    ("Sender's Email ID", self.msg["sender_email"]),
                 ],
             )
         ]
@@ -1632,13 +1632,13 @@ class MsgInfoView(PopUpView):
             )
             msg_info[1][1].append(("Edit History", keys))
         # Render the category using the existing table methods if links exist.
-        if message_links:
+        if self.message_links:
             msg_info.append(("Message Links", []))
-        if topic_links:
+        if self.topic_links:
             msg_info.append(("Topic Links", []))
-        if time_mentions:
-            msg_info.append(("Time mentions", time_mentions))
-        if msg["reactions"]:
+        if self.time_mentions:
+            msg_info.append(("Time mentions", self.time_mentions))
+        if self.msg["reactions"]:
             reactions = sorted(
                 (reaction["emoji_name"], reaction["user"]["full_name"])
                 for reaction in msg["reactions"]
@@ -1658,9 +1658,9 @@ class MsgInfoView(PopUpView):
         # computing their slice indexes
         self.button_widgets: List[Any] = []
 
-        if message_links:
+        if self.message_links:
             message_link_widgets, message_link_width = self.create_link_buttons(
-                controller, message_links
+                controller, self.message_links
             )
 
             # slice_index = Number of labels before message links + 1 newline
@@ -1669,16 +1669,16 @@ class MsgInfoView(PopUpView):
             slice_index = len(msg_info[0][1]) + len(msg_info[1][1]) + 2 + 2
 
             slice_index += sum([len(w) + 2 for w in self.button_widgets])
-            self.button_widgets.append(message_links)
+            self.button_widgets.append(self.message_links)
 
             widgets = (
                 widgets[:slice_index] + message_link_widgets + widgets[slice_index:]
             )
             popup_width = max(popup_width, message_link_width)
 
-        if topic_links:
+        if self.topic_links:
             topic_link_widgets, topic_link_width = self.create_link_buttons(
-                controller, topic_links
+                controller, self.topic_links
             )
 
             # slice_index = Number of labels before topic links + 1 newline
@@ -1686,7 +1686,7 @@ class MsgInfoView(PopUpView):
             #               + 2 for Viewing Actions category label and its newline
             slice_index = len(msg_info[0][1]) + len(msg_info[1][1]) + 2 + 2
             slice_index += sum([len(w) + 2 for w in self.button_widgets])
-            self.button_widgets.append(topic_links)
+            self.button_widgets.append(self.topic_links)
 
             widgets = widgets[:slice_index] + topic_link_widgets + widgets[slice_index:]
             popup_width = max(popup_width, topic_link_width)

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -36,6 +36,7 @@ from zulipterminal.config.ui_mappings import (
 )
 from zulipterminal.config.ui_sizes import LEFT_WIDTH
 from zulipterminal.helper import (
+    MessageInfoPopupContent,
     TidiedUserInfo,
     asynch,
     match_emoji,
@@ -1578,14 +1579,12 @@ class MsgInfoView(PopUpView):
         controller: Any,
         msg: Message,
         title: str,
-        topic_links: Dict[str, Tuple[str, int, bool]],
-        message_links: Dict[str, Tuple[str, int, bool]],
-        time_mentions: List[Tuple[str, str]],
+        message_info_content: MessageInfoPopupContent,
     ) -> None:
         self.msg = msg
-        self.topic_links = topic_links
-        self.message_links = message_links
-        self.time_mentions = time_mentions
+        self.topic_links = message_info_content["topic_links"]
+        self.message_links = message_info_content["message_links"]
+        self.time_mentions = message_info_content["time_mentions"]
         self.server_url = controller.model.server_url
         date_and_time = controller.model.formatted_local_time(
             self.msg["timestamp"], show_seconds=True, show_year=True

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1798,16 +1798,10 @@ class EditHistoryView(PopUpView):
         self,
         controller: Any,
         message: Message,
-        topic_links: Dict[str, Tuple[str, int, bool]],
-        message_links: Dict[str, Tuple[str, int, bool]],
-        time_mentions: List[Tuple[str, str]],
         title: str,
     ) -> None:
         self.controller = controller
         self.message = message
-        self.topic_links = topic_links
-        self.message_links = message_links
-        self.time_mentions = time_mentions
         width = 64
         widgets: List[Any] = []
 
@@ -1912,16 +1906,10 @@ class FullRenderedMsgView(PopUpView):
         self,
         controller: Any,
         message: Message,
-        topic_links: Dict[str, Tuple[str, int, bool]],
-        message_links: Dict[str, Tuple[str, int, bool]],
-        time_mentions: List[Tuple[str, str]],
         title: str,
     ) -> None:
         self.controller = controller
         self.message = message
-        self.topic_links = topic_links
-        self.message_links = message_links
-        self.time_mentions = time_mentions
         max_cols, max_rows = controller.maximum_popup_dimensions()
 
         # Get rendered message
@@ -1944,16 +1932,10 @@ class FullRawMsgView(PopUpView):
         self,
         controller: Any,
         message: Message,
-        topic_links: Dict[str, Tuple[str, int, bool]],
-        message_links: Dict[str, Tuple[str, int, bool]],
-        time_mentions: List[Tuple[str, str]],
         title: str,
     ) -> None:
         self.controller = controller
         self.message = message
-        self.topic_links = topic_links
-        self.message_links = message_links
-        self.time_mentions = time_mentions
         max_cols, max_rows = controller.maximum_popup_dimensions()
 
         # Get rendered message header and footer

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -959,12 +959,14 @@ class PopUpView(urwid.Frame):
         title: str,
         header: Optional[Any] = None,
         footer: Optional[Any] = None,
+        command_full_exit: Optional[str] = None,
     ) -> None:
         self.controller = controller
         self.command = command
         self.title = title
         self.log = urwid.SimpleFocusListWalker(body)
         self.body = urwid.ListBox(self.log)
+        self.command_full_exit = command_full_exit
 
         max_cols, max_rows = controller.maximum_popup_dimensions()
 
@@ -1060,7 +1062,8 @@ class PopUpView(urwid.Frame):
     def keypress(self, size: urwid_Size, key: str) -> str:
         if is_command_key("EXIT_POPUP", key) or is_command_key(self.command, key):
             self.controller.exit_popup()
-
+        elif self.command_full_exit and is_command_key(self.command_full_exit, key):
+            self.controller.exit_all_popups()
         return super().keypress(size, key)
 
 
@@ -1831,7 +1834,14 @@ class EditHistoryView(PopUpView):
             ]
             widgets.append(urwid.Text(feedback, align="center"))
 
-        super().__init__(controller, widgets, "MSG_INFO", width, title)
+        super().__init__(
+            controller,
+            widgets,
+            "EDIT_HISTORY",
+            width,
+            title,
+            command_full_exit="MSG_INFO",
+        )
 
     def _make_edit_block(self, snapshot: Dict[str, Any], tag: EditHistoryTag) -> Any:
         content = snapshot["content"]
@@ -1896,17 +1906,6 @@ class EditHistoryView(PopUpView):
 
         return author_prefix
 
-    def keypress(self, size: urwid_Size, key: str) -> str:
-        if is_command_key("EXIT_POPUP", key) or is_command_key("EDIT_HISTORY", key):
-            self.controller.show_msg_info(
-                msg=self.message,
-                topic_links=self.topic_links,
-                message_links=self.message_links,
-                time_mentions=self.time_mentions,
-            )
-            return key
-        return super().keypress(size, key)
-
 
 class FullRenderedMsgView(PopUpView):
     def __init__(
@@ -1931,25 +1930,13 @@ class FullRenderedMsgView(PopUpView):
         super().__init__(
             controller,
             [msg_box.content],
-            "MSG_INFO",
+            "FULL_RENDERED_MESSAGE",
             max_cols,
             title,
             urwid.Pile(msg_box.header),
             urwid.Pile(msg_box.footer),
+            command_full_exit="MSG_INFO",
         )
-
-    def keypress(self, size: urwid_Size, key: str) -> str:
-        if is_command_key("EXIT_POPUP", key) or is_command_key(
-            "FULL_RENDERED_MESSAGE", key
-        ):
-            self.controller.show_msg_info(
-                msg=self.message,
-                topic_links=self.topic_links,
-                message_links=self.message_links,
-                time_mentions=self.time_mentions,
-            )
-            return key
-        return super().keypress(size, key)
 
 
 class FullRawMsgView(PopUpView):
@@ -1983,23 +1970,13 @@ class FullRawMsgView(PopUpView):
         super().__init__(
             controller,
             body_list,
-            "MSG_INFO",
+            "FULL_RAW_MESSAGE",
             max_cols,
             title,
             urwid.Pile(msg_box.header),
             urwid.Pile(msg_box.footer),
+            command_full_exit="MSG_INFO",
         )
-
-    def keypress(self, size: urwid_Size, key: str) -> str:
-        if is_command_key("EXIT_POPUP", key) or is_command_key("FULL_RAW_MESSAGE", key):
-            self.controller.show_msg_info(
-                msg=self.message,
-                topic_links=self.topic_links,
-                message_links=self.message_links,
-                time_mentions=self.time_mentions,
-            )
-            return key
-        return super().keypress(size, key)
 
 
 class EmojiPickerView(PopUpView):


### PR DESCRIPTION
### What does this PR do, and why?

<details>
<summary>Old version</summary>

Refactoring: Group message data in a TypedDict / dataclass.

Group the following into a single piece of data, to simplify passing them as arguments across functions.
- message
- topic_links
- message_links
- time_mentions

Motivation: Was reviewing #1529, the redundancy felt awkward, addressed it with this PR.
Was previously discussed in #1455 comments.

</details>

**Objective**: Avoid passing Message Info data to all of its inner popups.

**Solution Steps:**

1. Introducing a Stacking of Popups
2. Extending PopupView to support a second command to allow both types of exiting.
3. Add a TypedDict to group the content of the message info popup

Why stack popups?
Currently, we create a new popup even when closing the uppermost popups.
With stacking, we can re-use the popups.
This allows us to not pass the entire data for creating the inner popups
to the outer popups.

Support 2 functions.
- Exiting the current popup - goes back to the previous popup.
- Exiting all popups - clears all popups.

Currently, the only popup that opens other popups is the MsgInfoView.
Affected widgets: EditHistoryView, FullRenderedMsgView, FullRawMsgView.

Hotkey behavior (from the widget):
- Press Esc or respective command -> go to MsgInfoView popup
- Press i from the widget -> close all popups (EXIT_POPUP command)

By adding new keypress handling to their parent PopupView, we can
pass their respective commands without having to implement custom
keypress handlers in each of the inner popup classes.


### External discussion & connections
- [ ] Discussed in **#zulip-terminal** in `Stacking of Popups (refactoring Message Info popup) #T1537`
- [ ] Fully fixes #
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [x] Merge will enable work on #1455 #1529

### How did you test this?
- [x] Manually - Behavioral changes
- [ ] Manually - Visual changes
- [x] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [x] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [ ] It contains test additions for any new behavior
- [x] It flows clearly from a previous branch commit, and/or prepares for the next commit