### PR TITLE
docs: Clarify supported Python versions in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ We also provide some sample Dockerfiles to build docker images in
 
 ### Installing into an isolated Python virtual environment
 
-With the python 3.6+ required for running, the following should work on most
+Zulip Terminal currently supports Python 3.8–3.11. With a supported Python 3.x installed, the following should work on most
 systems:
 1. `python3 -m venv zt_venv`
    (creates a virtual environment named `zt_venv` in the current directory)
@@ -456,7 +456,7 @@ process similar to that in the previous section.
 $ pip3 install --user pipenv
 ```
 2. Initialize the pipenv virtual environment for zulip-term (using the default
-   python 3; use eg. `--python 3.6` to be more specific)
+   python 3; use eg. `--python 3.10` to be more specific (any supported 3.8–3.11 version)
 
 ```
 $ pipenv --three


### PR DESCRIPTION
Clarify the supported Python versions for Zulip Terminal in the README.

Previously the documentation mentioned "python 3.6+ required for running",
which is misleading based on the currently tested versions.

This change:
- Updates the virtualenv instructions to state that Zulip Terminal currently
  supports Python 3.8–3.11.
- Updates the Pipenv example from `--python 3.6` to `--python 3.10`, and notes
  that any supported 3.8–3.11 version can be used.

Fixes: #1557
