### PR TITLE
Add linting for HELP_CATEGORIES

### DIFF
--- a/tools/lint-hotkeys
+++ b/tools/lint-hotkeys
@@ -30,6 +30,7 @@ def main(fix: bool) -> None:
     if fix:
         generate_hotkeys_file()
     else:
+        lint_help_categories()
         lint_hotkeys_file()
 
 
@@ -78,6 +79,22 @@ def lint_hotkeys_file() -> None:
             )
             error_flag = 1
     sys.exit(error_flag)
+
+
+def lint_help_categories() -> None:
+    """
+    Check if HELP_CATEGORIES contains all key categories
+    """
+    missing_categories = [
+        binding["key_category"]
+        for binding in KEY_BINDINGS.values()
+        if binding["key_category"] not in HELP_CATEGORIES
+    ]
+    if missing_categories:
+        print(
+            f"Missing categories in HELP_CATEGORIES (keys.py file): {missing_categories}"
+        )
+        sys.exit(1)
 
 
 def generate_hotkeys_file() -> None:


### PR DESCRIPTION
### What does this PR do, and why?
I was working on #1544 and added a new key under a new `topic_actions` category. I noticed that while linting passed, the `hotkeys.md` file wasn’t updating correctly when I ran `--fix`. It turned out the issue was that the `HELP_CATEGORIES` dictionary wasn't updated, so I added linting for that.


- Implemented a linting check to ensure all `key_category` values in `KEY_BINDINGS` are present in the `HELP_CATEGORIES` dictionary.
- Added functionality to print any missing categories if they are not found in `HELP_CATEGORIES`.

| New category | No new category |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/cec7d447-5fe3-48cd-aec8-3bb64d684f3e) | ![image](https://github.com/user-attachments/assets/e42b4480-2c94-4f96-a728-7c4f8f6eb3dd)| 

### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [ ] Discussed in **#zulip-terminal** in `topic`
- [ ] Fully fixes #
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [x] Manually - Behavioral changes
- [ ] Manually - Visual changes
- [ ] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [ ] It contains test additions for any new behavior
- [x] It flows clearly from a previous branch commit, and/or prepares for the next commit
