### PR TITLE
Current Terminal size added in About popup

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -16,3 +16,5 @@ Zeeshan Equbal <equbalzeeshan@gmail.com>
 Mounil K. Shah <mounilshah271@gmail.com> <mkshah_b18@ce.vjti.ac.in>
 Mounil K. Shah <mounilshah271@gmail.com>
 Vishwesh Pillai <vishwesh103@gmail.com>
+Sashank Ravipati <sashankr04@gmail.com>
+Niloth P <20315308+Niloth-p@users.noreply.github.com>

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -195,6 +195,8 @@ class TestAboutView:
 
         mocker.patch(MODULE + ".detected_python_in_full", lambda: "[Python version]")
 
+        terminal_size = "24 rows x 80 cols"
+
         self.about_view = AboutView(
             self.controller,
             "About",
@@ -208,6 +210,7 @@ class TestAboutView:
             maximum_footlinks=3,
             exit_confirmation_enabled=False,
             transparency_enabled=False,
+            terminal_size=terminal_size,
         )
 
     @pytest.mark.parametrize(
@@ -259,6 +262,7 @@ class TestAboutView:
             maximum_footlinks=3,
             exit_confirmation_enabled=False,
             transparency_enabled=False,
+            terminal_size="24 rows x 80 cols",
         )
 
         assert len(about_view.feature_level_content) == (
@@ -299,7 +303,8 @@ Transparency: disabled
 
 #### Detected Environment
 Platform: WSL
-Python: [Python version]"""
+Python: [Python version]
+Terminal Size: 24 rows x 80 cols"""
         assert self.about_view.copy_info == expected_output
 
 

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -4,6 +4,7 @@ Defines the `Controller`, which sets up the `Model`, `View`, and how they intera
 
 import itertools
 import os
+import shutil
 import signal
 import sys
 import time
@@ -301,6 +302,9 @@ class Controller:
         self.show_pop_up(NoticeView(self, text, width, "NOTICE"), "area:error")
 
     def show_about(self) -> None:
+        terminal_size = shutil.get_terminal_size()
+        terminal_size_str = f"{terminal_size.columns} cols x {terminal_size.lines} rows"
+
         self.show_pop_up(
             AboutView(
                 self,
@@ -315,6 +319,7 @@ class Controller:
                 maximum_footlinks=self.maximum_footlinks,
                 exit_confirmation_enabled=self.exit_confirmation,
                 transparency_enabled=self.transparency_enabled,
+                terminal_size=terminal_size_str,
             ),
             "area:help",
         )

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1092,6 +1092,7 @@ class AboutView(PopUpView):
         notify_enabled: bool,
         exit_confirmation_enabled: bool,
         transparency_enabled: bool,
+        terminal_size: str,
     ) -> None:
         self.feature_level_content = (
             [("Feature level", str(server_feature_level))]
@@ -1119,7 +1120,11 @@ class AboutView(PopUpView):
             ),
             (
                 "Detected Environment",
-                [("Platform", PLATFORM), ("Python", detected_python_in_full())],
+                [
+                    ("Platform", PLATFORM),
+                    ("Python", detected_python_in_full()),
+                    ("Terminal Size", terminal_size),
+                ],
             ),
         ]
 


### PR DESCRIPTION
closes #1536 
<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?
Adds a Terminal size label under the "Detected Environment " in About popup

![image](https://github.com/user-attachments/assets/4eb02f62-ff76-42b8-af33-6ebdb472f424)




### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [ ] Discussed in **#zulip-terminal** in `topic`
- [x] Fully fixes #1536 
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [x] Manually - Behavioral changes
- [x] Manually - Visual changes
- [x] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [ ] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [ ] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [ ] It has a commit summary describing the  motivation and reasoning for the change
- [ ] It individually passes linting and tests
- [ ] It contains test additions for any new behavior
- [ ] It flows clearly from a previous branch commit, and/or prepares for the next commit

### Visual changes    
![image](https://github.com/user-attachments/assets/23a8dde8-ce78-4f48-842a-6e8dc7d06f90)


