### PR TITLE
Add support for Python 3.12

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -239,6 +239,7 @@ jobs:
           - {PYTHON: 3.9, OS: ubuntu-latest, NAME: "CPython 3.9 (ubuntu)", EXPECT: "Linux"}
           - {PYTHON: "3.10", OS: ubuntu-latest, NAME: "CPython 3.10 (ubuntu)", EXPECT: "Linux"}
           - {PYTHON: "3.11", OS: ubuntu-latest, NAME: "CPython 3.11 (ubuntu)", EXPECT: "Linux"}
+          - {PYTHON: "3.12", OS: ubuntu-latest, NAME: "CPython 3.12 (ubuntu)", EXPECT: "Linux"}
           - {PYTHON: 'pypy-3.7', OS: ubuntu-latest, NAME: "PyPy 3.7 (ubuntu)", EXPECT: "Linux"}
           - {PYTHON: 'pypy-3.8', OS: ubuntu-latest, NAME: "PyPy 3.8 (ubuntu)", EXPECT: "Linux"}
           - {PYTHON: 'pypy-3.9', OS: ubuntu-latest, NAME: "PyPy 3.9 (ubuntu)", EXPECT: "Linux"}

--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,7 @@ setup(
         "beautifulsoup4>=4.11.1",
         "lxml~=4.9.2",
         "pygments>=2.14.0,<2.18.0",
-        "typing_extensions~=4.5.0",
+        "typing_extensions~=4.7.1",
         "python-dateutil>=2.8.2",
         "pytz>=2022.7.1",
         "tzlocal>=2.1",

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ setup(
         "Issues": "https://github.com/zulip/zulip-terminal/issues",
         "Hot Keys": "https://github.com/zulip/zulip-terminal/blob/main/docs/hotkeys.md",
     },
-    python_requires=">=3.7, <3.12",
+    python_requires=">=3.7, <3.13",
     keywords="",
     packages=find_packages(exclude=["tests", "tests.*"]),
     zip_safe=True,


### PR DESCRIPTION
<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?

Allows developing and installing zulip-terminal with Python 3.12.

### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [x] Discussed in **#zulip-terminal** in [Support developing with Python 3.12 #T1541](https://chat.zulip.org/#narrow/stream/206-zulip-terminal/topic/Support.20developing.20with.20Python.203.2E12.20.23T1541)

### How did you test this?
<!-- [x] all that apply -->
- [ ] Manually - Behavioral changes
- [ ] Manually - Visual changes
- [x] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [x] It contains test additions for any new behavior
- [x] It flows clearly from a previous branch commit, and/or prepares for the next commit

