### PR TITLE
about: Add current terminal size to About popup

### DIFF
--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -209,6 +209,7 @@ class TestAboutView:
             maximum_footlinks=3,
             exit_confirmation_enabled=False,
             transparency_enabled=False,
+            terminal_size=(80, 24),
         )
 
     @pytest.mark.parametrize(
@@ -260,6 +261,7 @@ class TestAboutView:
             maximum_footlinks=3,
             exit_confirmation_enabled=False,
             transparency_enabled=False,
+            terminal_size=(80, 24),
         )
 
         assert len(about_view.feature_level_content) == (
@@ -300,7 +302,8 @@ Transparency: disabled
 
 #### Detected Environment
 Platform: WSL
-Python: [Python version]"""
+Python: [Python version]
+Current terminal size: 80 x 24"""
         assert self.about_view.copy_info == expected_output
 
 

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -308,6 +308,7 @@ class Controller:
         )
 
     def show_about(self) -> None:
+        cols, rows = self.loop.screen.get_cols_rows()
         self.show_pop_up(
             AboutView(
                 self,
@@ -322,6 +323,7 @@ class Controller:
                 maximum_footlinks=self.maximum_footlinks,
                 exit_confirmation_enabled=self.exit_confirmation,
                 transparency_enabled=self.transparency_enabled,
+                terminal_size=(cols, rows),
             ),
             "area:help",
         )

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1109,6 +1109,7 @@ class AboutView(PopUpView):
         notify_enabled: bool,
         exit_confirmation_enabled: bool,
         transparency_enabled: bool,
+        terminal_size: Tuple[int, int],
     ) -> None:
         self.feature_level_content = (
             [("Feature level", str(server_feature_level))]
@@ -1136,7 +1137,11 @@ class AboutView(PopUpView):
             ),
             (
                 "Detected Environment",
-                [("Platform", PLATFORM), ("Python", detected_python_in_full())],
+                [
+                    ("Platform", PLATFORM),
+                    ("Python", detected_python_in_full()),
+                    ("Current terminal size", f"{terminal_size[0]} x {terminal_size[1]}"),
+                ],
             ),
         ]
 


### PR DESCRIPTION
Adds current terminal size to the Detected Environment section of the About popup, as described in #1536.