### PR TITLE
Fix:Improved issues with msg merging

### DIFF
--- a/zulipterminal/ui_tools/messages.py
+++ b/zulipterminal/ui_tools/messages.py
@@ -705,7 +705,9 @@ class MessageBox(urwid.Pile):
 
             if message["this"]["is_starred"]:
                 text["star"] = ("starred", "*")
-            if any(different[key] for key in ("recipients", "author", "timestamp")):
+            if any(different[key] for key in ("recipients", "author", "timestamp", "star_status")):
+                text["author"] = ("msg_sender", message["this"]["author"])
+                
                 this_year = date.today().year
                 msg_year = message["this"]["datetime"].year
                 if this_year != msg_year:


### PR DESCRIPTION
Hello! I’ve updated the message rendering logic to fix a bug where starred messages wouldn't correctly "split" from a merged block.

The Issue:
Currently, Zulip-terminal merges adjacent messages from the same sender to keep the UI clean. However, if you star one of those messages, the header (author name and timestamp) often remains hidden. This makes the UI confusing because the star icon appears without the necessary context of who sent the message and when.

The Fix:
1. I modified the main_view logic in MessageBox to treat a change in star status as a reason to show the message header.
2. Now, if a message is starred and the previous one isn't (or vice-versa), the UI will "split" the merge.
3. The standalone message will now correctly repeat the Author's name and the Timestamp alongside the star, rather than just showing a lonely star icon.

Changes:
1. Updated any_differences logic to ensure star_status triggers a header re-render.
2. Included star_status in the conditional checks for rendering the author's name and the message time.