### PR TITLE
messages: Update metadata handling for message reaction.

### DIFF
--- a/tests/ui_tools/test_messages.py
+++ b/tests/ui_tools/test_messages.py
@@ -1603,6 +1603,22 @@ class TestMessageBox:
                         {
                             "emoji_name": "thumbs_up",
                             "emoji_code": "1f44d",
+                            "user_id": 1001,
+                            "reaction_type": "unicode_emoji",
+                        },
+                    ],
+                },
+                "  :thumbs_up: 1  ",
+                [
+                    ("reaction", 17),
+                ],
+            ),
+            case(
+                {
+                    "reactions": [
+                        {
+                            "emoji_name": "thumbs_up",
+                            "emoji_code": "1f44d",
                             "user": {
                                 "email": "iago@zulip.com",
                                 "full_name": "Iago",

--- a/zulipterminal/ui_tools/messages.py
+++ b/zulipterminal/ui_tools/messages.py
@@ -272,10 +272,16 @@ class MessageBox(urwid.Pile):
             my_user_id = self.model.user_id
             reaction_stats = defaultdict(list)
             for reaction in reactions:
-                user_id = int(reaction["user"].get("id", -1))
+                user_id = reaction.get("user_id", -1)
                 if user_id == -1:
-                    user_id = int(reaction["user"]["user_id"])
-                user_name = reaction["user"]["full_name"]
+                    user_id = int(reaction["user"].get("id", -1))
+                    if user_id == -1:
+                        user_id = int(reaction["user"]["user_id"])
+                if user_id is None:
+                    user_name = reaction["user"]["full_name"]
+                user = self.model.get_user_info(user_id)
+                if user is not None:
+                    user_name = user.get("full_name", None)
                 if user_id == my_user_id:
                     user_name = "You"
                 reaction_stats[reaction["emoji_name"]].append((user_id, user_name))


### PR DESCRIPTION
### What does this PR do, and why?
Reaction metadata has been changed in the messages API endpoint as per ZFL 2 in [Zulip 3.0](https://zulip.com/api/changelog#changes-in-zulip-30). The `user_id` is used to identify the reaction's user.


<!-- Do you not understand something? Are you unsure about a certain approach? Want feedback? -->
- [x] The tests are failing for `reactions_view` 

Discussed in [zulip-terminal > reaction metadata](https://chat.zulip.org/#narrow/channel/206-zulip-terminal/topic/reaction.20metadata)

### External discussion & connections
- [x] Discussed in **#zulip-terminal** in `reaction metadata` 
- [ ] Fully fixes #
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
- [x] Manually - Behavioral changes
- [x] Manually - Visual changes
- [x] Adapting existing automated tests
- [x] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [ ] It individually passes linting and tests
- [x] It contains test additions for any new behavior
- [ ] It flows clearly from a previous branch commit, and/or prepares for the next commit

