### PR TITLE
Fix #1506 : Improve handling of narrows (views) with no messages

### DIFF
--- a/zulipterminal/ui_tools/messages.py
+++ b/zulipterminal/ui_tools/messages.py
@@ -51,7 +51,6 @@ class _MessageEditState(NamedTuple):
     message_id: int
     old_topic: str
 
-
 class MessageBox(urwid.Pile):
     # type of last_message is Optional[Message], but needs refactoring
     def __init__(self, message: Message, model: "Model", last_message: Any) -> None:
@@ -1189,3 +1188,34 @@ class MessageBox(urwid.Pile):
         elif is_command_key("MSG_SENDER_INFO", key):
             self.model.controller.show_msg_sender_info(self.message["sender_id"])
         return key
+
+class PlaceholderMessageBox(urwid.WidgetWrap):
+    def __init__(self, text: str) -> None:
+        self.message = {"id": -1}  # So it doesn’t explode when accessed
+        text_widget = urwid.Text(text)
+        self.original_widget = self  # Trickery: mimic MessageBox
+
+        super().__init__(text_widget)
+
+    def recipient_header(self) -> Any:
+        return urwid.Text("")  # Blank for empty narrow
+
+    def top_search_bar(self) -> Any:
+        return urwid.Text("")  # Stub for compatibility
+
+    def update_message_author_status(self) -> None:
+        pass  # Stub for compatibility
+
+    def keypress(self, size: Tuple[int, int], key: str) -> None:
+        if is_command_key("GO_DOWN", key):
+            return None
+        if is_command_key("GO_UP", key):
+            return None
+
+        elif is_command_key("GO_LEFT", key):
+            self.view.show_left_panel(visible=True)
+            return None
+
+        elif is_command_key("GO_RIGHT", key):
+            self.view.show_right_panel(visible=True)
+            return None


### PR DESCRIPTION
<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?
This PR improves handling of narrows with no messages by implementing a placeholder component


### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [ ] Discussed in **#zulip-terminal** in `topic`
- [ x] Fully fixes #1506
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [ ] Manually - Behavioral changes
- [ x] Manually - Visual changes
- [ ] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [ ] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [ ] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [ ] It has a commit summary describing the  motivation and reasoning for the change
- [ x] It individually passes linting and tests
- [ ] It contains test additions for any new behavior
- [x ] It flows clearly from a previous branch commit, and/or prepares for the next commit

### Visual changes    <!-- DELETE SECTION IF NO VISUAL CHANGE -->
<!-- Zulip tips at https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html -->
<!-- For video, try asciinema; after uploading, embed using
[![yourtitle](https://asciinema.org/a/<id>.png)](https://asciinema.org/a/<id>)
-->
<!-- NOTE: Attached videos/images will be clearer from smaller terminal windows -->
![image](https://github.com/user-attachments/assets/b7fbbe8d-12fa-43fa-bd85-2e84bb0776d3)
