### PR TITLE
core: Fix race condition in show_typing_notification

### DIFF
--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -613,3 +613,47 @@ class TestController:
             set_footer_text.assert_called_once_with()
         assert controller.is_typing_notification_in_progress is False
         assert controller.active_conversation_info == {}
+
+    def test_show_typing_notification_handles_concurrent_stop(
+        self,
+        mocker: MockerFixture,
+        controller: Controller,
+    ) -> None:
+        """
+        Regression test for #1501.
+
+        A `stop` typing event handled concurrently (model._handle_typing_event)
+        reassigns controller.active_conversation_info to a new {} rather than
+        mutating the current dict. show_typing_notification's loop used to
+        read self.active_conversation_info a second time to index
+        "sender_name", after already checking it was truthy in the while
+        condition; if the reassignment happened in between, that raised an
+        unhandled KeyError instead of cleanly ending the loop. This crashed
+        intermittently (timing-dependent), matching the flakiness reported in
+        the issue.
+
+        Run many trials with very short delays before the "stop" to make the
+        race window as small as possible and surface a regression reliably.
+        """
+        set_footer_text = mocker.patch(VIEW + ".set_footer_text")
+        mocker.patch(MODULE + ".time.sleep")
+
+        for delay in (0.0, 0.001):
+            for _ in range(50):
+                controller.active_conversation_info = {"sender_name": "hamlet"}
+                controller.is_typing_notification_in_progress = False
+
+                def mock_typing() -> None:
+                    controller.active_conversation_info = {}
+
+                timer = Timer(delay, mock_typing)
+                timer.start()
+                # @asynch runs synchronously under pytest (PYTEST_CURRENT_TEST
+                # is set), so this call races directly against the Timer's
+                # thread rather than spawning its own thread.
+                controller.show_typing_notification()
+                timer.join()
+
+        assert controller.is_typing_notification_in_progress is False
+        assert controller.active_conversation_info == {}
+        set_footer_text.assert_called_with()

--- a/zulipterminal/core.py
+++ b/zulipterminal/core.py
@@ -449,9 +449,18 @@ class Controller:
         self.is_typing_notification_in_progress = True
         dots = itertools.cycle(["", ".", "..", "..."])
 
-        # Until conversation becomes "inactive" like when a `stop` event is sent
-        while self.active_conversation_info:
-            sender_name = self.active_conversation_info["sender_name"]
+        # Until conversation becomes "inactive" like when a `stop` event is sent.
+        # A `stop` event handled concurrently (model._handle_typing_event)
+        # reassigns self.active_conversation_info to a new {}, rather than
+        # mutating the current dict, so each iteration takes its own
+        # reference up front and uses only that - reading self.
+        # active_conversation_info a second time to index "sender_name"
+        # could otherwise race with that reassignment and raise a KeyError.
+        while True:
+            active_conversation_info = self.active_conversation_info
+            if not active_conversation_info:
+                break
+            sender_name = active_conversation_info["sender_name"]
             self.view.set_footer_text(
                 [
                     ("footer_contrast", " " + sender_name + " "),


### PR DESCRIPTION
## Why

`Controller.show_typing_notification` loops while `self.active_conversation_info` is truthy, and on each iteration re-reads the attribute a second time to index `["sender_name"]`:

```python
while self.active_conversation_info:
    sender_name = self.active_conversation_info["sender_name"]
    ...
```

`model._handle_typing_event`'s `stop` handler reassigns `controller.active_conversation_info` to a brand-new `{}` (it doesn't mutate the existing dict in place):

```python
elif event["op"] == "stop":
    controller.active_conversation_info = {}
```

`show_typing_notification` is wrapped with `@asynch` and runs on its own thread in real usage, while `_handle_typing_event` runs on the event-polling thread. If the reassignment lands between the `while` check and the second read, the index raises an unhandled `KeyError: 'sender_name'` instead of the loop cleanly exiting. This isn't just a test artifact — it's a genuine TOCTOU race in production code, and matches the "intermittent... rerun and it passes" symptom described in #1501.

I confirmed this independently of the project's pytest fixtures (see "Testing" below): the exact `KeyError` reproduces reliably against the current code, and disappears after the fix, across thousands of trials at several timing windows.

## Fix

Snapshot `self.active_conversation_info` into a local variable once per loop iteration, and use only that snapshot for both the emptiness check and the `"sender_name"` index, instead of dereferencing the instance attribute twice. A concurrent reassignment after the snapshot is taken can no longer be observed mid-iteration.

## Testing

Added `test_show_typing_notification_handles_concurrent_stop` in `tests/core/test_core.py`, following the existing `test_show_typing_notification`'s real-`Timer`-based concurrency pattern, looping many trials at very short delays to reliably surface the race.

**Caveat:** I'm developing on Windows, where `urwid.raw_display` requires `fcntl` (POSIX-only), so I can't execute this repo's actual pytest suite (or even instantiate `Controller` for it) locally. I verified both the bug and the fix by driving `Controller.show_typing_notification` directly (unbound, against a minimal duck-typed stand-in object outside the fixture chain) with the same real-`Timer` + mocked-`time.sleep` setup:
- Against the current `core.py`: reproduced `KeyError: 'sender_name'` repeatedly across hundreds of trials at delays from 0.1ms to 100ms.
- Against the fix: zero exceptions across thousands of trials at the same range of delays.
- Also ran `black`, `isort`, `ruff check`, and `mypy` (target file only) against the changed files — all clean.

I wasn't able to run the new test through the project's actual pytest/fixture machinery before opening this PR; I'm relying on CI to confirm it passes there, and I'm happy to adjust based on CI results or review feedback.

Fixes #1501.