### PR TITLE
model: Optimize startup by using partial subscribers.

### DIFF
--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -271,7 +271,7 @@ class TestModel:
             fetch_event_types=fetch_event_types,
             apply_markdown=True,
             client_gravatar=True,
-            include_subscribers=True,
+            include_subscribers="partial",
         )
 
     @pytest.mark.parametrize(

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1083,17 +1083,19 @@ class Model:
 
         if stream_id:
             assert self.is_user_subscribed_to_stream(stream_id)
+            stream = self.stream_dict[stream_id]
+            subscribers = stream.get("subscribers") or stream.get(
+                "partial_subscribers", []
+            )
 
-            return [
-                sub
-                for sub in self.stream_dict[stream_id]["subscribers"]
-                if sub != self.user_id
-            ]
+            return [sub for sub in subscribers if sub != self.user_id]
         else:
             return [
                 sub
                 for _, stream in self.stream_dict.items()
-                for sub in stream["subscribers"]
+                for sub in (
+                    stream.get("subscribers") or stream.get("partial_subscribers", [])
+                )
                 if stream["name"] == stream_name
                 if sub != self.user_id
             ]
@@ -1549,7 +1551,9 @@ class Model:
 
             for stream_id in stream_ids:
                 if self.is_user_subscribed_to_stream(stream_id):
-                    subscribers = self.stream_dict[stream_id]["subscribers"]
+                    subscribers = self.stream_dict[stream_id].get(
+                        "subscribers"
+                    ) or self.stream_dict[stream_id].get("partial_subscribers", [])
                     if event["op"] == "peer_add":
                         subscribers.extend(user_ids)
                     else:
@@ -2110,7 +2114,7 @@ class Model:
                 fetch_event_types=fetch_types,
                 client_gravatar=True,
                 apply_markdown=True,
-                include_subscribers=True,
+                include_subscribers="partial",
             )
         except zulip.ZulipError as e:
             return str(e)

--- a/zulipterminal/ui_tools/views.py
+++ b/zulipterminal/ui_tools/views.py
@@ -1411,7 +1411,9 @@ class StreamInfoView(PopUpView):
             else:
                 stream_policy = STREAM_POST_POLICY[1]
 
-        total_members = len(stream["subscribers"])
+        total_members = stream.get("subscriber_count") or len(
+            stream.get("subscribers", [])
+        )
 
         stream_access_type = controller.model.stream_access_type(stream_id)
         type_of_stream = STREAM_ACCESS_TYPE[stream_access_type]["description"]


### PR DESCRIPTION
<!-- See README for documentation, or ask in #zulip-terminal if unclear -->
### What does this PR do, and why?
Optimizes startup performance for large Zulip servers by transitioning 
from `include_subscribers=True` to `include_subscribers="partial"` in 
`_register_desired_events`. This avoids fetching full subscriber lists 
for all streams at startup, which causes significant load delays for 
large communities like CZO.

- `_register_desired_events`: Changed `include_subscribers=True` to `"partial"`
- `get_other_subscribers_in_stream`: Handle both `subscribers` and `partial_subscribers`
- `_handle_subscription_event`: Handle both `subscribers` and `partial_subscribers`
- `StreamInfoView`: Use `subscriber_count` instead of `len(subscribers)`




### Outstanding aspect(s)    <!-- DELETE SECTION IF EMPTY -->
<!-- In what ways is this not fully implemented/functioning? Compared to a discussion/issue? -->
<!-- Do you not understand something? Are you unsure about a certain approach? Want feedback? -->
- [ ] Tests for `partial_subscribers` case in `get_other_subscribers_in_stream` are not yet added

### External discussion & connections
<!-- [x] all that apply, specifying topic and adding numbers after # for issues/PRs -->
- [ ] Discussed in **#zulip-terminal** in `topic`
- [ ] Fully fixes #
- [x] Partially fixes issue #1644 
- [ ] Builds upon previous unmerged work in PR #
- [ ] Is a follow-up to work in PR #
- [ ] Requires merge of PR #
- [ ] Merge will enable work on #

### How did you test this?
<!-- [x] all that apply -->
- [ ] Manually - Behavioral changes
- [ ] Manually - Visual changes
- [x] Adapting existing automated tests
- [ ] Adding automated tests for new behavior (or missing tests)
- [ ] Existing automated tests should already cover this (*only a refactor of tested code*)

### Self-review checklist for each commit
- [x] It is a [minimal coherent idea](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development)
- [x] It has a commit summary following the [documented style](https://github.com/zulip/zulip-terminal#structuring-commits---speeding-up-reviews-merging--development) (title & body)
- [x] It has a commit summary describing the  motivation and reasoning for the change
- [x] It individually passes linting and tests
- [ ] It contains test additions for any new behavior
- [ ] It flows clearly from a previous branch commit, and/or prepares for the next commit


