### PR TITLE
refactor: api_types/model: Remove deprecated event types.

### DIFF
--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -247,8 +247,6 @@ class TestModel:
             "subscription",
             "typing",
             "update_message_flags",
-            "update_global_notifications",
-            "update_display_settings",
             "user_settings",
             "realm_emoji",
             "realm_user",
@@ -263,8 +261,6 @@ class TestModel:
             "muted_topics",
             "realm_user",
             "realm_user_groups",
-            "update_global_notifications",
-            "update_display_settings",
             "user_settings",
             "realm_emoji",
             "custom_profile_fields",
@@ -4444,26 +4440,29 @@ class TestModel:
         model._handle_user_settings_event(event)
         assert model.user_settings()[setting] == value
 
-    @pytest.mark.parametrize("setting", [True, False])
-    def test_update_pm_content_in_desktop_notifications(self, mocker, model, setting):
-        setting_name = "pm_content_in_desktop_notifications"
+    @pytest.mark.parametrize("value", [True, False])
+    def test_update_pm_content_in_desktop_notifications(self, mocker, model, value):
+        setting = "pm_content_in_desktop_notifications"
         event = {
-            "type": "update_global_notifications",
-            "notification_name": setting_name,
-            "setting": setting,
+            "type": "user_settings",
+            "op": "update",
+            "property": setting,
+            "value": value,
         }
-        model._user_settings[setting_name] = not setting
+        model._user_settings[setting] = not value
 
-        model._handle_update_global_notifications_event(event)
+        model._handle_user_settings_event(event)
 
-        assert model.user_settings()[setting_name] == setting
+        assert model.user_settings()[setting] == event["value"]
 
-    @pytest.mark.parametrize("setting", [True, False])
-    def test_update_twenty_four_hour_format(self, mocker, model, setting):
+    @pytest.mark.parametrize("value", [True, False])
+    def test_update_twenty_four_hour_format(self, mocker, model, value):
+        setting = "twenty_four_hour_time"
         event = {
-            "type": "update_display_settings",
-            "setting_name": "twenty_four_hour_time",
-            "setting": setting,
+            "type": "user_settings",
+            "op": "update",
+            "property": setting,
+            "value": value,
         }
         first_msg_w = mocker.Mock()
         second_msg_w = mocker.Mock()
@@ -4471,11 +4470,11 @@ class TestModel:
         second_msg_w.original_widget.message = {"id": 2}
         self.controller.view.message_view = mocker.Mock(log=[first_msg_w, second_msg_w])
         create_msg_box_list = mocker.patch(MODULE + ".create_msg_box_list")
-        model._user_settings["twenty_four_hour_format"] = not setting
+        model._user_settings["twenty_four_hour_format"] = not value
 
-        model._handle_update_display_settings_event(event)
+        model._handle_user_settings_event(event)
 
-        assert model.user_settings()["twenty_four_hour_time"] == event["setting"]
+        assert model.user_settings()["twenty_four_hour_time"] == event["value"]
         assert create_msg_box_list.call_count == len(
             self.controller.view.message_view.log
         )

--- a/zulipterminal/api_types.py
+++ b/zulipterminal/api_types.py
@@ -589,7 +589,11 @@ class UpdateRealmEmojiEvent(TypedDict):
 # -----------------------------------------------------------------------------
 # See https://zulip.com/api/get-events#user_settings-update
 # This is specifically only those supported by ZT
-SupportedUserSettings = Literal["send_private_typing_notifications"]
+SupportedUserSettings = Literal[
+    "send_private_typing_notifications",
+    "twenty_four_hour_time",
+    "pm_content_in_desktop_notifications",
+]
 
 
 class UpdateUserSettingsEvent(TypedDict):
@@ -597,30 +601,6 @@ class UpdateUserSettingsEvent(TypedDict):
     op: Literal["update"]
     property: SupportedUserSettings
     value: Any
-
-
-# -----------------------------------------------------------------------------
-# See https://zulip.com/api/get-events#update_global_notifications
-# This is specifically only those supported by ZT
-SupportedGlobalNotificationSettings = Literal["pm_content_in_desktop_notifications"]
-
-
-class UpdateGlobalNotificationsEvent(TypedDict):
-    type: Literal["update_global_notifications"]
-    notification_name: SupportedGlobalNotificationSettings
-    setting: Any
-
-
-# -----------------------------------------------------------------------------
-# See https://zulip.com/api/get-events#update_display_settings
-# This is specifically only those supported by ZT
-SupportedDisplaySettings = Literal["twenty_four_hour_time"]
-
-
-class UpdateDisplaySettingsEvent(TypedDict):
-    type: Literal["update_display_settings"]
-    setting_name: SupportedDisplaySettings
-    setting: bool
 
 
 # -----------------------------------------------------------------------------
@@ -634,10 +614,8 @@ Event = Union[
     SubscriptionPeerAddRemoveEvent,
     TypingEvent,
     UpdateMessageFlagsEvent,
-    UpdateDisplaySettingsEvent,
     UpdateRealmEmojiEvent,
     UpdateUserSettingsEvent,
-    UpdateGlobalNotificationsEvent,
     RealmUserEvent,
 ]
 


### PR DESCRIPTION
<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?
This PR removes the legacy event types `update_display_settings` and `update_global_notifications`.

Handles  `twenty_four_hour_time` and `pm_content_in_desktop_notifications` user settings inside  Model._handle_user_settings_event. These settings were previously tied to the legacy events.

Updates tests accordingly.

### Outstanding aspect(s)    <!-- DELETE SECTION IF EMPTY -->
<!-- In what ways is this not fully implemented/functioning? Compared to a discussion/issue? -->
<!-- Do you not understand something? Are you unsure about a certain approach? Want feedback? -->
- [ ] 

### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [x] Discussed in **#zulip-terminal** in `topic`
- [x] Fully fixes #
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [x] Manually - Behavioral changes
- [x] Manually - Visual changes
- [x] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [x] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [] It contains test additions for any new behavior
- [x] It flows clearly from a previous branch commit, and/or prepares for the next commit

### Visual changes    <!-- DELETE SECTION IF NO VISUAL CHANGE -->
<!-- Zulip tips at https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html -->
<!-- For video, try asciinema; after uploading, embed using
[![yourtitle](https://asciinema.org/a/<id>.png)](https://asciinema.org/a/<id>)
-->
<!-- NOTE: Attached videos/images will be clearer from smaller terminal windows -->
### 12 hr format
<img width="1289" height="891" alt="12-hr-format" src="https://github.com/user-attachments/assets/4205d0d9-e506-4a9c-8c34-44c89a33cf4b" />
### 24 hr format
<img width="1289" height="891" alt="24-hr-format" src="https://github.com/user-attachments/assets/0fc02a53-7808-475e-9692-aab5840eb94f" />
