### PR TITLE
typing: api_types: Move Submessage type definition to api_types.

### DIFF
--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -23,7 +23,6 @@ from zulipterminal.cli.run import (
 from zulipterminal.model import ServerConnectionFailure
 from zulipterminal.version import ZT_VERSION
 
-
 MODULE = "zulipterminal.cli.run"
 CONTROLLER = MODULE + ".Controller"
 

--- a/tests/config/test_keys.py
+++ b/tests/config/test_keys.py
@@ -5,7 +5,6 @@ from pytest_mock import MockerFixture
 
 from zulipterminal.config import keys
 
-
 AVAILABLE_COMMANDS = list(keys.KEY_BINDINGS.keys())
 
 USED_KEYS = {key for values in keys.KEY_BINDINGS.values() for key in values["keys"]}

--- a/tests/config/test_themes.py
+++ b/tests/config/test_themes.py
@@ -28,7 +28,6 @@ from zulipterminal.config.themes import (
     validate_colors,
 )
 
-
 MODULE = "zulipterminal.config.themes"
 
 expected_complete_themes = {
@@ -48,9 +47,11 @@ def test_all_themes() -> None:
 @pytest.mark.parametrize(
     "theme_name",
     [
-        theme
-        if theme in expected_complete_themes
-        else pytest.param(theme, marks=pytest.mark.xfail(reason="incomplete"))
+        (
+            theme
+            if theme in expected_complete_themes
+            else pytest.param(theme, marks=pytest.mark.xfail(reason="incomplete"))
+        )
         for theme in THEMES
     ],
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,7 +32,6 @@ from zulipterminal.version import (
     SUPPORTED_SERVER_VERSIONS,
 )
 
-
 # --------------- Autouse Fixtures -----------------------------------------
 
 
@@ -422,7 +421,7 @@ def zulip_emoji() -> "OrderedDict[str, Dict[str, Any]]":
 
 
 def display_recipient_factory(
-    recipient_details_list: List[Tuple[int, str]]
+    recipient_details_list: List[Tuple[int, str]],
 ) -> List[Dict[str, Any]]:
     """
     Generate display_recipient field for (PM/group) messages

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -14,7 +14,6 @@ from zulipterminal.core import Controller
 from zulipterminal.helper import Index
 from zulipterminal.version import ZT_VERSION
 
-
 MODULE = "zulipterminal.core"
 MODEL = MODULE + ".Model"
 VIEW = MODULE + ".View"

--- a/tests/helper/test_helper.py
+++ b/tests/helper/test_helper.py
@@ -22,7 +22,6 @@ from zulipterminal.helper import (
     sort_unread_topics,
 )
 
-
 MODULE = "zulipterminal.helper"
 MODEL = "zulipterminal.model.Model"
 SERVER_URL = "https://chat.zulip.org"

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -25,7 +25,6 @@ from zulipterminal.model import (
     UserSettings,
 )
 
-
 MODULE = "zulipterminal.model"
 MODEL = MODULE + ".Model"
 CONTROLLER = "zulipterminal.core.Controller"
@@ -716,9 +715,11 @@ class TestModel:
             else model.user_id + 1
         )
         full_existing_reactions = [
-            dict(er, user={user_key: id})
-            if user_key is not None
-            else dict(user_id=id, emoji_code=er["emoji_code"])
+            (
+                dict(er, user={user_key: id})
+                if user_key is not None
+                else dict(user_id=id, emoji_code=er["emoji_code"])
+            )
             for er in existing_reactions
         ]
         message = dict(id=msg_id, reactions=full_existing_reactions)

--- a/tests/platform_code/test_platform_code.py
+++ b/tests/platform_code/test_platform_code.py
@@ -9,7 +9,6 @@ from zulipterminal.platform_code import (
     successful_GUI_return_code,
 )
 
-
 MODULE = "zulipterminal.platform_code"
 
 

--- a/tests/ui/test_ui.py
+++ b/tests/ui/test_ui.py
@@ -9,7 +9,6 @@ from zulipterminal.config.keys import keys_for_command
 from zulipterminal.ui import LEFT_WIDTH, RIGHT_WIDTH, TAB_WIDTH, View
 from zulipterminal.urwid_types import urwid_Box
 
-
 CONTROLLER = "zulipterminal.core.Controller"
 MODULE = "zulipterminal.ui"
 VIEW = MODULE + ".View"

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -22,7 +22,6 @@ from zulipterminal.ui_tools.views import (
     UsersView,
 )
 
-
 SUBDIR = "zulipterminal.ui_tools"
 VIEWS = SUBDIR + ".views"
 MESSAGEVIEW = VIEWS + ".MessageView"

--- a/tests/ui/test_utils.py
+++ b/tests/ui/test_utils.py
@@ -6,7 +6,6 @@ from pytest_mock import MockerFixture
 from zulipterminal.api_types import Message
 from zulipterminal.ui_tools.utils import create_msg_box_list, is_muted
 
-
 MODULE = "zulipterminal.ui_tools.utils"
 
 

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -33,7 +33,6 @@ from zulipterminal.ui_tools.boxes import (
 )
 from zulipterminal.urwid_types import urwid_Size
 
-
 MODULE = "zulipterminal.ui_tools.boxes"
 WRITEBOX = MODULE + ".WriteBox"
 

--- a/tests/ui_tools/test_buttons.py
+++ b/tests/ui_tools/test_buttons.py
@@ -22,7 +22,6 @@ from zulipterminal.ui_tools.buttons import (
 )
 from zulipterminal.urwid_types import urwid_MarkupTuple, urwid_Size
 
-
 MODULE = "zulipterminal.ui_tools.buttons"
 MSGLINKBUTTON = MODULE + ".MessageLinkButton"
 

--- a/tests/ui_tools/test_messages.py
+++ b/tests/ui_tools/test_messages.py
@@ -22,7 +22,6 @@ from zulipterminal.config.symbols import (
 )
 from zulipterminal.ui_tools.messages import MessageBox
 
-
 MODULE = "zulipterminal.ui_tools.messages"
 
 

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -32,7 +32,6 @@ from zulipterminal.ui_tools.views import (
 from zulipterminal.urwid_types import urwid_Size
 from zulipterminal.version import MINIMUM_SUPPORTED_SERVER_VERSION, ZT_VERSION
 
-
 MODULE = "zulipterminal.ui_tools.views"
 LISTWALKER = MODULE + ".urwid.SimpleFocusListWalker"
 
@@ -170,9 +169,9 @@ class TestPopUpView:
         mocker.patch(
             MODULE + ".is_command_key",
             side_effect=(
-                lambda command, key: False
-                if command == self.command
-                else is_command_key(command, key)
+                lambda command, key: (
+                    False if command == self.command else is_command_key(command, key)
+                )
             ),
         )
 

--- a/tests/widget/conftest.py
+++ b/tests/widget/conftest.py
@@ -1,0 +1,34 @@
+import json
+from typing import Any, Callable, Dict, Union
+
+import pytest
+
+from zulipterminal.api_types import Submessage
+
+
+@pytest.fixture
+def make_submessage() -> Callable[..., Submessage]:
+    def _make(
+        *,
+        content: Union[str, Dict[str, Any]],
+        message_id: int,
+        sender_id: int,
+        submessage_id: int,
+        msg_type: str = "widget",
+        event_type: str = "submessage",
+    ) -> Submessage:
+        if isinstance(content, str):
+            content_str = content
+        else:
+            content_str = json.dumps(content)
+
+        return {
+            "type": event_type,
+            "msg_type": msg_type,
+            "message_id": message_id,
+            "submessage_id": submessage_id,
+            "sender_id": sender_id,
+            "content": content_str,
+        }
+
+    return _make

--- a/tests/widget/test_widget.py
+++ b/tests/widget/test_widget.py
@@ -1,14 +1,30 @@
-from typing import Dict, List, Union
+from typing import Any, Callable, Dict, List, Union
 
 import pytest
 from pytest import param as case
 
+from zulipterminal.api_types import Submessage
 from zulipterminal.widget import (
-    Submessage,
     find_widget_type,
     process_poll_widget,
     process_todo_widget,
 )
+
+
+def normalize_submessages(
+    raw_submessages: List[Dict[str, Any]],
+    make_submessage: Callable[..., Submessage],
+) -> List[Submessage]:
+    return [
+        make_submessage(
+            content=entry["content"],
+            message_id=entry["message_id"],
+            sender_id=entry["sender_id"],
+            submessage_id=entry.get("submessage_id", entry.get("id", 0)),
+            msg_type=entry["msg_type"],
+        )
+        for entry in raw_submessages
+    ]
 
 
 @pytest.mark.parametrize(
@@ -62,13 +78,16 @@ from zulipterminal.widget import (
             ],
             "todo",
         ),
-        case([{}], "unknown"),
+        case([], "unknown"),
     ],
 )
 def test_find_widget_type(
-    submessages: List[Submessage], expected_widget_type: str
+    submessages: List[Dict[str, Any]],
+    expected_widget_type: str,
+    make_submessage: Callable[..., Submessage],
 ) -> None:
-    widget_type = find_widget_type(submessages)
+    normalized_submessages = normalize_submessages(submessages, make_submessage)
+    widget_type = find_widget_type(normalized_submessages)
 
     assert widget_type == expected_widget_type
 
@@ -340,14 +359,16 @@ def test_find_widget_type(
     ],
 )
 def test_process_todo_widget(
-    submessages: List[Submessage],
+    submessages: List[Dict[str, Any]],
     expected_title: str,
     expected_tasks: Dict[str, Dict[str, Union[str, bool]]],
+    make_submessage: Callable[..., Submessage],
 ) -> None:
-    title, tasks = process_todo_widget(submessages)
+    normalized_submessages = normalize_submessages(submessages, make_submessage)
+    result = process_todo_widget(normalized_submessages)
 
-    assert title == expected_title
-    assert tasks == expected_tasks
+    assert result["title"] == expected_title
+    assert result["tasks"] == expected_tasks
 
 
 @pytest.mark.parametrize(
@@ -655,11 +676,13 @@ def test_process_todo_widget(
     ],
 )
 def test_process_poll_widget(
-    submessages: List[Submessage],
+    submessages: List[Dict[str, Any]],
     expected_poll_question: str,
-    expected_options: Dict[str, Dict[str, Union[str, List[str]]]],
+    expected_options: Dict[str, Dict[str, Union[str, List[int]]]],
+    make_submessage: Callable[..., Submessage],
 ) -> None:
-    poll_question, options = process_poll_widget(submessages)
+    normalized_submessages = normalize_submessages(submessages, make_submessage)
+    result = process_poll_widget(normalized_submessages)
 
-    assert poll_question == expected_poll_question
-    assert options == expected_options
+    assert result["question"] == expected_poll_question
+    assert result["options"] == expected_options

--- a/tools/python_tools.py
+++ b/tools/python_tools.py
@@ -2,7 +2,6 @@
 
 import glob
 
-
 tools_exclusions = {
     f"tools/{name}"
     for name in {

--- a/zulipterminal/api_types.py
+++ b/zulipterminal/api_types.py
@@ -1,6 +1,7 @@
 """
 Types from the Zulip API, translated into python, to improve type checking
 """
+
 # NOTE: Only modify this file if it leads to a better match to the types used
 #       in the API at http://zulip.com/api
 
@@ -13,7 +14,6 @@ from zulip import EditPropagateMode  # one/all/later
 from zulip import EmojiType  # [unicode/realm/zulip_extra + _emoji]
 from zulip import MessageFlag  # superset of below, may only be changed indirectly
 from zulip import ModifiableMessageFlag  # directly modifiable read/starred/collapsed
-
 
 # This marks imported names that are intended for importing elsewhere
 __all__ = [
@@ -181,6 +181,15 @@ class SubscriptionSettingChange(TypedDict):
 ## TODO: Improve this typing to split private and stream message data
 
 
+class Submessage(TypedDict):
+    type: str
+    msg_type: str
+    message_id: int
+    submessage_id: int
+    sender_id: int
+    content: str
+
+
 class Message(TypedDict, total=False):
     id: int
     sender_id: int
@@ -195,7 +204,7 @@ class Message(TypedDict, total=False):
     subject_links: List[str]
     is_me_message: bool
     reactions: List[Dict[str, Any]]
-    submessages: List[Dict[str, Any]]
+    submessages: List[Submessage]
     flags: List[MessageFlag]
     sender_full_name: str
     sender_email: str

--- a/zulipterminal/config/color.py
+++ b/zulipterminal/config/color.py
@@ -23,7 +23,6 @@ from pygments.token import (
     Whitespace,
 )
 
-
 # fmt: off
 # Background is treated as transparent by default
 # This avoids the need for a dummy default color

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -548,9 +548,11 @@ def display_key_for_urwid_key(urwid_key: str) -> str:
         if urwid_map_key in urwid_key:
             urwid_key = urwid_key.replace(urwid_map_key, display_map_key)
     display_key = [
-        keyboard_key.capitalize()
-        if len(keyboard_key) > 1 and keyboard_key[0].islower()
-        else keyboard_key
+        (
+            keyboard_key.capitalize()
+            if len(keyboard_key) > 1 and keyboard_key[0].islower()
+            else keyboard_key
+        )
         for keyboard_key in urwid_key.split()
     ]
     return " ".join(display_key)

--- a/zulipterminal/config/themes.py
+++ b/zulipterminal/config/themes.py
@@ -1,13 +1,13 @@
 """
 Styles and their colour mappings in each theme, with helper functions
 """
+
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from pygments.token import STANDARD_TYPES, _TokenType
 
 from zulipterminal.config.color import Background, term16
 from zulipterminal.themes import gruvbox_dark, gruvbox_light, zt_blue, zt_dark, zt_light
-
 
 StyleSpec = Union[
     Tuple[Optional[str], str, str],

--- a/zulipterminal/config/ui_mappings.py
+++ b/zulipterminal/config/ui_mappings.py
@@ -17,7 +17,6 @@ from zulipterminal.config.symbols import (
 )
 from zulipterminal.helper import StreamAccessType, UserStatus
 
-
 EDIT_MODE_CAPTIONS: Dict[EditPropagateMode, str] = {
     "change_one": "Change only this message topic",
     "change_later": "Also change later messages to this topic",

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -50,7 +50,6 @@ from zulipterminal.ui_tools.views import (
 )
 from zulipterminal.version import ZT_VERSION
 
-
 ExceptionInfo = Tuple[Type[BaseException], BaseException, TracebackType]
 
 SCROLL_PROMPT = "(up/down scrolls)"
@@ -119,9 +118,11 @@ class Controller:
         # Register new ^C handler
         signal.signal(
             signal.SIGINT,
-            self.prompting_exit_handler
-            if self.exit_confirmation
-            else self.no_prompt_exit_handler,
+            (
+                self.prompting_exit_handler
+                if self.exit_confirmation
+                else self.no_prompt_exit_handler
+            ),
         )
 
     def raise_exception_in_main_thread(

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -45,7 +45,6 @@ from zulipterminal.platform_code import (
     successful_GUI_return_code,
 )
 
-
 StreamAccessType = Literal["public", "private", "web-public"]
 
 
@@ -171,9 +170,11 @@ def sort_unread_topics(
     return sorted(
         unread_topics.keys(),
         key=lambda stream_topic: (
-            stream_list.index(stream_topic[0])
-            if stream_topic[0] in stream_list
-            else len(stream_list),
+            (
+                stream_list.index(stream_topic[0])
+                if stream_topic[0] in stream_list
+                else len(stream_list)
+            ),
             stream_topic[1],
         ),
     )

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -53,6 +53,7 @@ from zulipterminal.api_types import (
     RealmUser,
     StreamComposition,
     StreamMessageUpdateRequest,
+    Submessage,
     Subscription,
     SubscriptionSettingChange,
     TypingStatusChange,
@@ -1408,7 +1409,7 @@ class Model:
             SubscriptionSettingChange(
                 stream_id=stream_id,
                 property="is_muted",
-                value=not self.is_muted_stream(stream_id)
+                value=not self.is_muted_stream(stream_id),
                 # True for muting and False for unmuting.
             )
         ]
@@ -1887,16 +1888,15 @@ class Model:
         message_id = event["message_id"]
         if message_id in self.index["messages"]:
             message = self.index["messages"][message_id]
-            message["submessages"].append(
-                {
-                    "type": event["type"],
-                    "msg_type": event["msg_type"],
-                    "message_id": event["message_id"],
-                    "submessage_id": event["submessage_id"],
-                    "sender_id": event["sender_id"],
-                    "content": event["content"],
-                }
-            )
+            submessage: Submessage = {
+                "type": event["type"],
+                "msg_type": event["msg_type"],
+                "message_id": event["message_id"],
+                "submessage_id": event["submessage_id"],
+                "sender_id": event["sender_id"],
+                "content": event["content"],
+            }
+            message["submessages"].append(submessage)
             self.index["messages"][message_id] = message
             self._update_rendered_view(message_id)
 

--- a/zulipterminal/scripts/render_symbols.py
+++ b/zulipterminal/scripts/render_symbols.py
@@ -5,7 +5,6 @@ from urwid import set_encoding
 
 from zulipterminal.config import symbols
 
-
 set_encoding("utf-8")
 
 palette = [

--- a/zulipterminal/themes/colors_gruvbox.py
+++ b/zulipterminal/themes/colors_gruvbox.py
@@ -8,10 +8,10 @@ This file uses the official gruvbox colors where possible.
 For color reference see:
     https://github.com/morhetz/gruvbox/blob/master/colors/gruvbox.vim
 """
+
 from enum import Enum
 
 from zulipterminal.config.color import color_properties
-
 
 # fmt: off
 # NOTE: The 24bit color codes use 256 color which can be

--- a/zulipterminal/themes/gruvbox_dark.py
+++ b/zulipterminal/themes/gruvbox_dark.py
@@ -14,7 +14,6 @@ from pygments.styles.solarized import SolarizedDarkStyle
 from zulipterminal.config.color import Background
 from zulipterminal.themes.colors_gruvbox import DefaultBoldColor as Color
 
-
 # fmt: off
 
 STYLES = {

--- a/zulipterminal/themes/gruvbox_light.py
+++ b/zulipterminal/themes/gruvbox_light.py
@@ -8,11 +8,11 @@ is released.
 
 For further details on themefiles look at the theme contribution guide
 """
+
 from pygments.styles.solarized import SolarizedLightStyle
 
 from zulipterminal.config.color import Background
 from zulipterminal.themes.colors_gruvbox import DefaultBoldColor as Color
-
 
 # fmt: off
 

--- a/zulipterminal/themes/zt_blue.py
+++ b/zulipterminal/themes/zt_blue.py
@@ -4,11 +4,11 @@ ZT BLUE
 This theme uses the default color scheme.
 For further details on themefiles look at the theme contribution guide
 """
+
 from pygments.styles.zenburn import ZenburnStyle
 
 from zulipterminal.config.color import Background
 from zulipterminal.config.color import DefaultBoldColor as Color
-
 
 # fmt: off
 STYLES = {

--- a/zulipterminal/themes/zt_dark.py
+++ b/zulipterminal/themes/zt_dark.py
@@ -4,11 +4,11 @@ ZT DARK
 This theme uses the default color scheme.
 For further details on themefiles look at the theme contribution guide.
 """
+
 from pygments.styles.material import MaterialStyle
 
 from zulipterminal.config.color import Background
 from zulipterminal.config.color import DefaultBoldColor as Color
-
 
 # fmt: off
 STYLES = {

--- a/zulipterminal/themes/zt_light.py
+++ b/zulipterminal/themes/zt_light.py
@@ -4,11 +4,11 @@ ZT LIGHT
 This theme uses the default color scheme.
 For further details on themefiles look at the theme contribution guide.
 """
+
 from pygments.styles.perldoc import PerldocStyle
 
 from zulipterminal.config.color import Background
 from zulipterminal.config.color import DefaultBoldColor as Color
-
 
 # fmt: off
 STYLES = {

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -52,7 +52,6 @@ from zulipterminal.helper import (
 from zulipterminal.ui_tools.buttons import EditModeButton
 from zulipterminal.urwid_types import urwid_Size
 
-
 # This constant defines the maximum character length of a message
 # in the compose box that does not trigger a confirmation popup.
 MAX_MESSAGE_LENGTH_CONFIRMATION_POPUP: Final = 15
@@ -581,9 +580,11 @@ class WriteBox(urwid.Pile):
 
         # Append user_id's to users with the same names.
         user_names_with_distinct_duplicates = [
-            f"{user['full_name']}|{user['user_id']}"
-            if user_names_counter[user["full_name"]] > 1
-            else user["full_name"]
+            (
+                f"{user['full_name']}|{user['user_id']}"
+                if user_names_counter[user["full_name"]] > 1
+                else user["full_name"]
+            )
             for user in sorted_matching_users
         ]
 

--- a/zulipterminal/ui_tools/messages.py
+++ b/zulipterminal/ui_tools/messages.py
@@ -39,7 +39,6 @@ from zulipterminal.widget import (
     process_todo_widget,
 )
 
-
 if typing.TYPE_CHECKING:
     from zulipterminal.model import Model
 
@@ -289,12 +288,16 @@ class MessageBox(urwid.Pile):
 
             reaction_texts = [
                 (
-                    "reaction_mine"
-                    if my_user_id in [id[0] for id in ids]
-                    else "reaction",
-                    f" :{reaction}: {len(ids)} "
-                    if len(reactions) > MAXIMUM_USERNAMES_VISIBLE
-                    else f" :{reaction}: {', '.join([id[1] for id in ids])} ",
+                    (
+                        "reaction_mine"
+                        if my_user_id in [id[0] for id in ids]
+                        else "reaction"
+                    ),
+                    (
+                        f" :{reaction}: {len(ids)} "
+                        if len(reactions) > MAXIMUM_USERNAMES_VISIBLE
+                        else f" :{reaction}: {', '.join([id[1] for id in ids])} "
+                    ),
                 )
                 for reaction, ids in reaction_stats.items()
             ]
@@ -736,7 +739,9 @@ class MessageBox(urwid.Pile):
             widget_type = find_widget_type(self.message.get("submessages", []))
 
             if widget_type == "todo":
-                title, tasks = process_todo_widget(self.message.get("submessages", []))
+                todo_result = process_todo_widget(self.message.get("submessages", []))
+                title = todo_result["title"]
+                tasks = todo_result["tasks"]
 
                 todo_widget = "<strong>To-do</strong>\n" + f"<strong>{title}</strong>"
 
@@ -758,9 +763,9 @@ class MessageBox(urwid.Pile):
                 self.message["content"] = todo_widget
 
             elif widget_type == "poll":
-                poll_question, poll_options = process_poll_widget(
-                    self.message.get("submessages", [])
-                )
+                poll_result = process_poll_widget(self.message.get("submessages", []))
+                poll_question = poll_result["question"]
+                poll_options = poll_result["options"]
 
                 # TODO: ZT doesn't yet support adding poll questions after the
                 # creation of the poll. So, if the poll question is not provided,
@@ -874,9 +879,7 @@ class MessageBox(urwid.Pile):
         return author_is_present
 
     @classmethod
-    def transform_content(
-        cls, content: Any, server_url: str
-    ) -> Tuple[
+    def transform_content(cls, content: Any, server_url: str) -> Tuple[
         Tuple[None, Any],
         Dict[str, Tuple[str, int, bool]],
         List[Tuple[str, str]],

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -60,7 +60,6 @@ from zulipterminal.ui_tools.messages import MessageBox
 from zulipterminal.ui_tools.utils import create_msg_box_list
 from zulipterminal.urwid_types import urwid_Size
 
-
 MIDDLE_COLUMN_MOUSE_SCROLL_LINES = 1
 SIDE_PANELS_MOUSE_SCROLL_LINES = 5
 

--- a/zulipterminal/unicode_emojis.py
+++ b/zulipterminal/unicode_emojis.py
@@ -1,6 +1,7 @@
 """
 Unicode emoji data, synchronized semi-regularly with the server source
 """
+
 # Ignore long lines
 # ruff: noqa: E501
 

--- a/zulipterminal/urwid_types.py
+++ b/zulipterminal/urwid_types.py
@@ -4,7 +4,6 @@ Types from the urwid API, to improve type checking
 
 from typing import Optional, Tuple, Union
 
-
 # FIXME: These should likely be migrated at least partially to urwid stubs
 
 urwid_Fixed = Tuple[()]  # noqa: N816

--- a/zulipterminal/widget.py
+++ b/zulipterminal/widget.py
@@ -3,33 +3,128 @@ Process widgets (submessages) like polls, todo lists, etc.
 """
 
 import json
-from typing import Dict, List, Tuple, Union
+from typing import Any, Dict, List, Union, cast
+
+from typing_extensions import Literal, TypedDict
+
+from zulipterminal.api_types import Submessage
 
 
-Submessage = Dict[str, Union[int, str]]
+class TodoItem(TypedDict):
+    task: str
+    desc: str
+    completed: bool
+
+
+class ProcessedTodoWidget(TypedDict):
+    title: str
+    tasks: Dict[str, TodoItem]
+
+
+class PollOption(TypedDict):
+    option: str
+    votes: List[int]
+
+
+class ProcessedPollWidget(TypedDict):
+    question: str
+    options: Dict[str, PollOption]
+
+
+class TodoTaskInput(TypedDict, total=False):
+    task: str
+    desc: str
+
+
+class TodoExtraData(TypedDict):
+    task_list_title: str
+    tasks: List[TodoTaskInput]
+
+
+class TodoWidgetInitial(TypedDict):
+    widget_type: Literal["todo"]
+    extra_data: TodoExtraData
+
+
+class TodoNewTaskEvent(TypedDict):
+    type: Literal["new_task"]
+    key: int
+    task: str
+    desc: str
+    completed: bool
+
+
+class TodoStrikeEvent(TypedDict):
+    type: Literal["strike"]
+    key: str
+
+
+class TodoTitleChangeEvent(TypedDict):
+    type: Literal["new_task_list_title"]
+    title: str
+
+
+TodoWidgetJSON = Union[
+    TodoWidgetInitial,
+    TodoNewTaskEvent,
+    TodoStrikeEvent,
+    TodoTitleChangeEvent,
+]
+
+
+class PollExtraData(TypedDict):
+    question: str
+    options: List[str]
+
+
+class PollWidgetInitial(TypedDict):
+    widget_type: Literal["poll"]
+    extra_data: PollExtraData
+
+
+class PollNewOptionEvent(TypedDict):
+    type: Literal["new_option"]
+    idx: int
+    option: str
+
+
+class PollQuestionChangeEvent(TypedDict):
+    type: Literal["question"]
+    question: str
+
+
+class PollVoteEvent(TypedDict):
+    type: Literal["vote"]
+    key: str
+    vote: int
+
+
+PollWidgetJSON = Union[
+    PollWidgetInitial,
+    PollNewOptionEvent,
+    PollQuestionChangeEvent,
+    PollVoteEvent,
+]
 
 
 def find_widget_type(submessages: List[Submessage]) -> str:
-    if submessages and "content" in submessages[0]:
-        content = submessages[0]["content"]
+    if not submessages or "content" not in submessages[0]:
+        return "unknown"
 
-        if isinstance(content, str):
-            try:
-                loaded_content = json.loads(content)
-                return loaded_content.get("widget_type", "unknown")
-            except json.JSONDecodeError:
-                return "unknown"
-        else:
-            return "unknown"
-    else:
+    content = submessages[0]["content"]
+
+    try:
+        loaded_content = json.loads(content)
+        return loaded_content.get("widget_type", "unknown")
+    except json.JSONDecodeError:
         return "unknown"
 
 
 def process_todo_widget(
     todo_list: List[Submessage],
-) -> Tuple[str, Dict[str, Dict[str, Union[str, bool]]]]:
+) -> ProcessedTodoWidget:
     title = ""
-    tasks = {}
+    tasks: Dict[str, TodoItem] = {}
 
     for entry in todo_list:
         content = entry.get("content")
@@ -37,50 +132,53 @@ def process_todo_widget(
         msg_type = entry.get("msg_type")
 
         if msg_type == "widget" and isinstance(content, str):
-            widget = json.loads(content)
+            widget: TodoWidgetJSON = json.loads(content)
 
-            if widget.get("widget_type") == "todo":
-                if "extra_data" in widget and widget["extra_data"] is not None:
-                    title = widget["extra_data"].get("task_list_title", "")
-                    if title == "":
-                        # Webapp uses "Task list" as default title
-                        title = "Task list"
-                    # Process initial tasks
-                    for i, task in enumerate(widget["extra_data"].get("tasks", [])):
-                        # Initial tasks get  ID as "index,canned"
-                        task_id = f"{i},canned"
-                        tasks[task_id] = {
-                            "task": task["task"],
-                            "desc": task.get("desc", ""),
-                            "completed": False,
-                        }
+            if cast(Dict[str, Any], widget).get("widget_type") == "todo":
+                todo_widget = cast(TodoWidgetInitial, widget)
+                title = todo_widget["extra_data"].get("task_list_title", "")
+                if title == "":
+                    # Webapp uses "Task list" as default title
+                    title = "Task list"
+                # Process initial tasks
+                for i, task in enumerate(todo_widget["extra_data"]["tasks"]):
+                    # Initial tasks get  ID as "index,canned"
+                    task_id = f"{i},canned"
+                    tasks[task_id] = {
+                        "task": task["task"],
+                        "desc": task.get("desc", ""),
+                        "completed": False,
+                    }
 
-            elif widget.get("type") == "new_task":
+            elif cast(Dict[str, Any], widget).get("type") == "new_task":
+                new_task_event = cast(TodoNewTaskEvent, widget)
                 # New tasks get ID as "key,sender_id"
-                task_id = f"{widget['key']},{sender_id}"
+                task_id = f"{new_task_event['key']},{sender_id}"
                 tasks[task_id] = {
-                    "task": widget["task"],
-                    "desc": widget.get("desc", ""),
+                    "task": new_task_event["task"],
+                    "desc": new_task_event.get("desc", ""),
                     "completed": False,
                 }
 
-            elif widget.get("type") == "strike":
+            elif cast(Dict[str, Any], widget).get("type") == "strike":
+                strike_event = cast(TodoStrikeEvent, widget)
                 # Strike event - toggle task completion state
-                task_id = widget["key"]
+                task_id = strike_event["key"]
                 if task_id in tasks:
                     tasks[task_id]["completed"] = not tasks[task_id]["completed"]
 
-            elif widget.get("type") == "new_task_list_title":
-                title = widget["title"]
+            elif cast(Dict[str, Any], widget).get("type") == "new_task_list_title":
+                title_event = cast(TodoTitleChangeEvent, widget)
+                title = title_event["title"]
 
-    return title, tasks
+    return ProcessedTodoWidget(title=title, tasks=tasks)
 
 
 def process_poll_widget(
     poll_content: List[Submessage],
-) -> Tuple[str, Dict[str, Dict[str, Union[str, List[str]]]]]:
+) -> ProcessedPollWidget:
     poll_question = ""
-    options = {}
+    options: Dict[str, PollOption] = {}
 
     for entry in poll_content:
         content = entry["content"]
@@ -88,20 +186,23 @@ def process_poll_widget(
         msg_type = entry["msg_type"]
 
         if msg_type == "widget" and isinstance(content, str):
-            widget = json.loads(content)
+            widget: PollWidgetJSON = json.loads(content)
 
-            if widget.get("widget_type") == "poll":
-                poll_question = widget["extra_data"]["question"]
-                for i, option in enumerate(widget["extra_data"]["options"]):
+            if cast(Dict[str, Any], widget).get("widget_type") == "poll":
+                poll_widget = cast(PollWidgetInitial, widget)
+                poll_question = poll_widget["extra_data"]["question"]
+                for i, option in enumerate(poll_widget["extra_data"]["options"]):
                     option_id = f"canned,{i}"
                     options[option_id] = {"option": option, "votes": []}
 
-            elif widget.get("type") == "question":
-                poll_question = widget["question"]
+            elif cast(Dict[str, Any], widget).get("type") == "question":
+                question_event = cast(PollQuestionChangeEvent, widget)
+                poll_question = question_event["question"]
 
-            elif widget.get("type") == "vote":
-                option_id = widget["key"]
-                vote_type = widget["vote"]
+            elif cast(Dict[str, Any], widget).get("type") == "vote":
+                vote_event = cast(PollVoteEvent, widget)
+                option_id = vote_event["key"]
+                vote_type = vote_event["vote"]
 
                 if option_id in options:
                     if vote_type == 1 and sender_id not in options[option_id]["votes"]:
@@ -109,10 +210,11 @@ def process_poll_widget(
                     elif vote_type == -1 and sender_id in options[option_id]["votes"]:
                         options[option_id]["votes"].remove(sender_id)
 
-            elif widget.get("type") == "new_option":
-                idx = widget["idx"]
-                new_option = widget["option"]
+            elif cast(Dict[str, Any], widget).get("type") == "new_option":
+                new_option_event = cast(PollNewOptionEvent, widget)
+                idx = new_option_event["idx"]
+                new_option = new_option_event["option"]
                 option_id = f"{sender_id},{idx}"
                 options[option_id] = {"option": new_option, "votes": []}
 
-    return poll_question, options
+    return ProcessedPollWidget(question=poll_question, options=options)


### PR DESCRIPTION
Fixes: https://github.com/zulip/zulip-terminal/issues/1576

Define Submessage as a TypedDict with explicit fields for better type safety and to establish a single source of truth.

Update Message.submessages to use List[Submessage] instead of List[Dict[str, Any]]. Import Submessage from api_types in widget.py and tests to avoid duplication.

Tests updated.

<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?

Moves [Submessage](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) type from [widget.py](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to [api_types.py](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and defines it as a [TypedDict](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) with explicit fields for better type safety and consistency across the codebase.

### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [x] Discussed in **#zulip-terminal** in `topic`
- [x] Fully fixes #
- [] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [x] Manually - Behavioral changes
- [ ] Manually - Visual changes
- [x] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [x] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [ ] It contains test additions for any new behavior
- [ ] It flows clearly from a previous branch commit, and/or prepares for the next commit
