### PR TITLE
Handle missing twenty_four_hour_time to prevent startup crash

### DIFF
--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -225,23 +225,39 @@ class Model:
         # "user_settings" only present in ZFl 89+ (v5.0)
         user_settings = self.initial_data.get("user_settings", None)
         # TODO: Support multiple settings locations via settings migration #1108
+
+        # Determine twenty_four_hour_time with proper fallbacks:
+        if user_settings is None:
+            t24 = self.initial_data.get("twenty_four_hour_time")
+        else:
+            t24 = user_settings.get("twenty_four_hour_time")
+        if t24 is None:
+            t24 = False
+        twenty_four_hour_time = bool(t24)
+
+        # Determine send_private_typing_notifications (default to True if not provided)
+        if user_settings is None:
+            send_private_typing_notifications = True
+        else:
+            send_private_typing_notifications = user_settings.get(
+                "send_private_typing_notifications", True
+            )
+
+        # Determine pm_content_in_desktop_notifications with fallback to initial_data
+        if user_settings is None:
+            pm_content_in_desktop_notifications = self.initial_data.get(
+                "pm_content_in_desktop_notifications", False
+            )
+        else:
+            pm_content_in_desktop_notifications = user_settings.get(
+                "pm_content_in_desktop_notifications",
+                self.initial_data.get("pm_content_in_desktop_notifications", False),
+            )
+
         self._user_settings = UserSettings(
-            send_private_typing_notifications=(
-                True
-                if user_settings is None
-                else user_settings["send_private_typing_notifications"]
-            ),  # ZFL 105, Zulip 5.0
-            # these settings were removed from the top-level object in ZFL 439 (v12.0)
-            twenty_four_hour_time=(
-                self.initial_data["twenty_four_hour_time"]
-                if user_settings is None
-                else user_settings["twenty_four_hour_time"]
-            ),
-            pm_content_in_desktop_notifications=(
-                self.initial_data["pm_content_in_desktop_notifications"]
-                if user_settings is None
-                else user_settings["pm_content_in_desktop_notifications"]
-            ),
+            send_private_typing_notifications=send_private_typing_notifications,
+            twenty_four_hour_time=twenty_four_hour_time,
+            pm_content_in_desktop_notifications=pm_content_in_desktop_notifications,
         )
 
         self.new_user_input = True


### PR DESCRIPTION
### What does this PR do, and why?

This PR prevents a startup crash caused by a missing `twenty_four_hour_time` key in `initial_data` or `user_settings`.

Under certain server responses, the `twenty_four_hour_time` field may be absent or `None`. The current implementation accesses this field via direct dictionary indexing, which raises a `KeyError` and causes `zulip-terminal` to crash on launch.

This change replaces direct indexing with safe `.get()` access and introduces a fallback to ensure a boolean value is always provided. This prevents the crash while preserving existing behavior.

---

### External discussion & connections

- [ ] Discussed in **#zulip-terminal**
- [ ] Fully fixes #
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

(No related issue number found — standalone bugfix.)

---

### How did you test this?

- [x] Manually - Behavioral changes  
- [x] Existing automated tests should already cover this (only a defensive fix, no new behavior)

**Testing details:**
- Reproduced the crash locally (`KeyError: 'twenty_four_hour_time'`)
- Verified that `zulip-term` launches successfully after the change
- Ran the full test suite locally to confirm no regressions in existing behavior

---

### Self-review checklist for each commit

- [x] It is a minimal coherent idea
- [x] It has a commit summary following the documented style
- [x] It has a commit summary describing the motivation and reasoning for the change
- [x] It individually passes linting and tests (excluding unrelated CLI test prefix differences due to argparse program name resolution in this environment)
- [ ] It contains test additions for any new behavior (No new behavior introduced)

---

### Visual changes

N/A — no visual changes.