### PR TITLE
Handle missing notification settings in initial_data

### DIFF
--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -235,10 +235,10 @@ class Model:
                 if user_settings is None
                 else user_settings["send_private_typing_notifications"]
             ),  # ZFL 105, Zulip 5.0
-            twenty_four_hour_time=self.initial_data["twenty_four_hour_time"],
-            pm_content_in_desktop_notifications=self.initial_data[
-                "pm_content_in_desktop_notifications"
-            ],
+            twenty_four_hour_time=self.initial_data.get("twenty_four_hour_time", False),
+            pm_content_in_desktop_notifications=self.initial_data.get(
+                "pm_content_in_desktop_notifications", False
+            ),
         )
 
         self.new_user_input = True


### PR DESCRIPTION
### Summary

When setting up zulip-terminal on Ubuntu with Python 3.11 and connecting to `https://chat.zulip.org` using my `zuliprc`, zulip-term crashed on startup with:

- `KeyError: 'twenty_four_hour_time'`
- `KeyError: 'pm_content_in_desktop_notifications'`

These keys were missing from `initial_data` in `Model.__init__`, but were accessed via `[...]`, which caused the client to crash instead of using a default.

This PR updates `UserSettings` initialization in `zulipterminal/model.py` to treat these settings as optional by using:

- `self.initial_data.get("twenty_four_hour_time", False)`
- `self.initial_data.get("pm_content_in_desktop_notifications", False)`

so that zulip-terminal falls back to `False` when these settings are absent, rather than raising a `KeyError`.

### How did you test this?

- [x] Manually – behavioral changes
  - Started zulip-terminal with `zulip-term --config-file ~/zuliprc` against `https://chat.zulip.org`.
  - Verified that zulip-term no longer crashes on startup and that streams/topics load as expected.

### Additional notes

- This is intended as a small robustness fix for cases where the server does not include these notification/time settings in the initial data payload.
- I’m happy to adjust the default values or add tests if there is a preferred pattern for handling missing user settings.
