### PR TITLE
    refactor: model: Pass `apply_markdown` parameter to preserve Markdown.

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -17,7 +17,7 @@ permissions:
   contents: read
 
 env:
-  LINTING_PYTHON_VERSION: 3.8
+  LINTING_PYTHON_VERSION: 3.9
 
 jobs:
   mypy:
@@ -171,7 +171,7 @@ jobs:
 
   base_pytest:
     runs-on: ubuntu-22.04
-    name: Install & test - CPython 3.7 (ubuntu), codecov
+    name: Install & test - CPython 3.9 (ubuntu), codecov
     steps:
       - uses: actions/checkout@v6
         with:
@@ -179,7 +179,7 @@ jobs:
       - name: Install Python version
         uses: actions/setup-python@v6
         with:
-          python-version: 3.7
+          python-version: 3.9
           cache: 'pip'
           cache-dependency-path: 'setup.py'
       - name: Output Python version
@@ -237,12 +237,9 @@ jobs:
       fail-fast: false
       matrix:
         env:
-          - {PYTHON: 3.8, OS: ubuntu-latest, NAME: "CPython 3.8 (ubuntu)", EXPECT: "Linux"}
           - {PYTHON: 3.9, OS: ubuntu-latest, NAME: "CPython 3.9 (ubuntu)", EXPECT: "Linux"}
           - {PYTHON: "3.10", OS: ubuntu-latest, NAME: "CPython 3.10 (ubuntu)", EXPECT: "Linux"}
           - {PYTHON: "3.11", OS: ubuntu-latest, NAME: "CPython 3.11 (ubuntu)", EXPECT: "Linux"}
-          - {PYTHON: 'pypy-3.7', OS: ubuntu-latest, NAME: "PyPy 3.7 (ubuntu)", EXPECT: "Linux"}
-          - {PYTHON: 'pypy-3.8', OS: ubuntu-latest, NAME: "PyPy 3.8 (ubuntu)", EXPECT: "Linux"}
           - {PYTHON: 'pypy-3.9', OS: ubuntu-latest, NAME: "PyPy 3.9 (ubuntu)", EXPECT: "Linux"}
           - {PYTHON: 'pypy-3.10', OS: ubuntu-latest, NAME: "PyPy 3.10 (ubuntu)", EXPECT: "Linux"}
           - {PYTHON: '3.11', OS: macos-latest, NAME: "CPython 3.11 (macos)", EXPECT: "MacOS"}

--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,7 @@ setup(
     tests_require=testing_deps,
     install_requires=[
         "urwid~=2.1.2",
-        "zulip>=0.8.2,<0.9.0",  # Next release, 0.9.0, requires Python 3.9
+        "zulip @ git+https://github.com/zulip/python-zulip-api.git@f1ca74c5cef483a097155f51e8f3f7a5422327f4#subdirectory=zulip",
         "urwid_readline>=0.15.1",
         "beautifulsoup4>=4.13.4",
         "lxml==4.9.4",

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -1711,7 +1711,7 @@ class TestModel:
                 {
                     "result": "success",
                     "msg": "",
-                    "raw_content": "Feels **great** to be back!",
+                    "message": {"content": "Feels **great** to be back!"},
                 },
                 "Feels **great** to be back!",
                 False,
@@ -1740,7 +1740,9 @@ class TestModel:
 
         return_value = model.fetch_raw_message_content(message_id)
 
-        self.client.get_raw_message.assert_called_once_with(message_id)
+        self.client.get_raw_message.assert_called_once_with(
+            message_id, apply_markdown=False
+        )
         assert self.display_error_if_present.called == display_error_called
         assert return_value == expected_raw_content
 

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -880,9 +880,9 @@ class Model:
         """
         Fetches raw message content of a message using its ID.
         """
-        response = self.client.get_raw_message(message_id)
+        response = self.client.get_raw_message(message_id, apply_markdown=False)
         if response["result"] == "success":
-            return response["raw_content"]
+            return response["message"]["content"]
         display_error_if_present(response, self.controller)
 
         return None


### PR DESCRIPTION
Fixes https://chat.zulip.org/#narrow/channel/378-api-design/topic/raw_content

Pass `apply_markdown=False` to `client.get_raw_message` to preserve Markdown in content.
    
Fetch message content from response["message"]["content"].
    
Update tests.

Update the zulip dependency in setup.py to point directly to the commit that added the `apply_markdown` parameter for get_raw_message.

<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?



### Outstanding aspect(s)    <!-- DELETE SECTION IF EMPTY -->
<!-- In what ways is this not fully implemented/functioning? Compared to a discussion/issue? -->
<!-- Do you not understand something? Are you unsure about a certain approach? Want feedback? -->
- [ ] 

### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [x] Discussed in **#zulip-terminal** in `topic`
- [x] Fully fixes #
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [ ] Manually - Behavioral changes
- [ ] Manually - Visual changes
- [x] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [x] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [ ] It contains test additions for any new behavior
- [ ] It flows clearly from a previous branch commit, and/or prepares for the next commit

### Visual changes    <!-- DELETE SECTION IF NO VISUAL CHANGE -->
<!-- Zulip tips at https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html -->
<!-- For video, try asciinema; after uploading, embed using
[![yourtitle](https://asciinema.org/a/<id>.png)](https://asciinema.org/a/<id>)
-->
<!-- NOTE: Attached videos/images will be clearer from smaller terminal windows -->
