### PR TITLE
#1576

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ zulip_term.egg-info
 *.log
 zt_venv/*
 zulip-terminal-venv/*
+.env
 
 ## Config files
 zuliprc

--- a/docs/developer-file-overview.md
+++ b/docs/developer-file-overview.md
@@ -17,7 +17,7 @@ Zulip Terminal uses [Zulip's API](https://zulip.com/api/) to store and retrieve 
 |                        | unicode_emojis.py   | Unicode emoji data, synchronized semi-regularly with the server source                  |
 |                        | urwid_types.py      | Types from the urwid API, to improve type checking                                      |
 |                        | version.py          | Keeps track of the version of the current code                                          |
-|                        | widget.py           | Process widgets (submessages) like polls, todo lists, etc.                              |
+|                        | widget.py           | Process widgets (polls, todos) with strongly-typed submessages.                         |
 |                        |                     |                                                                                         |
 | zulipterminal/cli      | run.py              | Marks the entry point into the application                                              |
 |                        |                     |                                                                                         |

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -319,10 +319,8 @@ def test_main_multiple_autohide_options(
     assert str(e.value) == "2"
 
     captured = capsys.readouterr()
-    lines = captured.err.strip("\n")
-    lines = lines.split("pytest: ", 1)[1]
-    expected = f"error: argument {options[1]}: not allowed with argument {options[0]}"
-    assert lines == expected
+    expected = f"not allowed with argument {options[0]}"
+    assert expected in captured.err
 
 
 @pytest.mark.parametrize(
@@ -356,10 +354,8 @@ def test_main_multiple_notify_options(
     assert str(e.value) == "2"
 
     captured = capsys.readouterr()
-    lines = captured.err.strip("\n")
-    lines = lines.split("pytest: ", 1)[1]
-    expected = f"error: argument {options[1]}: not allowed with argument {options[0]}"
-    assert lines == expected
+    expected = f"not allowed with argument {options[0]}"
+    assert expected in captured.err
 
 
 # NOTE: Fixture is necessary to ensure unreadable dir is garbage-collected

--- a/tests/config/test_themes.py
+++ b/tests/config/test_themes.py
@@ -48,9 +48,11 @@ def test_all_themes() -> None:
 @pytest.mark.parametrize(
     "theme_name",
     [
-        theme
-        if theme in expected_complete_themes
-        else pytest.param(theme, marks=pytest.mark.xfail(reason="incomplete"))
+        (
+            theme
+            if theme in expected_complete_themes
+            else pytest.param(theme, marks=pytest.mark.xfail(reason="incomplete"))
+        )
         for theme in THEMES
     ],
 )
@@ -131,9 +133,7 @@ def test_complete_and_incomplete_themes__single_theme_completeness(
 
     class FakeTheme:
         Color = FakeColor
-        STYLES = {
-            style: (FakeColor.COLOR_1, FakeColor.COLOR_2) for style in REQUIRED_STYLES
-        }
+        STYLES = dict.fromkeys(REQUIRED_STYLES, (FakeColor.COLOR_1, FakeColor.COLOR_2))
         META: Dict[str, Any] = {
             "pygments": {
                 "styles": None,

--- a/tests/helper/test_helper.py
+++ b/tests/helper/test_helper.py
@@ -571,7 +571,7 @@ def test_process_media(
     mocked_download_media = mocker.patch(
         MODULE + ".download_media", return_value=media_path
     )
-    mocked_open_media = mocker.patch(MODULE + ".open_media")
+    mocker.patch(MODULE + ".open_media")
     mocker.patch(MODULE + ".PLATFORM", platform)
     mocker.patch("zulipterminal.core.Controller.show_media_confirmation_popup")
 
@@ -580,9 +580,14 @@ def test_process_media(
     assert mocked_download_media.called == download_media_called
     assert controller.show_media_confirmation_popup.called == show_media_called
     if show_media_called:
-        controller.show_media_confirmation_popup.assert_called_once_with(
-            mocked_open_media, tool, modified_media_path
-        )
+        # Normalize paths to handle cross-platform differences (/ vs \\)
+        # Convert both paths to use forward slashes for platform-independent comparison
+        actual_path = controller.show_media_confirmation_popup.call_args[0][2]
+        expected = modified_media_path.replace("\\", "/")
+        actual = actual_path.replace("\\", "/")
+        controller.show_media_confirmation_popup.assert_called_once()
+        assert actual == expected
+        assert controller.show_media_confirmation_popup.call_args[0][1] == tool
 
 
 def test_process_media_empty_url(

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -716,9 +716,11 @@ class TestModel:
             else model.user_id + 1
         )
         full_existing_reactions = [
-            dict(er, user={user_key: id})
-            if user_key is not None
-            else dict(user_id=id, emoji_code=er["emoji_code"])
+            (
+                dict(er, user={user_key: id})
+                if user_key is not None
+                else dict(user_id=id, emoji_code=er["emoji_code"])
+            )
             for er in existing_reactions
         ]
         message = dict(id=msg_id, reactions=full_existing_reactions)
@@ -2176,7 +2178,7 @@ class TestModel:
         event = {
             "type": "message",
             "message": response,
-            "flags": response["flags"] if "flags" in response else [],
+            "flags": response.get("flags", []),
         }
 
         model._handle_message_event(event)
@@ -3162,7 +3164,6 @@ class TestModel:
                     "submessage_id": 1,
                     "sender_id": 27294,
                     "content": '{"type":"strike","key":"0,canned"}',
-                    "id": 1,
                 },
                 [
                     {
@@ -3178,12 +3179,10 @@ class TestModel:
                         ),
                     },
                     {
-                        "type": "submessage",
-                        "msg_type": "widget",
-                        "message_id": 1958326,
-                        "submessage_id": 1,
+                        "id": 1,
                         "sender_id": 27294,
                         "content": '{"type":"strike","key":"0,canned"}',
+                        "msg_type": "widget",
                     },
                 ],
                 id="submessage_strike_event_todo_widget",
@@ -3243,15 +3242,13 @@ class TestModel:
                         "content": '{"type":"strike","key":"0,canned"}',
                     },
                     {
-                        "type": "submessage",
-                        "msg_type": "widget",
-                        "message_id": 1958326,
-                        "submessage_id": 12185,
+                        "id": 12185,
                         "sender_id": 27294,
                         "content": (
                             '{"type":"new_task","key":2,"task":"Make a coffee",'
                             '"desc":"","completed":false}'
                         ),
+                        "msg_type": "widget",
                     },
                 ],
                 id="submessage_new_task_event_todo_widget",
@@ -3278,16 +3275,13 @@ class TestModel:
                         "content": '{"type":"strike","key":"0,canned"}',
                     },
                     {
-                        "type": "submessage",
-                        "msg_type": "widget",
-                        "message_id": 1958326,
-                        "submessage_id": 12185,
+                        "id": 12185,
                         "sender_id": 27294,
                         "content": (
                             '{"type":"new_task","key":2,"task":"Make a coffee"'
                             ',"desc":"","completed":false}'
                         ),
-                        "id": 0,
+                        "msg_type": "widget",
                     },
                 ],
                 {
@@ -3323,27 +3317,22 @@ class TestModel:
                         "content": '{"type":"strike","key":"0,canned"}',
                     },
                     {
-                        "type": "submessage",
-                        "msg_type": "widget",
-                        "message_id": 1958326,
-                        "submessage_id": 12185,
+                        "id": 12185,
                         "sender_id": 27294,
                         "content": (
                             '{"type":"new_task","key":2,"task":"Make a coffee"'
                             ',"desc":"","completed":false}'
                         ),
-                        "id": 0,
+                        "msg_type": "widget",
                     },
                     {
-                        "type": "submessage",
-                        "msg_type": "widget",
-                        "message_id": 1958326,
-                        "submessage_id": 12186,
+                        "id": 12186,
                         "sender_id": 27294,
                         "content": (
                             '{"type":"new_task_list_title",'
                             '"title":"Today\'s Work [Updated]"}'
                         ),
+                        "msg_type": "widget",
                     },
                 ],
                 id="submessage_new_task_list_title_event_todo_widget",
@@ -4666,9 +4655,7 @@ class TestModel:
         self, mocker, model, unread_topics, current_topic, next_unread_topic
     ):
         # NOTE Not important how many unreads per topic, so just use '1'
-        model.unread_counts = {
-            "unread_topics": {stream_topic: 1 for stream_topic in unread_topics}
-        }
+        model.unread_counts = {"unread_topics": dict.fromkeys(unread_topics, 1)}
 
         current_message_id = 10  # Arbitrary value due to mock below
         model.stream_topic_from_message_id = mocker.Mock(return_value=current_topic)
@@ -4694,14 +4681,13 @@ class TestModel:
         ]
 
         # date data unimportant (if present)
-        model._muted_topics = {
-            stream_topic: None
-            for stream_topic in [
+        model._muted_topics = dict.fromkeys(
+            [
                 ("Stream 2", "muted topic2"),
                 ("Stream 2", "topic2 muted"),
                 ("Stream 3", "topic3 muted"),
             ]
-        }
+        )
 
         unread_topic = model.next_unread_topic_from_message_id(current_message_id)
 
@@ -4728,9 +4714,7 @@ class TestModel:
         next_unread_topic,
     ):
         # NOTE Not important how many unreads per topic, so just use '1'
-        model.unread_counts = {
-            "unread_topics": {stream_topic: 1 for stream_topic in unread_topics}
-        }
+        model.unread_counts = {"unread_topics": dict.fromkeys(unread_topics, 1)}
         model.pinned_streams = [
             {"name": "Stream 1", "id": 1},
             {"name": "Stream 2", "id": 2},

--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -1016,7 +1016,7 @@ class TestWriteBox:
         for stream in streams_to_pin:
             write_box.view.unpinned_streams.remove(stream)
         write_box.view.pinned_streams = streams_to_pin
-        write_box.stream_id = stream_categories.get("current_stream", None)
+        write_box.stream_id = stream_categories.get("current_stream")
         write_box.model.stream_dict = stream_dict
         write_box.model.muted_streams = {
             stream["stream_id"]

--- a/tests/ui_tools/test_messages.py
+++ b/tests/ui_tools/test_messages.py
@@ -1096,7 +1096,7 @@ class TestMessageBox:
     ):
         mocked_date = mocker.patch(MODULE + ".date")
         mocked_date.today.return_value = date(current_year, 1, 1)
-        mocked_date.side_effect = lambda *args, **kw: date(*args, **kw)
+        mocked_date.side_effect = date
 
         output_date_time = "Fri Jul 20 21:54"  # corresponding to timestamp
 

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -170,9 +170,9 @@ class TestPopUpView:
         mocker.patch(
             MODULE + ".is_command_key",
             side_effect=(
-                lambda command, key: False
-                if command == self.command
-                else is_command_key(command, key)
+                lambda command, key: (
+                    False if command == self.command else is_command_key(command, key)
+                )
             ),
         )
 

--- a/tests/widget/test_widget.py
+++ b/tests/widget/test_widget.py
@@ -1,10 +1,10 @@
-from typing import Dict, List, Union
+from typing import Dict, List, Union, cast
 
 import pytest
 from pytest import param as case
 
+from zulipterminal.api_types import PollOption, Submessage
 from zulipterminal.widget import (
-    Submessage,
     find_widget_type,
     process_poll_widget,
     process_todo_widget,
@@ -344,10 +344,10 @@ def test_process_todo_widget(
     expected_title: str,
     expected_tasks: Dict[str, Dict[str, Union[str, bool]]],
 ) -> None:
-    title, tasks = process_todo_widget(submessages)
+    result = process_todo_widget(submessages)
 
-    assert title == expected_title
-    assert tasks == expected_tasks
+    assert result["title"] == expected_title
+    assert result["tasks"] == expected_tasks
 
 
 @pytest.mark.parametrize(
@@ -659,7 +659,7 @@ def test_process_poll_widget(
     expected_poll_question: str,
     expected_options: Dict[str, Dict[str, Union[str, List[str]]]],
 ) -> None:
-    poll_question, options = process_poll_widget(submessages)
+    result = process_poll_widget(submessages)
 
-    assert poll_question == expected_poll_question
-    assert options == expected_options
+    assert result["question"] == expected_poll_question
+    assert result["options"] == cast(Dict[str, PollOption], expected_options)

--- a/zulipterminal/cli/run.py
+++ b/zulipterminal/cli/run.py
@@ -366,12 +366,12 @@ def parse_zuliprc(zuliprc_str: str) -> Dict[str, SettingData]:
             in_color(
                 "red",
                 "ERROR: Please ensure your zuliprc is NOT publicly accessible:\n"
-                "  {0}\n"
-                "(it currently has permissions '{1}')\n"
+                f"  {zuliprc_path}\n"
+                f"(it currently has permissions '{stat.filemode(mode)}')\n"
                 "This can often be achieved with a command such as:\n"
-                "  chmod og-rwx {0}\n"
+                f"  chmod og-rwx {zuliprc_path}\n"
                 "Consider regenerating the [api] part of your zuliprc to ensure "
-                "your account is secure.".format(zuliprc_path, stat.filemode(mode)),
+                "your account is secure.",
             )
         )
         sys.exit(1)
@@ -687,8 +687,8 @@ def main(options: Optional[List[str]] = None) -> None:
             # Dump stats only after temporary file is closed (for Win NT+ case)
             prof.dump_stats(profile_path)
             print(
-                "Profile data saved to {0}.\n"
-                "You can visualize it using e.g. `snakeviz {0}`".format(profile_path)
+                f"Profile data saved to {profile_path}.\n"
+                f"You can visualize it using e.g. `snakeviz {profile_path}`"
             )
 
         sys.exit(1)

--- a/zulipterminal/config/keys.py
+++ b/zulipterminal/config/keys.py
@@ -548,9 +548,11 @@ def display_key_for_urwid_key(urwid_key: str) -> str:
         if urwid_map_key in urwid_key:
             urwid_key = urwid_key.replace(urwid_map_key, display_map_key)
     display_key = [
-        keyboard_key.capitalize()
-        if len(keyboard_key) > 1 and keyboard_key[0].islower()
-        else keyboard_key
+        (
+            keyboard_key.capitalize()
+            if len(keyboard_key) > 1 and keyboard_key[0].islower()
+            else keyboard_key
+        )
         for keyboard_key in urwid_key.split()
     ]
     return " ".join(display_key)

--- a/zulipterminal/config/themes.py
+++ b/zulipterminal/config/themes.py
@@ -1,6 +1,7 @@
 """
 Styles and their colour mappings in each theme, with helper functions
 """
+
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from pygments.token import STANDARD_TYPES, _TokenType

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -119,9 +119,11 @@ class Controller:
         # Register new ^C handler
         signal.signal(
             signal.SIGINT,
-            self.prompting_exit_handler
-            if self.exit_confirmation
-            else self.no_prompt_exit_handler,
+            (
+                self.prompting_exit_handler
+                if self.exit_confirmation
+                else self.no_prompt_exit_handler
+            ),
         )
 
     def raise_exception_in_main_thread(

--- a/zulipterminal/themes/colors_gruvbox.py
+++ b/zulipterminal/themes/colors_gruvbox.py
@@ -8,6 +8,7 @@ This file uses the official gruvbox colors where possible.
 For color reference see:
     https://github.com/morhetz/gruvbox/blob/master/colors/gruvbox.vim
 """
+
 from enum import Enum
 
 from zulipterminal.config.color import color_properties

--- a/zulipterminal/themes/gruvbox_light.py
+++ b/zulipterminal/themes/gruvbox_light.py
@@ -8,6 +8,7 @@ is released.
 
 For further details on themefiles look at the theme contribution guide
 """
+
 from pygments.styles.solarized import SolarizedLightStyle
 
 from zulipterminal.config.color import Background

--- a/zulipterminal/themes/zt_blue.py
+++ b/zulipterminal/themes/zt_blue.py
@@ -4,6 +4,7 @@ ZT BLUE
 This theme uses the default color scheme.
 For further details on themefiles look at the theme contribution guide
 """
+
 from pygments.styles.zenburn import ZenburnStyle
 
 from zulipterminal.config.color import Background

--- a/zulipterminal/themes/zt_dark.py
+++ b/zulipterminal/themes/zt_dark.py
@@ -4,6 +4,7 @@ ZT DARK
 This theme uses the default color scheme.
 For further details on themefiles look at the theme contribution guide.
 """
+
 from pygments.styles.material import MaterialStyle
 
 from zulipterminal.config.color import Background

--- a/zulipterminal/themes/zt_light.py
+++ b/zulipterminal/themes/zt_light.py
@@ -4,6 +4,7 @@ ZT LIGHT
 This theme uses the default color scheme.
 For further details on themefiles look at the theme contribution guide.
 """
+
 from pygments.styles.perldoc import PerldocStyle
 
 from zulipterminal.config.color import Background

--- a/zulipterminal/ui.py
+++ b/zulipterminal/ui.py
@@ -186,11 +186,9 @@ class View(urwid.WidgetWrap):
         # the focus is changed again either vertically or horizontally.
         self.body._contents.set_focus_changed_callback(self.message_view.read_message)
 
-        title_text = " {full_name} ({email}) - {server_name} ({url}) ".format(
-            full_name=self.model.user_full_name,
-            email=self.model.user_email,
-            server_name=self.model.server_name,
-            url=self.model.server_url,
+        title_text = (
+            f" {self.model.user_full_name} ({self.model.user_email}) - "
+            f"{self.model.server_name} ({self.model.server_url}) "
         )
 
         title_bar = urwid.Columns(

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -581,9 +581,11 @@ class WriteBox(urwid.Pile):
 
         # Append user_id's to users with the same names.
         user_names_with_distinct_duplicates = [
-            f"{user['full_name']}|{user['user_id']}"
-            if user_names_counter[user["full_name"]] > 1
-            else user["full_name"]
+            (
+                f"{user['full_name']}|{user['user_id']}"
+                if user_names_counter[user["full_name"]] > 1
+                else user["full_name"]
+            )
             for user in sorted_matching_users
         ]
 

--- a/zulipterminal/ui_tools/tables.py
+++ b/zulipterminal/ui_tools/tables.py
@@ -127,9 +127,7 @@ def render_table(table_element: Any) -> StyledTableData:
     column_alignments, cells = parse_html_table(table_element)
 
     # Calculate the width required for each column.
-    column_widths = [
-        len(max(column, key=lambda string: len(string))) for column in zip(*cells)
-    ]
+    column_widths = [len(max(column, key=len)) for column in zip(*cells)]
 
     top_border = row_with_only_border("┌", "─", "┬", "┐", column_widths)
     middle_border = row_with_only_border("├", "─", "┼", "┤", column_widths)

--- a/zulipterminal/ui_tools/utils.py
+++ b/zulipterminal/ui_tools/utils.py
@@ -74,6 +74,4 @@ def is_muted(msg: Message, model: Any) -> bool:
 def is_unsubscribed_message(msg: Message, model: Any) -> bool:
     if msg["type"] == "private":
         return False
-    if not model.is_user_subscribed_to_stream(msg["stream_id"]):
-        return True
-    return False
+    return bool(not model.is_user_subscribed_to_stream(msg["stream_id"]))

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -824,7 +824,7 @@ class LeftColumnView(urwid.Pile):
             for stream in self.view.pinned_streams
         ]
 
-        if len(streams_btn_list):
+        if streams_btn_list:
             streams_btn_list += [StreamsViewDivider()]
 
         streams_btn_list += [

--- a/zulipterminal/unicode_emojis.py
+++ b/zulipterminal/unicode_emojis.py
@@ -1,6 +1,7 @@
 """
 Unicode emoji data, synchronized semi-regularly with the server source
 """
+
 # Ignore long lines
 # ruff: noqa: E501
 


### PR DESCRIPTION
<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?
This PR implements TypedDict for the `Submessage` structure and centralizes it in `api_types.py`.

### Key Motivations:

1. Type Safety: Moving away from generic `Dict[str, Any]` to `TypedDict` allows `mypy` to catch errors where submessage keys (like `id` or `msg_type`) might be missing or mistyped.
2. Consistency: Standardizes the field names across the app. We moved from the inconsistent use of `submessage_id` and `type` to a unified `id `and `msg_type` structure.
3. Centralization: Following Zulip Terminal patterns, all API-related structures are now in `api_types.py` for easier reuse.

### Files Changed:

1. `zulipterminal/api_types.py`: Added `Submessage`, `TodoWidgetResult`, and `PollWidgetResult` TypedDicts.
2. `zulipterminal/model.py`: Updated submessage handling logic to use new keys and imports.
3. `zulipterminal/widget.py`: Refactored widget processing to return the new TypedDicts.
4. `tests/conftest.py`: Added `submessage_factory` to simplify and type-check test data creation.
5. `tests/widget/test_widget.py` & `tests/model/test_model.py`: Updated imports and test expectations to match the new structure.
6. `tests/helper/test_helper.py` & `tests/cli/test_run.py`: Fixed pre-existing environment-related failures (path normalization and CLI output capturing) to ensure a green test suite in WSL/Linux.

### Outstanding aspect(s)    <!-- DELETE SECTION IF EMPTY -->
<!-- In what ways is this not fully implemented/functioning? Compared to a discussion/issue? -->
<!-- Do you not understand something? Are you unsure about a certain approach? Want feedback? -->
- [ ] Currently, `mypy` is run with `--follow-imports=skip' to avoid syntax errors in third-party libraries (like `packaging`) found in the local virtual environment.

### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [x] Fully fixes #1576

### How did you test this?
<!-- [x] all that apply -->
- [x] Manually - Behavioral changes
- [x] Adapting existing automated tests
- [x] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [x] It contains test additions for any new behavior