### PR TITLE
compose: Limit stream box width to max stream name length

### DIFF
--- a/tests/ui_tools/test_boxes.py
+++ b/tests/ui_tools/test_boxes.py
@@ -53,6 +53,7 @@ class TestWriteBox:
         users_fixture: List[Dict[str, Any]],
         user_groups_fixture: List[Dict[str, Any]],
         streams_fixture: List[Dict[str, Any]],
+        stream_dict: Dict[int, Dict[str, Any]],
         unicode_emojis: "OrderedDict[str, Dict[str, Any]]",
         user_dict: Dict[str, MinimalUserData],
     ) -> WriteBox:
@@ -61,6 +62,7 @@ class TestWriteBox:
         write_box = WriteBox(self.view)
         write_box.view.users = users_fixture
         write_box.model.user_dict = user_dict
+        write_box.model.stream_dict = stream_dict
         write_box.model.max_stream_name_length = 60
         write_box.model.max_topic_length = 60
         write_box.model.max_message_length = 10000

--- a/zulipterminal/ui_tools/boxes.py
+++ b/zulipterminal/ui_tools/boxes.py
@@ -354,11 +354,16 @@ class WriteBox(urwid.Pile):
         )
         self.title_write_box.set_completer_delims("")
 
+        max_stream_name_length = max(
+            (len(stream["name"]) for stream in self.model.stream_dict.values()),
+            default=0,
+        )
+
         # NOTE: stream marker should be set during initialization
         self.header_write_box = urwid.Columns(
             [
                 ("pack", urwid.Text(("default", "?"))),
-                self.stream_write_box,
+                (max_stream_name_length + 1, self.stream_write_box),
                 ("pack", urwid.Text(STREAM_TOPIC_SEPARATOR)),
                 self.title_write_box,
             ],


### PR DESCRIPTION
Fixes #905
The Previous One:
<img width="1462" height="746" alt="Screenshot 2026-07-09 094651" src="https://github.com/user-attachments/assets/ce1f472b-48a6-4083-bdcb-6a2bba339294" />

Previously, the stream input widget in the compose header used urwid's default weight-based sizing, causing it to take up half of the available terminal width regardless of stream name lengths.

The Updated One :
<img width="1436" height="745" alt="Screenshot 2026-07-09 150724" src="https://github.com/user-attachments/assets/ab58e057-6ad4-4916-8b47-7bd4353faf30" />

Now we calculate the maximum stream name length from the user's subscriptions and allocate only that width (plus 1 for cursor padding) to the stream box, allowing the topic field to use all remaining space.