### PR TITLE
Add oxocarbon dark and light themes

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -151,10 +151,12 @@ unresolved such issues and report them there.
 
 ## Are there any themes available, other than the default one?
 
-Yes. There are five supported themes:
+Yes. There are seven supported themes:
 - `zt_dark` (alias: `default`)
 - `gruvbox_dark` (alias: `gruvbox`)
 - `gruvbox_light`
+- `oxocarbon_dark`
+- `oxocarbon_light`
 - `zt_light` (alias: `light`)
 - `zt_blue` (alias: `blue`)
 

--- a/tests/config/test_themes.py
+++ b/tests/config/test_themes.py
@@ -35,6 +35,8 @@ expected_complete_themes = {
     "zt_dark",
     "gruvbox_dark",
     "gruvbox_light",
+    "oxocarbon_dark",
+    "oxocarbon_light",
     "zt_light",
     "zt_blue",
 }

--- a/zulipterminal/config/themes.py
+++ b/zulipterminal/config/themes.py
@@ -6,7 +6,15 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 from pygments.token import STANDARD_TYPES, _TokenType
 
 from zulipterminal.config.color import Background, term16
-from zulipterminal.themes import gruvbox_dark, gruvbox_light, zt_blue, zt_dark, zt_light
+from zulipterminal.themes import (
+    gruvbox_dark,
+    gruvbox_light,
+    oxocarbon_dark,
+    oxocarbon_light,
+    zt_blue,
+    zt_dark,
+    zt_light,
+)
 
 
 StyleSpec = Union[
@@ -93,6 +101,8 @@ REQUIRED_META = {
 THEMES: Dict[str, Any] = {
     "gruvbox_dark": gruvbox_dark,
     "gruvbox_light": gruvbox_light,
+    "oxocarbon_dark": oxocarbon_dark,
+    "oxocarbon_light": oxocarbon_light,
     "zt_dark": zt_dark,
     "zt_light": zt_light,
     "zt_blue": zt_blue,

--- a/zulipterminal/themes/colors_oxocarbon.py
+++ b/zulipterminal/themes/colors_oxocarbon.py
@@ -1,0 +1,77 @@
+"""
+COLORS FOR OXOCARBON THEME
+--------------------------
+Contains the oxocarbon color palette used by the oxocarbon themes.
+For further details on themefiles look at the theme contribution guide.
+
+This palette is adapted from oxocarbon.nvim, which is distributed under
+the MIT License:
+    https://github.com/nyoom-engineering/oxocarbon.nvim
+
+    MIT License
+
+    Copyright (c) 2022 Riccardo Mazzarini
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the
+    "Software"), to deal in the Software without restriction, including
+    without limitation the rights to use, copy, modify, merge, publish,
+    distribute, sublicense, and/or sell copies of the Software, and to
+    permit persons to whom the Software is furnished to do so, subject to
+    the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+    OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+    TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+from enum import Enum
+
+from zulipterminal.config.color import color_properties
+
+
+# fmt: off
+# NOTE: The 256code values are approximations from the xterm 256-color
+# cube/grayscale ramp; the 24code values are the exact oxocarbon hex codes
+# and are what will be used on any true-color (24-bit) terminal.
+
+class OxocarbonColor(Enum):
+    # color          =  16code          256code   24code
+
+    # Background / grayscale ramp (dark -> light)
+    BG               = 'black           h234      #161616'
+    BG1              = 'black           h235      #262626'
+    BG2              = 'dark_gray       h237      #393939'
+    BG3              = 'dark_gray       h239      #525252'
+    FG_DIM           = 'white           h254      #dde1e6'
+    FG               = 'white           h255      #f2f4f8'
+    WHITE            = 'white           h231      #ffffff'
+
+    # Accent colors
+    CYAN             = 'dark_cyan       h36       #08bdba'
+    CYAN_LIGHT       = 'light_cyan      h43       #3ddbd9'
+    BLUE             = 'light_blue      h111      #78a9ff'
+    BLUE_LIGHT       = 'light_blue      h75       #33b1ff'
+    PINK             = 'light_magenta   h169      #ee5396'
+    PINK_LIGHT       = 'light_magenta   h211      #ff7eb6'
+    GREEN            = 'light_green     h78       #42be65'
+    PURPLE           = 'light_magenta   h141      #be95ff'
+
+    # Light-variant colors (oxocarbon background=light); accents above are
+    # shared between both variants.
+    SLATE            = 'dark_gray       h238      #37474f'
+    GRAY             = 'light_gray      h109      #90a4ae'
+    BLUE_DEEP        = 'dark_blue       h27       #0f62fe'
+    PURPLE_DEEP      = 'dark_magenta    h61       #673ab7'
+
+
+# fmt: on
+
+
+DefaultBoldColor = color_properties(OxocarbonColor, "BOLD")

--- a/zulipterminal/themes/oxocarbon_dark.py
+++ b/zulipterminal/themes/oxocarbon_dark.py
@@ -1,0 +1,101 @@
+"""
+OXOCARBON DARK
+--------------
+
+For syntax highlighting, this theme uses the Material pygments style as a
+base (closest stock match to oxocarbon's cool blue/cyan-leaning palette),
+with a few token overrides nudged towards the oxocarbon accent colors.
+
+For further details on themefiles look at the theme contribution guide
+"""
+
+from pygments.styles.material import MaterialStyle
+
+from zulipterminal.config.color import Background
+from zulipterminal.themes.colors_oxocarbon import DefaultBoldColor as Color
+
+
+# fmt: off
+
+STYLES = {
+    # style_name       :  foreground                   background
+    None               : (Color.FG_DIM,                Background.COLOR),
+    'selected'         : (Color.BG,                    Color.BLUE_LIGHT),
+    'msg_selected'     : (Color.BG,                    Color.BLUE_LIGHT),
+    'header'           : (Color.BG,                    Color.BLUE_LIGHT),
+    'general_narrow'   : (Color.BG,                    Color.BLUE_LIGHT),
+    'general_bar'      : (Color.FG_DIM,                Background.COLOR),
+    'msg_sender'       : (Color.PINK_LIGHT__BOLD,       Background.COLOR),
+    'unread'           : (Color.PURPLE,                 Background.COLOR),
+    'user_active'      : (Color.GREEN,                  Background.COLOR),
+    'user_idle'        : (Color.PINK_LIGHT,              Background.COLOR),
+    'user_offline'     : (Color.BG3,                     Background.COLOR),
+    'user_inactive'    : (Color.BG3,                     Background.COLOR),
+    'user_bot'         : (Color.BG3,                     Background.COLOR),
+    'title'            : (Color.FG__BOLD,                Background.COLOR),
+    'column_title'     : (Color.FG__BOLD,                Background.COLOR),
+    'time'             : (Color.BLUE_LIGHT,               Background.COLOR),
+    'bar'              : (Color.FG_DIM,                  Color.BG2),
+    'msg_emoji'        : (Color.PURPLE,                  Background.COLOR),
+    'reaction'         : (Color.PURPLE__BOLD,            Background.COLOR),
+    'reaction_mine'    : (Color.BG,                      Color.PURPLE),
+    'msg_heading'      : (Color.BG__BOLD,                Color.GREEN),
+    'msg_math'         : (Color.BG,                      Color.BG2),
+    'msg_mention'      : (Color.PINK__BOLD,              Background.COLOR),
+    'msg_link'         : (Color.BLUE_LIGHT,              Background.COLOR),
+    'msg_link_index'   : (Color.BLUE_LIGHT__BOLD,        Background.COLOR),
+    'msg_quote'        : (Color.BG3,                     Background.COLOR),
+    'msg_bold'         : (Color.FG__BOLD,                Background.COLOR),
+    'msg_time'         : (Color.BG,                      Color.FG_DIM),
+    'footer'           : (Color.BG,                      Color.FG_DIM),
+    'footer_contrast'  : (Color.FG_DIM,                  Background.COLOR),
+    'starred'          : (Color.PINK__BOLD,              Background.COLOR),
+    'unread_count'     : (Color.PINK_LIGHT,              Background.COLOR),
+    'starred_count'    : (Color.FG_DIM,                  Background.COLOR),
+    'table_head'       : (Color.FG__BOLD,                Background.COLOR),
+    'filter_results'   : (Color.BG,                      Color.GREEN),
+    'edit_topic'       : (Color.BG,                      Color.BG2),
+    'edit_tag'         : (Color.BG,                      Color.BG2),
+    'edit_author'      : (Color.PINK_LIGHT,              Background.COLOR),
+    'edit_time'        : (Color.BLUE_LIGHT,              Background.COLOR),
+    'current_user'     : (Color.FG_DIM,                  Background.COLOR),
+    'muted'            : (Color.BLUE_LIGHT,              Background.COLOR),
+    'popup_border'     : (Color.FG_DIM,                  Background.COLOR),
+    'popup_category'   : (Color.BLUE_LIGHT__BOLD,        Background.COLOR),
+    'popup_contrast'   : (Color.BG,                      Color.BG2),
+    'popup_important'  : (Color.PINK__BOLD,              Background.COLOR),
+    'widget_disabled'  : (Color.BG3,                     Background.COLOR),
+    'area:help'        : (Color.BG,                      Color.GREEN),
+    'area:msg'         : (Color.BG,                      Color.PURPLE),
+    'area:stream'      : (Color.BG,                      Color.BLUE_LIGHT),
+    'area:error'       : (Color.BG,                      Color.PINK),
+    'area:user'        : (Color.BG,                      Color.PINK_LIGHT),
+    'search_error'     : (Color.PINK,                    Background.COLOR),
+    'task:success'     : (Color.BG,                      Color.GREEN),
+    'task:error'       : (Color.BG,                      Color.PINK),
+    'task:warning'     : (Color.BG,                      Color.PURPLE),
+    'ui_code'          : (Color.BG,                      Color.FG_DIM),
+}
+
+META = {
+    'background': Color.BG,
+    'pygments': {
+        'styles'    : MaterialStyle().styles,
+        'background': 'h234',
+        'overrides' : {
+            'c'   : '#ff7eb6, italics',    # comment -> oxocarbon pink_light
+            'cp'  : '#be95ff',             # preproc -> purple
+            'cpf' : '#525252',             # preproc continuation -> bg3
+            'ge'  : '#dde1e6, italics',    # generic emph -> fg_dim
+            'gh'  : '#dde1e6, bold',       # generic heading -> fg_dim
+            'gu'  : '#dde1e6, underline',  # generic subheading -> fg_dim
+            'gp'  : '#33b1ff, bold',       # generic prompt -> blue_light
+            'gs'  : '#dde1e6, bold',       # generic strong -> fg_dim
+            'err' : '#ee5396',             # error -> pink
+            'n'   : '#dde1e6',             # name -> fg_dim
+            'p'   : '#dde1e6',             # punctuation -> fg_dim
+            'w'   : '#dde1e6',             # whitespace -> fg_dim
+        }
+    }
+}
+# fmt: on

--- a/zulipterminal/themes/oxocarbon_light.py
+++ b/zulipterminal/themes/oxocarbon_light.py
@@ -1,0 +1,106 @@
+"""
+OXOCARBON LIGHT
+---------------
+
+The light variant of oxocarbon: a near-white background (#ffffff) with a
+dark slate foreground (#37474f) and the carbon accent colors, adjusted for
+contrast on a light background (deeper blue/purple, where the dark theme
+uses their paler counterparts).
+
+For syntax highlighting, this theme uses the Lovelace pygments style as a
+light base (a cohesive, cool-leaning light palette), with a few token
+overrides nudged towards the oxocarbon accent colors.
+
+For further details on themefiles look at the theme contribution guide.
+"""
+
+from pygments.styles.lovelace import LovelaceStyle
+
+from zulipterminal.config.color import Background
+from zulipterminal.themes.colors_oxocarbon import DefaultBoldColor as Color
+
+
+# fmt: off
+
+STYLES = {
+    # style_name       :  foreground                   background
+    None               : (Color.SLATE,                 Background.COLOR),
+    'selected'         : (Color.WHITE,                  Color.BLUE_DEEP),
+    'msg_selected'     : (Color.WHITE,                  Color.BLUE_DEEP),
+    'header'           : (Color.WHITE,                  Color.BLUE_DEEP),
+    'general_narrow'   : (Color.WHITE,                  Color.BLUE_DEEP),
+    'general_bar'      : (Color.SLATE,                  Background.COLOR),
+    'msg_sender'       : (Color.PINK__BOLD,             Background.COLOR),
+    'unread'           : (Color.PURPLE_DEEP,            Background.COLOR),
+    'user_active'      : (Color.GREEN,                  Background.COLOR),
+    'user_idle'        : (Color.PINK,                   Background.COLOR),
+    'user_offline'     : (Color.BG3,                    Background.COLOR),
+    'user_inactive'    : (Color.BG3,                    Background.COLOR),
+    'user_bot'         : (Color.BG3,                    Background.COLOR),
+    'title'            : (Color.BG__BOLD,               Background.COLOR),
+    'column_title'     : (Color.BG__BOLD,               Background.COLOR),
+    'time'             : (Color.BLUE_DEEP,              Background.COLOR),
+    'bar'              : (Color.SLATE,                  Color.FG_DIM),
+    'msg_emoji'        : (Color.PURPLE_DEEP,            Background.COLOR),
+    'reaction'         : (Color.PURPLE_DEEP__BOLD,      Background.COLOR),
+    'reaction_mine'    : (Color.WHITE,                  Color.PURPLE_DEEP),
+    'msg_heading'      : (Color.BG__BOLD,               Color.GREEN),
+    'msg_math'         : (Color.SLATE,                  Color.FG_DIM),
+    'msg_mention'      : (Color.PINK__BOLD,             Background.COLOR),
+    'msg_link'         : (Color.BLUE_DEEP,              Background.COLOR),
+    'msg_link_index'   : (Color.BLUE_DEEP__BOLD,        Background.COLOR),
+    'msg_quote'        : (Color.BG3,                    Background.COLOR),
+    'msg_bold'         : (Color.BG__BOLD,               Background.COLOR),
+    'msg_time'         : (Color.WHITE,                  Color.SLATE),
+    'footer'           : (Color.WHITE,                  Color.BG3),
+    'footer_contrast'  : (Color.SLATE,                  Background.COLOR),
+    'starred'          : (Color.PINK__BOLD,             Background.COLOR),
+    'unread_count'     : (Color.PINK,                   Background.COLOR),
+    'starred_count'    : (Color.GRAY,                   Background.COLOR),
+    'table_head'       : (Color.BG__BOLD,               Background.COLOR),
+    'filter_results'   : (Color.BG,                     Color.GREEN),
+    'edit_topic'       : (Color.SLATE,                  Color.FG_DIM),
+    'edit_tag'         : (Color.SLATE,                  Color.FG_DIM),
+    'edit_author'      : (Color.PINK,                   Background.COLOR),
+    'edit_time'        : (Color.BLUE_DEEP,              Background.COLOR),
+    'current_user'     : (Color.SLATE,                  Background.COLOR),
+    'muted'            : (Color.BLUE_DEEP,              Background.COLOR),
+    'popup_border'     : (Color.SLATE,                  Background.COLOR),
+    'popup_category'   : (Color.BLUE_DEEP__BOLD,        Background.COLOR),
+    'popup_contrast'   : (Color.SLATE,                  Color.FG_DIM),
+    'popup_important'  : (Color.PINK__BOLD,             Background.COLOR),
+    'widget_disabled'  : (Color.GRAY,                   Background.COLOR),
+    'area:help'        : (Color.BG,                     Color.GREEN),
+    'area:msg'         : (Color.WHITE,                  Color.PURPLE_DEEP),
+    'area:stream'      : (Color.WHITE,                  Color.BLUE_DEEP),
+    'area:error'       : (Color.WHITE,                  Color.PINK),
+    'area:user'        : (Color.BG,                     Color.PINK_LIGHT),
+    'search_error'     : (Color.PINK,                   Background.COLOR),
+    'task:success'     : (Color.BG,                     Color.GREEN),
+    'task:error'       : (Color.WHITE,                  Color.PINK),
+    'task:warning'     : (Color.WHITE,                  Color.PURPLE_DEEP),
+    'ui_code'          : (Color.SLATE,                  Color.FG_DIM),
+}
+
+META = {
+    'background': Color.WHITE,
+    'pygments': {
+        'styles'    : LovelaceStyle().styles,
+        'background': '#f2f4f8',
+        'overrides' : {
+            'c'   : '#ee5396, italics',    # comment -> oxocarbon pink
+            'cp'  : '#673ab7',             # preproc -> deep purple
+            'cpf' : '#90a4ae',             # preproc continuation -> gray
+            'ge'  : '#37474f, italics',    # generic emph -> slate
+            'gh'  : '#37474f, bold',       # generic heading -> slate
+            'gu'  : '#37474f, underline',  # generic subheading -> slate
+            'gp'  : '#0f62fe, bold',       # generic prompt -> deep blue
+            'gs'  : '#37474f, bold',       # generic strong -> slate
+            'err' : '#ee5396',             # error -> pink
+            'n'   : '#37474f',             # name -> slate
+            'p'   : '#37474f',             # punctuation -> slate
+            'w'   : '#90a4ae',             # whitespace -> gray
+        }
+    }
+}
+# fmt: on


### PR DESCRIPTION
<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?

Adds two new bundled themes — `oxocarbon_dark` and `oxocarbon_light` —
derived from the [oxocarbon](https://github.com/nyoom-engineering/oxocarbon.nvim)
(IBM Carbon) palette, giving users another dark/light theme pair.

Their shared palette is factored into `colors_oxocarbon.py`, following the
structure of the existing gruvbox theme files, and both are registered in
`config/themes.py`.

- `oxocarbon_dark` renders the carbon accents on a near-black background.
- `oxocarbon_light` uses a white background with a slate foreground and
  deeper blue/purple accents for contrast.

Syntax highlighting uses the Material (dark) and Lovelace (light) pygments
styles as bases, with token overrides nudged towards the oxocarbon accents.

The palette is adapted from oxocarbon.nvim (MIT License), Copyright (c) 2022
Riccardo Mazzarini; the full notice is included in `colors_oxocarbon.py`.

### Outstanding aspect(s)    <!-- DELETE SECTION IF EMPTY -->
<!-- In what ways is this not fully implemented/functioning? Compared to a discussion/issue? -->
<!-- Do you not understand something? Are you unsure about a certain approach? Want feedback? -->
- [ ] The pygments base styles (Material/Lovelace) and the light-theme
  contrast choices are somewhat subjective — happy to adjust to reviewer
  preference.

### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [ ] Discussed in **#zulip-terminal** in `topic`
- [ ] Fully fixes #
- [x] Partially fixes issue #1133 
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [ ] Manually - Behavioral changes
- [x] Manually - Visual changes
- [x] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [x] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [x] It contains test additions for any new behavior
- [x] It flows clearly from a previous branch commit, and/or prepares for the next commit

### Visual changes    <!-- DELETE SECTION IF NO VISUAL CHANGE -->
<!-- Zulip tips at https://zulip.readthedocs.io/en/latest/tutorials/screenshot-and-gif-software.html -->
<!-- For video, try asciinema; after uploading, embed using
[![yourtitle](https://asciinema.org/a/<id>.png)](https://asciinema.org/a/<id>)
-->
<!-- NOTE: Attached videos/images will be clearer from smaller terminal windows -->
**oxocarbon_dark**

<img width="1919" height="1192" alt="image" src="https://github.com/user-attachments/assets/50a9716d-f181-4af9-81c0-86d339e06bc2" />

**oxocarbon_light**

<img width="1920" height="1200" alt="image" src="https://github.com/user-attachments/assets/b5a71855-b400-4d9f-9d36-7f93a35ded24" />
