### PR TITLE
Recipient headers for specific text searches

### DIFF
--- a/zulipterminal/ui_tools/messages.py
+++ b/zulipterminal/ui_tools/messages.py
@@ -121,6 +121,14 @@ class MessageBox(urwid.Pile):
         if len(self.model.narrow) == 2 and self.model.narrow[1][0] == "topic":
             return False
 
+        if self.model.is_search_narrow():
+            if len(self.model.narrow) == 1:
+                return True
+            if len(self.model.narrow) == 2:
+                return self.message["type"] != "private"
+            if len(self.model.narrow) == 3:
+                return self.model.narrow[1][0] != "topic"
+
         last_msg = self.last_message
         if self.message["type"] == "stream":
             return not (


### PR DESCRIPTION
<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?
Previously, when text searching, messages appear adjacent under the same heading, this can be confusing since they appear to be sequential but there may be messages in-between that don't meet the search criteria. PR adds logic to add recipient headers if the search isn't a specific dm or a topic narrow

### Outstanding aspect(s)    <!-- DELETE SECTION IF EMPTY -->
<!-- In what ways is this not fully implemented/functioning? Compared to a discussion/issue? -->
<!-- Do you not understand something? Are you unsure about a certain approach? Want feedback? -->
- [ ] Uncertain if automated tests are covering the feature or not (new to pytest) 
- [ ] Related follow-ups aren't fixed in this PR ... should they be?

### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [ ] Discussed in **#zulip-terminal** in `topic`
- [x] Fully fixes #1550 
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [ ] Manually - Behavioral changes
- [x] Manually - Visual changes
- [ ] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [x] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [x] It contains test additions for any new behavior
- [x] It flows clearly from a previous branch commit, and/or prepares for the next commit

### Visual changes    <!-- DELETE SECTION IF NO VISUAL CHANGE -->
<!-- Zulip tips at https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html -->
<!-- For video, try asciinema; after uploading, embed using
[![yourtitle](https://asciinema.org/a/<id>.png)](https://asciinema.org/a/<id>)
-->
<!-- NOTE: Attached videos/images will be clearer from smaller terminal windows -->
Before: ![swappy-20241024-191318](https://github.com/user-attachments/assets/9694d29a-a041-4b9b-901e-6db9d9d3c0b5)
After: ![swappy-20241024-191427](https://github.com/user-attachments/assets/9ca21108-5927-4293-b8e6-91014ff6b235)