### PR TITLE
Handling Empty Narrows

### DIFF
--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -1913,6 +1913,7 @@ class TestModel:
         mocker.patch(MODEL + "._update_topic_index")
         mocker.patch(MODULE + ".index_messages", return_value={})
         self.controller.view.message_view = mocker.Mock(log=[])
+        self.controller.is_in_empty_narrow = False
         create_msg_box_list = mocker.patch(
             MODULE + ".create_msg_box_list", return_value=["msg_w"]
         )
@@ -1932,6 +1933,7 @@ class TestModel:
         mocker.patch(MODEL + "._update_topic_index")
         mocker.patch(MODULE + ".index_messages", return_value={})
         self.controller.view.message_view = mocker.Mock(log=[mocker.Mock()])
+        self.controller.is_in_empty_narrow = False
         create_msg_box_list = mocker.patch(
             MODULE + ".create_msg_box_list", return_value=["msg_w"]
         )
@@ -1954,6 +1956,7 @@ class TestModel:
         mocker.patch(MODEL + "._update_topic_index")
         mocker.patch(MODULE + ".index_messages", return_value={})
         self.controller.view.message_view = mocker.Mock(log=[mocker.Mock()])
+        self.controller.is_in_empty_narrow = False
         mocker.patch(MODULE + ".create_msg_box_list", return_value=["msg_w"])
         model.notify_user = mocker.Mock()
         set_count = mocker.patch(MODULE + ".set_count")
@@ -2097,6 +2100,7 @@ class TestModel:
         (
             self.controller.view.left_panel.is_in_topic_view_with_stream_id.return_value
         ) = False
+        self.controller.is_in_empty_narrow = False
         model.notify_user = mocker.Mock()
         model.narrow = narrow
         model.recipients = recipients

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -276,6 +276,7 @@ class TestMessageView:
     @pytest.mark.parametrize("key", keys_for_command("GO_DOWN"))
     def test_keypress_GO_DOWN(self, mocker, msg_view, key, widget_size):
         size = widget_size(msg_view)
+        msg_view.model.controller.is_in_empty_narrow = False
         msg_view.new_loading = False
         mocker.patch(MESSAGEVIEW + ".focus_position", return_value=0)
         mocker.patch(MESSAGEVIEW + ".set_focus_valign")
@@ -291,6 +292,7 @@ class TestMessageView:
         self, mocker, msg_view, key, widget_size, view_is_focused
     ):
         size = widget_size(msg_view)
+        msg_view.model.controller.is_in_empty_narrow = False
         msg_view.new_loading = False
         mocker.patch(MESSAGEVIEW + ".focus_position", return_value=0)
         mocker.patch(MESSAGEVIEW + ".set_focus_valign")
@@ -315,6 +317,7 @@ class TestMessageView:
     @pytest.mark.parametrize("key", keys_for_command("GO_UP"))
     def test_keypress_GO_UP(self, mocker, msg_view, key, widget_size):
         size = widget_size(msg_view)
+        msg_view.model.controller.is_in_empty_narrow = False
         mocker.patch(MESSAGEVIEW + ".focus_position", return_value=0)
         mocker.patch(MESSAGEVIEW + ".set_focus_valign")
         msg_view.old_loading = False
@@ -330,6 +333,7 @@ class TestMessageView:
         self, mocker, msg_view, key, widget_size, view_is_focused
     ):
         size = widget_size(msg_view)
+        msg_view.model.controller.is_in_empty_narrow = False
         msg_view.old_loading = False
         mocker.patch(MESSAGEVIEW + ".focus_position", return_value=0)
         mocker.patch(MESSAGEVIEW + ".set_focus_valign")

--- a/tests/ui_tools/test_messages.py
+++ b/tests/ui_tools/test_messages.py
@@ -838,6 +838,7 @@ class TestMessageBox:
                 "color": "#bd6",
             },
         }
+        self.model.controller.is_in_empty_narrow = False
         last_message = dict(message, **to_vary_in_last_message)
         msg_box = MessageBox(message, self.model, last_message)
         view_components = msg_box.main_view()
@@ -890,6 +891,7 @@ class TestMessageBox:
     def test_main_view_generates_PM_header(
         self, mocker, message, to_vary_in_last_message
     ):
+        self.model.controller.is_in_empty_narrow = False
         last_message = dict(message, **to_vary_in_last_message)
         msg_box = MessageBox(message, self.model, last_message)
         view_components = msg_box.main_view()
@@ -1032,9 +1034,11 @@ class TestMessageBox:
             },
         }
         self.model.narrow = msg_narrow
+        self.model.controller.is_in_empty_narrow = False
         messages = messages_successful_response["messages"]
         current_message = messages[msg_type]
         msg_box = MessageBox(current_message, self.model, messages[0])
+
         search_bar = msg_box.top_search_bar()
         header_bar = msg_box.recipient_header()
 
@@ -1405,6 +1409,7 @@ class TestMessageBox:
         report_error = msg_box.model.controller.report_error
         report_warning = msg_box.model.controller.report_warning
         mocker.patch(MODULE + ".time", return_value=100)
+        msg_box.model.controller.is_in_empty_narrow = False
 
         msg_box.keypress(size, key)
 
@@ -1820,6 +1825,7 @@ class TestMessageBox:
         varied_message = dict(message_fixture, **to_vary_in_each_message)
         msg_box = MessageBox(varied_message, self.model, None)
         reactions = to_vary_in_each_message["reactions"]
+        msg_box.model.controller.is_in_empty_narrow = False
 
         reactions_view = msg_box.reactions_view(reactions)
 
@@ -1976,6 +1982,7 @@ class TestMessageBox:
         mocker.patch.object(msg_box, "keypress")
         msg_box.model = mocker.Mock()
         msg_box.model.controller.is_in_editor_mode.return_value = compose_box_is_open
+        msg_box.model.controller.is_in_empty_narrow = False
 
         msg_box.mouse_event(size, "mouse press", 1, col, row, focus)
 

--- a/tests/ui_tools/test_messages.py
+++ b/tests/ui_tools/test_messages.py
@@ -65,12 +65,6 @@ class TestMessageBox:
         assert msg_box.message_links == OrderedDict()
         assert msg_box.time_mentions == list()
 
-    def test_init_fails_with_bad_message_type(self):
-        message = dict(type="BLAH")
-
-        with pytest.raises(RuntimeError):
-            MessageBox(message, self.model, None)
-
     def test_private_message_to_self(self, mocker):
         message = dict(
             type="private",

--- a/tests/ui_tools/test_messages.py
+++ b/tests/ui_tools/test_messages.py
@@ -48,6 +48,7 @@ class TestMessageBox:
             display_recipient=[
                 {"id": 7, "email": "boo@zulip.com", "full_name": "Boo is awesome"}
             ],
+            id=457823,
             stream_id=5,
             subject="hi",
             sender_email="foo@zulip.com",
@@ -71,6 +72,7 @@ class TestMessageBox:
             display_recipient=[
                 {"full_name": "Foo Foo", "email": "foo@zulip.com", "id": None}
             ],
+            id=457823,
             sender_id=9,
             content="<p> self message. </p>",
             sender_full_name="Foo Foo",
@@ -82,6 +84,7 @@ class TestMessageBox:
             MODULE + ".MessageBox._is_private_message_to_self", return_value=True
         )
         mocker.patch.object(MessageBox, "main_view")
+
         msg_box = MessageBox(message, self.model, None)
 
         assert msg_box.recipient_emails == ["foo@zulip.com"]
@@ -753,6 +756,7 @@ class TestMessageBox:
                 "color": "#bd6",
             },
         }
+        self.model.controller.is_in_empty_narrow = False
         MessageBox(message, self.model, last_message)
 
     @pytest.mark.parametrize(
@@ -1149,8 +1153,11 @@ class TestMessageBox:
     ):
         message_fixture.update({"id": 4})
         varied_message = dict(message_fixture, **to_vary_in_each_message)
+        self.model.controller.is_in_empty_narrow = False
         msg_box = MessageBox(varied_message, self.model, varied_message)
+
         view_components = msg_box.main_view()
+
         assert len(view_components) == 1
         assert isinstance(view_components[0], Padding)
 
@@ -1160,7 +1167,9 @@ class TestMessageBox:
         messages = messages_successful_response["messages"]
         for message in messages:
             self.model.index["edited_messages"].add(message["id"])
+            self.model.controller.is_in_empty_narrow = False
             msg_box = MessageBox(message, self.model, message)
+
             view_components = msg_box.main_view()
 
             label = view_components[0].original_widget.contents[0]
@@ -1186,6 +1195,7 @@ class TestMessageBox:
     ):
         message = message_fixture
         last_msg = dict(message, **to_vary_in_last_message)
+        self.model.controller.is_in_empty_narrow = False
 
         msg_box = MessageBox(message, self.model, last_msg)
 
@@ -1389,6 +1399,7 @@ class TestMessageBox:
             to_vary_in_each_message["subject"] = ""
         varied_message = dict(message_fixture, **to_vary_in_each_message)
         message_type = varied_message["type"]
+        self.model.controller.is_in_empty_narrow = False
         msg_box = MessageBox(varied_message, self.model, message_fixture)
         size = widget_size(msg_box)
         msg_box.model.user_id = 1

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -93,6 +93,7 @@ class Controller:
 
         self.active_conversation_info: Dict[str, Any] = {}
         self.is_typing_notification_in_progress = False
+        self.is_in_empty_narrow = False
 
         self.show_loading()
         client_identifier = f"ZulipTerminal/{ZT_VERSION} {platform()}"
@@ -598,6 +599,7 @@ class Controller:
         if len(msg_id_list) == 0 or (anchor is not None and anchor not in msg_id_list):
             self.model.get_messages(num_before=30, num_after=10, anchor=anchor)
             msg_id_list = self.model.get_message_ids_in_current_narrow()
+        self.is_in_empty_narrow = bool(len(msg_id_list) == 0)
 
         w_list = create_msg_box_list(self.model, msg_id_list, focus_msg_id=anchor)
 

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -504,13 +504,15 @@ class Controller:
             self, question, callback, location="center"
         )
 
-    def search_messages(self, text: str) -> None:
+    def search_messages(self, text: str) -> bool:
         # Search for a text in messages
         self.model.index["search"].clear()
         self.model.set_search_narrow(text)
 
         self.model.get_messages(num_after=0, num_before=30, anchor=10000000000)
         msg_id_list = self.model.get_message_ids_in_current_narrow()
+        if len(msg_id_list) == 0:
+            return False
 
         w_list = create_msg_box_list(self.model, msg_id_list)
         self.view.message_view.log.clear()
@@ -518,6 +520,7 @@ class Controller:
         focus_position = 0
         if 0 <= focus_position < len(w_list):
             self.view.message_view.set_focus(focus_position)
+        return True
 
     def save_draft_confirmation_popup(self, draft: Composition) -> None:
         question = urwid.Text(

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1742,6 +1742,9 @@ class Model:
                 msg_w = msg_w_list[0]
 
             if self.current_narrow_contains_message(message):
+                if self.controller.is_in_empty_narrow:
+                    del msg_log[0]
+                    self.controller.is_in_empty_narrow = False
                 msg_log.append(msg_w)
 
             self.controller.update_screen()

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -1014,7 +1014,7 @@ class MessageSearchBox(urwid.Pile):
                 self.text_box,
             ]
         )
-        self.msg_narrow = urwid.Text("DONT HIDE")
+        self.msg_narrow = urwid.Text("")
         self.recipient_bar = urwid.LineBox(
             self.msg_narrow,
             title="Current message recipients",

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -1032,9 +1032,11 @@ class MessageSearchBox(urwid.Pile):
             return key
 
         elif is_command_key("EXECUTE_SEARCH", key):
-            self.controller.exit_editor_mode()
-            self.controller.search_messages(self.text_box.edit_text)
-            self.controller.view.middle_column.set_focus("body")
+            if self.controller.search_messages(self.text_box.edit_text):
+                self.controller.exit_editor_mode()
+                self.controller.view.middle_column.set_focus("body")
+            else:
+                self.controller.report_error(["No results found."])
             return key
 
         key = super().keypress(size, key)

--- a/zulipterminal/ui_tools/messages.py
+++ b/zulipterminal/ui_tools/messages.py
@@ -115,6 +115,8 @@ class MessageBox(urwid.Pile):
         super().__init__(self.main_view())
 
     def need_recipient_header(self) -> bool:
+        if self.model.controller.is_in_empty_narrow:
+            return False
         # Prevent redundant information in recipient bar
         if len(self.model.narrow) == 1 and self.model.narrow[0][0] == "pm-with":
             return False

--- a/zulipterminal/ui_tools/messages.py
+++ b/zulipterminal/ui_tools/messages.py
@@ -683,7 +683,8 @@ class MessageBox(urwid.Pile):
             "recipients": recipient_header is not None,
             "author": message["this"]["author"] != message["last"]["author"],
             "24h": (
-                message["last"]["datetime"] is not None
+                message["this"]["datetime"] is not None
+                and message["last"]["datetime"] is not None
                 and ((message["this"]["datetime"] - message["last"]["datetime"]).days)
             ),
             "timestamp": (

--- a/zulipterminal/ui_tools/messages.py
+++ b/zulipterminal/ui_tools/messages.py
@@ -198,8 +198,23 @@ class MessageBox(urwid.Pile):
         header.markup = title_markup
         return header
 
+    def empty_narrow_header(self) -> Any:
+        title_markup = ("header", [("general_narrow", "No selected message")])
+        title = urwid.Text(title_markup)
+        header = urwid.Columns(
+            [
+                ("pack", title),
+                (1, urwid.Text(("general_bar", " "))),
+                urwid.AttrWrap(urwid.Divider(MESSAGE_HEADER_DIVIDER), "general_bar"),
+            ]
+        )
+        header.markup = title_markup
+        return header
+
     def recipient_header(self) -> Any:
-        if self.message["type"] == "stream":
+        if self.model.controller.is_in_empty_narrow:
+            return self.empty_narrow_header()
+        elif self.message["type"] == "stream":
             return self.stream_header()
         else:
             return self.private_header()

--- a/zulipterminal/ui_tools/messages.py
+++ b/zulipterminal/ui_tools/messages.py
@@ -904,7 +904,8 @@ class MessageBox(urwid.Pile):
         return super().mouse_event(size, event, button, col, row, focus)
 
     def keypress(self, size: urwid_Size, key: str) -> Optional[str]:
-        if is_command_key("REPLY_MESSAGE", key):
+        is_in_empty_narrow = self.model.controller.is_in_empty_narrow
+        if is_command_key("REPLY_MESSAGE", key) and not is_in_empty_narrow:
             if self.message["type"] == "private":
                 self.model.controller.view.write_box.private_box_view(
                     recipient_user_ids=self.recipient_ids,
@@ -923,7 +924,7 @@ class MessageBox(urwid.Pile):
                 )
             else:
                 self.model.controller.view.write_box.stream_box_view(0)
-        elif is_command_key("STREAM_NARROW", key):
+        elif is_command_key("STREAM_NARROW", key) and not is_in_empty_narrow:
             if self.message["type"] == "private":
                 self.model.controller.narrow_to_user(
                     recipient_emails=self.recipient_emails,
@@ -934,7 +935,7 @@ class MessageBox(urwid.Pile):
                     stream_name=self.stream_name,
                     contextual_message_id=self.message["id"],
                 )
-        elif is_command_key("TOGGLE_NARROW", key):
+        elif is_command_key("TOGGLE_NARROW", key) and not is_in_empty_narrow:
             self.model.unset_search_narrow()
             if self.message["type"] == "private":
                 if len(self.model.narrow) == 1 and self.model.narrow[0][0] == "pm-with":
@@ -958,7 +959,7 @@ class MessageBox(urwid.Pile):
                         topic_name=self.topic_name,
                         contextual_message_id=self.message["id"],
                     )
-        elif is_command_key("TOPIC_NARROW", key):
+        elif is_command_key("TOPIC_NARROW", key) and not is_in_empty_narrow:
             if self.message["type"] == "private":
                 self.model.controller.narrow_to_user(
                     recipient_emails=self.recipient_emails,
@@ -974,12 +975,12 @@ class MessageBox(urwid.Pile):
             self.model.controller.narrow_to_all_messages(
                 contextual_message_id=self.message["id"]
             )
-        elif is_command_key("REPLY_AUTHOR", key):
+        elif is_command_key("REPLY_AUTHOR", key) and not is_in_empty_narrow:
             # All subscribers from recipient_ids are not needed here.
             self.model.controller.view.write_box.private_box_view(
                 recipient_user_ids=[self.message["sender_id"]],
             )
-        elif is_command_key("MENTION_REPLY", key):
+        elif is_command_key("MENTION_REPLY", key) and not is_in_empty_narrow:
             self.keypress(size, primary_key_for_command("REPLY_MESSAGE"))
             mention = f"@**{self.message['sender_full_name']}** "
             self.model.controller.view.write_box.msg_write_box.set_edit_text(mention)
@@ -987,7 +988,7 @@ class MessageBox(urwid.Pile):
                 len(mention)
             )
             self.model.controller.view.middle_column.set_focus("footer")
-        elif is_command_key("QUOTE_REPLY", key):
+        elif is_command_key("QUOTE_REPLY", key) and not is_in_empty_narrow:
             self.keypress(size, primary_key_for_command("REPLY_MESSAGE"))
 
             # To correctly quote a message that contains quote/code-blocks,
@@ -1015,7 +1016,7 @@ class MessageBox(urwid.Pile):
             self.model.controller.view.write_box.msg_write_box.set_edit_text(quote)
             self.model.controller.view.write_box.msg_write_box.set_edit_pos(len(quote))
             self.model.controller.view.middle_column.set_focus("footer")
-        elif is_command_key("EDIT_MESSAGE", key):
+        elif is_command_key("EDIT_MESSAGE", key) and not is_in_empty_narrow:
             # User can't edit messages of others that already have a subject
             # For private messages, subject = "" (empty string)
             # This also handles the realm_message_content_edit_limit_seconds == 0 case
@@ -1119,12 +1120,12 @@ class MessageBox(urwid.Pile):
                 write_box.header_write_box.focus_col = write_box.FOCUS_HEADER_BOX_TOPIC
 
             self.model.controller.view.middle_column.set_focus("footer")
-        elif is_command_key("MSG_INFO", key):
+        elif is_command_key("MSG_INFO", key) and not is_in_empty_narrow:
             self.model.controller.show_msg_info(
                 self.message, self.topic_links, self.message_links, self.time_mentions
             )
-        elif is_command_key("ADD_REACTION", key):
+        elif is_command_key("ADD_REACTION", key) and not is_in_empty_narrow:
             self.model.controller.show_emoji_picker(self.message)
-        elif is_command_key("MSG_SENDER_INFO", key):
+        elif is_command_key("MSG_SENDER_INFO", key) and not is_in_empty_narrow:
             self.model.controller.show_msg_sender_info(self.message["sender_id"])
         return key

--- a/zulipterminal/ui_tools/messages.py
+++ b/zulipterminal/ui_tools/messages.py
@@ -81,13 +81,10 @@ class MessageBox(urwid.Pile):
             self.stream_name = self.message["display_recipient"]
             self.stream_id = self.message["stream_id"]
             self.topic_name = self.message["subject"]
-        elif self.message["type"] == "private":
+        else:
             self.email = self.message["sender_email"]
             self.user_id = self.message["sender_id"]
-        else:
-            raise RuntimeError("Invalid message type")
 
-        if self.message["type"] == "private":
             if self._is_private_message_to_self():
                 recipient = self.message["display_recipient"][0]
                 self.recipients_names = recipient["full_name"]

--- a/zulipterminal/ui_tools/messages.py
+++ b/zulipterminal/ui_tools/messages.py
@@ -82,8 +82,10 @@ class MessageBox(urwid.Pile):
             self.stream_id = self.message["stream_id"]
             self.topic_name = self.message["subject"]
         else:
-            self.email = self.message["sender_email"]
-            self.user_id = self.message["sender_id"]
+            # Get sender details only for non-empty narrows
+            if self.message.get("id") is not None:
+                self.email = self.message["sender_email"]
+                self.user_id = self.message["sender_id"]
 
             if self._is_private_message_to_self():
                 recipient = self.message["display_recipient"][0]

--- a/zulipterminal/ui_tools/utils.py
+++ b/zulipterminal/ui_tools/utils.py
@@ -29,6 +29,46 @@ def create_msg_box_list(
     focus_msg = None
     last_msg = last_message
     muted_msgs = 0  # No of messages that are muted.
+
+    # Add a dummy message if no new or old messages are found
+    if not message_list and not last_msg:
+        message_type = "stream" if model.stream_id is not None else "private"
+        dummy_message = {
+            "id": None,
+            "content": (
+                "No search hits" if model.is_search_narrow() else "No messages here"
+            ),
+            "is_me_message": False,
+            "flags": ["read"],
+            "reactions": [],
+            "type": message_type,
+            "stream_id": model.stream_id if message_type == "stream" else None,
+            "stream_name": model.stream_dict[model.stream_id]["name"]
+            if message_type == "stream"
+            else None,
+            "subject": next(
+                (subnarrow[1] for subnarrow in model.narrow if subnarrow[0] == "topic"),
+                "No topics in channel",
+            )
+            if message_type == "stream"
+            else None,
+            "display_recipient": (
+                model.stream_dict[model.stream_id]["name"]
+                if message_type == "stream"
+                else [
+                    {
+                        "email": model.user_id_email_dict[recipient_id],
+                        "full_name": model.user_dict[
+                            model.user_id_email_dict[recipient_id]
+                        ]["full_name"],
+                        "id": recipient_id,
+                    }
+                    for recipient_id in model.recipients
+                ]
+            ),
+        }
+        message_list.append(dummy_message)
+
     for msg in message_list:
         if is_unsubscribed_message(msg, model):
             continue

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -193,6 +193,8 @@ class MessageView(urwid.ListBox):
         return super().mouse_event(size, event, button, col, row, focus)
 
     def keypress(self, size: urwid_Size, key: str) -> Optional[str]:
+        if self.model.controller.is_in_empty_narrow:
+            return super().keypress(size, key)
         if is_command_key("GO_DOWN", key) and not self.new_loading:
             try:
                 position = self.log.next_position(self.focus_position)


### PR DESCRIPTION
### What does this PR do, and why?
Fixes all the bugs related to empty narrows, and recipient bars when a message is not selected.

### External discussion & connections
- [ ] Discussed in **#zulip-terminal** in `topic`
- [x] Fully fixes #895
- [x] Partially fixes issue #1506 
- [x] Builds upon previous unmerged work in PR #278
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### Solution Space Exploration

Before settling on the dummy message approach, I explored a few other solutions as well:

1. I explored not switching narrows to empty narrows. We'd need to do some refactoring to `get_message_ids_in_current_narrow` to allow checking if a future narrow is empty, before switching to it.

2. And I also explored whether we could expand our system of handling narrows to also cater to narrows without messages, without handling it as an exception case and introducing a dummy message. I tried to move `top_search_bar` and `recipient_header` outside of `MessageBox` to change how they're tightly tied to the focused message, which is why they're not updated currently when in an empty narrow, and the erratic behavior.

3. Instead of a dummy message, I gave a shot at using a Text widget replacing the entire MessageView, like we do with the `PanelSearchBox`es when there are no search hits. But yes, I ran into a few cases with focus issues.
I tried moving the Text element inside, and modifying/turning off the `ModListWalker`'s action each time, to make it behave similar to the `SimpleFocusListWalker`, but that still wasn't a clean fix.

And other similar tangents, before realising the dummy message approach is the solid one, even if we were to implement any of these in the future, especially the 1st approach, the dummy message should be a backup.

I'm sure a more experienced person would have been able to figure this out much faster than I did, and without all this exploration, so I'd be interested in hearing the thinking process of someone who was able to / can narrow in on (pun intended) the dummy message solution right away.

I also decided against removing the message recipients section for empty narrows, because currently when opening the app, it shows up with "DONT HIDE", so I went with a solution that conforms to that behavior.

### Outstanding aspect(s)
- I've added the features for the dummy message, before adding the dummy message, so that it starts working as soon as added.
- Placed the current narrow state tracking variable in the controller class.
- I wasn't able to use even a single line of code as-is from #278, as this PR is quite different and uses several different decisions, so I just decided to add 278's author as a co-author for all ideas that were inspired from their PR.
- I haven't added "bugfix" prefix to the commit messages, should I add it to the commit that wires the dummy message?

### Next Steps
- [ ] Adding tests for empty narrows. None of the commits currently have any new tests.
- [ ] This introduces a bug. When you have an empty search narrow. And you receive a message event for that narrow, the message does not display until you restart the application, although it adds to the unread count.
I didn't want to hold back on the reviews any longer, so I've pushed the PR and will look into this soon.

### Follow-ups
- [ ] When activating user buttons, check if there exist previous DMs with the user, and if not, just open the compose box and do not switch to that narrow.
- [ ] When a new message arrives in an empty DM narrow, the recipient header (above the message, not the one in the recipient bar) is not inserted newly. It automatically gets fixed when one more new message arrives. I think it's not a high priority bug, since the recipient bar already matches the recipient header for the DM case.

### How did you test this?
- [x] Manually - Behavioral changes
- [x] Manually - Visual changes
- [x] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [ ] It contains test additions for any new behavior
- [x] It flows clearly from a previous branch commit, and/or prepares for the next commit
