### PR TITLE
ui_tools/views: Fix IndexError when set_focus called on empty ListBox.

### DIFF
--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -402,7 +402,8 @@ class StreamsView(urwid.Frame):
             self.log.clear()
             self.log.extend(self.streams_btn_list)
             self.set_focus("body")
-            self.log.set_focus(self.focus_index_before_search)
+            if self.log:  # Only set focus if list is not empty
+                self.log.set_focus(self.focus_index_before_search)
             self.view.controller.update_screen()
             return key
         return super().keypress(size, key)
@@ -478,7 +479,8 @@ class TopicsView(urwid.Frame):
             if topic_button.topic_name == topic_name:
                 self.log.insert(0, self.log.pop(topic_iterator))
                 self.list_box.set_focus_valign("bottom")
-                if sender_id == self.view.model.user_id:
+                # Only set focus if list is not empty
+                if sender_id == self.view.model.user_id and self.log:
                     self.list_box.set_focus(0)
                 return
         # No previous topics with same topic names are found
@@ -492,7 +494,8 @@ class TopicsView(urwid.Frame):
         )
         self.log.insert(0, new_topic_button)
         self.list_box.set_focus_valign("bottom")
-        if sender_id == self.view.model.user_id:
+        # Only set focus if list is not empty
+        if sender_id == self.view.model.user_id and self.log:
             self.list_box.set_focus(0)
 
     def mouse_event(
@@ -522,7 +525,8 @@ class TopicsView(urwid.Frame):
             self.log.clear()
             self.log.extend(self.topics_btn_list)
             self.set_focus("body")
-            self.log.set_focus(self.focus_index_before_search)
+            if self.log:  # Only set focus if list is not empty
+                self.log.set_focus(self.focus_index_before_search)
             self.view.controller.update_screen()
             return key
         return super().keypress(size, key)


### PR DESCRIPTION
Fixes a crash that occurs when clearing search results in streams or topics view when the underlying list is empty. The application would raise 'IndexError: Can't set focus, ListBox is empty' when attempting to restore focus position after clearing a search. Added checks before calling set_focus() in 4 locations:
- StreamsView.keypress() CLEAR_SEARCH handler
- TopicsView.keypress() CLEAR_SEARCH handler
- TopicsView.update_topics_list() (2 locations) The fix verifies the list is not empty before attempting to set focus, preventing the crash while maintaining expected behavior when lists contain items.

<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?



### Outstanding aspect(s)    <!-- DELETE SECTION IF EMPTY -->
<!-- In what ways is this not fully implemented/functioning? Compared to a discussion/issue? -->
<!-- Do you not understand something? Are you unsure about a certain approach? Want feedback? -->
- [ ] 

### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [ ] Discussed in **#zulip-terminal** in `topic`
- [ ] Fully fixes #
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [ ] Manually - Behavioral changes
- [ ] Manually - Visual changes
- [ ] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [ ] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [ ] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [ ] It has a commit summary describing the  motivation and reasoning for the change
- [ ] It individually passes linting and tests
- [ ] It contains test additions for any new behavior
- [ ] It flows clearly from a previous branch commit, and/or prepares for the next commit

### Visual changes    <!-- DELETE SECTION IF NO VISUAL CHANGE -->
<!-- Zulip tips at https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html -->
<!-- For video, try asciinema; after uploading, embed using
[![yourtitle](https://asciinema.org/a/<id>.png)](https://asciinema.org/a/<id>)
-->
<!-- NOTE: Attached videos/images will be clearer from smaller terminal windows -->
