### PR TITLE
tests: Add assertion for model.server_url in test_init

### DIFF
--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -89,7 +89,7 @@ class TestModel:
         assert model.user_full_name == user_profile["full_name"]
         assert model.user_email == user_profile["email"]
         assert model.server_name == initial_data["realm_name"]
-        # FIXME Add test here for model.server_url
+        assert model.server_url == ":///"
         model._update_users_data_from_initial_data.assert_called_once_with()
         assert model.users == []
         self.classify_unread_counts.assert_called_once_with(model)
@@ -117,6 +117,28 @@ class TestModel:
         assert model.active_emoji_data["joker"]["type"] == "realm_emoji"
         # zulip_extra_emoji replaces all other emoji types for 'zulip' emoji.
         assert model.active_emoji_data["zulip"]["type"] == "zulip_extra_emoji"
+
+    @pytest.mark.parametrize(
+        "base_url, expected_server_url",
+        [
+            ("chat.zulip.zulip", ":///"),
+            ("https://chat.zulip.org", "https://chat.zulip.org/"),
+            ("http://localhost:9991", "http://localhost:9991/"),
+        ],
+    )
+    def test_server_url_generation(
+        self, mocker, initial_data, user_profile, base_url, expected_server_url
+    ):
+        self.client.base_url = base_url
+        mocker.patch(MODEL + ".get_messages", return_value="")
+        self.client.register.return_value = initial_data
+        self.client.get_profile.return_value = user_profile
+        mocker.patch(MODEL + "._update_users_data_from_initial_data")
+        mocker.patch(MODULE + ".classify_unread_counts")
+
+        model = Model(self.controller)
+
+        assert model.server_url == expected_server_url
 
     @pytest.mark.parametrize(
         "sptn, expected_sptn_value",


### PR DESCRIPTION
<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?
Adds the missing assertion for `model.server_url` in `test_init`, resolving the existing `FIXME` comment.

Also extends coverage with a parametrized test covering different `base_url` scheme and `netloc` combinations to ensure correct normalization behavior.

### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [x] Discussed in **#zulip-terminal** in `topic` [PR: Add test for model.server_url in test_init](https://chat.zulip.org/#narrow/channel/206-zulip-terminal/topic/PR.3A.20Add.20test.20for.20model.2Eserver_url.20in.20test_init/with/2393792)
- [ ] Fully fixes #
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [ ] Manually - Behavioral changes
- [ ] Manually - Visual changes
- [ ] Adapting existing automated tests
- [x] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [x] It contains test additions for any new behavior
- [ ] It flows clearly from a previous branch commit, and/or prepares for the next commit
