### PR TITLE
Add support for PyPy 3.11 to GitHub Actions

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -243,6 +243,7 @@ jobs:
           - {PYTHON: 'pypy-3.8', OS: ubuntu-latest, NAME: "PyPy 3.8 (ubuntu)", EXPECT: "Linux"}
           - {PYTHON: 'pypy-3.9', OS: ubuntu-latest, NAME: "PyPy 3.9 (ubuntu)", EXPECT: "Linux"}
           - {PYTHON: 'pypy-3.10', OS: ubuntu-latest, NAME: "PyPy 3.10 (ubuntu)", EXPECT: "Linux"}
+          - {PYTHON: 'pypy-3.11', OS: ubuntu-latest, NAME: "PyPy 3.11 (ubuntu)", EXPECT: "Linux"}
           - {PYTHON: '3.11', OS: macos-latest, NAME: "CPython 3.11 (macos)", EXPECT: "MacOS"}
     env:
       EXPECT: ${{ matrix.env.EXPECT }}

--- a/setup.py
+++ b/setup.py
@@ -109,7 +109,7 @@ setup(
         "zulip>=0.8.2",
         "urwid_readline>=0.13",
         "beautifulsoup4>=4.11.1",
-        "lxml~=4.9.2",
+        "lxml~=5.3.1",
         "pygments>=2.14.0,<2.18.0",
         "typing_extensions~=4.5.0",
         "python-dateutil>=2.8.2",


### PR DESCRIPTION
<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?

Extends range of 3rd-stage testing to include PyPy 3.11.