### PR TITLE
about_popup: Add current terminal size to Detected Environment section

### DIFF
--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -170,9 +170,9 @@ class TestPopUpView:
         mocker.patch(
             MODULE + ".is_command_key",
             side_effect=(
-                lambda command, key: False
-                if command == self.command
-                else is_command_key(command, key)
+                lambda command, key: (
+                    False if command == self.command else is_command_key(command, key)
+                )
             ),
         )
 
@@ -209,6 +209,7 @@ class TestAboutView:
             maximum_footlinks=3,
             exit_confirmation_enabled=False,
             transparency_enabled=False,
+            terminal_size="80×24",
         )
 
     @pytest.mark.parametrize(
@@ -260,6 +261,7 @@ class TestAboutView:
             maximum_footlinks=3,
             exit_confirmation_enabled=False,
             transparency_enabled=False,
+            terminal_size="80×24",
         )
 
         assert len(about_view.feature_level_content) == (
@@ -300,7 +302,8 @@ Transparency: disabled
 
 #### Detected Environment
 Platform: WSL
-Python: [Python version]"""
+Python: [Python version]
+Current terminal size: 80×24"""
         assert self.about_view.copy_info == expected_output
 
 

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -308,6 +308,9 @@ class Controller:
         )
 
     def show_about(self) -> None:
+        cols, rows = self.loop.screen.get_cols_rows()
+        terminal_size = f"{cols} x {rows}"
+
         self.show_pop_up(
             AboutView(
                 self,
@@ -322,6 +325,7 @@ class Controller:
                 maximum_footlinks=self.maximum_footlinks,
                 exit_confirmation_enabled=self.exit_confirmation,
                 transparency_enabled=self.transparency_enabled,
+                terminal_size=terminal_size,
             ),
             "area:help",
         )

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -824,7 +824,7 @@ class LeftColumnView(urwid.Pile):
             for stream in self.view.pinned_streams
         ]
 
-        if len(streams_btn_list):
+        if streams_btn_list:
             streams_btn_list += [StreamsViewDivider()]
 
         streams_btn_list += [
@@ -1109,6 +1109,7 @@ class AboutView(PopUpView):
         notify_enabled: bool,
         exit_confirmation_enabled: bool,
         transparency_enabled: bool,
+        terminal_size: str,
     ) -> None:
         self.feature_level_content = (
             [("Feature level", str(server_feature_level))]
@@ -1136,7 +1137,11 @@ class AboutView(PopUpView):
             ),
             (
                 "Detected Environment",
-                [("Platform", PLATFORM), ("Python", detected_python_in_full())],
+                [
+                    ("Platform", PLATFORM),
+                    ("Python", detected_python_in_full()),
+                    ("Current terminal size", terminal_size),
+                ],
             ),
         ]
 


### PR DESCRIPTION
### What does this PR do?

Adds the current terminal window size to the "Detected Environment"
section of the About popup.

The terminal dimensions are obtained using `self.loop.screen.get_cols_rows()` in `core.py` and displayed as
"{cols} x {rows}" (for example "80 x 24").

### How was this tested?

- Ran the existing test suite
- Updated tests in `tests/ui_tools/test_popups.py`
- Verified the value appears in the About popup

Fixes #1536