### PR TITLE
about_popup: Add current terminal size to About popup.

### DIFF
--- a/tests/ui_tools/test_popups.py
+++ b/tests/ui_tools/test_popups.py
@@ -1,3 +1,4 @@
+import os
 from collections import OrderedDict
 from typing import Any, Callable, Dict, List, Optional, Tuple
 from unittest.mock import patch
@@ -209,6 +210,7 @@ class TestAboutView:
             maximum_footlinks=3,
             exit_confirmation_enabled=False,
             transparency_enabled=False,
+            terminal_size=os.terminal_size((80, 24)),
         )
 
     @pytest.mark.parametrize(
@@ -260,6 +262,7 @@ class TestAboutView:
             maximum_footlinks=3,
             exit_confirmation_enabled=False,
             transparency_enabled=False,
+            terminal_size=os.terminal_size((80, 24)),
         )
 
         assert len(about_view.feature_level_content) == (
@@ -297,6 +300,7 @@ Color depth: 256
 Notifications: disabled
 Exit confirmation: disabled
 Transparency: disabled
+Current terminal size: 80 x 24
 
 #### Detected Environment
 Platform: WSL

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -322,6 +322,7 @@ class Controller:
                 maximum_footlinks=self.maximum_footlinks,
                 exit_confirmation_enabled=self.exit_confirmation,
                 transparency_enabled=self.transparency_enabled,
+                terminal_size=os.get_terminal_size(),
             ),
             "area:help",
         )

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -2,6 +2,7 @@
 UI views for larger elements such as Streams, Messages, Topics, Help, etc
 """
 
+import os
 import threading
 from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
@@ -1109,6 +1110,7 @@ class AboutView(PopUpView):
         notify_enabled: bool,
         exit_confirmation_enabled: bool,
         transparency_enabled: bool,
+        terminal_size: os.terminal_size,
     ) -> None:
         self.feature_level_content = (
             [("Feature level", str(server_feature_level))]
@@ -1132,6 +1134,10 @@ class AboutView(PopUpView):
                         "enabled" if exit_confirmation_enabled else "disabled",
                     ),
                     ("Transparency", "enabled" if transparency_enabled else "disabled"),
+                    (
+                        "Current terminal size",
+                        f"{terminal_size.columns} x {terminal_size.lines}",
+                    ),
                 ],
             ),
             (


### PR DESCRIPTION
### What does this PR do, and why?
Adds the current terminal window size to the 'Detected Environment' 
section of the About popup. This is useful when reporting issues.

### External discussion & connections
- [x] Fully fixes #1536

### How did you test this?
- [x] Manually - Visual changes

### Self-review checklist for each commit
- [x] It is a minimal coherent idea
- [x] It has a commit summary following the documented style (title & body)
- [x] It has a commit summary describing the motivation and reasoning for the change