### PR TITLE
widget: Define TypedDicts for todo/poll widget outputs and JSON payloads

### DIFF
--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -3178,10 +3178,9 @@ class TestModel:
                         ),
                     },
                     {
-                        "type": "submessage",
+                        "id": 1,
                         "msg_type": "widget",
                         "message_id": 1958326,
-                        "submessage_id": 1,
                         "sender_id": 27294,
                         "content": '{"type":"strike","key":"0,canned"}',
                     },
@@ -3243,10 +3242,9 @@ class TestModel:
                         "content": '{"type":"strike","key":"0,canned"}',
                     },
                     {
-                        "type": "submessage",
+                        "id": 12185,
                         "msg_type": "widget",
                         "message_id": 1958326,
-                        "submessage_id": 12185,
                         "sender_id": 27294,
                         "content": (
                             '{"type":"new_task","key":2,"task":"Make a coffee",'
@@ -3278,16 +3276,14 @@ class TestModel:
                         "content": '{"type":"strike","key":"0,canned"}',
                     },
                     {
-                        "type": "submessage",
+                        "id": 12185,
                         "msg_type": "widget",
                         "message_id": 1958326,
-                        "submessage_id": 12185,
                         "sender_id": 27294,
                         "content": (
                             '{"type":"new_task","key":2,"task":"Make a coffee"'
                             ',"desc":"","completed":false}'
                         ),
-                        "id": 0,
                     },
                 ],
                 {
@@ -3323,22 +3319,19 @@ class TestModel:
                         "content": '{"type":"strike","key":"0,canned"}',
                     },
                     {
-                        "type": "submessage",
+                        "id": 12185,
                         "msg_type": "widget",
                         "message_id": 1958326,
-                        "submessage_id": 12185,
                         "sender_id": 27294,
                         "content": (
                             '{"type":"new_task","key":2,"task":"Make a coffee"'
                             ',"desc":"","completed":false}'
                         ),
-                        "id": 0,
                     },
                     {
-                        "type": "submessage",
+                        "id": 12186,
                         "msg_type": "widget",
                         "message_id": 1958326,
-                        "submessage_id": 12186,
                         "sender_id": 27294,
                         "content": (
                             '{"type":"new_task_list_title",'

--- a/tests/widget/test_widget.py
+++ b/tests/widget/test_widget.py
@@ -1,14 +1,93 @@
-from typing import Dict, List, Union
+import json
+from typing import Dict, List, Optional, Union
 
 import pytest
 from pytest import param as case
 
+from zulipterminal.api_types import PollOption, Submessage
 from zulipterminal.widget import (
-    Submessage,
     find_widget_type,
     process_poll_widget,
     process_todo_widget,
 )
+
+
+# Factories for constructing submessage test data
+
+
+def submessage_factory(
+    *, id: int, message_id: int, sender_id: int, content: str
+) -> Submessage:
+    """Construct a Submessage dict for use in widget tests."""
+    return {
+        "id": id,
+        "message_id": message_id,
+        "sender_id": sender_id,
+        "msg_type": "widget",
+        "content": content,
+    }
+
+
+# Todo widget JSON content helpers
+
+
+def todo_widget_content(
+    *, task_list_title: str = "", tasks: Optional[List[Dict[str, str]]] = None
+) -> str:
+    """Return JSON for initializing a todo widget."""
+    return json.dumps(
+        {
+            "widget_type": "todo",
+            "extra_data": {"task_list_title": task_list_title, "tasks": tasks or []},
+        }
+    )
+
+
+def todo_new_task_content(key: int, task: str, desc: str = "") -> str:
+    """Return JSON for adding a new task."""
+    return json.dumps(
+        {"type": "new_task", "key": key, "task": task, "desc": desc, "completed": False}
+    )
+
+
+def todo_strike_content(key: str) -> str:
+    """Return JSON for toggling task completion."""
+    return json.dumps({"type": "strike", "key": key})
+
+
+def todo_new_title_content(title: str) -> str:
+    """Return JSON for updating the todo list title."""
+    return json.dumps({"type": "new_task_list_title", "title": title})
+
+
+# Poll widget JSON content helpers
+
+
+def poll_widget_content(
+    *, question: str = "", options: Optional[List[str]] = None
+) -> str:
+    """Return JSON for initializing a poll widget."""
+    return json.dumps(
+        {
+            "widget_type": "poll",
+            "extra_data": {"question": question, "options": options or []},
+        }
+    )
+
+
+def poll_vote_content(key: str, vote: int = 1) -> str:
+    """Return JSON for casting or removing a vote."""
+    return json.dumps({"type": "vote", "key": key, "vote": vote})
+
+
+def poll_new_option_content(idx: int, option: str) -> str:
+    """Return JSON for adding a new poll option."""
+    return json.dumps({"type": "new_option", "idx": idx, "option": option})
+
+
+def poll_new_question_content(question: str) -> str:
+    """Return JSON for updating the poll question."""
+    return json.dumps({"type": "question", "question": question})
 
 
 @pytest.mark.parametrize(
@@ -657,7 +736,7 @@ def test_process_todo_widget(
 def test_process_poll_widget(
     submessages: List[Submessage],
     expected_poll_question: str,
-    expected_options: Dict[str, Dict[str, Union[str, List[str]]]],
+    expected_options: Dict[str, PollOption],
 ) -> None:
     poll_question, options = process_poll_widget(submessages)
 

--- a/zulipterminal/api_types.py
+++ b/zulipterminal/api_types.py
@@ -19,6 +19,22 @@ from zulip import ModifiableMessageFlag  # directly modifiable read/starred/coll
 __all__ = [
     "EditPropagateMode",
     "EmojiType",
+    # Widget event types (parsed from Submessage.content JSON)
+    "PollNewOptionEvent",
+    "PollQuestionEvent",
+    "PollVoteEvent",
+    "PollWidgetEvent",
+    "PollWidgetInit",
+    "TodoNewTaskEvent",
+    "TodoNewTitleEvent",
+    "TodoStrikeEvent",
+    "TodoWidgetEvent",
+    "TodoWidgetInit",
+    "WidgetEvent",
+    # Widget result types
+    "PollOption",
+    "Submessage",
+    "TodoTask",
 ]
 
 
@@ -181,6 +197,144 @@ class SubscriptionSettingChange(TypedDict):
 ## TODO: Improve this typing to split private and stream message data
 
 
+###############################################################################
+# Submessage data (for widgets like polls and todos)
+
+
+class Submessage(TypedDict):
+    """Submessage data from Message.submessages list."""
+
+    id: int
+    message_id: int
+    sender_id: int
+    msg_type: Literal["widget"]  # Currently only widget submessages exist
+    content: str  # JSON-encoded widget event data
+
+
+###############################################################################
+# Widget event types (parsed from Submessage.content JSON)
+# These represent the JSON structures sent in widget submessages
+
+
+class TodoInitialTask(TypedDict):
+    """Task structure in the initial todo widget creation."""
+
+    task: str
+    desc: NotRequired[str]
+
+
+class TodoWidgetExtraData(TypedDict):
+    """Extra data for todo widget initialization."""
+
+    task_list_title: str
+    tasks: List[TodoInitialTask]
+
+
+class TodoWidgetInit(TypedDict):
+    """Initial todo widget creation event."""
+
+    widget_type: Literal["todo"]
+    extra_data: TodoWidgetExtraData
+
+
+class TodoNewTaskEvent(TypedDict):
+    """Event for adding a new task to a todo widget."""
+
+    type: Literal["new_task"]
+    key: int
+    task: str
+    desc: NotRequired[str]
+    completed: bool
+
+
+class TodoStrikeEvent(TypedDict):
+    """Event for toggling task completion status."""
+
+    type: Literal["strike"]
+    key: str
+
+
+class TodoNewTitleEvent(TypedDict):
+    """Event for updating the todo list title."""
+
+    type: Literal["new_task_list_title"]
+    title: str
+
+
+class PollWidgetExtraData(TypedDict):
+    """Extra data for poll widget initialization."""
+
+    question: str
+    options: List[str]
+
+
+class PollWidgetInit(TypedDict):
+    """Initial poll widget creation event."""
+
+    widget_type: Literal["poll"]
+    extra_data: PollWidgetExtraData
+
+
+class PollQuestionEvent(TypedDict):
+    """Event for updating the poll question."""
+
+    type: Literal["question"]
+    question: str
+
+
+class PollVoteEvent(TypedDict):
+    """Event for casting or removing a vote."""
+
+    type: Literal["vote"]
+    key: str
+    vote: Literal[1, -1]  # 1 = add vote, -1 = remove vote
+
+
+class PollNewOptionEvent(TypedDict):
+    """Event for adding a new poll option."""
+
+    type: Literal["new_option"]
+    idx: int
+    option: str
+
+
+# Union types for widget events
+TodoWidgetEvent = Union[
+    TodoWidgetInit,
+    TodoNewTaskEvent,
+    TodoStrikeEvent,
+    TodoNewTitleEvent,
+]
+
+PollWidgetEvent = Union[
+    PollWidgetInit,
+    PollQuestionEvent,
+    PollVoteEvent,
+    PollNewOptionEvent,
+]
+
+WidgetEvent = Union[TodoWidgetEvent, PollWidgetEvent]
+
+
+###############################################################################
+# Widget result types (returned by widget processing functions)
+
+
+class TodoTask(TypedDict):
+    """Single task within a todo widget."""
+
+    task: str
+    desc: str
+    completed: bool
+
+
+class PollOption(TypedDict):
+    """Single option within a poll widget."""
+
+    option: str
+    votes: List[int]  # List of sender_ids who voted
+
+
 class Message(TypedDict, total=False):
     id: int
     sender_id: int
@@ -195,7 +349,7 @@ class Message(TypedDict, total=False):
     subject_links: List[str]
     is_me_message: bool
     reactions: List[Dict[str, Any]]
-    submessages: List[Dict[str, Any]]
+    submessages: List["Submessage"]
     flags: List[MessageFlag]
     sender_full_name: str
     sender_email: str

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -27,7 +27,7 @@ from urllib.parse import urlparse
 
 import zulip
 from bs4 import BeautifulSoup
-from typing_extensions import TypedDict
+from typing_extensions import Literal, TypedDict
 
 from zulipterminal import unicode_emojis
 from zulipterminal.api_types import (
@@ -1889,10 +1889,9 @@ class Model:
             message = self.index["messages"][message_id]
             message["submessages"].append(
                 {
-                    "type": event["type"],
-                    "msg_type": event["msg_type"],
+                    "id": event["submessage_id"],
+                    "msg_type": cast(Literal["widget"], event["msg_type"]),
                     "message_id": event["message_id"],
-                    "submessage_id": event["submessage_id"],
                     "sender_id": event["sender_id"],
                     "content": event["content"],
                 }

--- a/zulipterminal/widget.py
+++ b/zulipterminal/widget.py
@@ -3,23 +3,30 @@ Process widgets (submessages) like polls, todo lists, etc.
 """
 
 import json
-from typing import Dict, List, Tuple, Union
+from typing import Any, Dict, List, Tuple, cast
 
-
-Submessage = Dict[str, Union[int, str]]
+from zulipterminal.api_types import (
+    PollNewOptionEvent,
+    PollOption,
+    PollQuestionEvent,
+    PollVoteEvent,
+    PollWidgetInit,
+    Submessage,
+    TodoNewTaskEvent,
+    TodoNewTitleEvent,
+    TodoStrikeEvent,
+    TodoTask,
+    TodoWidgetInit,
+)
 
 
 def find_widget_type(submessages: List[Submessage]) -> str:
     if submessages and "content" in submessages[0]:
         content = submessages[0]["content"]
-
-        if isinstance(content, str):
-            try:
-                loaded_content = json.loads(content)
-                return loaded_content.get("widget_type", "unknown")
-            except json.JSONDecodeError:
-                return "unknown"
-        else:
+        try:
+            loaded_content: Dict[str, Any] = json.loads(content)
+            return loaded_content.get("widget_type", "unknown")
+        except json.JSONDecodeError:
             return "unknown"
     else:
         return "unknown"
@@ -27,26 +34,28 @@ def find_widget_type(submessages: List[Submessage]) -> str:
 
 def process_todo_widget(
     todo_list: List[Submessage],
-) -> Tuple[str, Dict[str, Dict[str, Union[str, bool]]]]:
+) -> Tuple[str, Dict[str, TodoTask]]:
     title = ""
-    tasks = {}
+    tasks: Dict[str, TodoTask] = {}
 
     for entry in todo_list:
-        content = entry.get("content")
-        sender_id = entry.get("sender_id")
-        msg_type = entry.get("msg_type")
+        content = entry["content"]
+        sender_id = entry["sender_id"]
+        msg_type = entry["msg_type"]
 
-        if msg_type == "widget" and isinstance(content, str):
-            widget = json.loads(content)
+        if msg_type == "widget":
+            widget: Dict[str, Any] = json.loads(content)
 
             if widget.get("widget_type") == "todo":
-                if "extra_data" in widget and widget["extra_data"] is not None:
-                    title = widget["extra_data"].get("task_list_title", "")
+                todo_init = cast(TodoWidgetInit, widget)
+                extra_data = todo_init.get("extra_data")
+                if extra_data is not None:
+                    title = extra_data.get("task_list_title", "")
                     if title == "":
                         # Webapp uses "Task list" as default title
                         title = "Task list"
                     # Process initial tasks
-                    for i, task in enumerate(widget["extra_data"].get("tasks", [])):
+                    for i, task in enumerate(extra_data.get("tasks", [])):
                         # Initial tasks get  ID as "index,canned"
                         task_id = f"{i},canned"
                         tasks[task_id] = {
@@ -56,52 +65,59 @@ def process_todo_widget(
                         }
 
             elif widget.get("type") == "new_task":
+                new_task = cast(TodoNewTaskEvent, widget)
                 # New tasks get ID as "key,sender_id"
-                task_id = f"{widget['key']},{sender_id}"
+                task_id = f"{new_task['key']},{sender_id}"
                 tasks[task_id] = {
-                    "task": widget["task"],
-                    "desc": widget.get("desc", ""),
+                    "task": new_task["task"],
+                    "desc": new_task.get("desc", ""),
                     "completed": False,
                 }
 
             elif widget.get("type") == "strike":
+                strike = cast(TodoStrikeEvent, widget)
                 # Strike event - toggle task completion state
-                task_id = widget["key"]
+                task_id = strike["key"]
                 if task_id in tasks:
                     tasks[task_id]["completed"] = not tasks[task_id]["completed"]
 
             elif widget.get("type") == "new_task_list_title":
-                title = widget["title"]
+                new_title = cast(TodoNewTitleEvent, widget)
+                title = new_title["title"]
 
     return title, tasks
 
 
 def process_poll_widget(
     poll_content: List[Submessage],
-) -> Tuple[str, Dict[str, Dict[str, Union[str, List[str]]]]]:
+) -> Tuple[str, Dict[str, PollOption]]:
     poll_question = ""
-    options = {}
+    options: Dict[str, PollOption] = {}
 
     for entry in poll_content:
         content = entry["content"]
         sender_id = entry["sender_id"]
         msg_type = entry["msg_type"]
 
-        if msg_type == "widget" and isinstance(content, str):
-            widget = json.loads(content)
+        if msg_type == "widget":
+            widget: Dict[str, Any] = json.loads(content)
 
             if widget.get("widget_type") == "poll":
-                poll_question = widget["extra_data"]["question"]
-                for i, option in enumerate(widget["extra_data"]["options"]):
+                poll_init = cast(PollWidgetInit, widget)
+                extra_data = poll_init["extra_data"]
+                poll_question = extra_data["question"]
+                for i, option in enumerate(extra_data["options"]):
                     option_id = f"canned,{i}"
                     options[option_id] = {"option": option, "votes": []}
 
             elif widget.get("type") == "question":
-                poll_question = widget["question"]
+                question_event = cast(PollQuestionEvent, widget)
+                poll_question = question_event["question"]
 
             elif widget.get("type") == "vote":
-                option_id = widget["key"]
-                vote_type = widget["vote"]
+                vote_event = cast(PollVoteEvent, widget)
+                option_id = vote_event["key"]
+                vote_type = vote_event["vote"]
 
                 if option_id in options:
                     if vote_type == 1 and sender_id not in options[option_id]["votes"]:
@@ -110,8 +126,9 @@ def process_poll_widget(
                         options[option_id]["votes"].remove(sender_id)
 
             elif widget.get("type") == "new_option":
-                idx = widget["idx"]
-                new_option = widget["option"]
+                new_option_event = cast(PollNewOptionEvent, widget)
+                idx = new_option_event["idx"]
+                new_option = new_option_event["option"]
                 option_id = f"{sender_id},{idx}"
                 options[option_id] = {"option": new_option, "votes": []}
 


### PR DESCRIPTION
### What does this PR do, and why?

This PR improves type safety for widget handling by defining TypedDicts for todo/poll widget outputs and JSON payloads.

**Changes include:**

- **Adding TypedDicts in [api_types.py](cci:7://file:///media/nexion/New%20Volume/zulip%20terminal/zulip-terminal/zulipterminal/api_types.py:0:0-0:0)** for all widget event JSON structures:
  - [TodoInitialTask](cci:2://file:///media/nexion/New%20Volume/zulip%20terminal/zulip-terminal/zulipterminal/api_types.py:218:0-222:26), [TodoWidgetExtraData](cci:2://file:///media/nexion/New%20Volume/zulip%20terminal/zulip-terminal/zulipterminal/api_types.py:225:0-229:32), [TodoWidgetInit](cci:2://file:///media/nexion/New%20Volume/zulip%20terminal/zulip-terminal/zulipterminal/api_types.py:232:0-236:35)
  - [TodoNewTaskEvent](cci:2://file:///media/nexion/New%20Volume/zulip%20terminal/zulip-terminal/zulipterminal/api_types.py:239:0-246:19), [TodoStrikeEvent](cci:2://file:///media/nexion/New%20Volume/zulip%20terminal/zulip-terminal/zulipterminal/api_types.py:249:0-253:12), [TodoNewTitleEvent](cci:2://file:///media/nexion/New%20Volume/zulip%20terminal/zulip-terminal/zulipterminal/api_types.py:256:0-260:14)
  - [PollWidgetExtraData](cci:2://file:///media/nexion/New%20Volume/zulip%20terminal/zulip-terminal/zulipterminal/api_types.py:263:0-267:22), [PollWidgetInit](cci:2://file:///media/nexion/New%20Volume/zulip%20terminal/zulip-terminal/zulipterminal/api_types.py:270:0-274:35), [PollQuestionEvent](cci:2://file:///media/nexion/New%20Volume/zulip%20terminal/zulip-terminal/zulipterminal/api_types.py:277:0-281:17)
  - [PollVoteEvent](cci:2://file:///media/nexion/New%20Volume/zulip%20terminal/zulip-terminal/zulipterminal/api_types.py:284:0-289:58), [PollNewOptionEvent](cci:2://file:///media/nexion/New%20Volume/zulip%20terminal/zulip-terminal/zulipterminal/api_types.py:292:0-297:15)
  - Union types: `TodoWidgetEvent`, `PollWidgetEvent`, `WidgetEvent`

- **Updating [widget.py](cci:7://file:///media/nexion/New%20Volume/zulip%20terminal/zulip-terminal/zulipterminal/widget.py:0:0-0:0)** to use typed structures with casts for JSON parsing, providing better type checking and IDE support

- **Adding factory fixtures** for Submessage content in tests:
  - [submessage_factory()](cci:1://file:///media/nexion/New%20Volume/zulip%20terminal/zulip-terminal/tests/widget/test_widget.py:17:0-27:5) for constructing Submessage dicts
  - Helper functions for todo and poll widget JSON content

- **[Submessage](cci:2://file:///media/nexion/New%20Volume/zulip%20terminal/zulip-terminal/zulipterminal/api_types.py:203:0-210:50)** is now properly defined in [api_types.py](cci:7://file:///media/nexion/New%20Volume/zulip%20terminal/zulip-terminal/zulipterminal/api_types.py:0:0-0:0) and used to improve the [Message](cci:2://file:///media/nexion/New%20Volume/zulip%20terminal/zulip-terminal/zulipterminal/api_types.py:337:0-368:28) TypedDict definition

### External discussion & connections
- [x] Discussed in **#zulip-terminal** in `Widget followup work`
- [x] Fully fixes #1576

### How did you test this?
- [x] Adapting existing automated tests
- [x] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the motivation and reasoning for the change
- [x] It individually passes linting and tests
- [x] It contains test additions for any new behavior
- [x] It flows clearly from a previous branch commit, and/or prepares for the next commit