### PR TITLE
[WIP] Support muted users

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -903,6 +903,7 @@ def initial_data(
             }
         ],
         "result": "success",
+        "muted_users": {},
         "queue_id": "1522420755:786",
         "realm_users": users_fixture,
         "cross_realm_bots": [

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -229,6 +229,7 @@ class TestController:
         controller.view.message_view = mocker.patch("urwid.ListBox")
         controller.model.user_id = 5140
         controller.model.user_email = "some@email"
+        controller.model._muted_users = set()
         controller.model.user_dict = {
             user_email: {
                 "user_id": user_id,
@@ -267,6 +268,7 @@ class TestController:
         controller.view.message_view = mocker.patch("urwid.ListBox")
         controller.model.user_email = "some@email"
         controller.model.user_id = 1
+        controller.model._muted_users = set()
         controller.model.stream_dict = {
             205: {
                 "color": "#ffffff",
@@ -295,6 +297,7 @@ class TestController:
         controller.view.message_view = mocker.patch("urwid.ListBox")
         controller.model.user_id = 1
         controller.model.user_email = "some@email"
+        controller.model._muted_users = set()
 
         controller.narrow_to_all_pm()  # FIXME: Add id narrowing test
 
@@ -316,6 +319,7 @@ class TestController:
         # FIXME: Expand upon is_muted_topic().
         mocker.patch(MODEL + ".is_muted_topic", return_value=False)
         controller.model.user_email = "some@email"
+        controller.model._muted_users = set()
         controller.model.stream_dict = {
             205: {
                 "color": "#ffffff",
@@ -343,6 +347,7 @@ class TestController:
         mocker.patch(MODEL + ".is_muted_topic", return_value=False)
         controller.model.user_email = "some@email"
         controller.model.user_id = 1
+        controller.model._muted_users = set()
         controller.model.stream_dict = {
             205: {
                 "color": "#ffffff",

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -275,6 +275,7 @@ class TestModel:
             "user_settings",
             "realm_emoji",
             "realm_user",
+            "muted_users",
         ]
         fetch_event_types = [
             "realm",

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -4113,6 +4113,17 @@ class TestModel:
         assert return_value == is_muted
 
     @pytest.mark.parametrize(
+        "user, is_muted",
+        [
+            case(1, False, id="unmuted_user"),
+            case(2, True, id="muted_user"),
+        ],
+    )
+    def test_is_muted_user(self, user, is_muted, model):
+        model._muted_users = {2}
+        assert model.is_muted_user(user) == is_muted
+
+    @pytest.mark.parametrize(
         "unread_topics, current_topic, next_unread_topic",
         [
             case(

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -190,6 +190,36 @@ class TestModel:
 
         assert model._muted_topics == locally_processed_data
 
+    @pytest.mark.parametrize(
+        "server_response, ids, zulip_feature_level",
+        [
+            (
+                [
+                    {"id": 32323, "timestamp": 1726810359},
+                    {"id": 37372, "timestamp": 214214214},
+                ],
+                {32323, 37372},
+                48,
+            ),
+            ([], set(), 0),
+        ],
+        ids=[
+            "zulip_feature_level:48",
+            "zulip_feature_level:0",
+        ],
+    )
+    def test_init_muted_users(
+        self, mocker, initial_data, server_response, ids, zulip_feature_level
+    ):
+        mocker.patch(MODEL + ".get_messages", return_value="")
+        initial_data["zulip_feature_level"] = zulip_feature_level
+        initial_data["muted_users"] = server_response
+        self.client.register = mocker.Mock(return_value=initial_data)
+
+        model = Model(self.controller)
+
+        assert model._muted_users == ids
+
     def test_init_InvalidAPIKey_response(self, mocker, initial_data):
         # Both network calls indicate the same response
         mocker.patch(MODEL + ".get_messages", return_value="Invalid API key")
@@ -262,6 +292,7 @@ class TestModel:
             "realm_emoji",
             "custom_profile_fields",
             "zulip_version",
+            "muted_users",
         ]
         model.client.register.assert_called_once_with(
             event_types=event_types,

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1078,6 +1078,8 @@ class TestRightColumnView:
         user_btn = mocker.patch(VIEWS + ".UserButton")
         users_view = mocker.patch(VIEWS + ".UsersView")
         right_col_view = RightColumnView(self.view)
+        mocker.patch("zulipterminal.model.Model.is_muted_user", return_value=False)
+        self.view.model.is_muted_user.return_value = False
         if status != "inactive":
             user_btn.assert_called_once_with(
                 user=self.view.users[0],

--- a/tests/ui_tools/test_messages.py
+++ b/tests/ui_tools/test_messages.py
@@ -776,6 +776,7 @@ class TestMessageBox:
                 "reactions": [],
                 "sender_full_name": "Alice",
                 "timestamp": 1532103879,
+                "sender_id": 32900,
             }
         ],
     )
@@ -814,6 +815,7 @@ class TestMessageBox:
                 "reactions": [],
                 "sender_full_name": "Alice",
                 "timestamp": 1532103879,
+                "sender_id": 32900,
             }
         ],
     )
@@ -867,6 +869,7 @@ class TestMessageBox:
                 "reactions": [],
                 "sender_full_name": "Alice",
                 "timestamp": 1532103879,
+                "sender_id": 32900,
             },
         ],
     )
@@ -1057,6 +1060,7 @@ class TestMessageBox:
                 "reactions": [],
                 "sender_full_name": "alice",
                 "timestamp": 1532103879,
+                "sender_id": 32900,
             }
         ],
     )
@@ -1116,6 +1120,8 @@ class TestMessageBox:
         last_msg = dict(message, **all_to_vary)
 
         msg_box = MessageBox(this_msg, self.model, last_msg)
+
+        self.model.is_muted_user.return_value = False
 
         expected_header[2] = output_date_time
         if current_year > 2018:

--- a/zulipterminal/api_types.py
+++ b/zulipterminal/api_types.py
@@ -613,6 +613,16 @@ class UpdateDisplaySettingsEvent(TypedDict):
     setting: bool
 
 
+class MutedUser(TypedDict):
+    user_id: int
+    timestamp: int
+
+
+class MutedUserEvent(TypedDict):
+    type: Literal["muted_users"]
+    muted_users: List[MutedUser]
+
+
 # -----------------------------------------------------------------------------
 Event = Union[
     MessageEvent,
@@ -628,6 +638,7 @@ Event = Union[
     UpdateUserSettingsEvent,
     UpdateGlobalNotificationsEvent,
     RealmUserEvent,
+    MutedUserEvent,
 ]
 
 ###############################################################################

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -957,6 +957,9 @@ class Model:
         topic_to_search = (stream_name, topic)
         return topic_to_search in self._muted_topics
 
+    def is_muted_user(self, user_id: int) -> bool:
+        return user_id in self._muted_users
+
     def stream_topic_from_message_id(
         self, message_id: int
     ) -> Optional[Tuple[int, str]]:

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -145,6 +145,7 @@ class Model:
             # zulip_version and zulip_feature_level are always returned in
             # POST /register from Feature level 3.
             "zulip_version",
+            "muted_users",
         ]
 
         # Events desired with their corresponding callback
@@ -208,6 +209,11 @@ class Model:
             )
             for stream_name, topic, *date_muted in muted_topics
         }
+        # NOTE: muted_users also contains timestamps, but we only store the user IDs
+        # muted_users was added in ZFL 48, Zulip 4.0
+        self._muted_users: Set[int] = set()
+        if self.server_feature_level >= 48:
+            self._update_muted_users(self.initial_data["muted_users"])
 
         groups = self.initial_data["realm_user_groups"]
         self.user_group_by_id: Dict[int, Dict[str, Any]] = {}
@@ -1203,6 +1209,9 @@ class Model:
             )
 
         return user_info
+
+    def _update_muted_users(self, muted_users: List[Dict[int, int]]) -> None:
+        self._muted_users = {muted_user["id"] for muted_user in muted_users}
 
     def _update_users_data_from_initial_data(self) -> None:
         # Dict which stores the active/idle status of users (by email)

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -161,6 +161,7 @@ class Model:
             "user_settings": self._handle_user_settings_event,
             "realm_emoji": self._handle_update_emoji_event,
             "realm_user": self._handle_realm_user_event,
+            "muted_users": self._handle_muted_users_event,
         }
 
         self.initial_data: Dict[str, Any] = {}
@@ -1674,6 +1675,13 @@ class Model:
                 text,
             )
         return ""
+
+    def _handle_muted_users_event(self, event: Event) -> None:
+        """
+        Handle muting/unmuting of users
+        """
+        assert event["type"] == "muted_users"
+        self._update_muted_users(event["muted_users"])
 
     def _handle_message_event(self, event: Event) -> None:
         """

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -726,6 +726,8 @@ class RightColumnView(urwid.Frame):
 
         users_btn_list = list()
         for user in users:
+            if self.view.model.is_muted_user(user["user_id"]):
+                continue
             status = user["status"]
             # Only include `inactive` users in search result.
             if status == "inactive" and not self.view.controller.is_in_editor_mode():


### PR DESCRIPTION
<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?
Adds support to handle muted users

TODO: Add support to mute and unmute users on ZT


### Outstanding aspect(s)    <!-- DELETE SECTION IF EMPTY -->
<!-- In what ways is this not fully implemented/functioning? Compared to a discussion/issue? -->
<!-- Do you not understand something? Are you unsure about a certain approach? Want feedback? -->
- [ ] 

### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [ ] Discussed in **#zulip-terminal** in `topic`
- [ ] Fully fixes #
- [ ] Partially fixes issue #1001
- [ ] Builds upon previous unmerged work in PR #1425
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [ ] Manually - Behavioral changes
- [ ] Manually - Visual changes
- [ ] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [ ] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [ ] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [ ] It has a commit summary describing the  motivation and reasoning for the change
- [ ] It individually passes linting and tests
- [ ] It contains test additions for any new behavior
- [ ] It flows clearly from a previous branch commit, and/or prepares for the next commit

### Visual changes    <!-- DELETE SECTION IF NO VISUAL CHANGE -->
<!-- Zulip tips at https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html -->
<!-- For video, try asciinema; after uploading, embed using
[![yourtitle](https://asciinema.org/a/<id>.png)](https://asciinema.org/a/<id>)
-->
<!-- NOTE: Attached videos/images will be clearer from smaller terminal windows -->
