### PR TITLE
Type hint: Add hints to TestMessageBox in ui_tools/test_messages.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,7 +128,7 @@ ignore_missing_imports = true
 module = [
     "tests.model.test_model",
     "tests.ui.test_ui_tools",
-    "tests.ui_tools.test_messages",
+    
 ]
 disallow_untyped_defs = false
 disallow_incomplete_defs = false

--- a/tests/ui_tools/test_messages.py
+++ b/tests/ui_tools/test_messages.py
@@ -3,11 +3,16 @@ from datetime import date
 from unittest.mock import patch
 
 import pytest
+from pytest_mock import MockerFixture
+from typing import Tuple,List,Any,Optional,Callable,Dict
 import pytz
 from bs4 import BeautifulSoup
 from pytest import param as case
-from urwid import Columns, Divider, Padding, Text
+from urwid import Columns, Divider, Padding, Text,Widget
 
+from zulipterminal.api_types import Message
+from zulipterminal.helper import Index
+from zulipterminal.urwid_types import urwid_Size
 from zulipterminal.config.keys import keys_for_command, primary_key_for_command
 from zulipterminal.config.symbols import (
     ALL_MESSAGES_MARKER,
@@ -31,7 +36,7 @@ SERVER_URL = "https://chat.zulip.zulip"
 
 class TestMessageBox:
     @pytest.fixture(autouse=True)
-    def mock_external_classes(self, mocker, initial_index):
+    def mock_external_classes(self, mocker: MockerFixture, initial_index:Index)-> None:
         self.model = mocker.MagicMock()
         self.model.index = initial_index
         self.model.stream_access_type.return_value = "public"
@@ -43,7 +48,11 @@ class TestMessageBox:
             ("private", [("email", ""), ("user_id", None)]),
         ],
     )
-    def test_init(self, mocker, message_type, set_fields):
+    def test_init(
+        self, 
+        mocker:MockerFixture, 
+        message_type: str, 
+        set_fields:List[Tuple[str,Any]])-> None:
         mocker.patch.object(MessageBox, "main_view")
         message = dict(
             display_recipient=[
@@ -66,13 +75,13 @@ class TestMessageBox:
         assert msg_box.message_links == OrderedDict()
         assert msg_box.time_mentions == list()
 
-    def test_init_fails_with_bad_message_type(self):
+    def test_init_fails_with_bad_message_type(self) -> None:
         message = dict(type="BLAH")
 
         with pytest.raises(RuntimeError):
             MessageBox(message, self.model, None)
 
-    def test_private_message_to_self(self, mocker):
+    def test_private_message_to_self(self, mocker:MockerFixture) -> None:
         message = dict(
             type="private",
             display_recipient=[
@@ -672,7 +681,10 @@ class TestMessageBox:
             ),
         ],
     )
-    def test_soup2markup(self, content, expected_markup, mocker):
+    def test_soup2markup( self, 
+    content:str, 
+    expected_markup:List[Any], 
+    mocker:MockerFixture ) -> None:
         mocker.patch(
             MODULE + ".get_localzone", return_value=pytz.timezone("Asia/Kolkata")
         )
@@ -754,7 +766,10 @@ class TestMessageBox:
             ),
         ],
     )
-    def test_main_view(self, mocker, message, last_message):
+    def test_main_view(self, 
+    mocker:MockerFixture, 
+    message:Message, 
+    last_message:Optional[Message]) -> None:
         self.model.stream_dict = {
             5: {
                 "color": "#bd6",
@@ -789,7 +804,9 @@ class TestMessageBox:
             ("<p>/me is excited!</p>", False),
         ],
     )
-    def test_main_view_renders_slash_me(self, mocker, message, content, is_me_message):
+    def test_main_view_renders_slash_me(self, 
+    mocker:MockerFixture,
+    message:Message, content:str, is_me_message:bool) -> None:
         mocker.patch(MODULE + ".urwid.Text")
         message["content"] = content
         message["is_me_message"] = is_me_message
@@ -832,8 +849,11 @@ class TestMessageBox:
         ],
     )
     def test_main_view_generates_stream_header(
-        self, mocker, message, to_vary_in_last_message
-    ):
+        self,
+        mocker:MockerFixture,
+        message:Message, 
+        to_vary_in_last_message:Dict[str,Any] )-> None:
+
         self.model.stream_dict = {
             5: {
                 "color": "#bd6",
@@ -889,8 +909,11 @@ class TestMessageBox:
         ],
     )
     def test_main_view_generates_PM_header(
-        self, mocker, message, to_vary_in_last_message
-    ):
+        self, 
+        mocker:MockerFixture, 
+        message:Message, 
+        to_vary_in_last_message:Dict[str,Any]
+    )-> None:
         last_message = dict(message, **to_vary_in_last_message)
         msg_box = MessageBox(message, self.model, last_message)
         view_components = msg_box.main_view()
@@ -1020,13 +1043,13 @@ class TestMessageBox:
     )
     def test_msg_generates_search_and_header_bar(
         self,
-        mocker,
-        messages_successful_response,
-        msg_type,
-        msg_narrow,
-        assert_header_bar,
-        assert_search_bar,
-    ):
+        mocker:MockerFixture,
+        messages_successful_response:Dict[str,Any],
+        msg_type: int,
+        msg_narrow:List[Any],
+        assert_header_bar:str,
+        assert_search_bar:Any,
+    ) -> None:
         self.model.stream_dict = {
             205: {
                 "color": "#bd6",
@@ -1087,13 +1110,13 @@ class TestMessageBox:
     )
     def test_main_view_content_header_without_header(
         self,
-        mocker,
-        message,
-        expected_header,
-        current_year,
-        starred_msg,
-        to_vary_in_last_message,
-    ):
+        mocker:MockerFixture,
+        message:Message,
+        expected_header:List[str],
+        current_year:int,
+        starred_msg:str,
+        to_vary_in_last_message:Dict[str,Any],
+    ) -> None:
         mocked_date = mocker.patch(MODULE + ".date")
         mocked_date.today.return_value = date(current_year, 1, 1)
         mocked_date.side_effect = lambda *args, **kw: date(*args, **kw)
@@ -1148,8 +1171,11 @@ class TestMessageBox:
         ],
     )
     def test_main_view_compact_output(
-        self, mocker, message_fixture, to_vary_in_each_message
-    ):
+        self, 
+        mocker:MockerFixture, 
+        message_fixture:Message, 
+        to_vary_in_each_message:Dict[str,Any]
+    )->None :
         message_fixture.update({"id": 4})
         varied_message = dict(message_fixture, **to_vary_in_each_message)
         msg_box = MessageBox(varied_message, self.model, varied_message)
@@ -1158,8 +1184,10 @@ class TestMessageBox:
         assert isinstance(view_components[0], Padding)
 
     def test_main_view_generates_EDITED_label(
-        self, mocker, messages_successful_response
-    ):
+        self, 
+        mocker:MockerFixture, 
+        messages_successful_response:Dict[str,Any]
+    )-> None:
         messages = messages_successful_response["messages"]
         for message in messages:
             self.model.index["edited_messages"].add(message["id"])
@@ -1183,10 +1211,10 @@ class TestMessageBox:
     )
     def test_update_message_author_status(
         self,
-        message_fixture,
-        update_required,
-        to_vary_in_last_message,
-    ):
+        message_fixture:Message,
+        update_required:bool,
+        to_vary_in_last_message:Dict[str,str],
+    )->None:
         message = message_fixture
         last_msg = dict(message, **to_vary_in_last_message)
 
@@ -1217,8 +1245,14 @@ class TestMessageBox:
         ],
     )
     def test_keypress_STREAM_MESSAGE(
-        self, mocker, msg_box, widget_size, narrow, expect_to_prefill, key
-    ):
+        self, 
+        mocker:MockerFixture, 
+        msg_box:MessageBox, 
+        widget_size:Callable[[Widget], urwid_Size], 
+        narrow:List[Any], 
+        expect_to_prefill: bool, 
+        key:str
+    )-> None:
         write_box = msg_box.model.controller.view.write_box
         msg_box.model.narrow = narrow
         size = widget_size(msg_box)
@@ -1377,17 +1411,17 @@ class TestMessageBox:
     )
     def test_keypress_EDIT_MESSAGE(
         self,
-        mocker,
-        message_fixture,
-        widget_size,
-        to_vary_in_each_message,
-        realm_editing_allowed,
-        msg_body_edit_limit,
-        expect_msg_body_edit_enabled,
-        expect_editing_to_succeed,
-        expect_footer_text,
-        key,
-    ):
+        mocker:MockerFixture,
+        message_fixture:Message,
+        widget_size:Callable[[Widget], urwid_Size],
+        to_vary_in_each_message : Dict[str,Any],
+        realm_editing_allowed : bool,
+        msg_body_edit_limit : Optional[int],
+        expect_msg_body_edit_enabled : Dict[str,bool],
+        expect_editing_to_succeed : Dict[str,bool],
+        expect_footer_text : Dict[str,Any],
+        key : str,
+    )-> None:
         if message_fixture["type"] == "private":
             to_vary_in_each_message["subject"] = ""
         varied_message = dict(message_fixture, **to_vary_in_each_message)
@@ -1586,7 +1620,10 @@ class TestMessageBox:
             # fmt: on
         ],
     )
-    def test_transform_content(self, mocker, raw_html, expected_content):
+    def test_transform_content(self, 
+    mocker:MockerFixture, 
+    raw_html : str, 
+    expected_content:str )-> None:
         expected_content = expected_content.replace("{}", QUOTED_TEXT_MARKER)
 
         content, *_ = MessageBox.transform_content(raw_html, SERVER_URL)
@@ -1734,11 +1771,11 @@ class TestMessageBox:
     )
     def test_reactions_view(
         self,
-        message_fixture,
-        to_vary_in_each_message,
-        expected_text,
-        expected_attributes,
-    ):
+        message_fixture : Message,
+        to_vary_in_each_message : Dict[str,Any],
+        expected_text : str,
+        expected_attributes : List[Tuple[Optional[str], int]],
+    )->None:
         self.model.user_id = 1
         varied_message = dict(message_fixture, **to_vary_in_each_message)
         msg_box = MessageBox(varied_message, self.model, None)
@@ -1858,8 +1895,11 @@ class TestMessageBox:
         ],
     )
     def test_footlinks_view(
-        self, message_links, expected_text, expected_attrib, expected_footlinks_width
-    ):
+        self, 
+        message_links : OrderedDict[str, Tuple[str, int, bool]] , expected_text : Optional[str], 
+        expected_attrib : Optional[List[Tuple[Optional[str], int]]], 
+        expected_footlinks_width : int
+    )-> None:
         footlinks, footlinks_width = MessageBox.footlinks_view(
             message_links,
             maximum_footlinks=3,
@@ -1883,7 +1923,8 @@ class TestMessageBox:
             (3, Padding),
         ],
     )
-    def test_footlinks_limit(self, maximum_footlinks, expected_instance):
+    def test_footlinks_limit(self, 
+    maximum_footlinks : int, expected_instance : Type[Any]) -> None:
         message_links = OrderedDict(
             [
                 ("https://github.com/zulip/zulip-terminal", ("ZT", 1, True)),
@@ -1905,8 +1946,13 @@ class TestMessageBox:
         ids=lambda param: f"left_click-key:{param}",
     )
     def test_mouse_event_left_click(
-        self, mocker, msg_box, key, widget_size, compose_box_is_open
-    ):
+        self, 
+        mocker : MockerFixture, 
+        msg_box : MessageBox, 
+        key : str, 
+        widget_size : Callable[[Widget], urwid_Size], 
+        compose_box_is_open : bool
+    ) -> None:
         expected_keypress = primary_key_for_command("ACTIVATE_BUTTON")
         size = widget_size(msg_box)
         col = 1

--- a/tests/ui_tools/test_messages.py
+++ b/tests/ui_tools/test_messages.py
@@ -1,18 +1,16 @@
 from collections import OrderedDict, defaultdict
 from datetime import date
-from unittest.mock import patch
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type, cast
+from unittest.mock import MagicMock, patch
 
 import pytest
-from pytest_mock import MockerFixture
-from typing import Tuple,List,Any,Optional,Callable,Dict
 import pytz
 from bs4 import BeautifulSoup
 from pytest import param as case
-from urwid import Columns, Divider, Padding, Text,Widget
+from pytest_mock import MockerFixture
+from urwid import Columns, Divider, Padding, Text, Widget
 
 from zulipterminal.api_types import Message
-from zulipterminal.helper import Index
-from zulipterminal.urwid_types import urwid_Size
 from zulipterminal.config.keys import keys_for_command, primary_key_for_command
 from zulipterminal.config.symbols import (
     ALL_MESSAGES_MARKER,
@@ -25,7 +23,9 @@ from zulipterminal.config.symbols import (
     STREAM_TOPIC_SEPARATOR,
     TIME_MENTION_MARKER,
 )
+from zulipterminal.helper import Index
 from zulipterminal.ui_tools.messages import MessageBox
+from zulipterminal.urwid_types import urwid_Size
 
 
 MODULE = "zulipterminal.ui_tools.messages"
@@ -36,7 +36,9 @@ SERVER_URL = "https://chat.zulip.zulip"
 
 class TestMessageBox:
     @pytest.fixture(autouse=True)
-    def mock_external_classes(self, mocker: MockerFixture, initial_index:Index)-> None:
+    def mock_external_classes(
+        self, mocker: MockerFixture, initial_index: Index
+    ) -> None:
         self.model = mocker.MagicMock()
         self.model.index = initial_index
         self.model.stream_access_type.return_value = "public"
@@ -49,10 +51,11 @@ class TestMessageBox:
         ],
     )
     def test_init(
-        self, 
-        mocker:MockerFixture, 
-        message_type: str, 
-        set_fields:List[Tuple[str,Any]])-> None:
+        self,
+        mocker: MockerFixture,
+        message_type: str,
+        set_fields: List[Tuple[str, Any]],
+    ) -> None:
         mocker.patch.object(MessageBox, "main_view")
         message = dict(
             display_recipient=[
@@ -65,7 +68,7 @@ class TestMessageBox:
             type=message_type,
         )
 
-        msg_box = MessageBox(message, self.model, None)
+        msg_box = MessageBox(cast(Message, message), self.model, None)
 
         assert msg_box.last_message == defaultdict(dict)
         for field, invalid_default in set_fields:
@@ -79,9 +82,9 @@ class TestMessageBox:
         message = dict(type="BLAH")
 
         with pytest.raises(RuntimeError):
-            MessageBox(message, self.model, None)
+            MessageBox(cast(Message, message), self.model, None)
 
-    def test_private_message_to_self(self, mocker:MockerFixture) -> None:
+    def test_private_message_to_self(self, mocker: MockerFixture) -> None:
         message = dict(
             type="private",
             display_recipient=[
@@ -98,10 +101,10 @@ class TestMessageBox:
             MODULE + ".MessageBox._is_private_message_to_self", return_value=True
         )
         mocker.patch.object(MessageBox, "main_view")
-        msg_box = MessageBox(message, self.model, None)
+        msg_box = MessageBox(cast(Message, message), self.model, None)
 
         assert msg_box.recipient_emails == ["foo@zulip.com"]
-        msg_box._is_private_message_to_self.assert_called_once_with()
+        cast(MagicMock, msg_box._is_private_message_to_self).assert_called_once_with()
 
     @pytest.mark.parametrize(
         "content, expected_markup",
@@ -681,10 +684,9 @@ class TestMessageBox:
             ),
         ],
     )
-    def test_soup2markup( self, 
-    content:str, 
-    expected_markup:List[Any], 
-    mocker:MockerFixture ) -> None:
+    def test_soup2markup(
+        self, content: str, expected_markup: List[Any], mocker: MockerFixture
+    ) -> None:
         mocker.patch(
             MODULE + ".get_localzone", return_value=pytz.timezone("Asia/Kolkata")
         )
@@ -766,10 +768,9 @@ class TestMessageBox:
             ),
         ],
     )
-    def test_main_view(self, 
-    mocker:MockerFixture, 
-    message:Message, 
-    last_message:Optional[Message]) -> None:
+    def test_main_view(
+        self, mocker: MockerFixture, message: Message, last_message: Optional[Message]
+    ) -> None:
         self.model.stream_dict = {
             5: {
                 "color": "#bd6",
@@ -804,9 +805,9 @@ class TestMessageBox:
             ("<p>/me is excited!</p>", False),
         ],
     )
-    def test_main_view_renders_slash_me(self, 
-    mocker:MockerFixture,
-    message:Message, content:str, is_me_message:bool) -> None:
+    def test_main_view_renders_slash_me(
+        self, mocker: MockerFixture, message: Message, content: str, is_me_message: bool
+    ) -> None:
         mocker.patch(MODULE + ".urwid.Text")
         message["content"] = content
         message["is_me_message"] = is_me_message
@@ -850,9 +851,10 @@ class TestMessageBox:
     )
     def test_main_view_generates_stream_header(
         self,
-        mocker:MockerFixture,
-        message:Message, 
-        to_vary_in_last_message:Dict[str,Any] )-> None:
+        mocker: MockerFixture,
+        message: Message,
+        to_vary_in_last_message: Dict[str, Any],
+    ) -> None:
 
         self.model.stream_dict = {
             5: {
@@ -909,11 +911,11 @@ class TestMessageBox:
         ],
     )
     def test_main_view_generates_PM_header(
-        self, 
-        mocker:MockerFixture, 
-        message:Message, 
-        to_vary_in_last_message:Dict[str,Any]
-    )-> None:
+        self,
+        mocker: MockerFixture,
+        message: Message,
+        to_vary_in_last_message: Dict[str, Any],
+    ) -> None:
         last_message = dict(message, **to_vary_in_last_message)
         msg_box = MessageBox(message, self.model, last_message)
         view_components = msg_box.main_view()
@@ -1043,12 +1045,12 @@ class TestMessageBox:
     )
     def test_msg_generates_search_and_header_bar(
         self,
-        mocker:MockerFixture,
-        messages_successful_response:Dict[str,Any],
+        mocker: MockerFixture,
+        messages_successful_response: Dict[str, Any],
         msg_type: int,
-        msg_narrow:List[Any],
-        assert_header_bar:str,
-        assert_search_bar:Any,
+        msg_narrow: List[Any],
+        assert_header_bar: str,
+        assert_search_bar: Any,
     ) -> None:
         self.model.stream_dict = {
             205: {
@@ -1110,16 +1112,16 @@ class TestMessageBox:
     )
     def test_main_view_content_header_without_header(
         self,
-        mocker:MockerFixture,
-        message:Message,
-        expected_header:List[str],
-        current_year:int,
-        starred_msg:str,
-        to_vary_in_last_message:Dict[str,Any],
+        mocker: MockerFixture,
+        message: Message,
+        expected_header: List[str],
+        current_year: int,
+        starred_msg: str,
+        to_vary_in_last_message: Dict[str, Any],
     ) -> None:
         mocked_date = mocker.patch(MODULE + ".date")
         mocked_date.today.return_value = date(current_year, 1, 1)
-        mocked_date.side_effect = lambda *args, **kw: date(*args, **kw)
+        mocked_date.side_effect = date
 
         output_date_time = "Fri Jul 20 21:54"  # corresponding to timestamp
 
@@ -1139,7 +1141,7 @@ class TestMessageBox:
         all_to_vary = dict(to_vary_in_last_message, **stars["last"])
         last_msg = dict(message, **all_to_vary)
 
-        msg_box = MessageBox(this_msg, self.model, last_msg)
+        msg_box = MessageBox(cast(Message, this_msg), self.model, last_msg)
 
         expected_header[2] = output_date_time
         if current_year > 2018:
@@ -1171,23 +1173,21 @@ class TestMessageBox:
         ],
     )
     def test_main_view_compact_output(
-        self, 
-        mocker:MockerFixture, 
-        message_fixture:Message, 
-        to_vary_in_each_message:Dict[str,Any]
-    )->None :
+        self,
+        mocker: MockerFixture,
+        message_fixture: Message,
+        to_vary_in_each_message: Dict[str, Any],
+    ) -> None:
         message_fixture.update({"id": 4})
         varied_message = dict(message_fixture, **to_vary_in_each_message)
-        msg_box = MessageBox(varied_message, self.model, varied_message)
+        msg_box = MessageBox(cast(Message, varied_message), self.model, varied_message)
         view_components = msg_box.main_view()
         assert len(view_components) == 1
         assert isinstance(view_components[0], Padding)
 
     def test_main_view_generates_EDITED_label(
-        self, 
-        mocker:MockerFixture, 
-        messages_successful_response:Dict[str,Any]
-    )-> None:
+        self, mocker: MockerFixture, messages_successful_response: Dict[str, Any]
+    ) -> None:
         messages = messages_successful_response["messages"]
         for message in messages:
             self.model.index["edited_messages"].add(message["id"])
@@ -1211,10 +1211,10 @@ class TestMessageBox:
     )
     def test_update_message_author_status(
         self,
-        message_fixture:Message,
-        update_required:bool,
-        to_vary_in_last_message:Dict[str,str],
-    )->None:
+        message_fixture: Message,
+        update_required: bool,
+        to_vary_in_last_message: Dict[str, str],
+    ) -> None:
         message = message_fixture
         last_msg = dict(message, **to_vary_in_last_message)
 
@@ -1245,14 +1245,14 @@ class TestMessageBox:
         ],
     )
     def test_keypress_STREAM_MESSAGE(
-        self, 
-        mocker:MockerFixture, 
-        msg_box:MessageBox, 
-        widget_size:Callable[[Widget], urwid_Size], 
-        narrow:List[Any], 
-        expect_to_prefill: bool, 
-        key:str
-    )-> None:
+        self,
+        mocker: MockerFixture,
+        msg_box: MessageBox,
+        widget_size: Callable[[Widget], urwid_Size],
+        narrow: List[Any],
+        expect_to_prefill: bool,
+        key: str,
+    ) -> None:
         write_box = msg_box.model.controller.view.write_box
         msg_box.model.narrow = narrow
         size = widget_size(msg_box)
@@ -1411,22 +1411,22 @@ class TestMessageBox:
     )
     def test_keypress_EDIT_MESSAGE(
         self,
-        mocker:MockerFixture,
-        message_fixture:Message,
-        widget_size:Callable[[Widget], urwid_Size],
-        to_vary_in_each_message : Dict[str,Any],
-        realm_editing_allowed : bool,
-        msg_body_edit_limit : Optional[int],
-        expect_msg_body_edit_enabled : Dict[str,bool],
-        expect_editing_to_succeed : Dict[str,bool],
-        expect_footer_text : Dict[str,Any],
-        key : str,
-    )-> None:
+        mocker: MockerFixture,
+        message_fixture: Message,
+        widget_size: Callable[[Widget], urwid_Size],
+        to_vary_in_each_message: Dict[str, Any],
+        realm_editing_allowed: bool,
+        msg_body_edit_limit: Optional[int],
+        expect_msg_body_edit_enabled: Dict[str, bool],
+        expect_editing_to_succeed: Dict[str, bool],
+        expect_footer_text: Dict[str, Any],
+        key: str,
+    ) -> None:
         if message_fixture["type"] == "private":
             to_vary_in_each_message["subject"] = ""
         varied_message = dict(message_fixture, **to_vary_in_each_message)
         message_type = varied_message["type"]
-        msg_box = MessageBox(varied_message, self.model, message_fixture)
+        msg_box = MessageBox(cast(Message, varied_message), self.model, message_fixture)
         size = widget_size(msg_box)
         msg_box.model.user_id = 1
         msg_box.model.initial_data = {
@@ -1620,10 +1620,9 @@ class TestMessageBox:
             # fmt: on
         ],
     )
-    def test_transform_content(self, 
-    mocker:MockerFixture, 
-    raw_html : str, 
-    expected_content:str )-> None:
+    def test_transform_content(
+        self, mocker: MockerFixture, raw_html: str, expected_content: str
+    ) -> None:
         expected_content = expected_content.replace("{}", QUOTED_TEXT_MARKER)
 
         content, *_ = MessageBox.transform_content(raw_html, SERVER_URL)
@@ -1771,14 +1770,14 @@ class TestMessageBox:
     )
     def test_reactions_view(
         self,
-        message_fixture : Message,
-        to_vary_in_each_message : Dict[str,Any],
-        expected_text : str,
-        expected_attributes : List[Tuple[Optional[str], int]],
-    )->None:
+        message_fixture: Message,
+        to_vary_in_each_message: Dict[str, Any],
+        expected_text: str,
+        expected_attributes: List[Tuple[Optional[str], int]],
+    ) -> None:
         self.model.user_id = 1
         varied_message = dict(message_fixture, **to_vary_in_each_message)
-        msg_box = MessageBox(varied_message, self.model, None)
+        msg_box = MessageBox(cast(Message, varied_message), self.model, None)
         reactions = to_vary_in_each_message["reactions"]
 
         mock_all_users_by_id = {
@@ -1895,11 +1894,12 @@ class TestMessageBox:
         ],
     )
     def test_footlinks_view(
-        self, 
-        message_links : OrderedDict[str, Tuple[str, int, bool]] , expected_text : Optional[str], 
-        expected_attrib : Optional[List[Tuple[Optional[str], int]]], 
-        expected_footlinks_width : int
-    )-> None:
+        self,
+        message_links: OrderedDict[str, Tuple[str, int, bool]],
+        expected_text: Optional[str],
+        expected_attrib: Optional[List[Tuple[Optional[str], int]]],
+        expected_footlinks_width: int,
+    ) -> None:
         footlinks, footlinks_width = MessageBox.footlinks_view(
             message_links,
             maximum_footlinks=3,
@@ -1923,8 +1923,9 @@ class TestMessageBox:
             (3, Padding),
         ],
     )
-    def test_footlinks_limit(self, 
-    maximum_footlinks : int, expected_instance : Type[Any]) -> None:
+    def test_footlinks_limit(
+        self, maximum_footlinks: int, expected_instance: Type[Any]
+    ) -> None:
         message_links = OrderedDict(
             [
                 ("https://github.com/zulip/zulip-terminal", ("ZT", 1, True)),
@@ -1946,12 +1947,12 @@ class TestMessageBox:
         ids=lambda param: f"left_click-key:{param}",
     )
     def test_mouse_event_left_click(
-        self, 
-        mocker : MockerFixture, 
-        msg_box : MessageBox, 
-        key : str, 
-        widget_size : Callable[[Widget], urwid_Size], 
-        compose_box_is_open : bool
+        self,
+        mocker: MockerFixture,
+        msg_box: MessageBox,
+        key: str,
+        widget_size: Callable[[Widget], urwid_Size],
+        compose_box_is_open: bool,
     ) -> None:
         expected_keypress = primary_key_for_command("ACTIVATE_BUTTON")
         size = widget_size(msg_box)


### PR DESCRIPTION
### What does this PR do, and why?
This PR adds comprehensive type hints to the `TestMessageBox` class and its associated helper functions within `zulipterminal/ui_tools/test_messages.py`. 

As part of the effort to improve the project's type safety, this change:
- Provides explicit types for parameters in various `@pytest.mark.parametrize` decorators.
- Type-hints fixtures such as `mocker`, `message_fixture`, and `widget_size`.
- Enables `mypy` for this file by removing the corresponding exclusion from `pyproject.toml`.

### External discussion & connections
- [x] Fully fixes #1337

### How did you test this?
- [x] Existing automated tests should already cover this (*only a refactor of tested code*)
- [x] Verified type-checking by running `mypy zulipterminal/ui_tools/messages.py`.
- [x] Verified test integrity by running `pytest zulipterminal/ui_tools/messages.py`.

### Self-review checklist for each commit
- [x] It has a commit summary describing the motivation and reasoning for the change
- [x] It individually passes linting and tests
- [x] It flows clearly from a previous branch commit, and/or prepares for the next commit