### PR TITLE
core: Update pyperclip guidance to include Wayland users.

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,16 +304,22 @@ email, from the [Stream information popup](docs/hotkeys.md#stream-list-actions).
 
 #### Linux
 
-On Linux, this module makes use of `xclip` or `xsel` commands, which should
-already come with the OS.
-If none of these commands are installed on your system, then install any ONE
-using:
+On Linux, this module makes use of `xclip`, `xsel`, or `wl-clipboard` utilities,
+where `xclip` and `xsel` are for use in X11 environments (of the two, `xclip` is
+recommended over `xsel`) and `wl-clipboard` is for use in Wayland environments.
+(If you are not certain which system you are using, check the `$WAYLAND_DISPLAY`
+environment variable; in Wayland this will generally be set to something like
+`wayland-0`, while in X11 the variable will be unset.)
+
+If none of these commands are installed on your system, then install ONE of the
+above utilities using the package manager appropriate for your system, for
+example:
 ```
-sudo apt-get install xclip [Recommended]
+sudo apt-get install xclip
 ```
-OR
+or
 ```
-sudo apt-get install xsel
+sudo apt-get install wl-clipboard
 ```
 
 #### OSX and WSL

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -582,10 +582,15 @@ class Controller:
                 " which could not find a copy/paste mechanism for your system. :("
                 "\nThis error should only appear on Linux. You can fix this by"
                 " installing any ONE of the copy/paste mechanisms below:\n",
-                ("msg_bold", "- xclip\n- xsel"),
-                "\n\nvia something like:\n",
-                ("ui_code", "apt-get install xclip [Recommended]\n"),
-                ("ui_code", "apt-get install xsel"),
+                "- On X11: ",
+                ("msg_bold", "xclip"),
+                " (recommended) or ",
+                ("msg_bold", "xsel\n"),
+                "- On Wayland: ",
+                ("msg_bold", "wl-clipboard"),
+                "\n\nvia something like one of the following:\n",
+                ("ui_code", "apt-get install xclip\n"),
+                ("ui_code", "apt-get install wl-clipboard"),
             ]
             self.show_pop_up(
                 NoticeView(self, body, 60, "UTILITY PACKAGE MISSING"), "area:error"


### PR DESCRIPTION
### What does this PR do, and why?

When first reading the getting started guide, I was surprised to see only X11 mentioned in [the clipboard compatibility section](https://github.com/zulip/zulip-terminal?tab=readme-ov-file#linux-1) and genuinely began to wonder whether zulip-terminal supported Wayland (the purported successor to X11). Personal investigation has revealed that the pyperclip version that zulip-terminal is currently using _does_ support Wayland, so this PR updates the documentation to reflect that. :)

In my experience, `wl-clipboard` (the utility that pyperclip & many other terminal apps use to copy-paste in Wayland, which provides the commands `wl-copy` and `wl-paste`) is **not** installed by default in major Wayland desktop environments, so this documentation is genuinely necessary to provide feature parity for Wayland users.

### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [x] Discussed in [#zulip-terminal > docs: copy/paste on Wayland #T1572](https://chat.zulip.org/#narrow/channel/206-zulip-terminal/topic/docs.3A.20copy.2Fpaste.20on.20Wayland.20.23T1572/with/2396014)
- [ ] Fully fixes #
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
- [ ] Manually - Behavioral changes
- [x] Manually - Visual changes
- [ ] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [x] It contains test additions for any new behavior
- [x] It flows clearly from a previous branch commit, and/or prepares for the next commit

### Visual changes
| Before | After |
| --- | --- |
| <img width="1336" height="994" alt="screenshot of zulip terminal popup showing the old, X11 specific error message" src="https://github.com/user-attachments/assets/7477f0d8-c985-4b03-a34d-17d7c3d26af1" /> | <img width="1336" height="994" alt="screenshot of zulip terminal popup showing the new X11/Wayland error message" src="https://github.com/user-attachments/assets/e73399be-ccb4-45bc-8315-a0953171a91e" /> |

