### PR TITLE
Improve ordering for next unread topic (n)

### DIFF
--- a/tests/helper/test_helper.py
+++ b/tests/helper/test_helper.py
@@ -280,6 +280,23 @@ def test_sort_unread_topics(
     assert sort_unread_topics(unread_topics, stream_list) == expected_value
 
 
+def test_sort_unread_topics_by_topic_list_order() -> None:
+    """With topic_order_by_stream, order follows topic list (most recent first)."""
+    unread_topics = {
+        (1, "topic1"): 1,
+        (1, "topic2"): 1,
+        (1, "topic3"): 1,
+    }
+    stream_list = [1]
+    topic_order_by_stream = {1: ["topic3", "topic1", "topic2"]}
+    result = sort_unread_topics(
+        unread_topics,
+        stream_list,
+        topic_order_by_stream=topic_order_by_stream,
+    )
+    assert result == [(1, "topic3"), (1, "topic1"), (1, "topic2")]
+
+
 @pytest.mark.parametrize(
     "muted_streams, muted_topics, vary_in_unreads",
     [

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -171,12 +171,6 @@ def sort_unread_topics(
     *,
     topic_order_by_stream: Optional[Dict[int, List[str]]] = None,
 ) -> List[Tuple[int, str]]:
-    """
-    Sort unread topics by stream order (left panel) and, within each stream,
-    by topic list order (most recent first) when topic_order_by_stream is
-    provided, otherwise by topic name for backward compatibility.
-    """
-
     def sort_key(stream_topic: Tuple[int, str]) -> Tuple[int, int, str]:
         stream_id, topic_name = stream_topic
         stream_rank = (
@@ -184,10 +178,7 @@ def sort_unread_topics(
             if stream_id in stream_list
             else len(stream_list)
         )
-        if (
-            topic_order_by_stream is not None
-            and stream_id in topic_order_by_stream
-        ):
+        if topic_order_by_stream is not None and stream_id in topic_order_by_stream:
             topic_list = topic_order_by_stream[stream_id]
             topic_rank = (
                 topic_list.index(topic_name)
@@ -195,7 +186,7 @@ def sort_unread_topics(
                 else len(topic_list)
             )
         else:
-            topic_rank = 0 
+            topic_rank = 0
         return (stream_rank, topic_rank, topic_name)
 
     return sorted(unread_topics.keys(), key=sort_key)
@@ -204,13 +195,8 @@ def sort_unread_topics(
 def _set_count_in_model(
     new_count: int, changed_messages: List[Message], unread_counts: UnreadCounts
 ) -> None:
-    """
-    This function doesn't explicitly set counts in model,
-    but updates `unread_counts` (which can update the model
-    if it's passed in, but is not tied to it).
-    """
-    # broader unread counts (for all_*) are updated
-    # later conditionally in _set_count_in_view.
+# broader unread counts (for all_*) are updated
+# later conditionally in _set_count_in_view.
     KeyT = TypeVar("KeyT")
 
     def update_unreads(unreads: Dict[KeyT, int], key: KeyT) -> None:

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -195,8 +195,8 @@ def sort_unread_topics(
 def _set_count_in_model(
     new_count: int, changed_messages: List[Message], unread_counts: UnreadCounts
 ) -> None:
-# broader unread counts (for all_*) are updated
-# later conditionally in _set_count_in_view.
+    # broader unread counts (for all_*) are updated
+    # later conditionally in _set_count_in_view.
     KeyT = TypeVar("KeyT")
 
     def update_unreads(unreads: Dict[KeyT, int], key: KeyT) -> None:

--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -166,17 +166,39 @@ def asynch(func: Callable[ParamT, None]) -> Callable[ParamT, None]:
 
 
 def sort_unread_topics(
-    unread_topics: Dict[Tuple[int, str], int], stream_list: List[int]
+    unread_topics: Dict[Tuple[int, str], int],
+    stream_list: List[int],
+    *,
+    topic_order_by_stream: Optional[Dict[int, List[str]]] = None,
 ) -> List[Tuple[int, str]]:
-    return sorted(
-        unread_topics.keys(),
-        key=lambda stream_topic: (
-            stream_list.index(stream_topic[0])
-            if stream_topic[0] in stream_list
-            else len(stream_list),
-            stream_topic[1],
-        ),
-    )
+    """
+    Sort unread topics by stream order (left panel) and, within each stream,
+    by topic list order (most recent first) when topic_order_by_stream is
+    provided, otherwise by topic name for backward compatibility.
+    """
+
+    def sort_key(stream_topic: Tuple[int, str]) -> Tuple[int, int, str]:
+        stream_id, topic_name = stream_topic
+        stream_rank = (
+            stream_list.index(stream_id)
+            if stream_id in stream_list
+            else len(stream_list)
+        )
+        if (
+            topic_order_by_stream is not None
+            and stream_id in topic_order_by_stream
+        ):
+            topic_list = topic_order_by_stream[stream_id]
+            topic_rank = (
+                topic_list.index(topic_name)
+                if topic_name in topic_list
+                else len(topic_list)
+            )
+        else:
+            topic_rank = 0 
+        return (stream_rank, topic_rank, topic_name)
+
+    return sorted(unread_topics.keys(), key=sort_key)
 
 
 def _set_count_in_model(

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -981,9 +981,19 @@ class Model:
         left_panel_stream_list = [
             stream["id"] for stream in (self.pinned_streams + self.unpinned_streams)
         ]
+        stream_ids_with_unread = {
+            stream_id for stream_id, _ in self.unread_counts["unread_topics"]
+        }
+        if current_topic is not None:
+            stream_ids_with_unread.add(current_topic[0])
+        topic_order_by_stream = {
+            stream_id: self.topics_in_stream(stream_id)
+            for stream_id in stream_ids_with_unread
+        }
         unread_topics = sort_unread_topics(
             self.unread_counts["unread_topics"],
             left_panel_stream_list,
+            topic_order_by_stream=topic_order_by_stream,
         )
         next_topic = False
         stream_start: Optional[Tuple[int, str]] = None
@@ -997,6 +1007,7 @@ class Model:
             unread_topics = sort_unread_topics(
                 {**self.unread_counts["unread_topics"], current_topic: 0},
                 left_panel_stream_list,
+                topic_order_by_stream=topic_order_by_stream,
             )
         # loop over unread_topics list twice for the case that last_unread_topic was
         # the last valid unread_topic in unread_topics list.


### PR DESCRIPTION
Issue : #1582 

Fixes the order when cycling through unread topics with n so it matches the topic list (most recent first), consistent with the web app.
Related: #T1333, #T1356.
### _Problem_

Pressing n (next unread topic) did not always follow the order of the topic list. Within a stream, unread topics were ordered alphabetically by topic name instead of by most recent activity. The web app (and the left-panel topic list) use recency order.

### _Solution_
### sort_unread_topics 1

- Added an optional topic_order_by_stream argument.
- When provided, topics within each stream are ordered by their position in that list (index 0 = most recent).
- When omitted, behavior is unchanged (stream order + alphabetical by topic name).

### next_unread_topic_from_message_id 2

- Builds topic_order_by_stream for every stream that has unread topics (or contains the current topic when it’s not in the unread list) by calling topics_in_stream(stream_id).
- Passes this into sort_unread_topics so the sequence used for n is: left-panel stream order, then within each stream the same order as the topic list (most recent first).

### _Testing_

- Helper: New test test_sort_unread_topics_by_topic_list_order in checks that with topic_order_by_stream the result order follows the given topic list.
- Regression: Existing test_sort_unread_topics and model tests for next_unread_topic_from_message_id still pass (no topic_order_by_stream → same as before).
- Manual check: use Explore mode, have unread messages in several topics, and press n repeatedly; order should match the topic list and the web app.