### PR TITLE
Sort unread topics by recency for n shortcut.

### DIFF
--- a/zulipterminal/helper.py
+++ b/zulipterminal/helper.py
@@ -166,14 +166,20 @@ def asynch(func: Callable[ParamT, None]) -> Callable[ParamT, None]:
 
 
 def sort_unread_topics(
-    unread_topics: Dict[Tuple[int, str], int], stream_list: List[int]
+    unread_topics: Dict[Tuple[int, str], int],
+    stream_list: List[int],
+    topic_msg_ids: Optional[Dict[int, Dict[str, Set[int]]]] = None,
 ) -> List[Tuple[int, str]]:
+    if topic_msg_ids is None:
+        topic_msg_ids = {}
+
     return sorted(
         unread_topics.keys(),
         key=lambda stream_topic: (
             stream_list.index(stream_topic[0])
             if stream_topic[0] in stream_list
             else len(stream_list),
+            -max(topic_msg_ids.get(stream_topic[0], {}).get(stream_topic[1], {0})),
             stream_topic[1],
         ),
     )

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -984,6 +984,7 @@ class Model:
         unread_topics = sort_unread_topics(
             self.unread_counts["unread_topics"],
             left_panel_stream_list,
+            self.index["topic_msg_ids"],
         )
         next_topic = False
         stream_start: Optional[Tuple[int, str]] = None
@@ -997,6 +998,7 @@ class Model:
             unread_topics = sort_unread_topics(
                 {**self.unread_counts["unread_topics"], current_topic: 0},
                 left_panel_stream_list,
+                self.index["topic_msg_ids"],
             )
         # loop over unread_topics list twice for the case that last_unread_topic was
         # the last valid unread_topic in unread_topics list.


### PR DESCRIPTION
Fixes #1582.

<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?

Before, using the `n` keybinding (`NEXT_UNREAD_TOPIC`) jumps to the next unread topic alphabetically within a stream. But it should be sorting unread topics by recency.

this pull request fixes this issue #1582 by using recency-based sorting
1. **`helper.py`:** Updated `sort_unread_topics` to accept an optional `topic_msg_ids` dictionary. Modified the sorting `key` to evaluate the maximum `message_id` within each topic (`-max(...)`), ensuring that the most recently active topics go to the top (bubble). The alphabetical topic name sorting (from earlier) is still being used as a secondary tie breaker.
2. **`model.py`:** Updated calls to `sort_unread_topics` in `next_unread_topic_from_message_id` to pass `self.index["topic_msg_ids"]`



### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [ ] Discussed in **#zulip-terminal** in `topic`
- [x] Fully fixes #1582 
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [x] Manually - Behavioral changes
- [ ] Manually - Visual changes
- [ ] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [x] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [ ] It individually passes linting and tests
- [x] It contains test additions for any new behavior
- [x] It flows clearly from a previous branch commit, and/or prepares for the next commit

### Visual Changes

Navigating with `n` in Explore mode. The selection correctly jumps from the recently active `(checkmark) test` topic to the next most recent unread topic (`test`), rather than sorting alphabetically, like earlier.

The header shows being in the test checkmark in the first screenshot (this is before pressing n)

In the second ss, after pressing n, the ui changes and the header now shows test without the checkmark and the message history of unread messages for that topic beneath it.


<img width="441" height="685" alt="image" src="https://github.com/user-attachments/assets/79999e1f-b169-4224-b44e-7e25f22328b1" />
<img width="441" height="685" alt="image" src="https://github.com/user-attachments/assets/35c5c6cf-2e4d-45c8-9c6f-0c2d8aa91d4a" />




