### PR TITLE
bugfix: model: Avoid KeyError when reading user settings at startup.

### DIFF
--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -126,7 +126,13 @@ class TestModel:
         assert "user_settings" not in initial_data  # we add it in tests
 
         if sptn is not None:
-            initial_data["user_settings"] = {"send_private_typing_notifications": sptn}
+            initial_data["user_settings"] = {
+                "send_private_typing_notifications": sptn,
+                "twenty_four_hour_time": initial_data["twenty_four_hour_time"],
+                "pm_content_in_desktop_notifications": initial_data[
+                    "pm_content_in_desktop_notifications"
+                ],
+            }
 
         mocker.patch(MODEL + ".get_messages", return_value="")
         self.client.register = mocker.Mock(return_value=initial_data)

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -235,10 +235,17 @@ class Model:
                 if user_settings is None
                 else user_settings["send_private_typing_notifications"]
             ),  # ZFL 105, Zulip 5.0
-            twenty_four_hour_time=self.initial_data["twenty_four_hour_time"],
-            pm_content_in_desktop_notifications=self.initial_data[
-                "pm_content_in_desktop_notifications"
-            ],
+            # these settings were removed from the top-level object in ZFL 439 (v12.0)
+            twenty_four_hour_time=(
+                self.initial_data["twenty_four_hour_time"]
+                if user_settings is None
+                else user_settings["twenty_four_hour_time"]
+            ),
+            pm_content_in_desktop_notifications=(
+                self.initial_data["pm_content_in_desktop_notifications"]
+                if user_settings is None
+                else user_settings["pm_content_in_desktop_notifications"]
+            ),
         )
 
         self.new_user_input = True


### PR DESCRIPTION
### What does this PR do and why?
This PR fixes #1600 .
The application crashes at startup when initializing a `Model` object.  The code tries to read some user settings directly from `initial_data`, which contains the payload returned by the Zulip API `POST /register` endpoint. 

In Zulip 12.0 (feature level 439), many of these settings were removed from the top level object into the `user_settings` dict.

This PR updates the code to retrieve user settings from the `user_settings` object when it is present in `initial_data`.

The tests were also updated to include all required user settings under the `user_settings`  key when it is present in `initial_data`.

### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [x] Discussed in **#zulip-terminal** in `crashes after trying to start for the first time`
- [x ] Fully fixes #
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [x] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [x] Manually - Behavioral changes
- [ ] Manually - Visual changes
- [x] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [x] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [ ] It contains test additions for any new behavior
- [x] It flows clearly from a previous branch commit, and/or prepares for the next commit

