### PR TITLE
bugfix: views: Fix index out of range in message view focus.

### DIFF
--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -123,8 +123,13 @@ class MessageView(urwid.ListBox):
     def main_view(self) -> List[Any]:
         msg_btn_list = create_msg_box_list(self.model)
         focus_msg = self.model.get_focus_in_current_narrow()
-        if focus_msg is None:
-            focus_msg = len(msg_btn_list) - 1
+        if (
+            not msg_btn_list
+            or focus_msg is None
+            or focus_msg < 0
+            or focus_msg >= len(msg_btn_list)
+        ):
+            focus_msg = max(0, len(msg_btn_list) - 1)
         self.focus_msg = focus_msg
         return msg_btn_list
 


### PR DESCRIPTION

### What does this PR do, and why?
Fixes error that causes zulip-term to crash at the start
When msg_btn_list is empty or focus_msg is invalid, ensure focus_msg is set to a valid index using max(0, len(msg_btn_list) - 1) instead of just len(msg_btn_list) - 1, which would cause an IndexError.

This prevents crashes when navigating to views with no messages.


### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [ ] Discussed in **#zulip-terminal** in `topic`
- [X] Fully fixes #1589
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [X] Manually - Behavioral changes
- [ ] Manually - Visual changes
- [ ] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

