### PR TITLE
Avoid ValueError when peer_remove references unknown subscriber.

### DIFF
--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -4187,6 +4187,27 @@ class TestModel:
         new_subscribers = model.stream_dict[stream_ids[0]]["subscribers"]
         assert new_subscribers == expected_subscribers
 
+    def test__handle_subscription_event_peer_remove_user_not_subscribed(
+        self, model, mocker, stream_dict
+    ):
+        # Regression test for #1220: peer_remove for a user_id that is
+        # not present in subscribers (e.g. because we missed the
+        # corresponding peer_add event) should not raise ValueError.
+        event = {
+            "type": "subscription",
+            "op": "peer_remove",
+            "stream_ids": [2],
+            "user_ids": [999],  # not present in subscribers
+        }
+
+        model.stream_dict = stream_dict
+        model.server_feature_level = 35
+
+        model._handle_subscription_event(event)
+
+        new_subscribers = model.stream_dict[2]["subscribers"]
+        assert new_subscribers == [1001, 11, 12]
+
     # NOTE: This only applies to feature level 34/35+
     @pytest.mark.parametrize(
         "event, feature_level, expected_subscribers",

--- a/zulipterminal/model.py
+++ b/zulipterminal/model.py
@@ -1554,7 +1554,13 @@ class Model:
                         subscribers.extend(user_ids)
                     else:
                         for user_id in user_ids:
-                            subscribers.remove(user_id)
+                            # A user_id may not be present in subscribers
+                            # if we missed the corresponding peer_add
+                            # event, or due to some other timing/sync
+                            # issue with the server. Avoid raising
+                            # ValueError in that case.
+                            if user_id in subscribers:
+                                subscribers.remove(user_id)
 
     def _handle_typing_event(self, event: Event) -> None:
         """


### PR DESCRIPTION
Fixes #1220

The `peer_remove` event handler assumed the user being removed was
always present in the stream's subscriber list. If the corresponding
`peer_add` event was missed for some reason, this caused a ValueError
and the exception popup described in the issue.

This adds a membership check before removing, and a test covering
the case where the user_id is not present in subscribers.