### PR TITLE
about_popup: Terminal size added in about popup.

### DIFF
--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -2,10 +2,12 @@ from collections import OrderedDict
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import pytest
+import urwid
 from pytest import param as case
 from pytest_mock import MockerFixture
 from urwid import Columns, Pile, Text, Widget
 
+from zulipterminal import urwid_types
 from zulipterminal.api_types import Message
 from zulipterminal.config.keys import is_command_key, keys_for_command
 from zulipterminal.config.ui_mappings import EDIT_MODE_CAPTIONS
@@ -195,6 +197,10 @@ class TestAboutView:
 
         mocker.patch(MODULE + ".detected_python_in_full", lambda: "[Python version]")
 
+
+        mock_screen = mocker.Mock(spec=urwid.raw_display.Screen)
+        mock_screen.get_cols_rows.return_value = (80, 24)
+
         self.about_view = AboutView(
             self.controller,
             "About",
@@ -208,6 +214,7 @@ class TestAboutView:
             maximum_footlinks=3,
             exit_confirmation_enabled=False,
             transparency_enabled=False,
+            screen=mock_screen,
         )
 
     @pytest.mark.parametrize(
@@ -246,6 +253,9 @@ class TestAboutView:
         mocker.patch(LISTWALKER, return_value=[])
         server_version, server_feature_level = zulip_version
 
+        mock_screen = mocker.Mock(spec=urwid.raw_display.Screen)
+        mock_screen.get_cols_rows.return_value = (80, 24)
+
         about_view = AboutView(
             self.controller,
             "About",
@@ -259,6 +269,7 @@ class TestAboutView:
             maximum_footlinks=3,
             exit_confirmation_enabled=False,
             transparency_enabled=False,
+            screen=mock_screen,
         )
 
         assert len(about_view.feature_level_content) == (
@@ -299,7 +310,8 @@ Transparency: disabled
 
 #### Detected Environment
 Platform: WSL
-Python: [Python version]"""
+Python: [Python version]
+Current terminal size: 80x24"""
         assert self.about_view.copy_info == expected_output
 
 

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -2,12 +2,10 @@ from collections import OrderedDict
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import pytest
-import urwid
 from pytest import param as case
 from pytest_mock import MockerFixture
 from urwid import Columns, Pile, Text, Widget
 
-from zulipterminal import urwid_types
 from zulipterminal.api_types import Message
 from zulipterminal.config.keys import is_command_key, keys_for_command
 from zulipterminal.config.ui_mappings import EDIT_MODE_CAPTIONS
@@ -197,10 +195,6 @@ class TestAboutView:
 
         mocker.patch(MODULE + ".detected_python_in_full", lambda: "[Python version]")
 
-
-        mock_screen = mocker.Mock(spec=urwid.raw_display.Screen)
-        mock_screen.get_cols_rows.return_value = (80, 24)
-
         self.about_view = AboutView(
             self.controller,
             "About",
@@ -214,7 +208,7 @@ class TestAboutView:
             maximum_footlinks=3,
             exit_confirmation_enabled=False,
             transparency_enabled=False,
-            screen=mock_screen,
+            terminal_size=(80, 24),
         )
 
     @pytest.mark.parametrize(
@@ -253,9 +247,6 @@ class TestAboutView:
         mocker.patch(LISTWALKER, return_value=[])
         server_version, server_feature_level = zulip_version
 
-        mock_screen = mocker.Mock(spec=urwid.raw_display.Screen)
-        mock_screen.get_cols_rows.return_value = (80, 24)
-
         about_view = AboutView(
             self.controller,
             "About",
@@ -269,14 +260,31 @@ class TestAboutView:
             maximum_footlinks=3,
             exit_confirmation_enabled=False,
             transparency_enabled=False,
-            screen=mock_screen,
+            terminal_size=(80, 24),
         )
 
         assert len(about_view.feature_level_content) == (
             1 if server_feature_level else 0
         )
 
-    def test_categories(self) -> None:
+    def test_categories(self, mocker: MockerFixture) -> None:
+        mocker.Mock()
+        self.about_view = AboutView(
+            self.controller,
+            "About",
+            zt_version=ZT_VERSION,
+            server_version=MINIMUM_SUPPORTED_SERVER_VERSION[0],
+            server_feature_level=MINIMUM_SUPPORTED_SERVER_VERSION[1],
+            theme_name="zt_dark",
+            color_depth=256,
+            notify_enabled=False,
+            autohide_enabled=False,
+            maximum_footlinks=3,
+            exit_confirmation_enabled=False,
+            transparency_enabled=False,
+            terminal_size=(80, 24),
+        )
+
         categories = [
             widget.text
             for widget in self.about_view.log
@@ -311,7 +319,7 @@ Transparency: disabled
 #### Detected Environment
 Platform: WSL
 Python: [Python version]
-Current terminal size: 80x24"""
+Current terminal size: 80 columns x 24 rows"""
         assert self.about_view.copy_info == expected_output
 
 

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -301,6 +301,7 @@ class Controller:
         self.show_pop_up(NoticeView(self, text, width, "NOTICE"), "area:error")
 
     def show_about(self) -> None:
+        screen = self.loop.screen
         self.show_pop_up(
             AboutView(
                 self,
@@ -315,6 +316,7 @@ class Controller:
                 maximum_footlinks=self.maximum_footlinks,
                 exit_confirmation_enabled=self.exit_confirmation,
                 transparency_enabled=self.transparency_enabled,
+                screen=screen,
             ),
             "area:help",
         )

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -301,7 +301,7 @@ class Controller:
         self.show_pop_up(NoticeView(self, text, width, "NOTICE"), "area:error")
 
     def show_about(self) -> None:
-        screen = self.loop.screen
+        terminal_size = self.loop.screen.get_cols_rows()
         self.show_pop_up(
             AboutView(
                 self,
@@ -316,7 +316,7 @@ class Controller:
                 maximum_footlinks=self.maximum_footlinks,
                 exit_confirmation_enabled=self.exit_confirmation,
                 transparency_enabled=self.transparency_enabled,
-                screen=screen,
+                terminal_size=terminal_size,
             ),
             "area:help",
         )

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1092,12 +1092,15 @@ class AboutView(PopUpView):
         notify_enabled: bool,
         exit_confirmation_enabled: bool,
         transparency_enabled: bool,
+        screen: urwid.raw_display.Screen,
     ) -> None:
         self.feature_level_content = (
             [("Feature level", str(server_feature_level))]
             if server_feature_level
             else []
         )
+
+        terminal_size = screen.get_cols_rows()
 
         contents = [
             ("Application", [("Zulip Terminal", zt_version)]),
@@ -1119,7 +1122,11 @@ class AboutView(PopUpView):
             ),
             (
                 "Detected Environment",
-                [("Platform", PLATFORM), ("Python", detected_python_in_full())],
+                [
+                    ("Platform", PLATFORM),
+                    ("Python", detected_python_in_full()),
+                    ("Current terminal size", f"{terminal_size[0]}x{terminal_size[1]}"),
+                ],
             ),
         ]
 
@@ -1137,7 +1144,6 @@ class AboutView(PopUpView):
 
         popup_width, column_widths = self.calculate_table_widths(contents, len(title))
         widgets = self.make_table_with_categories(contents, column_widths)
-
         super().__init__(controller, widgets, "ABOUT", popup_width, title)
 
     def keypress(self, size: urwid_Size, key: str) -> str:

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1076,10 +1076,6 @@ class NoticeView(PopUpView):
         super().__init__(controller, widgets, "EXIT_POPUP", width, title)
 
 
-
-
-
-
 class AboutView(PopUpView):
     def __init__(
         self,
@@ -1104,8 +1100,6 @@ class AboutView(PopUpView):
             else []
         )
 
-
-
         contents = [
             ("Application", [("Zulip Terminal", zt_version)]),
             ("Server", [("Version", server_version)] + self.feature_level_content),
@@ -1129,8 +1123,10 @@ class AboutView(PopUpView):
                 [
                     ("Platform", PLATFORM),
                     ("Python", detected_python_in_full()),
-                    ("Current terminal size",
-                     f"{terminal_size[0]} columns x {terminal_size[1]} rows"),
+                    (
+                        "Current terminal size",
+                        f"{terminal_size[0]} columns x {terminal_size[1]} rows",
+                    ),
                 ],
             ),
         ]
@@ -1155,10 +1151,6 @@ class AboutView(PopUpView):
         if is_command_key("COPY_ABOUT_INFO", key):
             self.controller.copy_to_clipboard(self.copy_info, "About info")
         return super().keypress(size, key)
-
-
-
-
 
 
 class UserInfoView(PopUpView):

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1076,6 +1076,10 @@ class NoticeView(PopUpView):
         super().__init__(controller, widgets, "EXIT_POPUP", width, title)
 
 
+
+
+
+
 class AboutView(PopUpView):
     def __init__(
         self,
@@ -1092,7 +1096,7 @@ class AboutView(PopUpView):
         notify_enabled: bool,
         exit_confirmation_enabled: bool,
         transparency_enabled: bool,
-        screen: urwid.raw_display.Screen,
+        terminal_size: Tuple[int, int],
     ) -> None:
         self.feature_level_content = (
             [("Feature level", str(server_feature_level))]
@@ -1100,7 +1104,7 @@ class AboutView(PopUpView):
             else []
         )
 
-        terminal_size = screen.get_cols_rows()
+
 
         contents = [
             ("Application", [("Zulip Terminal", zt_version)]),
@@ -1125,7 +1129,8 @@ class AboutView(PopUpView):
                 [
                     ("Platform", PLATFORM),
                     ("Python", detected_python_in_full()),
-                    ("Current terminal size", f"{terminal_size[0]}x{terminal_size[1]}"),
+                    ("Current terminal size",
+                     f"{terminal_size[0]} columns x {terminal_size[1]} rows"),
                 ],
             ),
         ]
@@ -1150,6 +1155,10 @@ class AboutView(PopUpView):
         if is_command_key("COPY_ABOUT_INFO", key):
             self.controller.copy_to_clipboard(self.copy_info, "About info")
         return super().keypress(size, key)
+
+
+
+
 
 
 class UserInfoView(PopUpView):


### PR DESCRIPTION
closes #1536 
<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?
Adds a Terminal size label under the "Detected Environment " in About popup

![image](https://github.com/user-attachments/assets/3fdac5f7-24cd-4d9c-9c82-57d6a9502cae)



### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [ ] Discussed in **#zulip-terminal** in `topic`
- [x] Fully fixes #1536 
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [x] Manually - Behavioral changes
- [x] Manually - Visual changes
- [x] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [ ] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [ ] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [ ] It has a commit summary describing the  motivation and reasoning for the change
- [ ] It individually passes linting and tests
- [ ] It contains test additions for any new behavior
- [ ] It flows clearly from a previous branch commit, and/or prepares for the next commit

### Visual changes    
![image](https://github.com/user-attachments/assets/dd593b3c-6b43-4a9f-8b59-6bac6f2de41f)


