### PR TITLE
messages: migrate to new bs4 API

### DIFF
--- a/zulipterminal/ui_tools/messages.py
+++ b/zulipterminal/ui_tools/messages.py
@@ -915,7 +915,7 @@ class MessageBox(urwid.Pile):
         blockquote_list = soup.find_all("blockquote")
         bq_len = len(blockquote_list)
         for tag in blockquote_list:
-            child_list = tag.findChildren(recursive=False)
+            child_list = tag.find_all(recursive=False)
             child_block = tag.find_all("blockquote")
             actual_padding = f"{padding_char} " * pad_count
             if len(child_list) == 1:
@@ -937,8 +937,8 @@ class MessageBox(urwid.Pile):
                 new_tag.string = actual_padding
                 # If the quoted message is multi-line message
                 # we deconstruct it and pad it at break-points (<br/>)
-                for br in child.findAll("br"):
-                    next_s = br.nextSibling
+                for br in child.find_all("br"):
+                    next_s = br.next_sibling
                     text = str(next_s.string).strip()
                     if text:
                         insert_tag = soup.new_tag("p")


### PR DESCRIPTION
<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?
Small PR - resolves the `bs4` deprecation warnings which you can see in the [CI logs](https://github.com/zulip/zulip-terminal/actions/runs/14682638921/job/41207209285#step:8:80):
```python
/home/runner/work/zulip-terminal/zulip-terminal/zulipterminal/ui_tools/messages.py:941: DeprecationWarning: Access to deprecated property nextSibling. (Replaced by next_sibling) -- Deprecated since version 4.0.0.

/home/runner/work/zulip-terminal/zulip-terminal/zulipterminal/ui_tools/messages.py:918: DeprecationWarning: Call to deprecated method findChildren. (Replaced by find_all) -- Deprecated since version 3.0.0.

/home/runner/work/zulip-terminal/zulip-terminal/zulipterminal/ui_tools/messages.py:940: DeprecationWarning: Call to deprecated method findAll. (Replaced by find_all) -- Deprecated since version 4.0.0.

/home/runner/work/zulip-terminal/zulip-terminal/zulipterminal/ui_tools/messages.py:941: DeprecationWarning: Access to deprecated property nextSibling. (Replaced by next_sibling) -- Deprecated since version 4.0.0.
```

### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [ ] Discussed in **#zulip-terminal** in `topic`
- [ ] Fully fixes #
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [x] Manually - Behavioral changes
- [ ] Manually - Visual changes
- [ ] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [x] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [ ] It contains test additions for any new behavior
- [ ] It flows clearly from a previous branch commit, and/or prepares for the next commit

