### PR TITLE
Feat/autocomplete users

### DIFF
--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -590,6 +590,160 @@ class TestModel:
         assert expected_user_ids == model.get_user_ids_in_topic_narrow(stream_id, topic)
 
     @pytest.mark.parametrize(
+        "index, expected_user_ids",
+        [
+            (
+                {
+                    "private_msg_ids": {101, 102},
+                    "messages": {
+                        101: {
+                            "timestamp": 1527921326,
+                            "display_recipient": [
+                                {
+                                    "id": 4,
+                                    "email": "hamlet@zulip.com",
+                                    "full_name": "King Hamlet",
+                                    "is_mirror_dummy": False,
+                                },
+                                {
+                                    "id": 5,
+                                    "email": "iago@zulip.com",
+                                    "full_name": "Iago",
+                                    "is_mirror_dummy": False,
+                                },
+                            ],
+                        },
+                        102: {
+                            "timestamp": 1527921400,
+                            "display_recipient": [
+                                {
+                                    "id": 4,
+                                    "email": "hamlet@zulip.com",
+                                    "full_name": "King Hamlet",
+                                    "is_mirror_dummy": False,
+                                },
+                                {
+                                    "id": 8,
+                                    "email": "prospero@zulip.com",
+                                    "full_name": "Prospero from The Tempest",
+                                    "is_mirror_dummy": False,
+                                },
+                            ],
+                        },
+                        999: {  # stream message, should be ignored
+                            "timestamp": 1527921999,
+                            "display_recipient": "general",
+                        },
+                    },
+                },
+                [8, 5],
+            ),
+            (
+                {  # user sends message to self
+                    "private_msg_ids": {201},
+                    "messages": {
+                        201: {
+                            "timestamp": 1527921500,
+                            "display_recipient": [
+                                {
+                                    "id": 4,
+                                    "email": "hamlet@zulip.com",
+                                    "full_name": "King Hamlet",
+                                    "is_mirror_dummy": False,
+                                },
+                            ],
+                        },
+                        109: {  # stream message, should be ignored
+                            "timestamp": 1527921999,
+                            "display_recipient": "test here",
+                        },
+                    },
+                    109: {  # stream message, should be ignored
+                        "timestamp": 1527921089,
+                        "display_recipient": "zulip terminal",
+                    },
+                },
+                [],
+            ),
+            (
+                {
+                    "private_msg_ids": {301, 302, 303},
+                    "messages": {
+                        301: {
+                            "timestamp": 1527921600,
+                            "display_recipient": [
+                                {
+                                    "id": 4,
+                                    "email": "hamlet@zulip.com",
+                                    "full_name": "King Hamlet",
+                                    "is_mirror_dummy": False,
+                                },
+                                {
+                                    "id": 5,
+                                    "email": "iago@zulip.com",
+                                    "full_name": "Iago",
+                                    "is_mirror_dummy": False,
+                                },
+                            ],
+                        },
+                        302: {
+                            "timestamp": 1527921700,
+                            "display_recipient": [
+                                {
+                                    "id": 5,
+                                    "email": "iago@zulip.com",
+                                    "full_name": "Iago",
+                                    "is_mirror_dummy": False,
+                                },
+                                {
+                                    "id": 4,
+                                    "email": "hamlet@zulip.com",
+                                    "full_name": "King Hamlet",
+                                    "is_mirror_dummy": False,
+                                },
+                                {
+                                    "id": 6,
+                                    "email": "prospero@zulip.com",
+                                    "full_name": "Prospero from The Tempest",
+                                    "is_mirror_dummy": False,
+                                },
+                            ],
+                        },
+                        303: {
+                            "timestamp": 1527921800,
+                            "display_recipient": [
+                                {
+                                    "id": 4,
+                                    "email": "hamlet@zulip.com",
+                                    "full_name": "King Hamlet",
+                                    "is_mirror_dummy": False,
+                                },
+                                {
+                                    "id": 6,
+                                    "email": "prospero@zulip.com",
+                                    "full_name": "Prospero from The Tempest",
+                                    "is_mirror_dummy": False,
+                                },
+                                {
+                                    "id": 7,
+                                    "email": "kenny@zulip.com",
+                                    "full_name": "Kenny Dehinde",
+                                    "is_mirror_dummy": False,
+                                },
+                            ],
+                        },
+                    },
+                },
+                [6, 7, 5],
+            ),
+        ],
+    )
+    def test_get_user_ids_in_recent_pms(self, mocker, model, index, expected_user_ids):
+        model.user_id = 4
+        model.index = index
+        assert expected_user_ids == model.get_user_ids_in_recent_pms()
+
+    @pytest.mark.parametrize(
         "response, expected_index, return_value",
         [
             (

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -524,6 +524,72 @@ class TestModel:
         assert current_ids == model.get_message_ids_in_current_narrow()
 
     @pytest.mark.parametrize(
+        "stream_id, topic, index, expected_user_ids",
+        [
+            (
+                1,
+                "general chat",
+                {
+                    "topic_msg_ids": {
+                        1: {
+                            "general chat": {101, 102, 103},
+                        }
+                    },
+                    "messages": {
+                        101: {"sender_id": 1},
+                        102: {"sender_id": 2},
+                        103: {"sender_id": 1},
+                    },
+                },
+                {1, 2},
+            ),
+            (
+                2,
+                "bug reports",
+                {
+                    "topic_msg_ids": {
+                        2: {
+                            "bug reports": {201, 202},
+                            "announcements": {203},
+                        }
+                    },
+                    "messages": {
+                        201: {"sender_id": 3},
+                        202: {"sender_id": 4},
+                        203: {"sender_id": 1},
+                    },
+                },
+                {3, 4},
+            ),
+            (
+                3,
+                "design",
+                {
+                    "topic_msg_ids": {
+                        1: {
+                            "general chat": {101},
+                        },
+                        3: {
+                            "design": {301, 302},
+                        },
+                    },
+                    "messages": {
+                        101: {"sender_id": 1},
+                        301: {"sender_id": 5},
+                        302: {"sender_id": 2},
+                    },
+                },
+                {5, 2},
+            ),
+        ],
+    )
+    def test_get_user_ids_in_topic_narrow(
+        self, mocker, model, index, stream_id, topic, expected_user_ids
+    ):
+        model.index = index
+        assert expected_user_ids == model.get_user_ids_in_topic_narrow(stream_id, topic)
+
+    @pytest.mark.parametrize(
         "response, expected_index, return_value",
         [
             (

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -388,6 +388,18 @@ class Model:
             ids = index["mentioned_msg_ids"]
         return ids.copy()
 
+    def get_user_ids_in_topic_narrow(self, stream_id: int, topic: str) -> Set[int]:
+        """
+        Gets sender ids for messages in topic narrow excluding the current user.
+        """
+        index = self.index
+        messages = index["messages"]
+        topic_msg_ids = index["topic_msg_ids"][stream_id].get(topic, set())
+        sender_ids = {messages[msg_id]["sender_id"] for msg_id in topic_msg_ids} - {
+            self.user_id
+        }
+        return sender_ids
+
     def current_narrow_contains_message(self, message: Message) -> bool:
         """
         Determine if a message conceptually belongs to a narrow

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -400,6 +400,26 @@ class Model:
         }
         return sender_ids
 
+    def get_user_ids_in_recent_pms(self) -> List[int]:
+        index = self.index
+        messages = index["messages"]
+        private_msg_ids = index["private_msg_ids"]
+
+        sorted_private_msg_ids = sorted(
+            private_msg_ids, key=lambda id: messages[id]["timestamp"], reverse=True
+        )
+
+        recipient_ids = []
+        exclude_recipient_ids = {self.user_id}
+        for msg_id in sorted_private_msg_ids:
+            display_recipient_ids = {
+                recipient["id"] for recipient in messages[msg_id]["display_recipient"]
+            } - exclude_recipient_ids
+            recipient_ids.extend(sorted(display_recipient_ids))
+            exclude_recipient_ids |= display_recipient_ids
+
+        return recipient_ids
+
     def current_narrow_contains_message(self, message: Message) -> bool:
         """
         Determine if a message conceptually belongs to a narrow

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -564,12 +564,29 @@ class WriteBox(urwid.Pile):
         ]
         matching_ids = {user["user_id"] for user in matching_users}
         matching_recipient_ids = set(self.recipient_user_ids) & set(matching_ids)
-        # Display subscribed users/recipients first.
-        sorted_matching_users = sorted(
-            matching_users,
-            key=lambda user: user["user_id"] in matching_recipient_ids,
-            reverse=True,
-        )
+
+        # get user ids in the topic narrow
+        if self.compose_box_status == "open_with_stream":
+            topic_narrow_user_ids = self.model.get_user_ids_in_topic_narrow(
+                self.stream_id, self.title_write_box.edit_text
+            )
+            matching_narrow_user_ids = set(topic_narrow_user_ids) & set(matching_ids)
+            # Display users in topic narrow first
+            sorted_matching_users = sorted(
+                matching_users,
+                key=lambda user: (
+                    user["user_id"] in matching_narrow_user_ids,
+                    user["user_id"] in matching_recipient_ids,
+                ),
+                reverse=True,
+            )
+        else:
+            # Display subscribed users/recipients first.
+            sorted_matching_users = sorted(
+                matching_users,
+                key=lambda user: user["user_id"] in matching_recipient_ids,
+                reverse=True,
+            )
 
         user_names = [user["full_name"] for user in sorted_matching_users]
 

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -565,18 +565,24 @@ class WriteBox(urwid.Pile):
         matching_ids = {user["user_id"] for user in matching_users}
         matching_recipient_ids = set(self.recipient_user_ids) & set(matching_ids)
 
-        # get user ids in the topic narrow
         if self.compose_box_status == "open_with_stream":
+            # get user ids in the topic narrow
             topic_narrow_user_ids = self.model.get_user_ids_in_topic_narrow(
                 self.stream_id, self.title_write_box.edit_text
             )
             matching_narrow_user_ids = set(topic_narrow_user_ids) & set(matching_ids)
-            # Display users in topic narrow first
+
+            # user ids with recent DMs
+            recent_dm_user_ids = self.model.get_user_ids_in_recent_pms()
+            matching_dm_user_ids = set(recent_dm_user_ids) & set(matching_ids)
+
+            # sort priority level:  topic narrow > stream > recent DMs
             sorted_matching_users = sorted(
                 matching_users,
                 key=lambda user: (
                     user["user_id"] in matching_narrow_user_ids,
                     user["user_id"] in matching_recipient_ids,
+                    user["user_id"] in matching_dm_user_ids,
                 ),
                 reverse=True,
             )


### PR DESCRIPTION
<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?
This PR fixes #1526.
__What I added__
- [x] It improves the autocomplete feature by prioritizing users in the current topic when using replying to a message.
- [x] It adds a new method `get_user_ids_in_topic_narrow` to `Model` 

__What's already included__
- __Prioritizing users in the current stream__: `WriteBox._setup_common_stream_compose()` sets the value of `WriteBox.recipient_user_ids ` to the users in the current stream
-  __Prioritizing real users over bot__: `Model._update_users_data_from_initial_data()` orders user data by status which prioritizes humans over bots.
- Prioritizing users which have recent DMs next

### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [x] Discussed in **#zulip-terminal** in `topic`
- [x] Fully fixes #
- [ ] Partially fixes issue #
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [x] Manually - Behavioral changes
- [x] Manually - Visual changes
- [ ] Adapting existing automated tests
- [x] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [x] It contains test additions for any new behavior
- [x] It flows clearly from a previous branch commit, and/or prepares for the next commit

### Visual changes    <!-- DELETE SECTION IF NO VISUAL CHANGE -->
<!-- Zulip tips at https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html -->
<!-- For video, try asciinema; after uploading, embed using
[![yourtitle](https://asciinema.org/a/<id>.png)](https://asciinema.org/a/<id>)
-->
<!-- NOTE: Attached videos/images will be clearer from smaller terminal windows -->
__Before__ 

[autocomplete_unfixed.webm](https://github.com/user-attachments/assets/d87faa69-834c-48a8-bc7c-ed3c4ef26b30)
__After__

[autocomplete_partial_fix.webm](https://github.com/user-attachments/assets/513f61cf-17c1-4140-b6bb-00a78b24043a)
