### PR TITLE
model: Use "direct" type for DMs on servers at feature level 174+

### DIFF
--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -12,6 +12,7 @@ from zulip import Client, ZulipError
 from zulipterminal.config.symbols import STREAM_TOPIC_SEPARATOR
 from zulipterminal.helper import initial_index, powerset
 from zulipterminal.model import (
+    DIRECT_MESSAGE_TYPE_FEATURE_LEVEL,
     MAX_MESSAGE_LENGTH,
     MAX_STREAM_NAME_LENGTH,
     MAX_TOPIC_NAME_LENGTH,
@@ -908,17 +909,34 @@ class TestModel:
             ({"result": "some_failure"}, False),
         ],
     )
+    # AFTER
     @pytest.mark.parametrize("recipients", [[5179], [5179, 5180]])
+    @pytest.mark.parametrize(
+        "feature_level, expected_type",
+        [
+            (DIRECT_MESSAGE_TYPE_FEATURE_LEVEL, "direct"),
+            (DIRECT_MESSAGE_TYPE_FEATURE_LEVEL - 1, "private"),
+        ],
+        ids=["feature_level:direct_type", "feature_level:private_type"],
+    )
     def test_send_private_message(
-        self, mocker, model, recipients, response, return_value, content="hi!"
+        self,
+        mocker,
+        model,
+        recipients,
+        response,
+        return_value,
+        feature_level,
+        expected_type,
+        content="hi!",
     ):
+        model.server_feature_level = feature_level
         self.client.send_message = mocker.Mock(return_value=response)
-
         result = model.send_private_message(recipients, content)
-
-        req = dict(type="private", to=recipients, content=content, read_by_sender=True)
+        req = dict(
+            type=expected_type, to=recipients, content=content, read_by_sender=True
+        )
         self.client.send_message.assert_called_once_with(req)
-
         assert result == return_value
         self.display_error_if_present.assert_called_once_with(response, self.controller)
         if result == "success":

--- a/zulipterminal/api_types.py
+++ b/zulipterminal/api_types.py
@@ -45,7 +45,7 @@ PRESENCE_PING_INTERVAL_SECS: Final = 60
 ###############################################################################
 # Core message types (used in Composition and Message below)
 
-DirectMessageString = Literal["private"]
+DirectMessageString = Literal["private", "direct"]
 StreamMessageString = Literal["stream"]
 
 MessageType = Union[DirectMessageString, StreamMessageString]

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -27,7 +27,7 @@ from urllib.parse import urlparse
 
 import zulip
 from bs4 import BeautifulSoup
-from typing_extensions import TypedDict
+from typing_extensions import Literal, TypedDict
 
 from zulipterminal import unicode_emojis
 from zulipterminal.api_types import (
@@ -99,6 +99,9 @@ class UserSettings(TypedDict):
     send_private_typing_notifications: bool
     twenty_four_hour_time: bool
     pm_content_in_desktop_notifications: bool
+
+
+DIRECT_MESSAGE_TYPE_FEATURE_LEVEL = 174
 
 
 class Model:
@@ -540,8 +543,13 @@ class Model:
 
     def send_private_message(self, recipients: List[int], content: str) -> bool:
         if recipients:
+            direct_message_type: Literal["private", "direct"] = (
+                "direct"
+                if self.server_feature_level >= DIRECT_MESSAGE_TYPE_FEATURE_LEVEL
+                else "private"
+            )
             composition = PrivateComposition(
-                type="private",
+                type=direct_message_type,
                 to=recipients,
                 content=content,
                 read_by_sender=True,


### PR DESCRIPTION
Zulip servers at API feature level 174 (Zulip 7.0) introduced "direct" as the preferred value for the `type` parameter when sending direct messages via POST /messages. Older servers require "private" and do not accept "direct".

This change:
- Widens `PrivateComposition.type` to `Literal["private", "direct"]`
- Adds `DIRECT_MESSAGE_TYPE_FEATURE_LEVEL = 174` in `model.py`
- Gates the type value in `send_private_message()` on the feature level
- Parametrizes the existing test to cover both code paths

Fixes #1388