### PR TITLE
widgets: Add poll and todo widget creation and interaction support. Fixes: #1575 && Fixes: #1573

### DIFF
--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -319,8 +319,10 @@ def test_main_multiple_autohide_options(
     assert str(e.value) == "2"
 
     captured = capsys.readouterr()
-    lines = captured.err.strip("\n")
-    lines = lines.split("pytest: ", 1)[1]
+    # Extract the final argparse error line without assuming the program name
+    # (it can be "pytest", "python", etc. depending on how tests are invoked).
+    error_line = captured.err.strip("\n").splitlines()[-1]
+    lines = error_line.split(": ", 1)[1]
     expected = f"error: argument {options[1]}: not allowed with argument {options[0]}"
     assert lines == expected
 
@@ -356,8 +358,10 @@ def test_main_multiple_notify_options(
     assert str(e.value) == "2"
 
     captured = capsys.readouterr()
-    lines = captured.err.strip("\n")
-    lines = lines.split("pytest: ", 1)[1]
+    # Extract the final argparse error line without assuming the program name
+    # (it can be "pytest", "python", etc. depending on how tests are invoked).
+    error_line = captured.err.strip("\n").splitlines()[-1]
+    lines = error_line.split(": ", 1)[1]
     expected = f"error: argument {options[1]}: not allowed with argument {options[0]}"
     assert lines == expected
 

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -70,6 +70,7 @@ class TestWriteBox:
         write_box.model.user_group_names = [
             groups["name"] for groups in user_groups_fixture
         ]
+        write_box.model.try_send_widget_command.return_value = None
 
         write_box.view.pinned_streams = []
         write_box.view.unpinned_streams = sorted(

--- a/tests/ui_tools/test_messages.py
+++ b/tests/ui_tools/test_messages.py
@@ -1892,8 +1892,7 @@ class TestMessageBox:
                  ("{} A\n"
                   "{} {} {} B\n"
                   "{} {} {} C\n"),
-                 id="quoted level 1-3",
-                 marks=pytest.mark.xfail(reason="rendered_bug")),
+                 id="quoted level 1-3"),
             case("""<blockquote>
                         <p><a href="https://chat.zulip.org/1">czo</a></p>
                         <blockquote>
@@ -1914,8 +1913,7 @@ class TestMessageBox:
                   "{} {} C\n"
                   "{} D\n"
                   "{} E\n"),
-                 id="quoted with links level 1-3-1",
-                 marks=pytest.mark.xfail(reason="rendered_bug")),
+                 id="quoted with links level 1-3-1"),
             # fmt: on
         ],
     )

--- a/tests/ui_tools/test_messages.py
+++ b/tests/ui_tools/test_messages.py
@@ -1016,7 +1016,7 @@ class TestMessageBox:
             assert msg_box.keypress((80,), "t") is None
             assert controller.loop.widget is popup_obj
 
-            kwargs = PopUpInputView.call_args.kwargs
+            _args, kwargs = PopUpInputView.call_args
             assert kwargs["prompt_text"] == "New title:"
             assert kwargs["default_text"] == "Today"
 
@@ -1078,7 +1078,7 @@ class TestMessageBox:
             assert msg_box.keypress((80,), "a") is None
             assert controller.loop.widget is popup_obj
 
-            kwargs = PopUpInputView.call_args.kwargs
+            _args, kwargs = PopUpInputView.call_args
             assert kwargs["prompt_text"] == "New task:"
             assert kwargs["default_text"] == ""
 

--- a/tests/widget/test_widget.py
+++ b/tests/widget/test_widget.py
@@ -62,6 +62,33 @@ from zulipterminal.widget import (
             ],
             "todo",
         ),
+        case(
+            [
+                {
+                    "id": 11901,
+                    "message_id": 1954464,
+                    "sender_id": 27294,
+                    "msg_type": "widget",
+                    "content": "not-json",
+                }
+            ],
+            "unknown",
+            id="invalid_json",
+        ),
+        case(
+            [
+                {
+                    "id": 11902,
+                    "message_id": 1954465,
+                    "sender_id": 27294,
+                    "msg_type": "widget",
+                    "content": {"widget_type": "poll"},
+                }
+            ],
+            "unknown",
+            id="non_string_content",
+        ),
+        case([], "unknown", id="empty_submessages"),
         case([{}], "unknown"),
     ],
 )

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -582,8 +582,10 @@ class Model:
 
         # Debug: Log what we're about to send
         self.controller.report_success(
-            f"DEBUG SENDING: POST /api/v1/submessage with content: "
-            f"{json.dumps(content)}"
+            [
+                f"DEBUG SENDING: POST /api/v1/submessage with content: "
+                f"{json.dumps(content)}"
+            ]
         )
 
         # Zulip REST endpoint:  POST /api/v1/submessage
@@ -596,12 +598,12 @@ class Model:
         # Debug: Log the response
         result = response.get("result", "NO RESULT")
         msg = response.get("msg", "NO MSG")
-        self.controller.report_success(f"DEBUG RESPONSE: {result} - {msg}")
+        self.controller.report_success([f"DEBUG RESPONSE: {result} - {msg}"])
 
         if response.get("result") != "success":
             msg = response.get("msg", "Unexpected error from the server")
             code = response.get("code", "?")
-            self.controller.report_error(f"Submessage error ({code}): {msg}")
+            self.controller.report_error([f"Submessage error ({code}): {msg}"])
             return False
 
         display_error_if_present(response, self.controller)
@@ -622,7 +624,9 @@ class Model:
         # optional: enforce "only my todo list"
         msg = self.index["messages"].get(message_id)
         if msg and msg.get("sender_id") != self.user_id:
-            self.controller.report_error("Only the creator can rename this to-do list.")
+            self.controller.report_error(
+                ["Only the creator can rename this to-do list."]
+            )
             return False
         return self._send_widget_submessage(message_id, content=payload)
 
@@ -630,7 +634,7 @@ class Model:
         msg = self.index["messages"].get(message_id)
         if msg and msg.get("sender_id") != self.user_id:
             self.controller.report_error(
-                "Only the creator can add tasks to this to-do list."
+                ["Only the creator can add tasks to this to-do list."]
             )
             return False
         return self._send_widget_submessage(message_id, content=payload)
@@ -642,7 +646,7 @@ class Model:
     def poll_vote(self, message_id: int, option_key: str, vote: int) -> bool:
         # vote must be +1 (vote) or -1 (unvote)
         if vote not in (1, -1):
-            self.controller.report_error("Invalid vote delta; must be 1 or -1.")
+            self.controller.report_error(["Invalid vote delta; must be 1 or -1."])
             return False
 
         payload = {

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -767,11 +767,21 @@ class WriteBox(urwid.Pile):
 
                     success = self.model.update_stream_message(**args)
                 else:
-                    success = self.model.send_stream_message(
+                    widget_result = self.model.try_send_widget_command(
+                        is_stream=True,
                         stream=self.stream_write_box.edit_text,
                         topic=topic,
+                        recipients=None,
                         content=self.msg_write_box.edit_text,
                     )
+                    if widget_result is not None:
+                        success = widget_result
+                    else:
+                        success = self.model.send_stream_message(
+                            stream=self.stream_write_box.edit_text,
+                            topic=topic,
+                            content=self.msg_write_box.edit_text,
+                        )
             else:
                 if self.msg_edit_state is not None:
                     success = self.model.update_private_message(
@@ -786,10 +796,20 @@ class WriteBox(urwid.Pile):
                         return key
                     self.update_recipients(self.to_write_box)
                     if self.recipient_user_ids:
-                        success = self.model.send_private_message(
+                        widget_result = self.model.try_send_widget_command(
+                            is_stream=False,
+                            stream=None,
+                            topic=None,
                             recipients=self.recipient_user_ids,
                             content=self.msg_write_box.edit_text,
                         )
+                        if widget_result is not None:
+                            success = widget_result
+                        else:
+                            success = self.model.send_private_message(
+                                recipients=self.recipient_user_ids,
+                                content=self.msg_write_box.edit_text,
+                            )
                     else:
                         self.view.controller.report_error(
                             ["Cannot send message without specifying recipients."]

--- a/zulipterminal/widget.py
+++ b/zulipterminal/widget.py
@@ -31,6 +31,7 @@ def process_todo_widget(
     title = ""
     tasks = {}
 
+    # First pass: Build the initial task list and handle structure events
     for entry in todo_list:
         content = entry.get("content")
         sender_id = entry.get("sender_id")
@@ -47,7 +48,8 @@ def process_todo_widget(
                         title = "Task list"
                     # Process initial tasks
                     for i, task in enumerate(widget["extra_data"].get("tasks", [])):
-                        # Initial tasks get  ID as "index,canned"
+                        # Initial tasks get ID as "i,canned"
+                        # (index first, then "canned")
                         task_id = f"{i},canned"
                         tasks[task_id] = {
                             "task": task["task"],
@@ -64,14 +66,22 @@ def process_todo_widget(
                     "completed": False,
                 }
 
-            elif widget.get("type") == "strike":
+            elif widget.get("type") == "new_task_list_title":
+                title = widget["title"]
+
+    # Second pass: Apply state changes (strike events, etc.)
+    for entry in todo_list:
+        content = entry.get("content")
+        msg_type = entry.get("msg_type")
+
+        if msg_type == "widget" and isinstance(content, str):
+            widget = json.loads(content)
+
+            if widget.get("type") == "strike":
                 # Strike event - toggle task completion state
                 task_id = widget["key"]
                 if task_id in tasks:
                     tasks[task_id]["completed"] = not tasks[task_id]["completed"]
-
-            elif widget.get("type") == "new_task_list_title":
-                title = widget["title"]
 
     return title, tasks
 


### PR DESCRIPTION
This PR adds full support for **poll** and **to-do widgets** in Zulip Terminal.  
Users can now **create widgets**, **interact with them**, and **edit to-do widgets** directly from the terminal UI. All changes are synchronized with the Zulip web client.



## Widget creation from the compose box

Zulip Terminal now supports creating widgets using simple compose-box commands.  
When a message starts with `/poll` or `/todo`, the client intercepts it, validates the input, and sends a widget message followed by the appropriate widget submessages in the same sequence used by the web app.

### Creating a poll

**Format**
/poll <question>
<option1>
<option2>


**Example**
/poll Lunch?
Pizza
Biryani
Salad

<img width="630" height="125" alt="1" src="https://github.com/user-attachments/assets/6334079d-adb8-48c0-b47b-68852a37b9d4" />
<img width="639" height="139" alt="2" src="https://github.com/user-attachments/assets/7a4c0021-8ad4-4716-ad25-d8cfc6779960" />


Rules:
- The question is required
- At least two options are required
- Requires a stream + topic for stream messages, or recipients for private messages

---

### Creating a to-do list

**Format**
/todo <title>
<task1>
<task2>



**Example**
/todo Weekend errands
Buy milk
Laundry
Call bank



Rules:
- The title is required
- At least one task is required
- Requires a valid stream/topic or PM recipients

---

## Interacting with widgets

When a widget message is focused in the message list, users can interact with it directly using the keyboard.

### Poll widgets
- Press **1–9** to vote for options 1–9
- Press **Shift + 1–9** (`! @ # $ % ^ & * (`) to remove a vote

### To-do widgets
- Press **1–9** to toggle completion of tasks 1–9

<img width="456" height="122" alt="image" src="https://github.com/user-attachments/assets/6270ef3f-a5a6-421d-b238-bd80885bd227" />


All interactions are reflected immediately and remain in sync with the web UI.

---

## Editing to-do widgets

For to-do widgets created by the current user:

- Press **`t`** to rename the to-do list title
- Press **`a`** to add a new task

<img width="702" height="293" alt="image" src="https://github.com/user-attachments/assets/c3df4a39-2b42-46c1-a815-3fdff1c7ca54" />

<img width="702" height="293" alt="image" src="https://github.com/user-attachments/assets/49e6255c-9896-4f5d-baaa-b62cad6bdf06" />


These actions send the corresponding widget submessages (`newtasklisttitle` and `newtask`).  
Editing is restricted to the original creator of the to-do list; attempts by other users are rejected.

---

## Implementation notes

- Added parsing and validation for widget commands in the compose path
- Implemented two-pass widget event handling to ensure correct ordering
- Fixed task key format to match server expectations
- Ensured required message flags are always present
- Added full integration with the widget submessage API

---

## Testing

Manual testing:
- Create poll and to-do widgets from the compose box
- Vote in polls and toggle to-do tasks from the terminal
- Rename to-do titles and add tasks as the creator
- Verify real-time sync with the web client
- Confirm that non-creators cannot edit to-do widgets