### PR TITLE
pass command instead of password in zuliprc

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,12 @@ to get the hang of things.
 
 ## Configuration
 
+configuration conssist of two file:
+- zulip_key, file contains the api_key
+- zuliprc, file consist of login configurations
+
+The `zulip_key`contains only the api_key.
+
 The `zuliprc` file contains two sections:
 - an `[api]` section with information required to connect to your Zulip server
 - a `[zterm]` section with configuration specific to `zulip-term`
@@ -216,13 +222,15 @@ A file with only the first section can be auto-generated in some cases by
 above). Parts of the second section can be added and adjusted in stages when
 you wish to customize the behavior of `zulip-term`.
 
+If you’re downloading the config file from your Zulip account, you should replace the `key` field with `passcmd`, setting its value to a command that outputs the api_key (e.g., cat zulip_key). If you’re not downloading it manually, zulip-term will configure this for you automatically, though it’s recommended to update the passcmd value afterward for better security.
+
 The example below, with dummy `[api]` section contents, represents a working
 configuration file with all the default compatible `[zterm]` values uncommented
 and with accompanying notes:
 ```
 [api]
 email=example@example.com
-key=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+passcmd=cat zulip_key
 site=https://example.zulipchat.com
 
 [zterm]
@@ -256,6 +264,7 @@ transparency=disabled
 ## If not set, this falls back to the $ZULIP_EDITOR_COMMAND then $EDITOR environment variables
 # editor: nano
 ```
+
 
 > **NOTE:** Most of these configuration settings may be specified on the
 command line when `zulip-term` is started; `zulip-term -h` or `zulip-term --help`


### PR DESCRIPTION
<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?
This PR updates the default config generation logic in zulip-term to support a more secure way of managing Zulip API keys. Instead of writing the API key directly into the zuliprc file, we now generate:
	•	a zuliprc file with a passcmd field
	•	a zulip_key file containing just the API key
• zulip_key: A temporary file that contains only the API key.
• zuliprc:	[api]: contains Zulip login configuration (email, server URL, and now passcmd)

Here’s how the new auto-generated zuliprc file looks:
```
[api]
email=abc@gmail.com
# Fill the passcmd field with a command that outputs the API key.
# The API key is temporarily stored in the 'zulip_key' file.
# After storing the key in a password manager, please delete the 'zulip_key' file.
passcmd=cat zulip_key
site=https://chat.zulip.org
```
If you’re downloading a zuliprc file from your Zulip account (which includes the key field), you’re encouraged to manually replace the key line with a passcmd, like this:

```
passcmd=cat zulip_key
```

You can (and should) later replace cat zulip_key with a command tied to your preferred secret storage tool

### Outstanding aspect(s)    <!-- DELETE SECTION IF EMPTY -->
<!-- In what ways is this not fully implemented/functioning? Compared to a discussion/issue? -->
<!-- Do you not understand something? Are you unsure about a certain approach? Want feedback? -->
- [ ] 

### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [x] Discussed in **#zulip-terminal** in `topic`
- [x] Fully fixes #1502 
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [] all that apply -->
- [x] Manually - Behavioral changes
- [ ] Manually - Visual changes
- [ ] Adapting existing automated tests
- [x] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [ ] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [ ] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [x] It contains test additions for any new behavior
- [ ] It flows clearly from a previous branch commit, and/or prepares for the next commit


