### PR TITLE
Always show recipient headers in search results

### DIFF
--- a/tests/ui_tools/test_messages.py
+++ b/tests/ui_tools/test_messages.py
@@ -903,34 +903,39 @@ class TestMessageBox:
         assert isinstance(view_components[0][2], Divider)
 
     @pytest.mark.parametrize(
-        "msg_narrow, msg_type, assert_header_bar, assert_search_bar",
+        "msg_narrow, searching, msg_type, assert_header_bar, assert_search_bar",
         [
             (
                 [],
+                False,
                 0,
                 f" {STREAM_MARKER_PUBLIC} PTEST {STREAM_TOPIC_SEPARATOR} ",
                 f" {ALL_MESSAGES_MARKER} All messages ",
             ),
             (
                 [],
+                False,
                 1,
                 f" {DIRECT_MESSAGE_MARKER} You and ",
                 f" {ALL_MESSAGES_MARKER} All messages ",
             ),
             (
                 [],
+                False,
                 2,
                 f" {DIRECT_MESSAGE_MARKER} You and ",
                 f" {ALL_MESSAGES_MARKER} All messages ",
             ),
             (
                 [["stream", "PTEST"]],
+                False,
                 0,
                 f" {STREAM_MARKER_PUBLIC} PTEST {STREAM_TOPIC_SEPARATOR} ",
                 ("bar", ("s#bd6", f" {STREAM_MARKER_PUBLIC} PTEST ")),
             ),
             (
                 [["stream", "PTEST"], ["topic", "b"]],
+                False,
                 0,
                 f" {STREAM_MARKER_PUBLIC} PTEST {STREAM_TOPIC_SEPARATOR}",
                 (
@@ -940,78 +945,91 @@ class TestMessageBox:
             ),
             (
                 [["is", "private"]],
+                False,
                 1,
                 f" {DIRECT_MESSAGE_MARKER} You and ",
                 f" {DIRECT_MESSAGE_MARKER} All direct messages ",
             ),
             (
                 [["is", "private"]],
+                False,
                 2,
                 f" {DIRECT_MESSAGE_MARKER} You and ",
                 f" {DIRECT_MESSAGE_MARKER} All direct messages ",
             ),
             (
                 [["pm-with", "boo@zulip.com"]],
+                False,
                 1,
                 f" {DIRECT_MESSAGE_MARKER} You and ",
                 f" {DIRECT_MESSAGE_MARKER} Direct message conversation ",
             ),
             (
                 [["pm-with", "boo@zulip.com, bar@zulip.com"]],
+                False,
                 2,
                 f" {DIRECT_MESSAGE_MARKER} You and ",
                 f" {DIRECT_MESSAGE_MARKER} Group direct message conversation ",
             ),
             (
                 [["is", "starred"]],
+                False,
                 0,
                 f" {STREAM_MARKER_PUBLIC} PTEST {STREAM_TOPIC_SEPARATOR} ",
                 f" {STARRED_MESSAGES_MARKER} Starred messages ",
             ),
             (
                 [["is", "starred"]],
+                False,
                 1,
                 f" {DIRECT_MESSAGE_MARKER} You and ",
                 f" {STARRED_MESSAGES_MARKER} Starred messages ",
             ),
             (
                 [["is", "starred"]],
+                False,
                 2,
                 f" {DIRECT_MESSAGE_MARKER} You and ",
                 f" {STARRED_MESSAGES_MARKER} Starred messages ",
             ),
             (
                 [["is", "starred"], ["search", "FOO"]],
+                True,
                 1,
                 f" {DIRECT_MESSAGE_MARKER} You and ",
                 f" {STARRED_MESSAGES_MARKER} Starred messages ",
             ),
             (
                 [["search", "FOO"]],
+                True,
                 0,
                 f" {STREAM_MARKER_PUBLIC} PTEST {STREAM_TOPIC_SEPARATOR} ",
                 f" {ALL_MESSAGES_MARKER} All messages ",
             ),
             (
                 [["is", "mentioned"]],
+                False,
                 0,
                 f" {STREAM_MARKER_PUBLIC} PTEST {STREAM_TOPIC_SEPARATOR} ",
                 f" {MENTIONED_MESSAGES_MARKER} Mentions ",
             ),
             (
                 [["is", "mentioned"]],
+                False,
                 1,
                 f" {DIRECT_MESSAGE_MARKER} You and ",
                 f" {MENTIONED_MESSAGES_MARKER} Mentions ",
             ),
             (
                 [["is", "mentioned"]],
+                False,
                 2,
                 f" {DIRECT_MESSAGE_MARKER} You and ",
                 f" {MENTIONED_MESSAGES_MARKER} Mentions ",
             ),
             (
                 [["is", "mentioned"], ["search", "FOO"]],
+                True,
                 1,
                 f" {DIRECT_MESSAGE_MARKER} You and ",
                 f" {MENTIONED_MESSAGES_MARKER} Mentions ",
@@ -1024,6 +1042,7 @@ class TestMessageBox:
         messages_successful_response,
         msg_type,
         msg_narrow,
+        searching,
         assert_header_bar,
         assert_search_bar,
     ):
@@ -1033,6 +1052,7 @@ class TestMessageBox:
             },
         }
         self.model.narrow = msg_narrow
+        self.model.is_search_narrow.return_value = searching
         messages = messages_successful_response["messages"]
         current_message = messages[msg_type]
         msg_box = MessageBox(current_message, self.model, messages[0])
@@ -1108,6 +1128,8 @@ class TestMessageBox:
         # The empty dict is responsible for INACTIVE status of test user.
         self.model.user_dict = {}  # called once in main_view explicitly
 
+        self.model.is_search_narrow.return_value = False
+
         stars = {
             msg: ({"flags": ["starred"]} if msg == starred_msg else {})
             for msg in ("this", "last")
@@ -1152,6 +1174,7 @@ class TestMessageBox:
     ):
         message_fixture.update({"id": 4})
         varied_message = dict(message_fixture, **to_vary_in_each_message)
+        self.model.is_search_narrow.return_value = False
         msg_box = MessageBox(varied_message, self.model, varied_message)
         view_components = msg_box.main_view()
         assert len(view_components) == 1
@@ -1163,6 +1186,7 @@ class TestMessageBox:
         messages = messages_successful_response["messages"]
         for message in messages:
             self.model.index["edited_messages"].add(message["id"])
+            self.model.is_search_narrow.return_value = False
             msg_box = MessageBox(message, self.model, message)
             view_components = msg_box.main_view()
 
@@ -1189,6 +1213,7 @@ class TestMessageBox:
     ):
         message = message_fixture
         last_msg = dict(message, **to_vary_in_last_message)
+        self.model.is_search_narrow.return_value = False
 
         msg_box = MessageBox(message, self.model, last_msg)
 

--- a/tests/ui_tools/test_messages.py
+++ b/tests/ui_tools/test_messages.py
@@ -1153,6 +1153,39 @@ class TestMessageBox:
         assert isinstance(view_components[1], Padding)
 
     @pytest.mark.parametrize(
+        "message",
+        [
+            {
+                "id": 4,
+                "type": "stream",
+                "display_recipient": "Verona",
+                "stream_id": 5,
+                "subject": "Test topic",
+                "flags": [],
+                "is_me_message": False,
+                "content": "<p>what are you planning to do this week</p>",
+                "reactions": [],
+                "sender_full_name": "alice",
+                "timestamp": 1532103879,
+            }
+        ],
+    )
+    def test_search_results_always_have_header(
+        self,
+        mocker,
+        message,
+    ):
+        self.model.is_search_narrow.return_value = True
+
+        msg_box = MessageBox(message, self.model, message)
+        view_components = msg_box.main_view()
+
+        assert len(view_components) == 3
+        assert isinstance(view_components[0], Columns)
+        assert isinstance(view_components[1], Columns)
+        assert isinstance(view_components[2], Padding)
+
+    @pytest.mark.parametrize(
         "to_vary_in_each_message",
         [
             {"sender_full_name": "bob"},

--- a/zulipterminal/ui_tools/messages.py
+++ b/zulipterminal/ui_tools/messages.py
@@ -120,6 +120,9 @@ class MessageBox(urwid.Pile):
         super().__init__(self.main_view())
 
     def need_recipient_header(self) -> bool:
+        if self.model.is_search_narrow():
+            return True
+
         # Prevent redundant information in recipient bar
         if len(self.model.narrow) == 1 and self.model.narrow[0][0] == "pm-with":
             return False


### PR DESCRIPTION
### What does this PR do, and why?

This PR updates the representation of messages in search results to more closely match the web UI.

Previously, search results in the terminal would omit recipient headers for messages in the same stream & topic. This is great for saving space, but presenting search results this way can sow confusion by silently dropping messages that may have provided important context in between the messages that match the search results.

The web UI solves this issue by always showing recipient messages when searching. This PR (hopefully) mimics that behavior. :)

Fixes #1550

### Outstanding aspect(s)
- [ ] question on approach when searching within topic narrow:

The original issue states:

> Note that it should not display the recipient part of the header in conversation views (specific DMs, topics), just like now, since the header information is in the part above that already.

I want to make sure that I'm understanding this correctly. As written, my understanding is that "in conversation views" excludes "search narrows for searching _within_ a conversation view", as these would presumably be search views, not conversation views. However, am I misunderstanding this? (Or is there an implicit "part of the header in [searches of] conversation views" phrase that is missing?)

Of note: given the space constraints on the terminal I personally think that it might be a good idea to remove the recipient header for searches that are very clearly constrained to a topic/DM (I have not yet taken the time to fully investigate the technical feasibility of this, though in a moment of doubt I partially implemented it before reverting to my current code change + understanding of the issue... :sweat_smile: ) I double checked what the web UI does, and it looks like the web UI does add the recipient header for all search results, [even when constrained to a single topic](https://chat.zulip.org/#narrow/channel/7-test-here/topic/arie/search/supercalifragilisticexpialidocious):

<img width="1556" height="926" alt="screenshot of zulip web ui showing a search for 'supercalifragilisticexpialidocious' in the arie topic of the #test here stream. all results have recipient headers" src="https://github.com/user-attachments/assets/ebd1c782-b88b-49dd-b105-9132e6830455" />


### External discussion & connections
- [ ] Discussed in **#zulip-terminal** in `topic`
- [x] Fully fixes #1550 
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
- [ ] Manually - Behavioral changes
- [x] Manually - Visual changes
- [x] Adapting existing automated tests
- [x] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests (it looks like official ci only ran against the final commit, but I can confirm that running `pytest` against the interstitial commit locally passes without any new test failures)
- [x] It contains test additions for any new behavior
- [x] It flows clearly from a previous branch commit, and/or prepares for the next commit

### Visual changes
took a single before/after of a search constrained to a specific topic, as that seems the most germane to my outstanding question(s), but please ask for more/smaller screenshots & I'll generate them!!

| Before | After |
| --- | --- |
| <img width="2198" height="1654" alt="before screenshot for a search for 'supercalifragilisticexpialidocious' in the arie topic of #test here. current message recipients are announced in the topic narrow then only once in the search results" src="https://github.com/user-attachments/assets/836944cb-5b8a-4bc0-8f49-01785708fcf1" /> | <img width="2198" height="1654" alt="after screenshot for a search for 'supercalifragilisticexpialodocious' in the arie topic of #test here. current message recipients are announced in the topic narrow then once for each search result" src="https://github.com/user-attachments/assets/da65cc7d-00bb-4de0-aee0-52b6c21dad90" /> |

[the same search results](https://chat.zulip.org/#narrow/channel/7-test-here/topic/arie/search/supercalifragilisticexpialidocious)  in the web ui



sincere gratitude to those who worked on #1552, which this PR is a continuation/redux of <3

