### PR TITLE
Fix sender_id logic in messages.py (#1151)

### DIFF
--- a/zulipterminal/ui_tools/messages.py
+++ b/zulipterminal/ui_tools/messages.py
@@ -650,9 +650,8 @@ class MessageBox(urwid.Pile):
         message = {
             key: {
                 "is_starred": "starred" in msg["flags"],
-                "author": (
-                    msg["sender_full_name"] if "sender_full_name" in msg else None
-                ),
+                "author": 
+                    msg.get("sender_id"),
                 "time": (
                     self.model.formatted_local_time(
                         msg["timestamp"], show_seconds=False
@@ -690,7 +689,7 @@ class MessageBox(urwid.Pile):
             text: Dict[str, urwid_MarkupTuple] = {key: (None, " ") for key in text_keys}
 
             if any(different[key] for key in ("recipients", "author", "24h")):
-                text["author"] = ("msg_sender", message["this"]["author"])
+                text["author"] = ("msg_sender", self.message["sender_full_name"])
 
                 # TODO: Refactor to use user ids for look up instead of emails.
                 email = self.message.get("sender_email", "")


### PR DESCRIPTION
### What does this PR do, and why?
Fixes the sender_id identification logic in messages.py for issue #1151.

### External discussion & connections
- [x] Fully fixes #1151
- [x] Discussed in #GSoC stream - Topic: GSoC 2026 - Choutankumar Naik

### How did you test this?
- [x] Manually - Behavioral changes
- [x] Manually - Visual changes