### PR TITLE
Support (un)resolving topics

### DIFF
--- a/docs/hotkeys.md
+++ b/docs/hotkeys.md
@@ -75,6 +75,11 @@
 |Show/hide user information|<kbd>i</kbd>|
 |Narrow to direct messages with user|<kbd>Enter</kbd>|
 
+## Topic list actions
+|Command|Key Combination|
+| :--- | :---: |
+|Show/hide topic information & (un)resolve topic|<kbd>i</kbd>|
+
 ## Begin composing a message
 |Command|Key Combination|
 | :--- | :---: |

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -312,6 +312,11 @@ KEY_BINDINGS: Dict[str, KeyBinding] = {
         'help_text': 'Show/hide stream information & modify settings',
         'key_category': 'stream_list',
     },
+    'TOPIC_INFO': {
+        'keys': ['i'],
+        'help_text': 'Show/hide topic information & (un)resolve topic',
+        'key_category': 'topic_list',
+    },
     'STREAM_MEMBERS': {
         'keys': ['m'],
         'help_text': 'Show/hide stream members',
@@ -467,6 +472,7 @@ HELP_CATEGORIES = {
     "msg_actions": "Message actions",
     "stream_list": "Stream list actions",
     "user_list": "User list actions",
+    "topic_list": "Topic list actions",
     "open_compose": "Begin composing a message",
     "compose_box": "Writing a message",
     "editor_navigation": "Editor: Navigation",

--- a/zulipterminal/config/themes.py
+++ b/zulipterminal/config/themes.py
@@ -71,6 +71,7 @@ REQUIRED_STYLES = {
     'area:help'       : 'standout',
     'area:msg'        : 'standout',
     'area:stream'     : 'standout',
+    'area:topic'      : 'standout',
     'area:error'      : 'standout',
     'area:user'       : 'standout',
     'search_error'    : 'standout',

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -44,6 +44,7 @@ from zulipterminal.ui_tools.views import (
     PopUpConfirmationView,
     StreamInfoView,
     StreamMembersView,
+    TopicInfoView,
     UserInfoView,
 )
 from zulipterminal.version import ZT_VERSION
@@ -292,6 +293,10 @@ class Controller:
     def show_stream_info(self, stream_id: int) -> None:
         show_stream_view = StreamInfoView(self, stream_id)
         self.show_pop_up(show_stream_view, "area:stream")
+
+    def show_topic_info(self, stream_id: int, topic_name: str) -> None:
+        show_topic_view = TopicInfoView(self, stream_id, topic_name)
+        self.show_pop_up(show_topic_view, "area:topic")
 
     def show_stream_members(self, stream_id: int) -> None:
         stream_members_view = StreamMembersView(self, stream_id)

--- a/zulipterminal/themes/gruvbox_dark.py
+++ b/zulipterminal/themes/gruvbox_dark.py
@@ -68,6 +68,7 @@ STYLES = {
     'area:help'        : (Color.DARK0_HARD,            Color.BRIGHT_GREEN),
     'area:msg'         : (Color.DARK0_HARD,            Color.NEUTRAL_PURPLE),
     'area:stream'      : (Color.DARK0_HARD,            Color.BRIGHT_BLUE),
+    'area:topic'       : (Color.DARK0_HARD,            Color.BRIGHT_BLUE),
     'area:error'       : (Color.DARK0_HARD,            Color.BRIGHT_RED),
     'area:user'        : (Color.DARK0_HARD,            Color.BRIGHT_YELLOW),
     'search_error'     : (Color.BRIGHT_RED,            Background.COLOR),

--- a/zulipterminal/themes/gruvbox_light.py
+++ b/zulipterminal/themes/gruvbox_light.py
@@ -67,6 +67,7 @@ STYLES = {
     'area:help'        : (Color.LIGHT0_HARD,            Color.FADED_GREEN),
     'area:msg'         : (Color.LIGHT0_HARD,            Color.NEUTRAL_PURPLE),
     'area:stream'      : (Color.LIGHT0_HARD,            Color.FADED_BLUE),
+    'area:topic'       : (Color.LIGHT0_HARD,            Color.FADED_BLUE),
     'area:error'       : (Color.LIGHT0_HARD,            Color.FADED_RED),
     'area:user'        : (Color.LIGHT0_HARD,            Color.FADED_YELLOW),
     'search_error'     : (Color.FADED_RED,              Background.COLOR),

--- a/zulipterminal/themes/zt_blue.py
+++ b/zulipterminal/themes/zt_blue.py
@@ -61,6 +61,7 @@ STYLES = {
     'widget_disabled' : (Color.DARK_GRAY,           Background.COLOR),
     'area:help'       : (Color.WHITE,               Color.DARK_GREEN),
     'area:stream'     : (Color.WHITE,               Color.DARK_CYAN),
+    'area:topic'      : (Color.WHITE,               Color.DARK_CYAN),
     'area:msg'        : (Color.WHITE,               Color.BROWN),
     'area:error'      : (Color.WHITE,               Color.DARK_RED),
     'area:user'       : (Color.WHITE,               Color.DARK_BLUE),

--- a/zulipterminal/themes/zt_dark.py
+++ b/zulipterminal/themes/zt_dark.py
@@ -62,6 +62,7 @@ STYLES = {
     'area:help'       : (Color.WHITE,               Color.DARK_GREEN),
     'area:msg'        : (Color.WHITE,               Color.BROWN),
     'area:stream'     : (Color.WHITE,               Color.DARK_CYAN),
+    'area:topic'      : (Color.WHITE,               Color.DARK_CYAN),
     'area:error'      : (Color.WHITE,               Color.DARK_RED),
     'area:user'       : (Color.WHITE,               Color.DARK_BLUE),
     'search_error'    : (Color.LIGHT_RED,           Background.COLOR),

--- a/zulipterminal/themes/zt_light.py
+++ b/zulipterminal/themes/zt_light.py
@@ -61,6 +61,7 @@ STYLES = {
     'widget_disabled' : (Color.LIGHT_GRAY,          Background.COLOR),
     'area:help'       : (Color.BLACK,               Color.LIGHT_GREEN),
     'area:stream'     : (Color.BLACK,               Color.LIGHT_BLUE),
+    'area:topic'      : (Color.BLACK,               Color.LIGHT_BLUE),
     'area:msg'        : (Color.BLACK,               Color.YELLOW),
     'area:error'      : (Color.BLACK,               Color.LIGHT_RED),
     'area:user'       : (Color.WHITE,               Color.DARK_BLUE),

--- a/zulipterminal/ui_tools/buttons.py
+++ b/zulipterminal/ui_tools/buttons.py
@@ -381,6 +381,8 @@ class TopicButton(TopButton):
             # Exit topic view
             self.view.associate_stream_with_topic(self.stream_id, self.topic_name)
             self.view.left_panel.show_stream_view()
+        elif is_command_key("TOPIC_INFO", key):
+            self.model.controller.show_topic_info(self.stream_id, self.topic_name)
         return super().keypress(size, key)
 
 

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -10,7 +10,7 @@ import pytz
 import urwid
 from typing_extensions import Literal
 
-from zulipterminal.api_types import EditPropagateMode, Message
+from zulipterminal.api_types import RESOLVED_TOPIC_PREFIX, EditPropagateMode, Message
 from zulipterminal.config.keys import (
     HELP_CATEGORIES,
     KEY_BINDINGS,
@@ -25,6 +25,7 @@ from zulipterminal.config.symbols import (
     COLUMN_TITLE_BAR_LINE,
     PINNED_STREAMS_DIVIDER,
     SECTION_DIVIDER_LINE,
+    STREAM_TOPIC_SEPARATOR,
 )
 from zulipterminal.config.ui_mappings import (
     BOT_TYPE_BY_ID,
@@ -1567,6 +1568,65 @@ class StreamMembersView(PopUpView):
             self.controller.show_stream_info(stream_id=self.stream_id)
             return key
         return super().keypress(size, key)
+
+
+class TopicInfoView(PopUpView):
+    def __init__(self, controller: Any, stream_id: int, topic: str) -> None:
+        self.stream_id = stream_id
+        self.controller = controller
+        stream = controller.model.stream_dict[stream_id]
+        self.topic_name = topic
+        stream_name = stream["name"]
+
+        title = f"{stream_name} {STREAM_TOPIC_SEPARATOR} {self.topic_name}"
+
+        topic_info_content: PopUpViewTableContent = []
+
+        popup_width, column_widths = self.calculate_table_widths(
+            topic_info_content, len(title)
+        )
+
+        if self.topic_name.startswith(RESOLVED_TOPIC_PREFIX):
+            self.resolve_topic_setting_button_label = "Unresolve Topic"
+        else:
+            self.resolve_topic_setting_button_label = "Resolve Topic"
+        resolve_topic_setting = urwid.Button(
+            self.resolve_topic_setting_button_label,
+            self.toggle_resolve_status,
+        )
+
+        curs_pos = len(self.resolve_topic_setting_button_label) + 1
+        # This shifts the cursor present over the first character of
+        # resolve_topic_button_setting label to last character + 1 so that it isn't
+        # visible
+
+        resolve_topic_setting._w = urwid.AttrMap(
+            urwid.SelectableIcon(
+                self.resolve_topic_setting_button_label, cursor_position=curs_pos
+            ),
+            None,
+            "selected",
+        )
+
+        # Manual because calculate_table_widths does not support buttons.
+        # Add 4 to button label to accommodate the buttons itself.
+        popup_width = max(
+            popup_width,
+            len(resolve_topic_setting.label) + 4,
+        )
+
+        self.widgets = self.make_table_with_categories(
+            topic_info_content, column_widths
+        )
+
+        self.widgets.append(resolve_topic_setting)
+        super().__init__(controller, self.widgets, "TOPIC_INFO", popup_width, title)
+
+    def toggle_resolve_status(self, args: Any) -> None:
+        self.controller.model.toggle_topic_resolve_status(
+            stream_id=self.stream_id, topic_name=self.topic_name
+        )
+        self.controller.exit_popup()
 
 
 class MsgInfoView(PopUpView):


### PR DESCRIPTION
<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?
This PR adds support for (un)resolving topics in ZT via TopicInfoView popup menu when topic is highlighted in left_stream_bar and i key is pressed to toggle topic settings.

Changes with respect to completion candidate PR:
- Added support beyond ZFL 183:
[Before Zulip 7.0 (feature level 183), the realm_community_topic_editing_limit_seconds property was returned by the response. It was removed because it had not been in use since the realm setting move_messages_within_stream_limit_seconds was introduced in feature level 162. ](https://zulip.com/api/register-queue)

- Changes to tests
- Dropped the first commit



### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [x] Discussed in **#zulip-terminal** in `Support (un)resolving topics #T1235 (fix #T1075)`
- [x] Fully fixes #1075 
- [ ] Partially fixes issue #
- [x] Builds upon previous unmerged work in PR #1235 
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [x] Manually - Behavioral changes
- [x] Manually - Visual changes
- [x] Adapting existing automated tests
- [x] Adding automated tests for new behavior (or missing tests)
- [x] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [x] It contains test additions for any new behavior
- [x] It flows clearly from a previous branch commit, and/or prepares for the next commit

### Visual changes    <!-- DELETE SECTION IF NO VISUAL CHANGE -->
| | |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/fb32f4f6-d2af-45a1-a0c5-149c9500b3d1)| ![image](https://github.com/user-attachments/assets/b0d4eab4-dbf6-462b-ab9f-48d16c6fefeb)|
