### PR TITLE
fix: Add EmptyNarrowPlaceholder for narrows with no messages

### DIFF
--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -12,6 +12,7 @@ from pytest_mock import MockerFixture
 from zulipterminal.config.themes import generate_theme
 from zulipterminal.core import Controller
 from zulipterminal.helper import Index
+from zulipterminal.ui_tools.views import EmptyNarrowPlaceholder
 from zulipterminal.version import ZT_VERSION
 
 
@@ -155,6 +156,27 @@ class TestController:
         widget = controller.view.message_view.log.extend.call_args_list[0][0][0][0]
         id_list = index_stream["stream_msg_ids_by_stream_id"][stream_id]
         assert {widget.original_widget.message["id"]} == id_list
+
+    def test_narrow_to_empty_stream_inserts_placeholder(
+        self,
+        mocker: MockerFixture,
+        controller: Controller,
+        stream_name: str = "EMPTY_STREAM",
+    ) -> None:
+        controller.view.message_view = mocker.patch("urwid.ListBox")
+        mocker.patch(MODEL + ".set_narrow", return_value=False)
+        mocker.patch(MODEL + ".get_message_ids_in_current_narrow", return_value=set())
+        mocker.patch(MODEL + ".get_messages")
+        mocker.patch(MODULE + ".create_msg_box_list", return_value=[])
+        mocker.patch(MODEL + ".get_focus_in_current_narrow", return_value=None)
+
+        controller._narrow_to(anchor=None, stream=stream_name)
+
+        controller.view.message_view.log.clear.assert_called_once_with()
+        extend_args = controller.view.message_view.log.extend.call_args_list[0][0][0]
+        assert len(extend_args) == 1
+        placeholder_w = extend_args[0]
+        assert isinstance(placeholder_w.original_widget, EmptyNarrowPlaceholder)
 
     @pytest.mark.parametrize(
         ["initial_narrow", "initial_stream_id", "anchor", "expected_final_focus"],

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -24,6 +24,7 @@ from zulipterminal.model import (
     ServerConnectionFailure,
     UserSettings,
 )
+from zulipterminal.ui_tools.views import EmptyNarrowPlaceholder
 
 
 MODULE = "zulipterminal.model"
@@ -2019,6 +2020,30 @@ class TestModel:
         expected_last_msg = log[0].original_widget.message
         create_msg_box_list.assert_called_once_with(
             model, [message_fixture["id"]], last_message=expected_last_msg
+        )
+
+    def test__handle_message_event_replaces_placeholder(
+        self, mocker, model, message_fixture
+    ):
+        model._have_last_message[repr([])] = True
+        mocker.patch(MODEL + "._update_topic_index")
+        mocker.patch(MODULE + ".index_messages", return_value={})
+        placeholder_widget = mocker.MagicMock(spec=EmptyNarrowPlaceholder)
+        placeholder_w = mocker.Mock()
+        placeholder_w.original_widget = placeholder_widget
+        log = [placeholder_w]
+        self.controller.view.message_view = mocker.Mock(log=log)
+        create_msg_box_list = mocker.patch(
+            MODULE + ".create_msg_box_list", return_value=["msg_w"]
+        )
+        model.notify_user = mocker.Mock()
+        event = {"type": "message", "message": message_fixture}
+
+        model._handle_message_event(event)
+
+        assert self.controller.view.message_view.log == ["msg_w"]
+        create_msg_box_list.assert_called_once_with(
+            model, [message_fixture["id"]], last_message=None
         )
 
     def test__handle_message_event_with_flags(self, mocker, model, message_fixture):

--- a/tests/ui/test_ui_tools.py
+++ b/tests/ui/test_ui_tools.py
@@ -10,6 +10,7 @@ from zulipterminal.config.symbols import STATUS_ACTIVE
 from zulipterminal.helper import powerset
 from zulipterminal.ui_tools.views import (
     SIDE_PANELS_MOUSE_SCROLL_LINES,
+    EmptyNarrowPlaceholder,
     LeftColumnView,
     MessageView,
     MiddleColumnView,
@@ -27,6 +28,88 @@ SUBDIR = "zulipterminal.ui_tools"
 VIEWS = SUBDIR + ".views"
 MESSAGEVIEW = VIEWS + ".MessageView"
 MIDCOLVIEW = VIEWS + ".MiddleColumnView"
+
+
+class TestEmptyNarrowPlaceholder:
+    @pytest.fixture(autouse=True)
+    def mock_external_classes(self, mocker):
+        self.model = mocker.MagicMock()
+
+    @pytest.fixture
+    def placeholder(self):
+        return EmptyNarrowPlaceholder(self.model)
+
+    def test_recipient_header_returns_empty_markup(self, placeholder):
+        header = placeholder.recipient_header()
+        assert header.markup == ""
+
+    @pytest.mark.parametrize(
+        "narrow, is_search_narrow, expected_text",
+        [
+            ([], False, "≡ All messages"),
+            ([["is", "private"]], False, "§ All direct messages"),
+            ([["is", "starred"]], False, "* Starred messages"),
+            ([["is", "mentioned"]], False, "@ Mentions"),
+        ],
+    )
+    def test_top_search_bar_non_stream_narrow(
+        self, mocker, placeholder, narrow, is_search_narrow, expected_text
+    ):
+        self.model.narrow = narrow
+        self.model.is_search_narrow.return_value = is_search_narrow
+
+        header = placeholder.top_search_bar()
+
+        assert expected_text in str(header.markup)
+
+    def test_top_search_bar_stream_narrow(self, mocker, placeholder):
+        stream_id = 205
+        self.model.narrow = [["stream", "PTEST"]]
+        self.model.is_search_narrow.return_value = False
+        self.model.stream_id = stream_id
+        self.model.stream_dict = {stream_id: {"color": "#ffffff", "name": "PTEST"}}
+        self.model.stream_access_type.return_value = "public"
+
+        header = placeholder.top_search_bar()
+
+        assert "PTEST" in str(header.markup)
+
+    def test_top_search_bar_stream_topic_narrow(self, mocker, placeholder):
+        stream_id = 205
+        self.model.narrow = [["stream", "PTEST"], ["topic", "Test"]]
+        self.model.is_search_narrow.return_value = False
+        self.model.stream_id = stream_id
+        self.model.stream_dict = {stream_id: {"color": "#ffffff", "name": "PTEST"}}
+        self.model.stream_access_type.return_value = "public"
+
+        header = placeholder.top_search_bar()
+
+        assert "PTEST" in str(header.markup)
+        assert "topic narrow" in str(header.markup)
+
+    def test_top_search_bar_dm_narrow(self, mocker, placeholder):
+        self.model.narrow = [["pm-with", "foo@example.com"]]
+        self.model.is_search_narrow.return_value = False
+
+        header = placeholder.top_search_bar()
+
+        assert "Direct message conversation" in str(header.markup)
+
+    def test_top_search_bar_group_dm_narrow(self, mocker, placeholder):
+        self.model.narrow = [["pm-with", "foo@example.com,bar@example.com"]]
+        self.model.is_search_narrow.return_value = False
+
+        header = placeholder.top_search_bar()
+
+        assert "Group direct message conversation" in str(header.markup)
+
+    def test_top_search_bar_search_narrow(self, mocker, placeholder):
+        self.model.narrow = [["is", "starred"], ["search", "foo"]]
+        self.model.is_search_narrow.return_value = True
+
+        header = placeholder.top_search_bar()
+
+        assert "Search Results" in str(header.markup)
 
 
 class TestModListWalker:
@@ -461,6 +544,85 @@ class TestMessageView:
         self.model.mark_message_ids_as_read.assert_called_once_with(
             [message_fixture["id"]]
         )
+
+    def test_read_message_with_placeholder_updates_search_box_only(
+        self, mocker, msg_box
+    ):
+        mocker.patch(MESSAGEVIEW + ".main_view", return_value=[msg_box])
+        mocker.patch(MESSAGEVIEW + ".set_focus")
+        mocker.patch(MESSAGEVIEW + ".update_search_box_narrow")
+        msg_view = MessageView(self.model, self.view)
+        msg_view.body = mocker.Mock()
+
+        placeholder = mocker.MagicMock(spec=EmptyNarrowPlaceholder)
+        msg_w = mocker.MagicMock()
+        msg_w.original_widget = placeholder
+        msg_view.body.get_focus.return_value = (msg_w, 0)
+
+        msg_view.read_message()
+
+        msg_view.update_search_box_narrow.assert_called_once_with(placeholder)
+        self.model.mark_message_ids_as_read.assert_not_called()
+
+    @pytest.mark.parametrize("key", keys_for_command("GO_DOWN"))
+    def test_keypress_GO_DOWN_exception_with_placeholder(
+        self, mocker, msg_view, key, widget_size
+    ):
+        size = widget_size(msg_view)
+        msg_view.new_loading = False
+        mocker.patch(MESSAGEVIEW + ".focus_position", return_value=0)
+        msg_view.log.next_position = Exception()
+        placeholder = mocker.MagicMock(spec=EmptyNarrowPlaceholder)
+        mocker.patch(
+            MESSAGEVIEW + ".focus",
+            mocker.MagicMock(original_widget=placeholder),
+        )
+        mocker.patch.object(msg_view, "load_new_messages")
+
+        msg_view.keypress(size, key)
+
+        msg_view.load_new_messages.assert_not_called()
+
+    @pytest.mark.parametrize("key", keys_for_command("GO_UP"))
+    def test_keypress_GO_UP_exception_with_placeholder(
+        self, mocker, msg_view, key, widget_size
+    ):
+        size = widget_size(msg_view)
+        msg_view.old_loading = False
+        mocker.patch(MESSAGEVIEW + ".focus_position", return_value=0)
+        msg_view.log.prev_position = Exception()
+        placeholder = mocker.MagicMock(spec=EmptyNarrowPlaceholder)
+        mocker.patch(
+            MESSAGEVIEW + ".focus",
+            mocker.MagicMock(original_widget=placeholder),
+        )
+        mocker.patch.object(msg_view, "load_old_messages")
+
+        msg_view.keypress(size, key)
+
+        msg_view.load_old_messages.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "key",
+        keys_for_command("THUMBS_UP")
+        + keys_for_command("TOGGLE_STAR_STATUS")
+        + keys_for_command("REACTION_AGREEMENT"),
+    )
+    def test_keypress_message_action_with_placeholder_no_op(
+        self, mocker, msg_view, key, widget_size
+    ):
+        size = widget_size(msg_view)
+        placeholder = mocker.MagicMock(spec=EmptyNarrowPlaceholder)
+        mocker.patch(
+            MESSAGEVIEW + ".focus",
+            mocker.MagicMock(original_widget=placeholder),
+        )
+        mocker.patch("urwid.ListBox.keypress", return_value=key)
+
+        msg_view.keypress(size, key)
+
+        self.model.toggle_message_reaction.assert_not_called()
+        self.model.toggle_message_star_status.assert_not_called()
 
 
 class TestStreamsViewDivider:

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -36,6 +36,7 @@ from zulipterminal.ui_tools.views import (
     EditHistoryView,
     EditModeView,
     EmojiPickerView,
+    EmptyNarrowPlaceholder,
     ExceptionView,
     FullRawMsgView,
     FullRenderedMsgView,
@@ -119,9 +120,11 @@ class Controller:
         # Register new ^C handler
         signal.signal(
             signal.SIGINT,
-            self.prompting_exit_handler
-            if self.exit_confirmation
-            else self.no_prompt_exit_handler,
+            (
+                self.prompting_exit_handler
+                if self.exit_confirmation
+                else self.no_prompt_exit_handler
+            ),
         )
 
     def raise_exception_in_main_thread(
@@ -614,7 +617,10 @@ class Controller:
         assert focus_position is not None
 
         self.view.message_view.log.clear()
-        if 0 <= focus_position < len(w_list):
+        if not w_list:
+            placeholder = urwid.AttrMap(EmptyNarrowPlaceholder(self.model), None)
+            self.view.message_view.log.extend([placeholder])
+        elif 0 <= focus_position < len(w_list):
             self.view.message_view.log.extend(w_list, focus_position)
         else:
             self.view.message_view.log.extend(w_list)

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -82,6 +82,7 @@ from zulipterminal.helper import (
 )
 from zulipterminal.platform_code import notify
 from zulipterminal.ui_tools.utils import create_msg_box_list
+from zulipterminal.ui_tools.views import EmptyNarrowPlaceholder
 
 
 class ServerConnectionFailure(Exception):
@@ -1408,7 +1409,7 @@ class Model:
             SubscriptionSettingChange(
                 stream_id=stream_id,
                 property="is_muted",
-                value=not self.is_muted_stream(stream_id)
+                value=not self.is_muted_stream(stream_id),
                 # True for muting and False for unmuting.
             )
         ]
@@ -1732,7 +1733,10 @@ class Model:
             repr(self.narrow), False
         ):
             msg_log = self.controller.view.message_view.log
-            if msg_log:
+            has_placeholder = msg_log and isinstance(
+                msg_log[-1].original_widget, EmptyNarrowPlaceholder
+            )
+            if msg_log and not has_placeholder:
                 last_message = msg_log[-1].original_widget.message
             else:
                 last_message = None
@@ -1745,6 +1749,8 @@ class Model:
                 msg_w = msg_w_list[0]
 
             if self.current_narrow_contains_message(message):
+                if has_placeholder:
+                    msg_log.remove(msg_log[0])
                 msg_log.append(msg_w)
 
             self.controller.update_screen()

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -21,10 +21,14 @@ from zulipterminal.config.keys import (
 )
 from zulipterminal.config.markdown_examples import MARKDOWN_ELEMENTS
 from zulipterminal.config.symbols import (
+    ALL_MESSAGES_MARKER,
     CHECK_MARK,
     COLUMN_TITLE_BAR_LINE,
+    DIRECT_MESSAGE_MARKER,
+    MENTIONED_MESSAGES_MARKER,
     PINNED_STREAMS_DIVIDER,
     SECTION_DIVIDER_LINE,
+    STARRED_MESSAGES_MARKER,
 )
 from zulipterminal.config.ui_mappings import (
     BOT_TYPE_BY_ID,
@@ -63,6 +67,82 @@ from zulipterminal.urwid_types import urwid_Size
 
 MIDDLE_COLUMN_MOUSE_SCROLL_LINES = 1
 SIDE_PANELS_MOUSE_SCROLL_LINES = 5
+
+
+class EmptyNarrowPlaceholder(urwid.WidgetWrap):
+    """
+    Focusable placeholder shown when a narrow contains no messages.
+    Implements recipient_header() and top_search_bar() so the search box
+    updates correctly even when there is nothing to focus on in the message
+    list.
+    """
+
+    def __init__(self, model: Any) -> None:
+        self.model = model
+        text = urwid.Text("No messages here.", align="center")
+        super().__init__(text)
+
+    def recipient_header(self) -> Any:
+        title = urwid.Text("")
+        header = urwid.AttrWrap(title, "bar")
+        header.markup = ""
+        return header
+
+    def top_search_bar(self) -> Any:
+        curr_narrow = self.model.narrow
+        is_search_narrow = self.model.is_search_narrow()
+        if is_search_narrow:
+            curr_narrow = [
+                sub_narrow for sub_narrow in curr_narrow if sub_narrow[0] != "search"
+            ]
+        else:
+            self.model.controller.view.search_box.text_box.set_edit_text("")
+        if curr_narrow == []:
+            text_to_fill = f" {ALL_MESSAGES_MARKER} All messages "
+        elif len(curr_narrow) == 1 and curr_narrow[0][1] == "private":
+            text_to_fill = f" {DIRECT_MESSAGE_MARKER} All direct messages "
+        elif len(curr_narrow) == 1 and curr_narrow[0][1] == "starred":
+            text_to_fill = f" {STARRED_MESSAGES_MARKER} Starred messages "
+        elif len(curr_narrow) == 1 and curr_narrow[0][1] == "mentioned":
+            text_to_fill = f" {MENTIONED_MESSAGES_MARKER} Mentions "
+        elif curr_narrow[0][0] == "stream":
+            stream_id = self.model.stream_id
+            assert stream_id is not None
+            bar_color = f"s{self.model.stream_dict[stream_id]['color']}"
+            stream_access_type = self.model.stream_access_type(stream_id)
+            stream_icon = STREAM_ACCESS_TYPE[stream_access_type]["icon"]
+            stream_name = self.model.stream_dict[stream_id]["name"]
+            if len(curr_narrow) == 2 and curr_narrow[1][0] == "topic":
+                text_to_fill = (
+                    "bar",  # type: ignore[assignment]
+                    (bar_color, f" {stream_icon} {stream_name}: topic narrow "),
+                )
+            else:
+                text_to_fill = (
+                    "bar",  # type: ignore[assignment]
+                    (bar_color, f" {stream_icon} {stream_name} "),
+                )
+        elif len(curr_narrow) == 1 and len(curr_narrow[0][1].split(",")) > 1:
+            text_to_fill = (
+                f" {DIRECT_MESSAGE_MARKER} Group direct message conversation "
+            )
+        else:
+            text_to_fill = f" {DIRECT_MESSAGE_MARKER} Direct message conversation "
+        if is_search_narrow:
+            title_markup = (
+                "header",
+                [
+                    ("general_narrow", text_to_fill),
+                    (None, " "),
+                    ("filter_results", "Search Results"),
+                ],
+            )
+        else:
+            title_markup = ("header", [("general_narrow", text_to_fill)])
+        title = urwid.Text(title_markup)
+        header = urwid.AttrWrap(title, "bar")
+        header.markup = title_markup
+        return header
 
 
 class ModListWalker(urwid.SimpleFocusListWalker):
@@ -201,7 +281,9 @@ class MessageView(urwid.ListBox):
 
                 return key
             except Exception:
-                if self.focus:
+                if self.focus and not isinstance(
+                    self.focus.original_widget, EmptyNarrowPlaceholder
+                ):
                     id = self.focus.original_widget.message["id"]
                     self.load_new_messages(id)
                 return key
@@ -213,7 +295,9 @@ class MessageView(urwid.ListBox):
                 self.set_focus_valign("middle")
                 return key
             except Exception:
-                if self.focus:
+                if self.focus and not isinstance(
+                    self.focus.original_widget, EmptyNarrowPlaceholder
+                ):
                     id = self.focus.original_widget.message["id"]
                     self.load_old_messages(id)
                 return key
@@ -230,15 +314,27 @@ class MessageView(urwid.ListBox):
             else:
                 return super().keypress(size, primary_key_for_command("SCROLL_DOWN"))
 
-        elif is_command_key("THUMBS_UP", key) and self.focus is not None:
+        elif (
+            is_command_key("THUMBS_UP", key)
+            and self.focus is not None
+            and not isinstance(self.focus.original_widget, EmptyNarrowPlaceholder)
+        ):
             message = self.focus.original_widget.message
             self.model.toggle_message_reaction(message, reaction_to_toggle="thumbs_up")
 
-        elif is_command_key("TOGGLE_STAR_STATUS", key) and self.focus is not None:
+        elif (
+            is_command_key("TOGGLE_STAR_STATUS", key)
+            and self.focus is not None
+            and not isinstance(self.focus.original_widget, EmptyNarrowPlaceholder)
+        ):
             message = self.focus.original_widget.message
             self.model.toggle_message_star_status(message)
 
-        elif is_command_key("REACTION_AGREEMENT", key) and self.focus is not None:
+        elif (
+            is_command_key("REACTION_AGREEMENT", key)
+            and self.focus is not None
+            and not isinstance(self.focus.original_widget, EmptyNarrowPlaceholder)
+        ):
             message = self.focus.original_widget.message
             message_reactions = message["reactions"]
             if message_reactions:
@@ -272,6 +368,9 @@ class MessageView(urwid.ListBox):
         if msg_w is None:
             return
         self.update_search_box_narrow(msg_w.original_widget)
+
+        if isinstance(msg_w.original_widget, EmptyNarrowPlaceholder):
+            return
 
         # Do not read messages in explore mode.
         if self.model.controller.in_explore_mode:


### PR DESCRIPTION
Fixes issue #1506. When navigating to a narrow with no messages (e.g. an empty stream, starred messages with none starred, or a DM with no history), the UI previously entered a broken state: keyboard navigation stopped working, the "Current message recipients" bar showed stale content from the previous narrow, and the narrow title failed to update.

The root cause was that urwid requires a focusable widget in the message list. With an empty list, no action was triggered to update the search box or recipient bar.

This fix introduces EmptyNarrowPlaceholder, a focusable widget inserted into the message list when a narrow is empty. It:
- Shows "No messages here." in the message area
- Implements top_search_bar() to correctly update the narrow title from model state (no message needed)
- Implements recipient_header() to clear the recipient bar
- Is safely removed when a real message arrives via a server event
- Guards message-specific keypresses (THUMBS_UP, TOGGLE_STAR_STATUS, REACTION_AGREEMENT, GO_UP/GO_DOWN loading) from operating on the placeholder

<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?



### Outstanding aspect(s)    <!-- DELETE SECTION IF EMPTY -->
<!-- In what ways is this not fully implemented/functioning? Compared to a discussion/issue? -->
<!-- Do you not understand something? Are you unsure about a certain approach? Want feedback? -->
- [ ] 

### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [ ] Discussed in **#zulip-terminal** in `topic`
- [ ] Fully fixes #
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [ ] Manually - Behavioral changes
- [ ] Manually - Visual changes
- [ ] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [ ] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [ ] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [ ] It has a commit summary describing the  motivation and reasoning for the change
- [ ] It individually passes linting and tests
- [ ] It contains test additions for any new behavior
- [ ] It flows clearly from a previous branch commit, and/or prepares for the next commit

### Visual changes    <!-- DELETE SECTION IF NO VISUAL CHANGE -->
<!-- Zulip tips at https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html -->
<!-- For video, try asciinema; after uploading, embed using
[![yourtitle](https://asciinema.org/a/<id>.png)](https://asciinema.org/a/<id>)
-->
<!-- NOTE: Attached videos/images will be clearer from smaller terminal windows -->
