### PR TITLE
Preparation for deprecating reactions' user metadata

### DIFF
--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -790,6 +790,75 @@ class TestModel:
 
         assert has_reacted == expected_has_user_reacted
 
+    @pytest.mark.parametrize(
+        "user_data, expected_user_id",
+        [
+            case({"user_id": 456}, 456, id="reaction_event_user_id"),
+            case(
+                {"user": {"user_id": 123}},
+                123,
+                id="reaction_event_user",
+            ),
+            case(
+                {"user_id": 101},
+                101,
+                id="reaction_user_id",
+            ),
+            case(
+                {"user": {"id": 202}},
+                202,
+                id="reaction_user",
+            ),
+        ],
+    )
+    def test_get_user_id_from_reaction_success(
+        self,
+        model: Model,
+        user_data: Dict[str, Any],
+        expected_user_id: int,
+    ):
+        reaction = {
+            "type": "reaction",
+            "op": "add",
+            "reaction_type": "unicode_emoji",
+            "emoji_code": "1f44d",
+            "emoji_name": "thumbs_up",
+            "message_id": "24757",
+            **user_data,
+        }
+        assert model.get_user_id_from_reaction(reaction) == expected_user_id
+
+    @pytest.mark.parametrize(
+        "user_data",
+        [
+            case({}, id="reaction_event_missing_user_id_user"),
+            case(
+                {"user": {"id": "not_an_int"}},
+                id="invalid_user",
+            ),
+            case(
+                {"user_id": "not_an_int"},
+                id="invalid_user_id",
+            ),
+        ],
+    )
+    def test_get_user_id_from_reaction_failure(
+        self,
+        model: Model,
+        user_data: Dict[str, Any],
+    ):
+        reaction = {
+            "type": "reaction",
+            "op": "add",
+            "reaction_type": "unicode_emoji",
+            "emoji_code": "1f44d",
+            "emoji_name": "thumbs_up",
+            "message_id": "24757",
+            **user_data,
+        }
+        with pytest.raises((AssertionError, AttributeError)):
+            model.get_user_id_from_reaction(reaction)
+
     @pytest.mark.parametrize("recipient_user_ids", [[5140], [5140, 5179]])
     @pytest.mark.parametrize("status", ["start", "stop"])
     def test_send_typing_status_by_user_ids(

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -2832,7 +2832,7 @@ class TestModel:
                                 "user": {
                                     "email": f"User email #{user_id}",
                                     "full_name": f"User #{user_id}",
-                                    "user_id": user_id,
+                                    "id": user_id,
                                 },
                                 "reaction_type": type,
                                 "emoji_code": code,

--- a/zulipterminal/api_types.py
+++ b/zulipterminal/api_types.py
@@ -408,7 +408,8 @@ class UpdateMessagesLocationEvent(BaseUpdateMessageEvent):
 class ReactionEvent(TypedDict):
     type: Literal["reaction"]
     op: str
-    user: Dict[str, Any]  # 'email', 'user_id', 'full_name'
+    user_id: NotRequired[int]  # Added in Zulip v3.0, ZFL 2 replacing 'user'
+    user: NotRequired[Dict[str, Any]]  # 'email', 'user_id', 'full_name'
     reaction_type: EmojiType
     emoji_code: str
     emoji_name: str

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1849,9 +1849,20 @@ class Model:
                 )
             else:
                 for reaction in message["reactions"]:
-                    # Since Who reacted is not displayed,
-                    # remove the first one encountered
-                    if reaction["emoji_code"] == event["emoji_code"]:
+                    reaction_user_id = (
+                        reaction["user"]["id"]
+                        if "user" in reaction
+                        else reaction["user_id"]
+                    )
+                    event_user_id = (
+                        event["user"]["user_id"]
+                        if event.get("user") and isinstance(event["user"], dict)
+                        else event["user_id"]
+                    )
+                    if (
+                        reaction["emoji_code"] == event["emoji_code"]
+                        and reaction_user_id == event_user_id
+                    ):
                         message["reactions"].remove(reaction)
                         break
 

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1835,18 +1835,28 @@ class Model:
         if message_id in self.index["messages"]:
             message = self.index["messages"][message_id]
             if event["op"] == "add":
-                message["reactions"].append(
-                    {
-                        key: event.get(key)
-                        for key in [
-                            "user",
-                            "reaction_type",
-                            "emoji_code",
-                            "emoji_name",
-                            "user_id",
-                        ]
+                reactions_entry = {
+                    key: event.get(key)
+                    for key in [
+                        "user",
+                        "reaction_type",
+                        "emoji_code",
+                        "emoji_name",
+                        "user_id",
+                    ]
+                }
+
+                # Convert from reaction event schema to message reactions schema
+                if isinstance(event.get("user"), dict) and isinstance(
+                    reactions_entry["user"], dict
+                ):
+                    reactions_entry["user"] = {
+                        **event["user"],
+                        "id": event["user"].get("user_id"),
                     }
-                )
+                    reactions_entry["user"].pop("user_id", None)
+
+                message["reactions"].append(reactions_entry)
             else:
                 for reaction in message["reactions"]:
                     reaction_user_id = (

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1838,7 +1838,13 @@ class Model:
                 message["reactions"].append(
                     {
                         key: event.get(key)
-                        for key in ["user", "reaction_type", "emoji_code", "emoji_name"]
+                        for key in [
+                            "user",
+                            "reaction_type",
+                            "emoji_code",
+                            "emoji_name",
+                            "user_id",
+                        ]
                     }
                 )
             else:

--- a/zulipterminal/ui_tools/messages.py
+++ b/zulipterminal/ui_tools/messages.py
@@ -272,10 +272,8 @@ class MessageBox(urwid.Pile):
             my_user_id = self.model.user_id
             reaction_stats = defaultdict(list)
             for reaction in reactions:
-                user_id = int(reaction["user"].get("id", -1))
-                if user_id == -1:
-                    user_id = int(reaction["user"]["user_id"])
-                user_name = reaction["user"]["full_name"]
+                user_id = self.model.get_user_id_from_reaction(reaction)
+                user_name = self.model._all_users_by_id[user_id]["full_name"]
                 if user_id == my_user_id:
                     user_name = "You"
                 reaction_stats[reaction["emoji_name"]].append((user_id, user_name))

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -241,11 +241,10 @@ class MessageView(urwid.ListBox):
         elif is_command_key("REACTION_AGREEMENT", key) and self.focus is not None:
             message = self.focus.original_widget.message
             message_reactions = message["reactions"]
-            if len(message_reactions) > 0:
-                for reaction in message_reactions:
-                    emoji = reaction["emoji_name"]
-                    self.model.toggle_message_reaction(message, emoji)
-                    break
+            if message_reactions:
+                self.model.toggle_message_reaction(
+                    message, message_reactions[0]["emoji_name"]
+                )
 
         key = super().keypress(size, key)
         return key

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1657,7 +1657,12 @@ class MsgInfoView(PopUpView):
             msg_info.append(("Time mentions", time_mentions))
         if msg["reactions"]:
             reactions = sorted(
-                (reaction["emoji_name"], reaction["user"]["full_name"])
+                (
+                    reaction["emoji_name"],
+                    controller.model._all_users_by_id[
+                        controller.model.get_user_id_from_reaction(reaction)
+                    ]["full_name"],
+                )
                 for reaction in msg["reactions"]
             )
             grouped_reactions: Dict[str, str] = dict()


### PR DESCRIPTION
<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?
- Prepares for the deprecation of user metadata from messages' reactions and reaction events
    - Supports both `user_id` (ZFL>=2) and `user["id"]` for messages' reactions (with added test cases)
    - Supports both `user_id` (ZFL>=2) and `user["user_id"]` for reaction events (with added test cases)
    - Introduces a common `get_user_id_from_reaction()` for handling the different possible fields
    - Switches to using `_all_users_by_id["user_id"]` to remove dependency on `reaction["user"]["full_name"]
    - Improves the `ReactionEvent` schema to support both versions
- Fixes a bug in reaction event handling (remove op), and adds tests covering the missing cases
- Refactors the reactions' functions a bit before the above changes

### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [x] Discussed in **#zulip-terminal** in `reaction metadata`
- [ ] Fully fixes #
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [x] Manually - Behavioral changes
- [ ] Manually - Visual changes
- [x] Adapting existing automated tests
- [x] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [x] It contains test additions for any new behavior
- [x] It flows clearly from a previous branch commit, and/or prepares for the next commit

### Visual changes    <!-- DELETE SECTION IF NO VISUAL CHANGE -->
<!-- Zulip tips at https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html -->
<!-- For video, try asciinema; after uploading, embed using
[![yourtitle](https://asciinema.org/a/<id>.png)](https://asciinema.org/a/<id>)
-->
<!-- NOTE: Attached videos/images will be clearer from smaller terminal windows -->
