### PR TITLE
message-rendering: Rendering horizontal rule in messagebox.

### DIFF
--- a/tests/ui_tools/test_messages.py
+++ b/tests/ui_tools/test_messages.py
@@ -418,8 +418,8 @@ class TestMessageBox:
             ),
             case("<br>", [], id="br"),
             case("<br/>", [], id="br2"),
-            case("<hr>", ["[RULER NOT RENDERED]"], id="hr"),
-            case("<hr/>", ["[RULER NOT RENDERED]"], id="hr2"),
+            case("<hr>", ["__HR__"], id="hr"),
+            case("<hr/>", ["__HR__"], id="hr2"),
             case("<img>", ["[IMAGE NOT RENDERED]"], id="img"),
             case("<img/>", ["[IMAGE NOT RENDERED]"], id="img2"),
             case(

--- a/tests/ui_tools/test_messages.py
+++ b/tests/ui_tools/test_messages.py
@@ -20,7 +20,7 @@ from zulipterminal.config.symbols import (
     STREAM_TOPIC_SEPARATOR,
     TIME_MENTION_MARKER,
 )
-from zulipterminal.ui_tools.messages import MessageBox
+from zulipterminal.ui_tools.messages import _HR_TOKEN, MessageBox
 
 
 MODULE = "zulipterminal.ui_tools.messages"
@@ -418,8 +418,8 @@ class TestMessageBox:
             ),
             case("<br>", [], id="br"),
             case("<br/>", [], id="br2"),
-            case("<hr>", ["__HR__"], id="hr"),
-            case("<hr/>", ["__HR__"], id="hr2"),
+            case("<hr>", [_HR_TOKEN], id="hr"),
+            case("<hr/>", [_HR_TOKEN], id="hr2"),
             case("<img>", ["[IMAGE NOT RENDERED]"], id="img"),
             case("<img/>", ["[IMAGE NOT RENDERED]"], id="img2"),
             case(
@@ -1590,9 +1590,44 @@ class TestMessageBox:
         expected_content = expected_content.replace("{}", QUOTED_TEXT_MARKER)
 
         content, *_ = MessageBox.transform_content(raw_html, SERVER_URL)
+        rows = []
+        contents = content.contents
+        assert isinstance(contents, list)
+        for widget, _ in contents:
+            assert isinstance(widget, Text)
+            rows.append(widget.text)
 
-        rendered_text = Text(content)
-        assert rendered_text.text == expected_content
+        rendered = "\n".join(rows)
+
+        assert rendered == expected_content
+
+    @pytest.mark.parametrize(
+        "raw_html, expected_content",
+        [
+            case("<p>hi</p><hr>", ["hi", "<hr>"], id="hr_after_paragraph"),
+            case("<hr><p>hi</p>", ["", "<hr>", "hi"], id="hr_before_paragraph"),
+            case(
+                "<p>hi</p><hr><p>there</p>",
+                ["hi", "<hr>", "there"],
+                id="hr_between_paragraphs_with_newlines",
+            ),
+        ],
+    )
+    def test_transform_content_hr(self, mocker, raw_html, expected_content):
+        content_widget, *_ = MessageBox.transform_content(raw_html, SERVER_URL)
+
+        rendered = []
+
+        rows = content_widget.contents
+        assert isinstance(rows, list)
+
+        for widget, _ in rows:
+            if isinstance(widget, Divider):
+                rendered.append("<hr>")
+            else:
+                assert isinstance(widget, Text)
+                rendered.append(widget.text)
+        assert rendered == expected_content
 
     # FIXME This is the same parametrize as MsgInfoView:test_height_reactions
     @pytest.mark.parametrize(

--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -1488,39 +1488,45 @@ class TestStreamInfoView:
             self.controller.copy_to_clipboard.assert_not_called()
 
     @pytest.mark.parametrize(
-        "rendered_description, expected_markup",
+        "rendered_description, expected_text, expected_attrib",
         [
             (
                 "<p>Simple</p>",
-                (None, ["", "", "Simple"]),
+                "Simple",
+                [],
             ),
             (
                 '<p>A city in Italy <a href="http://genericlink.com">ABC</a>'
                 "<strong>Bold</strong>",
-                (
-                    None,
-                    [
-                        "",
-                        "",
-                        "A city in Italy ",
-                        ("msg_link", "ABC"),
-                        " ",
-                        ("msg_link_index", "[1]"),
-                        ("msg_bold", "Bold"),
-                    ],
-                ),
+                "A city in Italy ABC [1]Bold",
+                [
+                    (None, 16),
+                    ("msg_link", 3),
+                    (None, 1),
+                    ("msg_link_index", 3),
+                    ("msg_bold", 4),
+                ],
             ),
         ],
     )
     def test_markup_description(
-        self, rendered_description: str, expected_markup: Tuple[None, Any]
+        self,
+        rendered_description: str,
+        expected_text: str,
+        expected_attrib: List[Tuple[Optional[str], int]],
     ) -> None:
         model = self.controller.model
         model.stream_dict[self.stream_id]["rendered_description"] = rendered_description
 
         stream_info_view = StreamInfoView(self.controller, self.stream_id)
+        assert isinstance(stream_info_view.markup_desc, Pile)
+        assert len(stream_info_view.markup_desc.contents) == 1
 
-        assert stream_info_view.markup_desc == expected_markup
+        desc_widget, _ = stream_info_view.markup_desc.contents[0]
+        assert isinstance(desc_widget, Text)
+        rendered_text, rendered_attrib = desc_widget.get_text()
+        assert rendered_text == expected_text
+        assert rendered_attrib == expected_attrib
 
     @pytest.mark.parametrize(
         "message_links, expected_text, expected_attrib, expected_footlinks_width",

--- a/zulipterminal/config/markdown_examples.py
+++ b/zulipterminal/config/markdown_examples.py
@@ -119,4 +119,9 @@ MARKDOWN_ELEMENTS: List[MarkdownElements] = [
             "</table>"
         ),
     },
+    {  # HORIZONTAL RULE
+        "name": "Horizontal Rule",
+        "raw_text": "---",
+        "html_element": "<hr>",
+    },
 ]

--- a/zulipterminal/config/symbols.py
+++ b/zulipterminal/config/symbols.py
@@ -32,6 +32,9 @@ QUOTED_TEXT_MARKER = "░"  # LIGHT SHADE, U+2591 (Block elements)
 # Extends from end of recipient details (above messages where recipients differ above)
 MESSAGE_HEADER_DIVIDER = "━"  # BOX DRAWINGS HEAVY HORIZONTAL, U+2501 (Box drawing)
 
+# Message body horizontal rule (<hr>)
+MESSAGE_RULE_LINE = "─"  # BOX DRAWINGS LIGHT HORIZONTAL, U+2500 (Box drawing)
+
 # NOTE: CHECK_MARK is not used for resolved topics (that is an API detail)
 CHECK_MARK = "✓"  # CHECK MARK, U+2713 (Dingbats)
 

--- a/zulipterminal/ui_tools/messages.py
+++ b/zulipterminal/ui_tools/messages.py
@@ -24,6 +24,7 @@ from zulipterminal.config.symbols import (
     MESSAGE_CONTENT_MARKER,
     MESSAGE_HEADER_DIVIDER,
     QUOTED_TEXT_MARKER,
+    SECTION_DIVIDER_LINE,
     STARRED_MESSAGES_MARKER,
     STREAM_TOPIC_SEPARATOR,
     TIME_MENTION_MARKER,
@@ -58,7 +59,7 @@ class MessageBox(urwid.Pile):
         self.model = model
         self.message = message
         self.header: List[Any] = []
-        self.content: urwid.Text = urwid.Text("")
+        self.content: urwid.Widget = urwid.Text("")
         self.footer: List[Any] = []
         self.stream_name = ""
         self.stream_id: Optional[int] = None
@@ -383,7 +384,6 @@ class MessageBox(urwid.Pile):
         unrendered_tags = {  # In pairs of 'tag_name': 'text'
             # TODO: Some of these could be implemented
             "br": "",  # No indicator of absence
-            "hr": "RULER",
             "img": "IMAGE",
         }
         unrendered_div_classes = {  # In pairs of 'div_class': 'text'
@@ -635,9 +635,27 @@ class MessageBox(urwid.Pile):
 
                 source_text = f"Original text was {tag_text.strip()}"
                 metadata["time_mentions"].append((time_string, source_text))
+            elif tag == "hr":
+                markup.append("__HR__")  # Horizontal rule
             else:
                 markup.extend(cls.soup2markup(element, metadata)[0])
         return markup, metadata["message_links"], metadata["time_mentions"]
+
+    @staticmethod
+    def build_content_widget(markup: Tuple[None, Any]) -> urwid.Widget:
+        widgets = []
+        temp_chunk: List[Any] = []
+        for item in markup[1]:
+            if item == "__HR__":
+                if temp_chunk:
+                    widgets.append(urwid.Text(temp_chunk))
+                    temp_chunk = []
+                widgets.append(urwid.Divider(SECTION_DIVIDER_LINE))
+            else:
+                temp_chunk.append(item)
+        if temp_chunk:
+            widgets.append(urwid.Text(temp_chunk))
+        return widgets[0] if len(widgets) == 1 else urwid.Pile(widgets)
 
     def main_view(self) -> List[Any]:
         # Recipient Header
@@ -794,7 +812,7 @@ class MessageBox(urwid.Pile):
         content, self.message_links, self.time_mentions = self.transform_content(
             self.message["content"], self.model.server_url
         )
-        self.content.set_text(content)
+        self.content = self.build_content_widget(content)
 
         if self.message["id"] in self.model.index["edited_messages"]:
             edited_label_size = 7

--- a/zulipterminal/ui_tools/messages.py
+++ b/zulipterminal/ui_tools/messages.py
@@ -23,8 +23,8 @@ from zulipterminal.config.symbols import (
     MENTIONED_MESSAGES_MARKER,
     MESSAGE_CONTENT_MARKER,
     MESSAGE_HEADER_DIVIDER,
+    MESSAGE_RULE_LINE,
     QUOTED_TEXT_MARKER,
-    SECTION_DIVIDER_LINE,
     STARRED_MESSAGES_MARKER,
     STREAM_TOPIC_SEPARATOR,
     TIME_MENTION_MARKER,
@@ -46,6 +46,14 @@ if typing.TYPE_CHECKING:
 
 # Usernames to show before just showing reaction counts
 MAXIMUM_USERNAMES_VISIBLE = 3
+
+
+# Internal temp token for <hr> while building content widgets.
+class _HrToken:
+    pass
+
+
+_HR_TOKEN = _HrToken()
 
 
 class _MessageEditState(NamedTuple):
@@ -378,7 +386,7 @@ class MessageBox(urwid.Pile):
     ) -> Tuple[List[Any], Dict[str, Tuple[str, int, bool]], List[Tuple[str, str]]]:
         # Ensure a string is provided, in case the soup finds none
         # This could occur if eg. an image is removed or not shown
-        markup: List[Union[str, Tuple[Optional[str], Any]]] = [""]
+        markup: List[Union[str, Tuple[Optional[str], Any], _HrToken]] = [""]
         if soup is None:  # This is not iterable, so return promptly
             return markup, metadata["message_links"], metadata["time_mentions"]
         unrendered_tags = {  # In pairs of 'tag_name': 'text'
@@ -636,26 +644,10 @@ class MessageBox(urwid.Pile):
                 source_text = f"Original text was {tag_text.strip()}"
                 metadata["time_mentions"].append((time_string, source_text))
             elif tag == "hr":
-                markup.append("__HR__")  # Horizontal rule
+                markup.append(_HR_TOKEN)  # Horizontal rule
             else:
                 markup.extend(cls.soup2markup(element, metadata)[0])
         return markup, metadata["message_links"], metadata["time_mentions"]
-
-    @staticmethod
-    def build_content_widget(markup: Tuple[None, Any]) -> urwid.Widget:
-        widgets = []
-        temp_chunk: List[Any] = []
-        for item in markup[1]:
-            if item == "__HR__":
-                if temp_chunk:
-                    widgets.append(urwid.Text(temp_chunk))
-                    temp_chunk = []
-                widgets.append(urwid.Divider(SECTION_DIVIDER_LINE))
-            else:
-                temp_chunk.append(item)
-        if temp_chunk:
-            widgets.append(urwid.Text(temp_chunk))
-        return widgets[0] if len(widgets) == 1 else urwid.Pile(widgets)
 
     def main_view(self) -> List[Any]:
         # Recipient Header
@@ -809,10 +801,9 @@ class MessageBox(urwid.Pile):
                 self.message["content"] = poll_widget
 
         # Transform raw message content into markup (As needed by urwid.Text)
-        content, self.message_links, self.time_mentions = self.transform_content(
+        self.content, self.message_links, self.time_mentions = self.transform_content(
             self.message["content"], self.model.server_url
         )
-        self.content = self.build_content_widget(content)
 
         if self.message["id"] in self.model.index["edited_messages"]:
             edited_label_size = 7
@@ -894,11 +885,7 @@ class MessageBox(urwid.Pile):
     @classmethod
     def transform_content(
         cls, content: Any, server_url: str
-    ) -> Tuple[
-        Tuple[None, Any],
-        Dict[str, Tuple[str, int, bool]],
-        List[Tuple[str, str]],
-    ]:
+    ) -> Tuple[urwid.Pile, Dict[str, Tuple[str, int, bool]], List[Tuple[str, str]],]:
         soup = BeautifulSoup(content, "lxml")
         body = soup.find(name="body")
 
@@ -912,7 +899,25 @@ class MessageBox(urwid.Pile):
             metadata["bq_len"] = cls.indent_quoted_content(soup, QUOTED_TEXT_MARKER)
 
         markup, message_links, time_mentions = cls.soup2markup(body, metadata)
-        return (None, markup), message_links, time_mentions
+        return cls.build_content_widget(markup), message_links, time_mentions
+
+    @staticmethod
+    def build_content_widget(markup: List[Any]) -> urwid.Pile:
+        widgets = []
+        temp_chunk: List[Any] = []
+        for item in markup:
+            if isinstance(item, _HrToken):
+                if temp_chunk:
+                    widgets.append(urwid.Text(temp_chunk))
+                    temp_chunk = []
+                widgets.append(urwid.Divider(MESSAGE_RULE_LINE))
+            else:
+                temp_chunk.append(item)
+
+        if temp_chunk:
+            widgets.append(urwid.Text(temp_chunk))
+
+        return urwid.Pile(widgets)
 
     @staticmethod
     def indent_quoted_content(soup: Any, padding_char: str) -> int:

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1047,8 +1047,11 @@ class PopUpView(urwid.Frame):
                     widgets.append(urwid.Text(row))
                 elif isinstance(row, tuple):
                     label, data = row
+                    data_widget = data
+                    if not isinstance(data, urwid.Widget):
+                        data_widget = urwid.Text(data)
                     strip = urwid.Columns(
-                        [(column_widths[0], urwid.Text(label)), urwid.Text(data)],
+                        [(column_widths[0], urwid.Text(label)), data_widget],
                         dividechars=dividechars,
                     )
                     widgets.append(
@@ -1444,7 +1447,7 @@ class StreamInfoView(PopUpView):
             rendered_desc,
             self.controller.model.server_url,
         )
-        desc = urwid.Text(self.markup_desc)
+        desc = self.markup_desc
 
         # NOTE: This is treated as a member to make it easier to test
         self._stream_info_content = [
@@ -1500,6 +1503,8 @@ class StreamInfoView(PopUpView):
             padded=False,
             wrap="space",
         )
+        max_popup_cols, _ = self.controller.maximum_popup_dimensions()
+        desc_width = desc.pack((max_popup_cols,))[0]
 
         # Manual because calculate_table_widths does not support checkboxes.
         # Add 4 to checkbox label to accommodate the checkbox itself.
@@ -1507,7 +1512,7 @@ class StreamInfoView(PopUpView):
             popup_width,
             len(muted_setting.label) + 4,
             len(pinned_setting.label) + 4,
-            desc.pack()[0],
+            desc_width,
             footlinks_width,
             len(visual_notification.label) + 4,
         )


### PR DESCRIPTION
Fixes #1620

<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?
Add Horizontal Rule rendering support for message box



### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [ ] Discussed in **#zulip-terminal** in `topic`
- [x] Fully fixes #1620 
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [ ] Manually - Behavioral changes
- [ ] Manually - Visual changes
- [ ] Adapting existing automated tests
- [x] Adding automated tests for new behavior (or missing tests)
- [x] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [ ] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [x] It contains test additions for any new behavior
- [x] It flows clearly from a previous branch commit, and/or prepares for the next commit

### Visual changes    <!-- DELETE SECTION IF NO VISUAL CHANGE -->
<!-- Zulip tips at https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html -->
<!-- For video, try asciinema; after uploading, embed using
[![yourtitle](https://asciinema.org/a/<id>.png)](https://asciinema.org/a/<id>)
-->
<!-- NOTE: Attached videos/images will be clearer from smaller terminal windows -->
<img width="1065" height="168" alt="Screenshot From 2026-02-22 23-21-44" src="https://github.com/user-attachments/assets/2146da61-d8e7-4148-90f2-aa3831ec7526" />

