### PR TITLE
view: Require topic narrow before next unread topic navigation.

### DIFF
--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -942,6 +942,23 @@ class TestMiddleColumnView:
         assert mid_col_view.controller.narrow_to_topic.called is False
         assert return_value == key
 
+    @pytest.mark.parametrize("key", keys_for_command("NEXT_UNREAD_TOPIC"))
+    def test_keypress_NEXT_UNREAD_TOPIC_stream_narrow_without_topic(
+        self, mid_col_view, mocker, widget_size, key
+    ):
+        size = widget_size(mid_col_view)
+        mocker.patch(MIDCOLVIEW + ".focus_position")
+        message_view = mocker.patch.object(self.view, "message_view")
+        message_view.focus = None
+
+        mid_col_view.model.narrow = [["stream", "stream"]]
+
+        return_value = mid_col_view.keypress(size, key)
+
+        assert mid_col_view.model.next_unread_topic_from_message_id.called is False
+        assert mid_col_view.controller.narrow_to_topic.called is False
+        assert return_value == key
+
     @pytest.mark.parametrize("key", keys_for_command("NEXT_UNREAD_PM"))
     def test_keypress_NEXT_UNREAD_PM_stream(
         self, mid_col_view, mocker, key, widget_size

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -617,7 +617,11 @@ class MiddleColumnView(urwid.Frame):
                 )
                 if stream_topic is None:
                     return key
-            elif narrow[0][0] == "stream" and narrow[1][0] == "topic":
+            elif (
+                len(narrow) == 2
+                and narrow[0][0] == "stream"
+                and narrow[1][0] == "topic"
+            ):
                 stream_topic = self.model.next_unread_topic_from_message_id(None)
             else:
                 return key


### PR DESCRIPTION
Pressing `n` (NEXT_UNREAD_TOPIC) from a stream-only narrow could raise IndexError by indexing narrow[1] without checking if a topic narrow was active.

<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?
This PR adds a length check before trying to access `narrow[1]` to make sure we do not try to access an index out of bounds.

### How did you test this?
<!-- [x] all that apply -->
- [x] Manually - Behavioral changes
- [ ] Manually - Visual changes
- [ ] Adapting existing automated tests
- [x] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [x] It contains test additions for any new behavior
- [ ] It flows clearly from a previous branch commit, and/or prepares for the next commit