### PR TITLE
views: Preserve focus and search on external pin events

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -1221,6 +1221,77 @@ class TestLeftColumnView:
             ]
         )
 
+    def test_update_stream_view_restores_focus_by_stream_id(self, mocker):
+        mocker.patch(VIEWS + ".LeftColumnView.streams_view")
+        mocker.patch(VIEWS + ".LeftColumnView.menu_view")
+        mocker.patch(VIEWS + ".LeftColumnView.show_stream_view")
+        left_col_view = LeftColumnView(self.view)
+        left_col_view.is_in_topic_view = False
+
+        # Simulate focus on a stream widget with stream_id=42 at index 3.
+        focused_widget = mocker.Mock(stream_id=42)
+        self.view.stream_w = mocker.Mock()
+        self.view.stream_w.log.get_focus.return_value = (focused_widget, 3)
+        self.view.stream_w.stream_search_box.edit_text = ""
+
+        # After rebuild, stream_id=42 moved to index 1 (e.g. another stream
+        # was pinned and pushed to the top).
+        new_widgets = [
+            mocker.Mock(stream_id=99),
+            mocker.Mock(stream_id=42),
+            mocker.Mock(stream_id=7),
+        ]
+        self.view.stream_w.log.__iter__ = mocker.Mock(return_value=iter(new_widgets))
+
+        left_col_view.update_stream_view()
+
+        # Focus should follow stream_id=42 to its new position (index 1),
+        # not stay at the old index (3).
+        self.view.stream_w.log.set_focus.assert_called_once_with(1)
+        left_col_view.show_stream_view.assert_called_once()
+
+    def test_update_stream_view_restores_search_text(self, mocker):
+        mocker.patch(VIEWS + ".LeftColumnView.streams_view")
+        mocker.patch(VIEWS + ".LeftColumnView.menu_view")
+        mocker.patch(VIEWS + ".LeftColumnView.show_stream_view")
+        left_col_view = LeftColumnView(self.view)
+        left_col_view.is_in_topic_view = False
+
+        focused_widget = mocker.Mock(stream_id=10)
+        self.view.stream_w = mocker.Mock()
+        self.view.stream_w.log.get_focus.return_value = (focused_widget, 0)
+        self.view.stream_w.stream_search_box.edit_text = "foo"
+
+        new_widgets = [mocker.Mock(stream_id=10)]
+        self.view.stream_w.log.__iter__ = mocker.Mock(return_value=iter(new_widgets))
+
+        left_col_view.update_stream_view()
+
+        self.view.stream_w.stream_search_box.set_edit_text.assert_called_once_with(
+            "foo"
+        )
+
+    def test_update_stream_view_no_set_focus_when_stream_not_found(self, mocker):
+        mocker.patch(VIEWS + ".LeftColumnView.streams_view")
+        mocker.patch(VIEWS + ".LeftColumnView.menu_view")
+        mocker.patch(VIEWS + ".LeftColumnView.show_stream_view")
+        left_col_view = LeftColumnView(self.view)
+        left_col_view.is_in_topic_view = False
+
+        # Focus was on stream_id=42 which no longer exists after rebuild.
+        focused_widget = mocker.Mock(stream_id=42)
+        self.view.stream_w = mocker.Mock()
+        self.view.stream_w.log.get_focus.return_value = (focused_widget, 2)
+        self.view.stream_w.stream_search_box.edit_text = ""
+
+        new_widgets = [mocker.Mock(stream_id=99), mocker.Mock(stream_id=7)]
+        self.view.stream_w.log.__iter__ = mocker.Mock(return_value=iter(new_widgets))
+
+        left_col_view.update_stream_view()
+
+        # Should not call set_focus since stream_id=42 is gone.
+        self.view.stream_w.log.set_focus.assert_not_called()
+
 
 class TestTabView:
     @pytest.fixture

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -902,24 +902,23 @@ class LeftColumnView(urwid.Pile):
         )
 
     def update_stream_view(self) -> None:
-        # Preserve focus position and search state before rebuilding the
-        # stream list, so that an external pinning event does not disrupt
-        # the user's current position or active search (see issue #1487).
-        old_focus_index = 0
+        old_stream_id = None
         old_search_text = ""
         if hasattr(self.view, "stream_w"):
-            _, old_focus_index = self.view.stream_w.log.get_focus()
+            widget, _ = self.view.stream_w.log.get_focus()
+            if widget is not None and hasattr(widget, "stream_id"):
+                old_stream_id = widget.stream_id
             old_search_text = self.view.stream_w.stream_search_box.edit_text
 
         self.stream_v = self.streams_view()
 
-        # Restore focus. Clamp in case the list shrank after a pin/unpin event.
-        new_len = len(self.view.stream_w.log)
-        if new_len > 0:
-            clamped = min(old_focus_index or 0, new_len - 1)
-            self.view.stream_w.log.set_focus(clamped)
+        # Restore focus by finding the same stream in the rebuilt list.
+        if old_stream_id is not None:
+            for i, widget in enumerate(self.view.stream_w.log):
+                if hasattr(widget, "stream_id") and widget.stream_id == old_stream_id:
+                    self.view.stream_w.log.set_focus(i)
+                    break
 
-        # Restore search text so an in-progress search is not interrupted.
         if old_search_text:
             self.view.stream_w.stream_search_box.set_edit_text(old_search_text)
 

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -323,6 +323,12 @@ class StreamsView(urwid.Frame):
         self.log = urwid.SimpleFocusListWalker(streams_btn_list)
         self.streams_btn_list = streams_btn_list
         self.focus_index_before_search = 0
+        # Initialize search_lock before super().__init__() to prevent an
+        # AttributeError if an external pinning event triggers update_streams
+        # (via @asynch) before construction completes (see issue #1487).
+        self.search_lock = threading.Lock()
+        self.empty_search = False
+
         list_box = urwid.ListBox(self.log)
         self.stream_search_box = PanelSearchBox(
             self, "SEARCH_STREAMS", self.update_streams
@@ -333,8 +339,6 @@ class StreamsView(urwid.Frame):
                 [self.stream_search_box, urwid.Divider(SECTION_DIVIDER_LINE)]
             ),
         )
-        self.search_lock = threading.Lock()
-        self.empty_search = False
 
     @asynch
     def update_streams(self, search_box: Any, new_text: str) -> None:
@@ -898,7 +902,27 @@ class LeftColumnView(urwid.Pile):
         )
 
     def update_stream_view(self) -> None:
+        # Preserve focus position and search state before rebuilding the
+        # stream list, so that an external pinning event does not disrupt
+        # the user's current position or active search (see issue #1487).
+        old_focus_index = 0
+        old_search_text = ""
+        if hasattr(self.view, "stream_w"):
+            _, old_focus_index = self.view.stream_w.log.get_focus()
+            old_search_text = self.view.stream_w.stream_search_box.edit_text
+
         self.stream_v = self.streams_view()
+
+        # Restore focus. Clamp in case the list shrank after a pin/unpin event.
+        new_len = len(self.view.stream_w.log)
+        if new_len > 0:
+            clamped = min(old_focus_index or 0, new_len - 1)
+            self.view.stream_w.log.set_focus(clamped)
+
+        # Restore search text so an in-progress search is not interrupted.
+        if old_search_text:
+            self.view.stream_w.stream_search_box.set_edit_text(old_search_text)
+
         if not self.is_in_topic_view:
             self.show_stream_view()
 


### PR DESCRIPTION
<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?

When a stream pin/unpin event arrives from an external client, 
update_stream_view() rebuilt StreamsView from scratch. This reset 
focus to the top of the list and cleared any active search. If a 
pin event occurred while the search box was active, it also caused 
an AttributeError due to search_lock not yet being initialized.

This fixes the bugs in #1487 by saving and restoring focus position 
and search text around the rebuild, and by moving search_lock 
initialization earlier in StreamsView.__init__().

### External discussion & connections
- [x] Fully fixes #1487


### How did you test this?
- [x] Adding automated tests for new behavior (or missing tests)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [x] It contains test additions for any new behavior