### PR TITLE
docs: Update Python version requirement to 3.8-3.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ We also provide some sample Dockerfiles to build docker images in
 
 ### Installing into an isolated Python virtual environment
 
-With the python 3.6+ required for running, the following should work on most
+With python 3.8 to 3.11 required for running, the following should work on most
 systems:
 1. `python3 -m venv zt_venv`
    (creates a virtual environment named `zt_venv` in the current directory)
@@ -456,7 +456,7 @@ process similar to that in the previous section.
 $ pip3 install --user pipenv
 ```
 2. Initialize the pipenv virtual environment for zulip-term (using the default
-   python 3; use eg. `--python 3.6` to be more specific)
+   python 3; use eg. `--python 3.8` to be more specific)
 
 ```
 $ pipenv --three


### PR DESCRIPTION
Fixes #1579

Updates README to reflect actual Python version support:
- Changed "python 3.6+" to "python 3.8 to 3.11"
- Updated example from `--python 3.6` to `--python 3.8`
- Removed unsupported versions 3.6, 3.7
- Added supported version 3.11 (was missing)

The Python version badges in the README are dynamically generated from PyPI, which already shows the correct versions. This PR updates the text documentation to match.